### PR TITLE
Tweaks to file split, trash and drag'n'drop

### DIFF
--- a/nw/gui/dialogs/docmerge.py
+++ b/nw/gui/dialogs/docmerge.py
@@ -46,7 +46,7 @@ class GuiDocMerge(QDialog):
         self.outerBox.addLayout(self.innerBox)
 
         self.doMergeForm = QGridLayout()
-        self.doMergeForm.setContentsMargins(10,5,0,10)
+        self.doMergeForm.setContentsMargins(0,0,0,0)
 
         self.listBox = QListWidget()
         self.listBox.setDragDropMode(QAbstractItemView.InternalMove)

--- a/nw/gui/dialogs/docsplit.py
+++ b/nw/gui/dialogs/docsplit.py
@@ -46,16 +46,16 @@ class GuiDocSplit(QDialog):
         self.outerBox.addLayout(self.innerBox)
 
         self.doMergeForm = QGridLayout()
-        self.doMergeForm.setContentsMargins(10,5,0,10)
+        self.doMergeForm.setContentsMargins(0,0,0,0)
 
         self.listBox = QListWidget()
         self.listBox.setDragDropMode(QAbstractItemView.NoDragDrop)
 
         self.splitLevel = QComboBox(self)
-        self.splitLevel.addItem("Split on Title (Level 1)",   1)
-        self.splitLevel.addItem("Split on Chapter (Level 2)", 2)
-        self.splitLevel.addItem("Split on Scene (Level 3)",   3)
-        self.splitLevel.addItem("Split on Section (Level 4)", 4)
+        self.splitLevel.addItem("Split on Header Level 1 (Title)",      1)
+        self.splitLevel.addItem("Split up to Header Level 2 (Chapter)", 2)
+        self.splitLevel.addItem("Split up to Header Level 3 (Scene)",   3)
+        self.splitLevel.addItem("Split up to Header Level 4 (Section)", 4)
         self.splitLevel.setCurrentIndex(2)
         self.splitLevel.currentIndexChanged.connect(self._populateList)
 

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -613,16 +613,22 @@ class GuiDocTree(QTreeWidget):
         """
         sHandle = self.getSelectedHandle()
         if sHandle is None:
+            logger.error("No handle selected")
             return
 
-        dIndex  = self.indexAt(theEvent.pos())
+        dIndex = self.indexAt(theEvent.pos())
         if not dIndex.isValid():
+            logger.error("Invalid drop index")
             return
 
         dItem   = self.itemFromIndex(dIndex)
         dHandle = dItem.text(self.C_HANDLE)
         snItem  = self.theProject.getItem(sHandle)
         dnItem  = self.theProject.getItem(dHandle)
+        if dnItem is None:
+            self.makeAlert("The item cannot be moved to that location.", nwAlert.ERROR)
+            return
+
         isSame  = snItem.itemClass == dnItem.itemClass
         isNone  = snItem.itemClass == nwItemClass.NO_CLASS
         isNote  = snItem.itemLayout == nwItemLayout.NOTE

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -252,6 +252,7 @@ class GuiDocTree(QTreeWidget):
         deleteItem function for each document in the Trash folder.
         """
 
+        logger.debug("Emptying Trash folder")
         if self.theProject.trashRoot is None:
             self.makeAlert("There is no Trash folder.", nwAlert.INFO)
             return False
@@ -261,7 +262,6 @@ class GuiDocTree(QTreeWidget):
             theTrash.remove(self.theProject.trashRoot)
 
         nTrash = len(theTrash)
-        print(theTrash)
         if nTrash == 0:
             self.makeAlert("The Trash folder is empty.", nwAlert.INFO)
             return False
@@ -275,6 +275,7 @@ class GuiDocTree(QTreeWidget):
         if msgRes != QMessageBox.Yes:
             return False
 
+        logger.verbose("Deleting %d files from Trash" % nTrash)
         for tHandle in self.getTreeFromHandle(self.theProject.trashRoot):
             if tHandle == self.theProject.trashRoot:
                 continue

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -281,6 +281,12 @@ class GuiMainMenu(QMenuBar):
         self.aDeleteItem.triggered.connect(lambda : self.theParent.treeView.deleteItem(None))
         self.projMenu.addAction(self.aDeleteItem)
 
+        # Project > Empty Trash
+        self.aEmptyTrash = QAction("Empty Trash", self)
+        self.aEmptyTrash.setStatusTip("Permanently delete all files in the Trash folder")
+        self.aEmptyTrash.triggered.connect(self.theParent.treeView.emptyTrash)
+        self.projMenu.addAction(self.aEmptyTrash)
+
         # Project > Separator
         self.projMenu.addSeparator()
 


### PR DESCRIPTION
This addresses some points from issue #161.

* Changed the wording on the dropdown box in the Split Document dialog to clarify its meaning.
* Added a menu option to empty the trash folder.
* Added a check to catch when the user tries to move an item to the Orphaned Items folder.