### PR TITLE
Spinning cursor when loading and spell checking

### DIFF
--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import (
     QTextCursor, QTextOption, QKeySequence, QFont, QColor, QPalette,
-    QTextDocument
+    QTextDocument, QCursor
 )
 
 from nw.project import NWDoc
@@ -209,7 +209,7 @@ class GuiDocEditor(QTextEdit):
         risk overwriting the file if it exists. This can for instance
         happen of the file contains binary elements or an encoding that
         novelWriter does not support. If load is successful, or the
-        document is new (empty string) we set up the editor for editing
+        document is new (empty string), we set up the editor for editing
         the file.
         """
 
@@ -219,6 +219,7 @@ class GuiDocEditor(QTextEdit):
             self.clearEditor()
             return False
 
+        qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
         self.hLight.setHandle(tHandle)
 
         # Check that the document is not too big for full, initial spell
@@ -246,6 +247,7 @@ class GuiDocEditor(QTextEdit):
             self.theParent.noticeBar.showNote("This document is read only.")
 
         self.hLight.spellCheck = spTemp
+        qApp.restoreOverrideCursor()
 
         return True
 
@@ -277,8 +279,9 @@ class GuiDocEditor(QTextEdit):
         return True
 
     def updateDocMargins(self):
-        """Automatically adjust the margins so the text is centred, but
-        only if Config.textFixedW is enabled or we're in Zen mode.
+        """Automatically adjust the margins so the text is centred if
+        Config.textFixedW is enabled or we're in Zen mode. Otherwise,
+        just ensure the margins are set correctly.
         """
 
         if self.mainConf.textFixedW or self.theParent.isZenMode:
@@ -335,7 +338,7 @@ class GuiDocEditor(QTextEdit):
         return theText
 
     def setCursorPosition(self, thePosition):
-        if thePosition > 0:
+        if thePosition >= 0:
             theCursor = self.textCursor()
             theCursor.setPosition(thePosition)
             self.setTextCursor(theCursor)
@@ -361,8 +364,8 @@ class GuiDocEditor(QTextEdit):
     def setSpellCheck(self, theMode):
         """This is the master spell check setting function, and this one
         should call all other setSpellCheck functions in other classes.
-        If the spell check mode is not defined, then toggle the current
-        status saved in the class.
+        If the spell check mode (theMode) is not defined (None), then
+        toggle the current status saved in this class.
         """
 
         if theMode is None:
@@ -375,23 +378,27 @@ class GuiDocEditor(QTextEdit):
         self.theParent.mainMenu.setSpellCheck(theMode)
         self.theProject.setSpellCheck(theMode)
         self.hLight.setSpellCheck(theMode)
-        self.reHighlightDocument()
+        if not self.bigDoc:
+            self.spellCheckDocument()
 
         logger.verbose("Spell check is set to %s" % str(theMode))
 
         return True
 
-    def reHighlightDocument(self):
+    def spellCheckDocument(self):
         """Rerun the highlighter to update spell checking status of the
         currently loaded text. The fastest way to do this, at least as
         of Qt 5.13, is to clear the text and put it back.
         """
 
+        logger.verbose("Running spell checker")
         if self.spellCheck:
             theText = self.getText()
             self.clear()
             bfTime = time()
+            qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
             self.setPlainText(theText)
+            qApp.restoreOverrideCursor()
             afTime = time()
             logger.debug("Document re-highlighted in %.3f milliseconds" % (1000*(afTime-bfTime)))
 

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -393,11 +393,13 @@ class GuiDocEditor(QTextEdit):
 
         logger.verbose("Running spell checker")
         if self.spellCheck:
-            theText = self.getText()
-            self.clear()
             bfTime = time()
             qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
-            self.setPlainText(theText)
+            if self.bigDoc:
+                theText = self.getText()
+                self.setPlainText(theText)
+            else:
+                self.hLight.rehighlight()
             qApp.restoreOverrideCursor()
             afTime = time()
             logger.debug("Document re-highlighted in %.3f milliseconds" % (1000*(afTime-bfTime)))

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -663,7 +663,7 @@ class GuiMainMenu(QMenuBar):
         self.aReRunSpell = QAction("Re-Run Spell Check", self)
         self.aReRunSpell.setStatusTip("Run the spell checker on current document")
         self.aReRunSpell.setShortcut("F7")
-        self.aReRunSpell.triggered.connect(self.theParent.docEditor.reHighlightDocument)
+        self.aReRunSpell.triggered.connect(self.theParent.docEditor.spellCheckDocument)
         self.toolsMenu.addAction(self.aReRunSpell)
 
         # Tools > Separator


### PR DESCRIPTION
This PR switches the cursor to a wait cursor when loading a document or running the spell checker on the whole document.

The issue with the current implementation is that it resets the undo stack for big documents. This is because for a large document, the text is reloaded when the spell checker is run on the full text. This takes about 9 seconds on the 820k words test document. Any other method I've tried takes about 4 minutes. I still don't understand this difference.