### PR TITLE
Hard line breaks

### DIFF
--- a/nw/convert/text/tohtml.py
+++ b/nw/convert/text/tohtml.py
@@ -67,7 +67,8 @@ class ToHtml(Tokenizer):
 
             if tType == self.T_EMPTY:
                 if len(thisPar) > 0:
-                    self.theResult += "<p%s>%s</p>\n" % (hStyle," ".join(thisPar))
+                    tTemp = "".join(thisPar)
+                    self.theResult += "<p%s>%s</p>\n" % (hStyle,tTemp.rstrip())
                 thisPar = []
 
             elif tType == self.T_HEAD1:
@@ -92,7 +93,10 @@ class ToHtml(Tokenizer):
                 tTemp = tText
                 for xPos, xLen, xFmt in reversed(tFormat):
                     tTemp = tTemp[:xPos]+htmlTags[xFmt]+tTemp[xPos+xLen:]
-                thisPar.append(tTemp)
+                if tText.endswith("  "):
+                    thisPar.append(tTemp.rstrip()+"<br/>")
+                else:
+                    thisPar.append(tTemp.rstrip()+" ")
 
             elif tType == self.T_COMMENT and self.doComments:
                 self.theResult += "<div class='comment'>%s</div>\n" % tText

--- a/nw/convert/text/tolatex.py
+++ b/nw/convert/text/tolatex.py
@@ -95,7 +95,10 @@ class ToLaTeX(Tokenizer):
                 self.theResult += "\\bigskip\n\n"
 
             elif tType == self.T_TEXT:
-                thisPar.append(self._escapeUnicode(tText))
+                if tText.endswith("  "):
+                    thisPar.append(self._escapeUnicode(tText.rstrip())+"\\newline")
+                else:
+                    thisPar.append(self._escapeUnicode(tText.rstrip()))
 
             elif tType == self.T_PBREAK:
                 self.theResult += "\\newpage\n\n"

--- a/nw/convert/text/totext.py
+++ b/nw/convert/text/totext.py
@@ -80,7 +80,8 @@ class ToText(Tokenizer):
             # indicating a new paragraph.
             if tType == self.T_EMPTY:
                 if len(thisPar) > 0:
-                    self.theResult += "%s\n\n" % " ".join(thisPar)
+                    tTemp = " ".join(thisPar)
+                    self.theResult += "%s\n\n" % tTemp.rstrip())
                 thisPar = []
 
             elif tType == self.T_HEAD1:

--- a/nw/convert/text/totext.py
+++ b/nw/convert/text/totext.py
@@ -81,7 +81,7 @@ class ToText(Tokenizer):
             if tType == self.T_EMPTY:
                 if len(thisPar) > 0:
                     tTemp = " ".join(thisPar)
-                    self.theResult += "%s\n\n" % tTemp.rstrip())
+                    self.theResult += "%s\n\n" % tTemp.rstrip()
                 thisPar = []
 
             elif tType == self.T_HEAD1:

--- a/nw/convert/tokenizer.py
+++ b/nw/convert/tokenizer.py
@@ -171,10 +171,9 @@ class Tokenizer():
 
         self.theTokens = []
         for aLine in self.theText.splitlines():
-            aLine = aLine.strip()
 
             # Tag lines starting with specific characters
-            if len(aLine) == 0:
+            if len(aLine.strip()) == 0:
                 self.theTokens.append((self.T_EMPTY,"",None,self.A_LEFT))
             elif aLine[0] == "%":
                 self.theTokens.append((self.T_COMMENT,aLine[1:].strip(),None,self.A_LEFT))

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -81,6 +81,8 @@ class GuiDocEditor(QTextEdit):
 
         # Custom Shortcuts
         QShortcut(QKeySequence("Ctrl+."), self, context=Qt.WidgetShortcut, activated=self._openSpellContext)
+        QShortcut(Qt.Key_Return | Qt.ControlModifier, self, context=Qt.WidgetShortcut, activated=self._insertHardBreak)
+        QShortcut(Qt.Key_Enter  | Qt.ControlModifier, self, context=Qt.WidgetShortcut, activated=self._insertHardBreak)
 
         # Set Up Word Count Thread and Timer
         self.wcInterval = self.mainConf.wordCountTimer
@@ -323,6 +325,13 @@ class GuiDocEditor(QTextEdit):
     #  Internal Functions
     ##
 
+    def _insertHardBreak(self):
+        theCursor = self.textCursor()
+        theCursor.beginEditBlock()
+        theCursor.insertText("  \n")
+        theCursor.endEditBlock()
+        return
+
     def _openSpellContext(self):
         self._openContextMenu(self.cursorRect().center())
         return
@@ -388,7 +397,6 @@ class GuiDocEditor(QTextEdit):
             self.wcTimer.start()
         if self.mainConf.doReplace and not self.hasSelection:
             self._docAutoReplace(self.qDocument.findBlock(thePos))
-        # logger.verbose("Doc change signal took %.3f µs" % ((time()-self.lastEdit)*1e6))
         return
 
     def _docAutoReplace(self, theBlock):

--- a/nw/gui/dochighlight.py
+++ b/nw/gui/dochighlight.py
@@ -13,8 +13,8 @@
 import logging
 import nw
 
-from PyQt5.QtCore import QRegularExpression
-from PyQt5.QtGui  import QColor, QTextCharFormat, QFont, QSyntaxHighlighter
+from PyQt5.QtCore import Qt, QRegularExpression
+from PyQt5.QtGui  import QColor, QTextCharFormat, QFont, QSyntaxHighlighter, QBrush
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self.colSpell  = QColor(*self.theTheme.colSpell)
         self.colTagErr = QColor(*self.theTheme.colTagErr)
         self.colRepTag = QColor(*self.theTheme.colRepTag)
+        self.colTrail  = QColor(*self.theTheme.colEmph,64)
 
         self.hStyles = {
             "header1"   : self._makeFormat(self.colHead, "bold",1.8),
@@ -85,6 +86,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             "italic"    : self._makeFormat(self.colEmph, "italic"),
             "strike"    : self._makeFormat(self.colEmph, "strike"),
             "underline" : self._makeFormat(self.colEmph, "underline"),
+            "trailing"  : self._makeFormat(self.colTrail,"background"),
             "dialogue1" : self._makeFormat(self.colDialN),
             "dialogue2" : self._makeFormat(self.colDialD),
             "dialogue3" : self._makeFormat(self.colDialS),
@@ -133,6 +135,13 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self.hRules.append((
             r"^%.*$", {
                 0 : self.hStyles["hidden"],
+            }
+        ))
+
+        # Trailing Spaces, 2+
+        self.hRules.append((
+            r"[ ]{2,}$", {
+                0 : self.hStyles["trailing"],
             }
         ))
 
@@ -283,6 +292,8 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 theFormat.setFontStrikeOut(True)
             if "underline" in fmtStyle:
                 theFormat.setFontUnderline(True)
+            if "background" in fmtStyle:
+                theFormat.setBackground(QBrush(fmtCol,Qt.SolidPattern))
 
         if fmtSize is not None:
             theFormat.setFontPointSize(round(fmtSize*self.mainConf.textSize))

--- a/sample/sampleNovel/data_b/a8a28a246524_main.nwd
+++ b/sample/sampleNovel/data_b/a8a28a246524_main.nwd
@@ -1,16 +1,16 @@
 ## Interlude
 
-I am the very model of a modern Major-General
-I've information vegetable, animal, and mineral
-I know the kings of England, and I quote the fights historical
+I am the very model of a modern Major-General  
+I've information vegetable, animal, and mineral  
+I know the kings of England, and I quote the fights historical  
 From Marathon to Waterloo, in order categorical
 
-I'm very well acquainted, too, with matters mathematical
-I understand equations, both the simple and quadratical
-About binomial theorem I'm teeming with a lot o’ news
+I'm very well acquainted, too, with matters mathematical  
+I understand equations, both the simple and quadratical  
+About binomial theorem I'm teeming with a lot o’ news  
 With many cheerful facts about the square of the hypotenuse
 
-With many cheerful facts about the square of the hypotenuse
-With many cheerful facts about the square of the hypotenuse
+With many cheerful facts about the square of the hypotenuse  
+With many cheerful facts about the square of the hypotenuse  
 With many cheerful facts about the square of the hypotepotenuse
 

--- a/sample/sampleNovel/data_b/a8a28a246524_main.nwd
+++ b/sample/sampleNovel/data_b/a8a28a246524_main.nwd
@@ -14,3 +14,5 @@ With many cheerful facts about the square of the hypotenuse
 With many cheerful facts about the square of the hypotenuse  
 With many cheerful facts about the square of the hypotepotenuse
 
+
+

--- a/sample/sampleNovel/nwProject.nwx
+++ b/sample/sampleNovel/nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.3.1" fileVersion="1.0" timeStamp="2019-10-23 21:21:02">
+<novelWriterXML appVersion="0.3.2" fileVersion="1.0" timeStamp="2019-10-28 21:28:10">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
@@ -10,7 +10,7 @@
   <settings>
     <spellCheck>True</spellCheck>
     <lastEdited>ba8a28a246524</lastEdited>
-    <lastViewed>636b6aa9b697b</lastViewed>
+    <lastViewed>ba8a28a246524</lastViewed>
     <lastWordCount>859</lastWordCount>
     <autoReplace>
       <A>B</A>
@@ -103,10 +103,10 @@
       <status>Finished</status>
       <expanded>False</expanded>
       <layout>UNNUMBERED</layout>
-      <charCount>614</charCount>
+      <charCount>628</charCount>
       <wordCount>101</wordCount>
       <paraCount>3</paraCount>
-      <cursorPos>633</cursorPos>
+      <cursorPos>583</cursorPos>
     </item>
     <item handle="96b68994dfa3d" order="4" parent="e7ded148d6e4a">
       <name>A Note on Ipsums</name>

--- a/sample/sampleNovel/nwProject.nwx
+++ b/sample/sampleNovel/nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.3.2" fileVersion="1.0" timeStamp="2019-10-28 21:28:10">
+<novelWriterXML appVersion="0.3.2" fileVersion="1.0" timeStamp="2019-10-28 21:42:26">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
@@ -103,7 +103,7 @@
       <status>Finished</status>
       <expanded>False</expanded>
       <layout>UNNUMBERED</layout>
-      <charCount>628</charCount>
+      <charCount>626</charCount>
       <wordCount>101</wordCount>
       <paraCount>3</paraCount>
       <cursorPos>583</cursorPos>


### PR DESCRIPTION
Added the markdown feature of two or more spaces at the end of a line for hard line breaks. Now supported by html and LaTeX export as well, which includes html preview.

The editor will highlight two or more trailing spaces at the end of a line so that the hard line break is visible. In addition, a hard line break can be inserted by pressing `Ctrl+Enter`.