### PR TITLE
Prevent re-highlight on resize

### DIFF
--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -250,7 +250,7 @@ class GuiDocEditor(QTextEdit):
 
     def updateDocMargins(self):
         """Automatically adjust the margins so the text is centred, but
-        only if Config.textFixedW is set to True.
+        only if Config.textFixedW is enabled or we're in Zen mode.
         """
 
         if self.mainConf.textFixedW or self.theParent.isZenMode:
@@ -273,7 +273,13 @@ class GuiDocEditor(QTextEdit):
         docFormat = self.qDocument.rootFrame().frameFormat()
         docFormat.setLeftMargin(tM)
         docFormat.setRightMargin(tM)
+
+        # Updating root frame triggers a QTextDocument->contentsChange
+        # signal, which we do not want as it re-runs the syntax
+        # highlighter and spell checker, so we block it briefly.
+        self.qDocument.blockSignals(True)
         self.qDocument.rootFrame().setFrameFormat(docFormat)
+        self.qDocument.blockSignals(False)
 
         return
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -106,11 +106,13 @@ class GuiMain(QMainWindow):
         self.viewPane.setLayout(self.docView)
 
         self.splitView = QSplitter(Qt.Horizontal)
+        self.splitView.setOpaqueResize(False)
         self.splitView.addWidget(self.editPane)
         self.splitView.addWidget(self.viewPane)
 
         self.splitMain = QSplitter(Qt.Horizontal)
         self.splitMain.setContentsMargins(4,4,4,4)
+        self.splitMain.setOpaqueResize(False)
         self.splitMain.addWidget(self.treePane)
         self.splitMain.addWidget(self.splitView)
         self.splitMain.setSizes(self.mainConf.mainPanePos)


### PR DESCRIPTION
This PR adresses issue #150.

Resizing the window triggers a full re-highlighting of the entire document on each step, due to a change of the document root frame triggering a contentsChange signal to be emitted for **the entire document**. That is completely unnecessary, so this fix blocks the signal emission for the document object when the frame margins are altered.

The PR also disables opaque slider movement for the main splitters. The text reflow is performed after the new slider position is dropped.