### PR TITLE
Added version checking for Qt5 and PyQt5 dependencies

### DIFF
--- a/nw/common.py
+++ b/nw/common.py
@@ -57,7 +57,7 @@ def colRange(rgbStart, rgbEnd, nStep):
     if len(rgbStart) != 3 and len(rgbEnd) != 3 and nStep < 1:
         logger.error("Cannot create colour range from given parameters")
         return None
-    
+
     if nStep == 1:
         return rgbStart
     elif nStep == 2:
@@ -81,3 +81,27 @@ def colRange(rgbStart, rgbEnd, nStep):
     print(retCol)
 
     return retCol
+
+def splitVersionNumber(vString):
+    """ Splits a version string on the form aa.bb.cc into major, minor and patch, and computes an
+    integer value aabbcc.
+    """
+
+    vMajor = 0
+    vMinor = 0
+    vPatch = 0
+    vInt   = 0
+
+    vBits  = vString.split(".")
+    nBits  = len(vBits)
+
+    if nBits > 0:
+        vMajor = checkInt(vBits[0],0)
+    if nBits > 1:
+        vMinor = checkInt(vBits[1],0)
+    if nBits > 2:
+        vPatch = checkInt(vBits[2],0)
+
+    vInt = vMajor*10000 + vMinor*100 + vPatch
+
+    return [vMajor, vMinor, vPatch, vInt]

--- a/nw/config.py
+++ b/nw/config.py
@@ -19,6 +19,10 @@ from appdirs      import user_config_dir
 from datetime     import datetime
 
 from nw.constants import nwFiles
+from nw.common    import splitVersionNumber
+
+from PyQt5.Qt     import PYQT_VERSION_STR
+from PyQt5.QtCore import QT_VERSION_STR
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +100,21 @@ class Config:
 
         # Path
         self.recentList = [""]*10
+
+        # Check Qt5 Versions
+        verQt = splitVersionNumber(QT_VERSION_STR)
+        self.verQtString = QT_VERSION_STR
+        self.verQtMajor  = verQt[0]
+        self.verQtMinor  = verQt[1]
+        self.verQtPatch  = verQt[2]
+        self.verQtValue  = verQt[3]
+
+        verQt = splitVersionNumber(PYQT_VERSION_STR)
+        self.verPyQtString = PYQT_VERSION_STR
+        self.verPyQtMajor  = verQt[0]
+        self.verPyQtMinor  = verQt[1]
+        self.verPyQtPatch  = verQt[2]
+        self.verPyQtValue  = verQt[3]
 
         return
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -144,7 +144,8 @@ class GuiDocEditor(QTextEdit):
         # Also set the document text options for the document text flow
         theOpt = QTextOption()
         if self.mainConf.tabWidth is not None:
-            theOpt.setTabStopDistance(self.mainConf.tabWidth)
+            if self.mainConf.verQtValue >= 51000:
+                theOpt.setTabStopDistance(self.mainConf.tabWidth)
         if self.mainConf.doJustify:
             theOpt.setAlignment(Qt.AlignJustify)
         self.qDocument.setDefaultTextOption(theOpt)

--- a/nw/gui/winmain.py
+++ b/nw/gui/winmain.py
@@ -57,6 +57,9 @@ class GuiMain(QMainWindow):
         self.theIndex    = NWIndex(self.theProject, self)
         self.hasProject  = False
 
+        logger.info("Qt5 Version:   %s (%d)" % (self.mainConf.verQtString,   self.mainConf.verQtValue))
+        logger.info("PyQt5 Version: %s (%d)" % (self.mainConf.verPyQtString, self.mainConf.verPyQtValue))
+
         self.resize(*self.mainConf.winGeometry)
         self._setWindowTitle()
         self.setWindowIcon(QIcon(path.join(self.mainConf.appIcon)))


### PR DESCRIPTION
Addresses issue #44 

For non-essential features (currently custom tab stop length) using the later versions of Qt5, a version check has been added before the PyQt5 command is executed.

Testing novelWriter with Qt 5.5.1 works, although the above mentioned feature requires 5.10.