### PR TITLE
Export Fixes

### DIFF
--- a/nw/convert/text/tohtml.py
+++ b/nw/convert/text/tohtml.py
@@ -40,11 +40,16 @@ class ToHtml(Tokenizer):
     def doAutoReplace(self):
         Tokenizer.doAutoReplace(self)
 
+        if self.forPreview:
+            tabFmt = "&nbsp;"*8
+        else:
+            tabFmt = "&emsp;"
+
         repDict = {
             "<"  : "&lt;",
             ">"  : "&gt;",
             "&"  : "&amp;",
-            "\t" : "&emsp;",
+            "\t" : tabFmt,
             nwUnicode.U_ENDASH : nwUnicode.H_ENDASH,
             nwUnicode.U_EMDASH : nwUnicode.H_EMDASH,
             nwUnicode.U_HELLIP : nwUnicode.H_HELLIP,

--- a/nw/convert/text/tohtml.py
+++ b/nw/convert/text/tohtml.py
@@ -41,9 +41,10 @@ class ToHtml(Tokenizer):
         Tokenizer.doAutoReplace(self)
 
         repDict = {
-            "<" : "&lt;",
-            ">" : "&gt;",
-            "&" : "&amp;",
+            "<"  : "&lt;",
+            ">"  : "&gt;",
+            "&"  : "&amp;",
+            "\t" : "&emsp;",
             nwUnicode.U_ENDASH : nwUnicode.H_ENDASH,
             nwUnicode.U_EMDASH : nwUnicode.H_EMDASH,
             nwUnicode.U_HELLIP : nwUnicode.H_HELLIP,

--- a/nw/convert/text/totext.py
+++ b/nw/convert/text/totext.py
@@ -30,6 +30,7 @@ class ToText(Tokenizer):
         Tokenizer.doAutoReplace(self)
 
         repDict = {
+            "\t" : "    ",
             nwUnicode.U_NBSP : " ",
         }
         xRep = re.compile("|".join([re.escape(k) for k in repDict.keys()]), flags=re.DOTALL)
@@ -92,7 +93,7 @@ class ToText(Tokenizer):
             # indicating a new paragraph.
             if tType == self.T_EMPTY:
                 if len(thisPar) > 0:
-                    tTemp = " ".join(thisPar)
+                    tTemp = "\n".join(thisPar)
                     self.theResult += "%s\n\n" % tTemp.rstrip()
                 thisPar = []
 

--- a/nw/convert/tokenizer.py
+++ b/nw/convert/tokenizer.py
@@ -285,7 +285,7 @@ class Tokenizer():
                 tFormat = tToken[2]
                 self.theTokens[n] = (tType,tText,tFormat,self.A_CENTRE)
 
-            self.theTokens[n] = (self.T_PBREAK,"",None,self.A_LEFT)
+            self.theTokens.append((self.T_PBREAK,"",None,self.A_LEFT))
 
         return
 

--- a/nw/convert/tokenizer.py
+++ b/nw/convert/tokenizer.py
@@ -62,14 +62,14 @@ class Tokenizer():
         self.theTokens   = None
         self.theResult   = None
 
-        self.wordWrap    = 80
+        self.wordWrap    = 0
         self.doComments  = False
         self.doKeywords  = False
 
         self.fmtTitle    = "%title%"
-        self.fmtChapter  = "Chapter %numword%: %title%"
+        self.fmtChapter  = "%title%"
         self.fmtUnNum    = "%title%"
-        self.fmtScene    = "* * *"
+        self.fmtScene    = "%title%"
         self.fmtSection  = "%title%"
 
         self.hideScene   = False
@@ -224,7 +224,7 @@ class Tokenizer():
         isScene = self.theItem.itemLayout == nwItemLayout.SCENE
         isNote  = self.theItem.itemLayout == nwItemLayout.NOTE
 
-        # No special header formatting for notes and no layout files
+        # No special header formatting for notes and no-layout files
         if isNone: return
         if isNote: return
 

--- a/nw/gui/elements/docviewer.py
+++ b/nw/gui/elements/docviewer.py
@@ -117,18 +117,6 @@ class GuiDocViewer(QTextBrowser):
         self.theHandle = tHandle
         self.theProject.setLastViewed(tHandle)
 
-        print("")
-        print("*"*140)
-        print("")
-        print(aDoc.theResult)
-        print("")
-        print("*"*140)
-        print("")
-        print(self.toHtml())
-        print("")
-        print("*"*140)
-        print("")
-
         self.theParent.docMeta.refreshReferences(tHandle)
 
         return True
@@ -183,8 +171,8 @@ class GuiDocViewer(QTextBrowser):
 
         styleSheet = (
             "body {{"
-            "  font-size: {textSize:.1f}pt;"
             "  color: rgb({tColR},{tColG},{tColB});"
+            "  font-size: {textSize:.1f}pt;"
             "}}\n"
             "h1, h2, h3, h4 {{"
             "  color: rgb({hColR},{hColG},{hColB});"
@@ -232,8 +220,6 @@ class GuiDocViewer(QTextBrowser):
             kColB    = self.theTheme.colKey[2],
         )
         self.qDocument.setDefaultStyleSheet(styleSheet)
-
-        print(styleSheet)
 
         return True
 

--- a/nw/gui/elements/docviewer.py
+++ b/nw/gui/elements/docviewer.py
@@ -39,6 +39,7 @@ class GuiDocViewer(QTextBrowser):
 
         self.qDocument = self.document()
         self.setMinimumWidth(300)
+        self.setOpenExternalLinks(False)
         self.initViewer()
 
         theOpt = QTextOption()
@@ -116,6 +117,18 @@ class GuiDocViewer(QTextBrowser):
         self.theHandle = tHandle
         self.theProject.setLastViewed(tHandle)
 
+        print("")
+        print("*"*140)
+        print("")
+        print(aDoc.theResult)
+        print("")
+        print("*"*140)
+        print("")
+        print(self.toHtml())
+        print("")
+        print("*"*140)
+        print("")
+
         self.theParent.docMeta.refreshReferences(tHandle)
 
         return True
@@ -173,21 +186,8 @@ class GuiDocViewer(QTextBrowser):
             "  font-size: {textSize:.1f}pt;"
             "  color: rgb({tColR},{tColG},{tColB});"
             "}}\n"
-            "h1 {{"
+            "h1, h2, h3, h4 {{"
             "  color: rgb({hColR},{hColG},{hColB});"
-            "  font-size: {h1Size:.1f}pt;"
-            "}}\n"
-            "h2 {{"
-            "  color: rgb({hColR},{hColG},{hColB});"
-            "  font-size: {h2Size:.1f}pt;"
-            "}}\n"
-            "h3 {{"
-            "  color: rgb({hColR},{hColG},{hColB});"
-            "  font-size: {h3Size:.1f}pt;"
-            "}}\n"
-            "h4 {{"
-            "  color: rgb({hColR},{hColG},{hColB});"
-            "  font-size: {h4Size:.1f}pt;"
             "}}\n"
             "a {{"
             "  color: rgb({aColR},{aColG},{aColB});"
@@ -212,10 +212,6 @@ class GuiDocViewer(QTextBrowser):
         ).format(
             textSize = self.mainConf.textSize,
             preSize  = self.mainConf.textSize*0.9,
-            h1Size   = self.mainConf.textSize*1.8,
-            h2Size   = self.mainConf.textSize*1.6,
-            h3Size   = self.mainConf.textSize*1.4,
-            h4Size   = self.mainConf.textSize*1.2,
             tColR    = self.theTheme.colText[0],
             tColG    = self.theTheme.colText[1],
             tColB    = self.theTheme.colText[2],
@@ -236,6 +232,8 @@ class GuiDocViewer(QTextBrowser):
             kColB    = self.theTheme.colKey[2],
         )
         self.qDocument.setDefaultStyleSheet(styleSheet)
+
+        print(styleSheet)
 
         return True
 

--- a/sample/sampleNovel/data_5/3b69b83cdafc_main.nwd
+++ b/sample/sampleNovel/data_5/3b69b83cdafc_main.nwd
@@ -2,3 +2,10 @@
 
 **By Jane Doh**
 
+More Text
+
+Even More Text
+
+What is this?
+
+Where is this?

--- a/sample/sampleNovel/data_b/a8a28a246524_main.nwd
+++ b/sample/sampleNovel/data_b/a8a28a246524_main.nwd
@@ -10,6 +10,6 @@ I understand equations, both the simple and quadratical
 About binomial theorem I'm teeming with a lot o’ news  
 With many cheerful facts about the square of the hypotenuse
 
-With many cheerful facts about the square of the hypotenuse  
-With many cheerful facts about the square of the hypotenuse  
-With many cheerful facts about the square of the hypotepotenuse
+	With many cheerful facts about the square of the hypotenuse  
+	With many cheerful facts about the square of the hypotenuse  
+	With many cheerful facts about the square of the hypotepotenuse

--- a/sample/sampleNovel/nwProject.nwx
+++ b/sample/sampleNovel/nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.3.2" fileVersion="1.0" timeStamp="2019-10-31 16:42:12">
+<novelWriterXML appVersion="0.3.2" fileVersion="1.0" timeStamp="2019-11-01 16:56:25">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
@@ -9,9 +9,9 @@
   </project>
   <settings>
     <spellCheck>True</spellCheck>
-    <lastEdited>b8136a5a774a0</lastEdited>
+    <lastEdited>53b69b83cdafc</lastEdited>
     <lastViewed>ba8a28a246524</lastViewed>
-    <lastWordCount>884</lastWordCount>
+    <lastWordCount>895</lastWordCount>
     <autoReplace>
       <A>B</A>
       <B>E</B>
@@ -48,10 +48,10 @@
       <status>Started</status>
       <expanded>False</expanded>
       <layout>TITLE</layout>
-      <charCount>23</charCount>
-      <wordCount>5</wordCount>
-      <paraCount>1</paraCount>
-      <cursorPos>16</cursorPos>
+      <charCount>73</charCount>
+      <wordCount>16</wordCount>
+      <paraCount>5</paraCount>
+      <cursorPos>85</cursorPos>
     </item>
     <item handle="e7ded148d6e4a" order="1" parent="7031beac91f75">
       <name>Some Chapter</name>
@@ -94,7 +94,7 @@
       <charCount>412</charCount>
       <wordCount>82</wordCount>
       <paraCount>2</paraCount>
-      <cursorPos>448</cursorPos>
+      <cursorPos>43</cursorPos>
     </item>
     <item handle="ba8a28a246524" order="3" parent="e7ded148d6e4a">
       <name>Interlude</name>
@@ -103,10 +103,10 @@
       <status>Finished</status>
       <expanded>False</expanded>
       <layout>UNNUMBERED</layout>
-      <charCount>630</charCount>
+      <charCount>633</charCount>
       <wordCount>101</wordCount>
       <paraCount>3</paraCount>
-      <cursorPos>648</cursorPos>
+      <cursorPos>164</cursorPos>
     </item>
     <item handle="96b68994dfa3d" order="4" parent="e7ded148d6e4a">
       <name>A Note on Ipsums</name>


### PR DESCRIPTION
This fixes a few issues with the export:

* Make sure tabs are exported as four spaces to text and `&emsp;` to html.
* Make sure tabs are visible as 8 non-breaking spaces in the document view panel.
* Make sure hard line breaks are exported to text files.
* Fix a bug for title and partition pages where the page break was overwriting the last line of the page rather than be appended to it. Issue #112