### PR TITLE
Open project from command line

### DIFF
--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -126,13 +126,17 @@ def main(sysArgs=None):
     confPath   = None
     testMode   = False
     qtStyle    = "Fusion"
+    cmdOpen    = None
 
     # Parse Options
     try:
-        inOpts, inArgs = getopt.getopt(sysArgs,shortOpt,longOpt)
+        inOpts, inRemain = getopt.getopt(sysArgs,shortOpt,longOpt)
     except getopt.GetoptError:
         print(helpMsg)
         sys.exit(2)
+
+    if len(inRemain) > 0:
+        cmdOpen = inRemain[0]
 
     for inOpt, inArg in inOpts:
         if inOpt in ("-h","--help"):
@@ -165,6 +169,7 @@ def main(sysArgs=None):
     # Set Config Options
     CONFIG.showGUI   = not testMode
     CONFIG.debugInfo = debugLevel < logging.INFO
+    CONFIG.cmdOpen   = cmdOpen
 
     # Set Logging
     if showTime: debugStr = timeStr+debugStr

--- a/nw/config.py
+++ b/nw/config.py
@@ -41,6 +41,7 @@ class Config:
         self.appHandle = nw.__package__.lower()
         self.showGUI   = True
         self.debugInfo = False
+        self.cmdOpen   = None
 
         # Set Paths
         self.confPath  = None
@@ -57,7 +58,7 @@ class Config:
         self.iconPath  = None
 
         # Set default values
-        self.confChanged  = False
+        self.confChanged = False
 
         ## General
         self.guiTheme  = "default"

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -182,6 +182,10 @@ class GuiMain(QMainWindow):
 
         logger.debug("GUI initialisation complete")
 
+        if self.mainConf.cmdOpen is not None:
+            logger.debug("Opening project from additional command line option")
+            self.openProject(self.mainConf.cmdOpen)
+
         return
 
     def clearGUI(self):


### PR DESCRIPTION
If the command line parser have any remaining, unparsed arguments, the first one is treated as the project path the user wants to open. When the GUI is constructed, a call is sent to the openProject function with this argument. The project class will handle any garbage that may end up here if this is not intended.