### PR TITLE
Docview Meta Data

### DIFF
--- a/nw/gui/elements/docviewer.py
+++ b/nw/gui/elements/docviewer.py
@@ -113,6 +113,8 @@ class GuiDocViewer(QTextBrowser):
         self.theHandle = tHandle
         self.theProject.setLastViewed(tHandle)
 
+        self.theParent.docMeta.refreshReferences(tHandle)
+
         return True
 
     def loadFromTag(self, theTag):

--- a/nw/gui/elements/viewdetails.py
+++ b/nw/gui/elements/viewdetails.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""novelWriter GUI DocView Details
+
+ novelWriter – GUI DocView Details
+===================================
+ Class holding the document view details panel
+
+ File History:
+ Created: 2019-09-31 [0.3.2]
+
+"""
+
+import logging
+import nw
+
+from PyQt5.QtGui     import QFont
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QLabel, QGroupBox, QComboBox
+
+from nw.constants    import nwLabels
+
+logger = logging.getLogger(__name__)
+
+class GuiDocViewDetails(QWidget):
+
+    def __init__(self, theParent, theProject):
+        QWidget.__init__(self, theParent)
+
+        logger.debug("Initialising DocViewDetails ...")
+        self.mainConf   = nw.CONFIG
+        self.debugGUI   = self.mainConf.debugGUI
+        self.theParent  = theParent
+        self.theProject = theProject
+
+        self.outerBox   = QHBoxLayout(self)
+        self.outerBox.setContentsMargins(4,4,4,4)
+
+        self.refTags     = QGroupBox("Referenced From", self)
+        self.refTagsForm = QHBoxLayout(self.refTags)
+        self.refTags.setLayout(self.refTagsForm)
+
+        self.refList = QLabel("None")
+        self.refList.linkActivated.connect(self._linkClicked)
+
+        self.refTagsForm.addWidget(self.refList)
+        self.outerBox.addWidget(self.refTags)
+        self.setLayout(self.outerBox)
+        self.setContentsMargins(0,0,0,0)
+
+        logger.debug("DocViewDetails initialisation complete")
+
+        return
+
+    def refreshReferences(self, tHandle):
+
+        theRefs = self.theParent.theIndex.buildReferenceList(tHandle)
+        if theRefs:
+            self.setVisible(True)
+        else:
+            self.setVisible(False)
+            return
+
+        theList = []
+        for tHandle in theRefs:
+            tItem = self.theProject.getItem(tHandle)
+            if tItem is not None:
+                theList.append("<a href='#tag=%s'>%s</a>" % (tHandle,tItem.itemName))
+
+        self.refList.setText(", ".join(theList))
+
+        return
+
+    ##
+    #  Internal Functions
+    ##
+
+    def _linkClicked(self, theLink):
+        if len(theLink) == 18:
+            tHandle = theLink[-13:]
+            self.theParent.viewDocument(tHandle)
+        return
+
+# END Class GuiDocViewDetails

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -25,7 +25,7 @@ class GuiMainStatus(QStatusBar):
     def __init__(self, theParent):
         QStatusBar.__init__(self, theParent)
 
-        logger.debug("Initialising GuiMainStatus ...")
+        logger.debug("Initialising MainStatus ...")
 
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
@@ -80,7 +80,7 @@ class GuiMainStatus(QStatusBar):
         self.sessionTimer.timeout.connect(self._updateTime)
         self.sessionTimer.start()
 
-        logger.debug("GuiMainStatus initialisation complete")
+        logger.debug("MainStatus initialisation complete")
 
         self.clearStatus()
 

--- a/nw/project/index.py
+++ b/nw/project/index.py
@@ -319,6 +319,28 @@ class NWIndex():
 
         return True
 
+    def buildReferenceList(self, theHandle):
+
+        theRefs = {}
+
+        tItem = self.theProject.getItem(theHandle)
+        if theHandle is None:
+            return theRefs
+
+        theTag = None
+        for tTag in self.tagIndex:
+            if theHandle == self.tagIndex[tTag][1]:
+                theTag = tTag
+                break
+
+        if theTag is not None:
+            for tHandle in self.refIndex:
+                for nLine, tKey, tTag, nTitle in self.refIndex[tHandle]:
+                    if tTag == theTag:
+                        theRefs[tHandle] = nLine
+
+        return theRefs
+
     def buildTagNovelMap(self, theTags, theFilters=None):
 
         tagMap   = {}

--- a/nw/project/index.py
+++ b/nw/project/index.py
@@ -341,6 +341,13 @@ class NWIndex():
 
         return theRefs
 
+    def getTagSource(self, theTag):
+        if theTag in self.tagIndex:
+            theRef = self.tagIndex[theTag]
+            if len(theRef) == 3:
+                return theRef[1], theRef[0]
+        return None, 0
+
     def buildTagNovelMap(self, theTags, theFilters=None):
 
         tagMap   = {}


### PR DESCRIPTION
This PR adds a panel at the bottom of a viewed document with all the documents referencing it. If there are no backlinks, the panel is not visible.

In addition, all references set in a document with the `@` keywords are now converted to clickable links in the document viewer.

This PR is related to issue #76.