### PR TITLE
Bugfixes

### DIFF
--- a/nw/gui/configeditor.py
+++ b/nw/gui/configeditor.py
@@ -259,7 +259,7 @@ class GuiConfigEditGeneral(QWidget):
         self.mainConf.backupOnClose   = backupOnClose
         self.mainConf.askBeforeBackup = askBeforeBackup
 
-        self.mainConf.confChanged   = True
+        self.mainConf.confChanged = True
 
         return validEntries, needsRestart
 

--- a/nw/gui/dochighlight.py
+++ b/nw/gui/dochighlight.py
@@ -185,6 +185,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         # Build a QRegExp for each pattern and for the spell checker
         self.rules   = [(QRegularExpression(a),b) for (a,b) in self.hRules]
         self.spellRx = QRegularExpression(r"\b[^\s]+\b")
+        self.spellRx.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
 
         return True
 

--- a/nw/gui/winmain.py
+++ b/nw/gui/winmain.py
@@ -225,7 +225,7 @@ class GuiMain(QMainWindow):
         if self.docEditor.docChanged:
             self.saveDocument()
 
-        if self.theProject.projChanged:
+        if self.theProject.projAltered:
             saveOK   = self.saveProject()
             doBackup = False
             if self.theProject.doBackup and self.mainConf.backupOnClose:

--- a/nw/gui/winmain.py
+++ b/nw/gui/winmain.py
@@ -502,6 +502,7 @@ class GuiMain(QMainWindow):
             logger.debug("Applying new preferences")
             self.initMain()
             self.theTheme.updateTheme()
+            self.saveDocument()
             self.docEditor.initEditor()
             self.docViewer.initViewer()
         return True

--- a/nw/project/project.py
+++ b/nw/project/project.py
@@ -34,22 +34,23 @@ class NWProject():
         # Internal
         self.theParent   = theParent
         self.mainConf    = self.theParent.mainConf
-        self.projChanged = None
-        self.projOpened  = None
+        self.projOpened  = None # The time stamp of when the project file was opened
+        self.projChanged = None # The project has unsaved changes
+        self.projAltered = None # The project has been altered this session (used to trigger backup)
 
         # Debug
         self.handleSeed  = None
 
         # Class Settings
-        self.projTree    = None
-        self.treeOrder   = None
-        self.treeRoots   = None
-        self.trashRoot   = None
-        self.projPath    = None
-        self.projMeta    = None
-        self.projCache   = None
-        self.projDict    = None
-        self.projFile    = None
+        self.projTree    = None # Holds all the items of the project
+        self.treeOrder   = None # The order of the tree items on the tree view
+        self.treeRoots   = None # The root items of the tree
+        self.trashRoot   = None # The handle of the trash root folder
+        self.projPath    = None # The full path to where the currently open project is saved
+        self.projMeta    = None # The full path to the project's meta data folder
+        self.projCache   = None # The full path to the project's cache folder
+        self.projDict    = None # The spell check dictionary
+        self.projFile    = None # The file name of the project main xml file
 
         # Project Meta
         self.projName    = None
@@ -140,8 +141,9 @@ class NWProject():
 
     def clearProject(self):
 
-        self.projChanged = None
         self.projOpened  = None
+        self.projChanged = None
+        self.projAltered = False
 
         # Project Settings
         self.projTree    = {}
@@ -267,6 +269,7 @@ class NWProject():
         self._scanProjectFolder()
         self.setProjectChanged(False)
         self.projOpened = time()
+        self.projAltered = False
 
         return True
 
@@ -458,6 +461,9 @@ class NWProject():
     def setProjectChanged(self, bValue):
         self.projChanged = bValue
         self.theParent.setProjectStatus(self.projChanged)
+        if bValue:
+            # If we've changed the project at all, this should be True
+            self.projAltered = True
         return self.projChanged
 
     ##


### PR DESCRIPTION
This PR addresses the following problems:

* The backup request dialog should pop up on any change to the project during the last session, not just on unsaved changes as it currently does.
* The regex that searches for words for the spell check highlighter was not including unicode characters, so it would underline parts of words using unicode characters even if the word was spellec correctly.
* When having unsaved changes in an open document, while changing editor configuration options, the document would be reloaded from disk when the changes were applied. This means the unsaved changes were lost. The document is now saved before the editor is re-initialised.