### PR TITLE
Pandoc Export

### DIFF
--- a/nw/convert/file/latex.py
+++ b/nw/convert/file/latex.py
@@ -37,6 +37,7 @@ class LaTeXFile(TextFile):
             self.outFile = open(filePath,mode="wt+",encoding="utf8")
             self.outFile.write("\\documentclass[12pt]{report}\n")
             self.outFile.write("\\usepackage[utf8]{inputenc}\n")
+            self.outFile.write("\\usepackage[T1]{fontenc}\n")
             self.outFile.write("\n")
             self.outFile.write("\\begin{document}\n")
         except Exception as e:

--- a/nw/convert/file/text.py
+++ b/nw/convert/file/text.py
@@ -39,7 +39,7 @@ class TextFile():
         self.makeAlert  = self.theParent.makeAlert
 
         self.setComments(False)
-        self.setMeta(False)
+        self.setKeywords(False)
         self.setWordWrap(80)
 
         return
@@ -60,8 +60,8 @@ class TextFile():
         self.theConv.setComments(doComments)
         return
 
-    def setMeta(self, doMeta):
-        self.theConv.setCommands(doMeta)
+    def setKeywords(self, doKeywords):
+        self.theConv.setKeywords(doKeywords)
         return
 
     def setWordWrap(self, wordWrap):
@@ -83,12 +83,12 @@ class TextFile():
         self.theConv.setUnNumberedFormat(fmtUnNum)
         return
 
-    def setSceneFormat(self, fmtScene):
-        self.theConv.setSceneFormat(fmtScene)
+    def setSceneFormat(self, fmtScene, hideScene):
+        self.theConv.setSceneFormat(fmtScene, hideScene)
         return
 
-    def setSectionFormat(self, fmtSection):
-        self.theConv.setSectionFormat(fmtSection)
+    def setSectionFormat(self, fmtSection, hideSection):
+        self.theConv.setSectionFormat(fmtSection, hideSection)
         return
 
     ##

--- a/nw/convert/text/tohtml.py
+++ b/nw/convert/text/tohtml.py
@@ -83,7 +83,10 @@ class ToHtml(Tokenizer):
                 self.theResult += "<h4%s>%s</h4>\n" % (hStyle,tText)
 
             elif tType == self.T_SEP:
-                self.theResult += "<div%s>%s</div>\n" % (hStyle,tText)
+                self.theResult += "<p%s>%s</p>\n" % (hStyle,tText)
+
+            elif tType == self.T_SKIP:
+                self.theResult += "<p>&nbsp;</p>\n"
 
             elif tType == self.T_TEXT:
                 tTemp = tText
@@ -94,8 +97,8 @@ class ToHtml(Tokenizer):
             elif tType == self.T_COMMENT and self.doComments:
                 self.theResult += "<div class='comment'>%s</div>\n" % tText
 
-            elif tType == self.T_COMMAND and self.doCommands:
-                self.theResult += "<pre>%s</pre>\n" % tText
+            elif tType == self.T_KEYWORD and self.doKeywords:
+                self.theResult += "<pre>@%s</pre>\n" % tText
 
         # print(self.theResult)
 

--- a/nw/convert/text/tolatex.py
+++ b/nw/convert/text/tolatex.py
@@ -90,6 +90,10 @@ class ToLaTeX(Tokenizer):
                 self.theResult += "%s\n" % self._escapeUnicode(tText)
                 self.theResult += endText
 
+            elif tType == self.T_SKIP:
+                self.theResult += "\\bigskip\n"
+                self.theResult += "\\bigskip\n\n"
+
             elif tType == self.T_TEXT:
                 thisPar.append(self._escapeUnicode(tText))
 
@@ -99,7 +103,7 @@ class ToLaTeX(Tokenizer):
             elif tType == self.T_COMMENT and self.doComments:
                 self.theResult += "%s\n\n" % tText
 
-            elif tType == self.T_COMMAND and self.doCommands:
+            elif tType == self.T_KEYWORD and self.doKeywords:
                 self.theResult += "%% @%s\n\n" % tText
 
         return

--- a/nw/convert/text/tomarkdown.py
+++ b/nw/convert/text/tomarkdown.py
@@ -98,13 +98,16 @@ class ToMarkdown(Tokenizer):
             elif tType == self.T_SEP:
                 self.theResult += "%s\n\n" % tText
 
+            elif tType == self.T_SKIP:
+                self.theResult += "\n\n\n\n"
+
             elif tType == self.T_TEXT:
                 thisPar.append(tText)
 
             elif tType == self.T_COMMENT and self.doComments:
                 self.theResult += "%s\n\n" % tText
 
-            elif tType == self.T_COMMAND and self.doCommands:
+            elif tType == self.T_KEYWORD and self.doKeywords:
                 self.theResult += "%s\n\n" % tText
 
         return

--- a/nw/convert/text/totext.py
+++ b/nw/convert/text/totext.py
@@ -105,13 +105,16 @@ class ToText(Tokenizer):
                     tText = self._centreText(tText,self.wordWrap)
                 self.theResult += "%s\n\n" % tText
 
+            elif tType == self.T_SEP:
+                self.theResult += "\n\n\n\n"
+
             elif tType == self.T_TEXT:
                 thisPar.append(tText)
 
             elif tType == self.T_COMMENT and self.doComments:
                 self.theResult += "%s\n\n" % tText
 
-            elif tType == self.T_COMMAND and self.doCommands:
+            elif tType == self.T_KEYWORD and self.doKeywords:
                 self.theResult += "%s\n\n" % tText
 
         return

--- a/nw/convert/tokenizer.py
+++ b/nw/convert/tokenizer.py
@@ -42,7 +42,7 @@ class Tokenizer():
     T_HEAD4   =  7 # Header 4
     T_TEXT    =  8 # Text line
     T_SEP     =  9 # Scene separator
-    T_SKIP    = 10 # Scene separator
+    T_SKIP    = 10 # Paragraph break
     T_PBREAK  = 11 # Page break
 
     A_LEFT    =  1 # Left aligned


### PR DESCRIPTION
This PR adds a new tab to the export dialog for Pandoc support.

When selecting Pandoc in the Settings tab, the project is first exported to either markdown or html, depending on what final format is requested from the Pandoc tab. Open Office and Word documents are converted from html, and epub and zimwiki files are exported from markdown.

A few additional options have been added to the main GUI to. Since Pandoc seems to ignore alignement settings in the html, the option to just skip scene and section headings have been added. 

More settings need to be added to the Pandoc tab for epub export, but it seems to work fine for office documents.