### PR TITLE
Highlighter Improvements

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -323,6 +323,9 @@ class Config:
         self.showLineEndings = self._parseLine(
             cnfParse, cnfSec, "showlineendings", self.CNF_BOOL, self.showLineEndings
         )
+        self.bigDocLimit = self._parseLine(
+            cnfParse, cnfSec, "bigdoclimit", self.CNF_INT, self.bigDocLimit
+        )
 
         ## Backup
         cnfSec = "Backup"
@@ -413,6 +416,7 @@ class Config:
         cnfParse.set(cnfSec,"spellcheck",      str(self.spellLanguage))
         cnfParse.set(cnfSec,"showtabsnspaces", str(self.showTabsNSpaces))
         cnfParse.set(cnfSec,"showlineendings", str(self.showLineEndings))
+        cnfParse.set(cnfSec,"bigdoclimit",     str(self.bigDocLimit))
 
         ## Backup
         cnfSec = "Backup"

--- a/nw/config.py
+++ b/nw/config.py
@@ -93,6 +93,7 @@ class Config:
         self.wordCountTimer  = 5.0
         self.showTabsNSpaces = False
         self.showLineEndings = False
+        self.bigDocLimit     = 800
 
         self.fmtApostrophe   = nwUnicode.U_RSQUO
         self.fmtSingleQuotes = [nwUnicode.U_LSQUO,nwUnicode.U_RSQUO]

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -264,6 +264,7 @@ class GuiConfigEditGeneral(QWidget):
         guiDark         = self.guiDarkIcons.isChecked()
         spellTool       = self.spellToolList.currentData()
         spellLanguage   = self.spellLangList.currentData()
+        bigDocLimit     = self.spellBigDoc.value()
         autoSaveDoc     = self.autoSaveDoc.value()
         autoSaveProj    = self.autoSaveProj.value()
         backupPath      = self.projBackupPath.text()
@@ -278,6 +279,7 @@ class GuiConfigEditGeneral(QWidget):
         self.mainConf.guiDark         = guiDark
         self.mainConf.spellTool       = spellTool
         self.mainConf.spellLanguage   = spellLanguage
+        self.mainConf.bigDocLimit     = bigDocLimit
         self.mainConf.autoSaveDoc     = autoSaveDoc
         self.mainConf.autoSaveProj    = autoSaveProj
         self.mainConf.backupPath      = backupPath

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -173,11 +173,24 @@ class GuiConfigEditGeneral(QWidget):
             self.spellToolList.setCurrentIndex(toolIdx)
         self._doUpdateSpellTool(0)
 
-        self.spellLangForm.addWidget(QLabel("Provider"), 0, 0)
-        self.spellLangForm.addWidget(self.spellToolList, 0, 1)
-        self.spellLangForm.addWidget(QLabel("Language"), 1, 0)
-        self.spellLangForm.addWidget(self.spellLangList, 1, 1)
-        self.spellLangForm.setColumnStretch(2, 1)
+        self.spellBigDoc = QSpinBox(self)
+        self.spellBigDoc.setMinimum(10)
+        self.spellBigDoc.setMaximum(10000)
+        self.spellBigDoc.setSingleStep(10)
+        self.spellBigDoc.setToolTip((
+            "Disable spell checking when loading large documents. "
+            "Spell checking will only run on paragraphs you edit."
+        ))
+        self.spellBigDoc.setValue(self.mainConf.bigDocLimit)
+
+        self.spellLangForm.addWidget(QLabel("Provider"),   0, 0)
+        self.spellLangForm.addWidget(self.spellToolList,   0, 1, 1, 3)
+        self.spellLangForm.addWidget(QLabel("Language"),   1, 0)
+        self.spellLangForm.addWidget(self.spellLangList,   1, 1, 1, 3)
+        self.spellLangForm.addWidget(QLabel("Size limit"), 2, 0)
+        self.spellLangForm.addWidget(self.spellBigDoc,     2, 1)
+        self.spellLangForm.addWidget(QLabel("kb"),         2, 2)
+        self.spellLangForm.setColumnStretch(4, 1)
 
         # AutoSave
         self.autoSave     = QGroupBox("Automatic Save", self)
@@ -540,6 +553,7 @@ class GuiConfigEditEditor(QWidget):
         self.outerBox.addWidget(self.quoteStyle,  2, 1, 2, 1)
         self.outerBox.addWidget(self.showGuides,  4, 1)
         self.outerBox.setColumnStretch(2, 1)
+        self.outerBox.setRowStretch(5, 1)
         self.setLayout(self.outerBox)
 
         return

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -214,7 +214,14 @@ class GuiDocEditor(QTextEdit):
             return False
 
         self.hLight.setHandle(tHandle)
+        spTemp = self.hLight.spellCheck
+        self.hLight.spellCheck = False
+
+        bfTime = time()
         self.setPlainText(theDoc)
+        afTime = time()
+        logger.debug("Document highlighted in %.3f milliseconds" % (1000*(afTime-bfTime)))
+
         self.setCursorPosition(self.nwDocument.theItem.cursorPos)
         self.lastEdit = time()
         self._runCounter()
@@ -226,6 +233,8 @@ class GuiDocEditor(QTextEdit):
             self.setReadOnly(False)
         else:
             self.theParent.noticeBar.showNote("This document is read only.")
+
+        self.hLight.spellCheck = spTemp
 
         return True
 

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -225,7 +225,8 @@ class GuiDocEditor(QTextEdit):
         # checking. If it is too big, we switch to only check as we type
         self._checkDocSize(len(theDoc))
         spTemp = self.hLight.spellCheck
-        self.hLight.spellCheck = not self.bigDoc
+        if self.bigDoc:
+            self.hLight.spellCheck = False
 
         bfTime = time()
         self.setPlainText(theDoc)

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -618,7 +618,7 @@ class GuiMainMenu(QMenuBar):
         self.aReRunSpell = QAction("Re-Run Spell Check", self)
         self.aReRunSpell.setStatusTip("Run the spell checker on current document")
         self.aReRunSpell.setShortcut("F7")
-        self.aReRunSpell.triggered.connect(self.theParent.docEditor.updateSpellCheck)
+        self.aReRunSpell.triggered.connect(self.theParent.docEditor.reHighlightDocument)
         self.toolsMenu.addAction(self.aReRunSpell)
 
         # Tools > Separator

--- a/nw/gui/tools/dochighlight.py
+++ b/nw/gui/tools/dochighlight.py
@@ -234,20 +234,20 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             return
 
         elif theText.startswith("# "): # Header 1
-            self.setFormat(0, 1, self.hStyles["header1"])
-            self.setFormat(1, len(theText), self.hStyles["header1h"])
+            self.setFormat(0, 1, self.hStyles["header1h"])
+            self.setFormat(1, len(theText), self.hStyles["header1"])
 
         elif theText.startswith("## "): # Header 2
-            self.setFormat(0, 2, self.hStyles["header2"])
-            self.setFormat(2, len(theText), self.hStyles["header2h"])
+            self.setFormat(0, 2, self.hStyles["header2h"])
+            self.setFormat(2, len(theText), self.hStyles["header2"])
 
         elif theText.startswith("### "): # Header 3
-            self.setFormat(0, 3, self.hStyles["header3"])
-            self.setFormat(3, len(theText), self.hStyles["header3h"])
+            self.setFormat(0, 3, self.hStyles["header3h"])
+            self.setFormat(3, len(theText), self.hStyles["header3"])
 
         elif theText.startswith("#### "): # Header 4
-            self.setFormat(0, 4, self.hStyles["header4"])
-            self.setFormat(4, len(theText), self.hStyles["header4h"])
+            self.setFormat(0, 4, self.hStyles["header4h"])
+            self.setFormat(4, len(theText), self.hStyles["header4"])
 
         elif theText.startswith("%"): # Comments
             self.setFormat(0, len(theText), self.hStyles["hidden"])

--- a/nw/gui/tools/dochighlight.py
+++ b/nw/gui/tools/dochighlight.py
@@ -101,47 +101,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             "value"     : self._makeFormat(self.colVal),
         }
 
-        # Headers
         self.hRules = []
-        self.hRules.append((
-            r"^(#{1}) (.*)[^\n]", {
-                0 : self.hStyles["header1"],
-                1 : self.hStyles["header1h"],
-            }
-        ))
-        self.hRules.append((
-            r"^(#{2}) (.*)[^\n]", {
-                0 : self.hStyles["header2"],
-                1 : self.hStyles["header2h"],
-            }
-        ))
-        self.hRules.append((
-            r"^(#{3}) (.*)[^\n]", {
-                0 : self.hStyles["header3"],
-                1 : self.hStyles["header3h"],
-            }
-        ))
-        self.hRules.append((
-            r"^(#{4}) (.*)[^\n]", {
-                0 : self.hStyles["header4"],
-                1 : self.hStyles["header4h"],
-            }
-        ))
-
-        # Keyword/Value
-        # self.hRules.append((
-        #     r"^(@.+?)\s*:\s*(.+?)$", {
-        #         1 : self.hStyles["keyword"],
-        #         2 : self.hStyles["value"],
-        #     }
-        # ))
-
-        # Comments
-        self.hRules.append((
-            r"^%.*$", {
-                0 : self.hStyles["hidden"],
-            }
-        ))
 
         # Trailing Spaces, 2+
         self.hRules.append((
@@ -242,11 +202,10 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
     def highlightBlock(self, theText):
 
-        if self.theHandle is None:
+        if self.theHandle is None or not theText:
             return
 
-        if theText.startswith("@"):
-            # Highlighting of keywords and commands
+        if theText.startswith("@"): # Keywords and commands
             tItem = self.theParent.theProject.getItem(self.theHandle)
             isValid, theBits, thePos = self.theIndex.scanThis(theText)
             isGood = self.theIndex.checkThese(theBits, tItem)
@@ -265,11 +224,26 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                         kwFmt.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
                         self.setFormat(xPos, xLen, kwFmt)
 
-            # We're done, no need to continue
-            return
+        elif theText.startswith("# "): # Header 1
+            self.setFormat(0, 1, self.hStyles["header1"])
+            self.setFormat(1, len(theText), self.hStyles["header1h"])
 
-        else:
-            # For other text, just use our regex rules
+        elif theText.startswith("## "): # Header 2
+            self.setFormat(0, 2, self.hStyles["header2"])
+            self.setFormat(2, len(theText), self.hStyles["header2h"])
+
+        elif theText.startswith("### "): # Header 3
+            self.setFormat(0, 3, self.hStyles["header3"])
+            self.setFormat(3, len(theText), self.hStyles["header3h"])
+
+        elif theText.startswith("#### "): # Header 4
+            self.setFormat(0, 4, self.hStyles["header4"])
+            self.setFormat(4, len(theText), self.hStyles["header4h"])
+
+        elif theText.startswith("%"): # Comments
+            self.setFormat(0, len(theText), self.hStyles["hidden"])
+
+        else: # Text Paragraph
             for rX, xFmt in self.rxRules:
                 rxItt = rX.globalMatch(theText, 0)
                 while rxItt.hasNext():

--- a/nw/gui/tools/dochighlight.py
+++ b/nw/gui/tools/dochighlight.py
@@ -201,6 +201,11 @@ class GuiDocHighlighter(QSyntaxHighlighter):
     ##
 
     def highlightBlock(self, theText):
+        """Highlight a single block. Prefer to check first character for
+        all formats that are defined by their initial characters. This
+        is significantly faster than running the regex checks we use for
+        text paragraphs.
+        """
 
         if self.theHandle is None or not theText:
             return
@@ -223,6 +228,10 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                         kwFmt.setUnderlineColor(self.colTagErr)
                         kwFmt.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
                         self.setFormat(xPos, xLen, kwFmt)
+
+            # We never want to run the spell checker on keyword/values,
+            # so we force a return here
+            return
 
         elif theText.startswith("# "): # Header 1
             self.setFormat(0, 1, self.hStyles["header1"])
@@ -277,6 +286,10 @@ class GuiDocHighlighter(QSyntaxHighlighter):
     ##
 
     def _makeFormat(self, fmtCol=None, fmtStyle=None, fmtSize=None):
+        """Generate a valid character format to be applied to the text
+        that is to be highlighted.
+        """
+
         theFormat = QTextCharFormat()
 
         if fmtCol is not None:

--- a/tests/reference/novelwriter.conf
+++ b/tests/reference/novelwriter.conf
@@ -1,5 +1,5 @@
 [Main]
-timestamp = 2019-11-09 14:38:32
+timestamp = 2019-11-19 21:49:29
 theme = default
 syntax = default_light
 guidark = False
@@ -36,6 +36,7 @@ spelltool = internal
 spellcheck = en
 showtabsnspaces = False
 showlineendings = False
+bigdoclimit = 800
 
 [Backup]
 backuppath = 


### PR DESCRIPTION
This PR attempts to boost the performance of the syntax highlighter and spell checker.

First of all, an option to set a limit of how large documents are spell checked on load can now be set in preferences. The default size is 800 kb. That should only take a couple of seconds with spell enchant. When the document is larger than the set limit, the initial check is skipped, and the user has to press F7 manually to run the spell checker on the whole document.

When "big document mode" is active, spell check as you type is still active, and a paragraph or line is spell checked when it is altered.

In addition, the syntax highlighting performance has been improved by a factor 2. The highlighting of a 820000 word test document was reduced from ~800 ms to ~400 ms. Both by skipping empty text blocks, and skipping running regex searches on text that is highlighted based on the first 1 -4 characters. That is, the number of regex searches per line is reduced by about 30%.

The way a text document is rehighlighted is also done in a different way to avoid a strange bottle neck in the QSyntaxHighlighter from the Qt library. While running the syntax higlighter with spell checking initially took ~9 seconds on the 820000 word document, rerunning it too well over 3 minutes. This is now instead done by clearing the document and setting the text again. Unfortunately, this also clears undo history.