### PR TITLE
File saving and opening

### DIFF
--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -22,7 +22,6 @@ class nwFiles():
 
     APP_ICON   = "novelWriter.svg"
     PROJ_FILE  = "nwProject.nwx"
-    PROJ_COUNT = "projCount.txt"
     PROJ_DICT  = "wordlist.txt"
     SESS_INFO  = "sessionInfo.log"
     INDEX_FILE = "tagsIndex.json"

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -330,7 +330,7 @@ class GuiMain(QMainWindow):
 
         return True
 
-    def saveProject(self, isAuto=False):
+    def saveProject(self):
         """Save the current project.
         """
         if not self.hasProject:
@@ -344,7 +344,7 @@ class GuiMain(QMainWindow):
             return False
 
         self.treeView.saveTreeOrder()
-        self.theProject.saveProject(isAuto)
+        self.theProject.saveProject()
         self.theIndex.saveIndex()
         self.mainMenu.updateRecentProjects()
 
@@ -840,7 +840,7 @@ class GuiMain(QMainWindow):
         if (self.hasProject and self.theProject.projChanged and
             self.theProject.projPath is not None):
             logger.debug("Autosaving project")
-            self.saveProject(isAuto=True)
+            self.saveProject()
         return
 
     def _autoSaveDocument(self):

--- a/nw/project/document.py
+++ b/nw/project/document.py
@@ -100,25 +100,23 @@ class NWDoc():
             mkdir(dataPath)
             logger.debug("Created folder %s" % dataPath)
 
-        docTemp = path.join(dataPath,docFile[:-3]+"tmp")
-        docBack = path.join(dataPath,docFile[:-3]+"bak")
-
-        if path.isfile(docTemp):
-            unlink(docTemp)
-        if path.isfile(docBack):
-            rename(docBack,docTemp)
-        if path.isfile(docPath):
-            rename(docPath,docBack)
+        docTemp = path.join(dataPath, docFile+"~")
+        docBack = path.join(dataPath, docFile[:-3]+"bak")
 
         try:
-            with open(docPath,mode="w",encoding="utf8") as outFile:
+            with open(docTemp,mode="w",encoding="utf8") as outFile:
                 outFile.write(docText)
         except Exception as e:
             self.makeAlert(["Could not save document.",str(e)], nwAlert.ERROR)
             return False
 
-        if path.isfile(docTemp):
-            unlink(docTemp)
+        # If we're here, the file was successfully saved,
+        # so let's sort out the temps and backups
+        if path.isfile(docBack):
+            unlink(docBack)
+        if path.isfile(docPath):
+            rename(docPath, docBack)
+        rename(docTemp, docPath)
 
         self.theParent.statusBar.setStatus("Saved Document: %s" % self.theItem.itemName)
 
@@ -132,8 +130,8 @@ class NWDoc():
         dataPath = path.join(self.theProject.projPath, docDir)
         chkList = []
         chkList.append(path.join(dataPath, docFile))
-        chkList.append(path.join(dataPath,docFile[:-3]+"tmp"))
-        chkList.append(path.join(dataPath,docFile[:-3]+"bak"))
+        chkList.append(path.join(dataPath, docFile+"~"))
+        chkList.append(path.join(dataPath, docFile[:-3]+"bak"))
         for chkFile in chkList:
             if path.isfile(chkFile):
                 try:
@@ -147,7 +145,7 @@ class NWDoc():
     @staticmethod
     def assemblePath(tHandle, docExt):
         if tHandle is None:
-            return None
+            return None, None
         docDir  = "data_"+tHandle[0]
         docFile = tHandle[1:13]+"_"+docExt
         return docDir, docFile

--- a/nw/project/project.py
+++ b/nw/project/project.py
@@ -22,6 +22,7 @@ from time import time
 
 from nw.project.status import NWStatus
 from nw.project.item import NWItem
+from nw.tools import projectMaintenance
 from nw.common import checkString, checkBool, checkInt
 from nw.constants import (
     nwFiles, nwConst, nwItemType, nwItemClass, nwItemLayout, nwAlert
@@ -199,6 +200,11 @@ class NWProject():
 
         if not self._checkFolder(self.projMeta):
             return
+
+        try:
+            projectMaintenance(self)
+        except Exception as E:
+            logger.error(str(E))
 
         try:
             nwXML = etree.parse(fileName)

--- a/nw/project/project.py
+++ b/nw/project/project.py
@@ -50,7 +50,6 @@ class NWProject():
         self.trashRoot = None # The handle of the trash root folder
         self.projPath  = None # The full path to where the currently open project is saved
         self.projMeta  = None # The full path to the project's meta data folder
-        self.projCache = None # The full path to the project's cache folder
         self.projDict  = None # The spell check dictionary
         self.projFile  = None # The file name of the project main xml file
 
@@ -154,7 +153,6 @@ class NWProject():
         self.trashRoot   = None
         self.projPath    = None
         self.projMeta    = None
-        self.projCache   = None
         self.projDict    = None
         self.projFile    = nwFiles.PROJ_FILE
         self.projName    = ""
@@ -196,13 +194,10 @@ class NWProject():
         self.projPath = path.dirname(fileName)
         logger.debug("Opening project: %s" % self.projPath)
 
-        self.projMeta  = path.join(self.projPath,"meta")
-        self.projCache = path.join(self.projPath,"cache")
-        self.projDict  = path.join(self.projMeta, nwFiles.PROJ_DICT)
+        self.projMeta = path.join(self.projPath,"meta")
+        self.projDict = path.join(self.projMeta, nwFiles.PROJ_DICT)
 
         if not self._checkFolder(self.projMeta):
-            return
-        if not self._checkFolder(self.projCache):
             return
 
         try:
@@ -299,12 +294,10 @@ class NWProject():
             self.makeAlert("Project path not set, cannot save.", nwAlert.ERROR)
             return False
 
-        self.projMeta  = path.join(self.projPath,"meta")
-        self.projCache = path.join(self.projPath,"cache")
+        self.projMeta = path.join(self.projPath,"meta")
 
-        if not self._checkFolder(self.projPath):  return
-        if not self._checkFolder(self.projMeta):  return
-        if not self._checkFolder(self.projCache): return
+        if not self._checkFolder(self.projPath): return
+        if not self._checkFolder(self.projMeta): return
 
         logger.debug("Saving project: %s" % self.projPath)
 

--- a/nw/project/project.py
+++ b/nw/project/project.py
@@ -210,8 +210,20 @@ class NWProject():
             nwXML = etree.parse(fileName)
         except Exception as e:
             self.makeAlert(["Failed to parse project xml.",str(e)], nwAlert.ERROR)
-            self.clearProject()
-            return False
+
+            # Trying to open backup file instead
+            backFile = fileName[:-3]+"bak"
+            if path.isfile(backFile):
+                self.makeAlert("Attempting to open backup project file instead.", nwAlert.INFO)
+                try:
+                    nwXML = etree.parse(backFile)
+                except Exception as e:
+                    self.makeAlert(["Failed to parse project xml.",str(e)], nwAlert.ERROR)
+                    self.clearProject()
+                    return False
+            else:
+                self.clearProject()
+                return False
 
         xRoot   = nwXML.getroot()
         nwxRoot = xRoot.tag
@@ -295,6 +307,11 @@ class NWProject():
         return True
 
     def saveProject(self):
+        """Save the project main XML file. The saving command itself
+        uses a temporary filename, and the file is renamed afterwards to
+        make sure if the save fails, we're not left with a truncated
+        file.
+        """
 
         if self.projPath is None:
             self.makeAlert("Project path not set, cannot save.", nwAlert.ERROR)

--- a/nw/tools/__init__.py
+++ b/nw/tools/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from nw.tools.analyse import TextAnalysis
+from nw.tools.legacy import projectMaintenance
 from nw.tools.optlaststate import OptLastState
 from nw.tools.spellcheck import NWSpellCheck
 from nw.tools.spellenchant import NWSpellEnchant
@@ -10,6 +11,7 @@ from nw.tools.wordcount import countWords
 
 __all__ = [
     "TextAnalysis",
+    "projectMaintenance",
     "OptLastState",
     "NWSpellCheck",
     "NWSpellEnchant",

--- a/nw/tools/legacy.py
+++ b/nw/tools/legacy.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""novelWriter Legacy Tools
+
+ novelWriter – Legacy Tools
+============================
+ Various functions to handle old projects
+
+ File History:
+ Created: 2020-02-13 [0.4.3]
+
+"""
+
+import logging
+import nw
+
+from os import path, unlink, rmdir
+
+logger = logging.getLogger(__name__)
+
+def projectMaintenance(theProject):
+    """Wrapper class for handling various tasks related to managing old
+    projects with content from older versions of novelWriter.
+    """
+
+    # Remove no longer used project cache folder
+    if path.isdir(theProject.projPath):
+        cacheDir = path.join(theProject.projPath, "cache")
+        if path.isdir(cacheDir):
+            logger.info("Deprecated cache folder found")
+            rmList = []
+            for i in range(10):
+                rmList.append(path.join(cacheDir, "nwProject.nwx.%d" % i))
+            rmList.append(path.join(cacheDir, "projCount.txt"))
+            for rmFile in rmList:
+                if path.isfile(rmFile):
+                    logger.info("Deleting: %s" % rmFile)
+                    try:
+                        unlink(rmFile)
+                    except Exception as e:
+                        logger.error(str(e))
+            logger.info("Deleting: %s" % cacheDir)
+            try:
+                rmdir(cacheDir)
+            except Exception as e:
+                logger.error(str(e))
+
+    return

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -37,7 +37,6 @@ def testMainWindows(qtbot, nwTempGUI, nwRef):
     assert nwGUI.theProject.trashRoot is None
     assert nwGUI.theProject.projPath is None
     assert nwGUI.theProject.projMeta is None
-    assert nwGUI.theProject.projCache is None
     assert nwGUI.theProject.projFile == "nwProject.nwx"
     assert nwGUI.theProject.projName == ""
     assert nwGUI.theProject.bookTitle == ""
@@ -62,7 +61,6 @@ def testMainWindows(qtbot, nwTempGUI, nwRef):
     assert nwGUI.theProject.trashRoot is None
     assert nwGUI.theProject.projPath == nwTempGUI
     assert nwGUI.theProject.projMeta == path.join(nwTempGUI,"meta")
-    assert nwGUI.theProject.projCache == path.join(nwTempGUI,"cache")
     assert nwGUI.theProject.projFile == "nwProject.nwx"
     assert nwGUI.theProject.projName == ""
     assert nwGUI.theProject.bookTitle == ""


### PR DESCRIPTION
This PR changes the following:
* Remove the cache folder and 10 copies of the project file.
* Saving the project and a document is written to a temp file, which is then renamed to the final file.
* Before the renaming of the temp file, the old file is renamed to .bak for backup.
* If the main project file cannot be opened, the backup file is opened instead.