### PR TITLE
Replace PyQt5 with PySide2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ addons:
       - libenchant-dev
 #     - python3-pyqt5
 #     - python3-pyqt5.qtsvg
-      - python3-pyside2.qtcore
-      - python3-pyside2.qtgui
-      - python3-pyside2.qtwidgets
-      - python3-pyside2.qtsvg
-      - python3-pyside2.qttest
+#     - python3-pyside2.qtcore
+#     - python3-pyside2.qtgui
+#     - python3-pyside2.qtwidgets
+#     - python3-pyside2.qtsvg
+#     - python3-pyside2.qttest
 python:
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,13 @@ addons:
   apt:
     packages:
       - libenchant-dev
-      - python3-pyqt5
-      - python3-pyqt5.qtsvg
+#     - python3-pyqt5
+#     - python3-pyqt5.qtsvg
+      - python3-pyside2.qtcore
+      - python3-pyside2.qtgui
+      - python3-pyside2.qtwidgets
+      - python3-pyside2.qtsvg
+      - python3-pyside2.qttest
 python:
   - "3.6"
   - "3.7"

--- a/novelWriter.py
+++ b/novelWriter.py
@@ -8,17 +8,27 @@ if sys.hexversion < 0x030600F0:
     sys.exit(1)
 
 try:
-    import PyQt5.QtWidgets
-    import PyQt5.QtGui
-    import PyQt5.QtCore
+    import PySide2.QtCore
 except:
-    print("ERROR: Failed to load dependency python3-pyqt5")
+    print("ERROR: Failed to load dependency python3-pyside2.qtcore")
     sys.exit(1)
 
 try:
-    import PyQt5.QtSvg
+    import PySide2.QtGui
 except:
-    print("ERROR: Failed to load dependency python3-pyqt5.qtsvg")
+    print("ERROR: Failed to load dependency python3-pyside2.qtgui")
+    sys.exit(1)
+
+try:
+    import PySide2.QtWidgets
+except:
+    print("ERROR: Failed to load dependency python3-pyside2.qtwidgets")
+    sys.exit(1)
+
+try:
+    import PySide2.QtSvg
+except:
+    print("ERROR: Failed to load dependency python3-pyside2.qtsvg")
     sys.exit(1)
 
 try:

--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -16,7 +16,7 @@ import logging
 
 from os import path, remove, rename
 
-from PyQt5.QtWidgets import QApplication
+from PySide2.QtWidgets import QApplication
 
 from nw.guimain import GuiMain
 from nw.config import Config

--- a/nw/config.py
+++ b/nw/config.py
@@ -19,8 +19,8 @@ from os import path, mkdir, makedirs
 from appdirs import user_config_dir
 from datetime import datetime
 
-from PySide2.Qt import PYQT_VERSION_STR
-from PySide2.QtCore import QT_VERSION_STR
+from PySide2 import __version__ as PYQT_VERSION_STR
+from PySide2.QtCore import __version__ as QT_VERSION_STR
 
 from nw.constants import nwFiles, nwUnicode
 from nw.common import splitVersionNumber

--- a/nw/config.py
+++ b/nw/config.py
@@ -19,8 +19,8 @@ from os import path, mkdir, makedirs
 from appdirs import user_config_dir
 from datetime import datetime
 
-from PyQt5.Qt import PYQT_VERSION_STR
-from PyQt5.QtCore import QT_VERSION_STR
+from PySide2.Qt import PYQT_VERSION_STR
+from PySide2.QtCore import QT_VERSION_STR
 
 from nw.constants import nwFiles, nwUnicode
 from nw.common import splitVersionNumber

--- a/nw/convert/file/text.py
+++ b/nw/convert/file/text.py
@@ -15,7 +15,7 @@ import nw
 
 from os import path
 
-from PyQt5.QtWidgets import QMessageBox
+from PySide2.QtWidgets import QMessageBox
 
 from nw.convert.text.totext import ToText
 from nw.constants import nwAlert, nwItemType, nwItemLayout, nwItemClass

--- a/nw/convert/tokenizer.py
+++ b/nw/convert/tokenizer.py
@@ -15,7 +15,7 @@ import re
 import nw
 
 from operator import itemgetter
-from PyQt5.QtCore import QRegularExpression
+from PySide2.QtCore import QRegularExpression
 
 from nw.project.document import NWDoc
 from nw.tools.translate import numberToWord

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -15,9 +15,9 @@ import nw
 
 from os import path
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtGui import QFont
+from PySide2.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QLineEdit, QLabel, QWidget, QTabWidget,
     QDialogButtonBox, QSpinBox, QGroupBox, QComboBox, QMessageBox, QCheckBox,
     QGridLayout, QFontComboBox, QPushButton, QFileDialog

--- a/nw/gui/dialogs/docmerge.py
+++ b/nw/gui/dialogs/docmerge.py
@@ -13,8 +13,8 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QGridLayout, QPushButton,
     QListWidget, QAbstractItemView, QListWidgetItem
 )

--- a/nw/gui/dialogs/docsplit.py
+++ b/nw/gui/dialogs/docsplit.py
@@ -13,8 +13,8 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QGridLayout, QPushButton, QComboBox,
     QListWidget, QAbstractItemView, QListWidgetItem
 )

--- a/nw/gui/dialogs/export.py
+++ b/nw/gui/dialogs/export.py
@@ -16,8 +16,8 @@ import nw
 
 from os import path
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QWidget, QTabWidget, QGridLayout,
     QGroupBox, QCheckBox, QLabel, QComboBox, QLineEdit, QPushButton,
     QFileDialog, QProgressBar, QSpinBox, QMessageBox

--- a/nw/gui/dialogs/itemeditor.py
+++ b/nw/gui/dialogs/itemeditor.py
@@ -15,8 +15,8 @@ import nw
 
 from os import path
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QGroupBox, QFormLayout, QLineEdit,
     QPushButton, QComboBox
 )

--- a/nw/gui/dialogs/projecteditor.py
+++ b/nw/gui/dialogs/projecteditor.py
@@ -15,9 +15,9 @@ import nw
 
 from os import path
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon, QPixmap, QColor, QBrush
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtGui import QIcon, QPixmap, QColor, QBrush
+from PySide2.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QFormLayout, QLineEdit, QPlainTextEdit,
     QLabel, QWidget, QTabWidget, QDialogButtonBox, QListWidget, QPushButton,
     QListWidgetItem, QColorDialog, QAbstractItemView, QTreeWidget, QCheckBox,

--- a/nw/gui/dialogs/sessionlog.py
+++ b/nw/gui/dialogs/sessionlog.py
@@ -16,9 +16,9 @@ import nw
 from os import path
 from datetime import datetime
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtGui import QFont
+from PySide2.QtWidgets import (
     QDialog, QHBoxLayout, QTreeWidget, QTreeWidgetItem, QDialogButtonBox,
     QGridLayout, QLabel, QGroupBox, QCheckBox
 )

--- a/nw/gui/dialogs/timelineview.py
+++ b/nw/gui/dialogs/timelineview.py
@@ -15,9 +15,9 @@ import nw
 
 from os import path
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor, QPixmap
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtGui import QColor, QPixmap
+from PySide2.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QTableWidget, QTableWidgetItem, QLabel,
     QDialogButtonBox, QPushButton, QHeaderView, QGridLayout, QGroupBox,
     QCheckBox

--- a/nw/gui/elements/docdetails.py
+++ b/nw/gui/elements/docdetails.py
@@ -13,9 +13,9 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QFrame, QGridLayout, QLabel
+from PySide2.QtCore import Qt
+from PySide2.QtGui import QFont
+from PySide2.QtWidgets import QFrame, QGridLayout, QLabel
 
 from nw.constants import nwLabels
 

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -15,11 +15,11 @@ import nw
 
 from time import time
 
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt, QTimer
+from PySide2.QtWidgets import (
     qApp, QTextEdit, QAction, QMenu, QShortcut, QMessageBox
 )
-from PyQt5.QtGui import (
+from PySide2.QtGui import (
     QTextCursor, QTextOption, QKeySequence, QFont, QColor, QPalette,
     QTextDocument, QCursor
 )

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -222,7 +222,7 @@ class GuiDocTree(QTreeWidget):
     def saveTreeOrder(self):
         theList = []
         for i in range(self.topLevelItemCount()):
-            if self.topLevelItem(i) == self.orphRoot:
+            if id(self.topLevelItem(i)) == id(self.orphRoot):
                 continue
             theList = self._scanChildren(theList, self.topLevelItem(i), i)
         self.theProject.setTreeOrder(theList)
@@ -427,7 +427,7 @@ class GuiDocTree(QTreeWidget):
         nWords = 0
         for n in range(self.topLevelItemCount()):
             tItem = self.topLevelItem(n)
-            if tItem == self.orphRoot:
+            if id(tItem) == id(self.orphRoot):
                 continue
             nWords += int(tItem.text(self.C_COUNT))
         self.theProject.setProjectWordCount(nWords)

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -13,9 +13,9 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt, QSize
-from PyQt5.QtGui import QFont, QColor
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt, QSize
+from PySide2.QtGui import QFont, QColor
+from PySide2.QtWidgets import (
     QTreeWidget, QTreeWidgetItem, QAbstractItemView, QApplication, QMessageBox
 )
 

--- a/nw/gui/elements/docviewer.py
+++ b/nw/gui/elements/docviewer.py
@@ -13,9 +13,9 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QTextBrowser
-from PyQt5.QtGui import QTextOption, QFont, QPalette, QColor, QTextCursor
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QTextBrowser
+from PySide2.QtGui import QTextOption, QFont, QPalette, QColor, QTextCursor
 
 from nw.convert import ToHtml
 from nw.constants import nwAlert, nwItemType, nwDocAction

--- a/nw/gui/elements/noticebar.py
+++ b/nw/gui/elements/noticebar.py
@@ -13,7 +13,7 @@
 import logging
 import nw
 
-from PyQt5.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton
+from PySide2.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton
 
 logger = logging.getLogger(__name__)
 

--- a/nw/gui/elements/searchbar.py
+++ b/nw/gui/elements/searchbar.py
@@ -86,13 +86,13 @@ class GuiSearchBar(QFrame):
         if not self.isVisible():
             self.setVisible(True)
         self.searchBox.setText(theText)
-        self.searchBox.setFocus(True)
+        self.searchBox.setFocus()
         logger.verbose("Setting search text to '%s'" % theText)
         return True
 
     def setReplaceText(self, theText):
         self._replaceVisible(True)
-        self.replaceBox.setFocus(True)
+        self.replaceBox.setFocus()
         self.replaceBox.setText(theText)
         return True
 

--- a/nw/gui/elements/searchbar.py
+++ b/nw/gui/elements/searchbar.py
@@ -13,8 +13,8 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
     QFrame, QGridLayout, QLabel, QLineEdit, QPushButton, QApplication
 )
 

--- a/nw/gui/elements/viewdetails.py
+++ b/nw/gui/elements/viewdetails.py
@@ -13,8 +13,8 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt, QSize
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt, QSize
+from PySide2.QtWidgets import (
     QWidget, QLabel, QScrollArea, QFrame, QToolButton, QCheckBox, QGridLayout
 )
 

--- a/nw/gui/icons.py
+++ b/nw/gui/icons.py
@@ -15,9 +15,9 @@ import nw
 
 from os import path
 
-from PyQt5.QtCore import QSize
-from PyQt5.QtSvg import QSvgWidget
-from PyQt5.QtGui import QIcon, QPixmap
+from PySide2.QtCore import QSize
+from PySide2.QtSvg import QSvgWidget
+from PySide2.QtGui import QIcon, QPixmap
 
 logger = logging.getLogger(__name__)
 

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -55,8 +55,10 @@ class GuiMainMenu(QMenuBar):
 
     def setAvailableRoot(self):
         for itemClass in nwItemClass:
-            if itemClass == nwItemClass.NO_CLASS: continue
-            if itemClass == nwItemClass.TRASH:    continue
+            if itemClass == nwItemClass.NO_CLASS:
+                continue
+            if itemClass == nwItemClass.TRASH:
+                continue
             self.rootItems[itemClass].setEnabled(
                 self.theProject.checkRootUnique(itemClass)
             )
@@ -75,10 +77,11 @@ class GuiMainMenu(QMenuBar):
         self.recentMenu.clear()
         for n in range(len(self.mainConf.recentList)):
             recentProject = self.mainConf.recentList[n]
-            if recentProject == "": continue
+            if recentProject == "":
+                continue
             menuItem = QAction("%s" % recentProject, self.projMenu)
             menuItem.triggered.connect(
-                lambda menuItem, n=n : self.openRecentProject(menuItem, n)
+                lambda a1=menuItem, a2=n : self.openRecentProject(a1, a2)
             )
             self.recentMenu.addAction(menuItem)
 
@@ -249,11 +252,9 @@ class GuiMainMenu(QMenuBar):
         self.rootItems[nwItemClass.OBJECT]    = QAction("Object Root",    self.rootMenu)
         self.rootItems[nwItemClass.ENTITY]    = QAction("Entity Root",    self.rootMenu)
         self.rootItems[nwItemClass.CUSTOM]    = QAction("Custom Root",    self.rootMenu)
-        nCount = 0
         for itemClass in self.rootItems.keys():
-            nCount += 1 # This forces the lambdas to be unique
             self.rootItems[itemClass].triggered.connect(
-                lambda nCount, itemClass=itemClass : self._newTreeItem(nwItemType.ROOT, itemClass)
+                lambda a1=nwItemType.ROOT, a2=itemClass : self._newTreeItem(a1, a2)
             )
             self.rootMenu.addAction(self.rootItems[itemClass])
 

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -13,9 +13,9 @@
 import logging
 import nw
 
-from PyQt5.QtCore import QUrl
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QMenuBar, QAction, QMessageBox
+from PySide2.QtCore import QUrl
+from PySide2.QtGui import QDesktopServices
+from PySide2.QtWidgets import QMenuBar, QAction, QMessageBox
 
 from nw.constants import nwItemType, nwItemClass, nwDocAction
 

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -255,7 +255,7 @@ class GuiMainMenu(QMenuBar):
             self.rootItems[itemClass].triggered.connect(
                 lambda nCount, itemClass=itemClass : self._newTreeItem(nwItemType.ROOT, itemClass)
             )
-        self.rootMenu.addActions(self.rootItems.values())
+            self.rootMenu.addAction(self.rootItems[itemClass])
 
         # Project > New Folder
         self.aCreateFolder = QAction("Create Folder", self)

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -15,9 +15,9 @@ import nw
 
 from time import time
 
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QColor, QPixmap, QFont
-from PyQt5.QtWidgets import QStatusBar, QLabel
+from PySide2.QtCore import Qt, QTimer
+from PySide2.QtGui import QColor, QPixmap, QFont
+from PySide2.QtWidgets import QStatusBar, QLabel
 
 from nw.tools import NWSpellCheck
 

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -16,8 +16,8 @@ import nw
 
 from os import path, listdir
 
-from PyQt5.QtWidgets import qApp
-from PyQt5.QtGui import QPalette, QColor, QIcon
+from PySide2.QtWidgets import qApp
+from PySide2.QtGui import QPalette, QColor, QIcon
 
 from nw.constants import nwAlert
 from nw.gui.icons import GuiIcons

--- a/nw/gui/tools/dochighlight.py
+++ b/nw/gui/tools/dochighlight.py
@@ -13,8 +13,8 @@
 import logging
 import nw
 
-from PyQt5.QtCore import Qt, QRegularExpression
-from PyQt5.QtGui import (
+from PySide2.QtCore import Qt, QRegularExpression
+from PySide2.QtGui import (
     QColor, QTextCharFormat, QFont, QSyntaxHighlighter, QBrush
 )
 

--- a/nw/gui/tools/wordcounter.py
+++ b/nw/gui/tools/wordcounter.py
@@ -13,7 +13,7 @@
 import logging
 import nw
 
-from PyQt5.QtCore import QThread
+from PySide2.QtCore import QThread
 
 from nw.tools.wordcount import countWords
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -17,7 +17,7 @@ import nw
 from os import path
 
 from PySide2.QtCore import Qt, QTimer
-from PySide2.QtGui import QIcon, QPixmap, QColor
+from PySide2.QtGui import QIcon, QPixmap, QColor, QKeySequence
 from PySide2.QtWidgets import (
     qApp, QMainWindow, QVBoxLayout, QFrame, QSplitter, QFileDialog, QShortcut,
     QMessageBox, QProgressDialog, QDialog
@@ -152,17 +152,12 @@ class GuiMain(QMainWindow):
 
         # Shortcuts and Actions
         self._connectMenuActions()
-        # QShortcut(
-        #     Qt.Key_Return,
-        #     self.treeView,
-        #     context=Qt.WidgetShortcut,
-        #     activated=self._treeKeyPressReturn
-        # )
-        # QShortcut(
-        #     Qt.Key_Escape,
-        #     self,
-        #     activated=self._keyPressEscape
-        # )
+        keyReturn = QShortcut(self.treeView)
+        keyReturn.setKey(QKeySequence(Qt.Key_Return))
+        keyReturn.activated.connect(self._treeKeyPressReturn)
+        keyEscape = QShortcut(self)
+        keyEscape.setKey(QKeySequence(Qt.Key_Escape))
+        keyEscape.activated.connect(self._keyPressEscape)
 
         # Forward Functions
         self.setStatus = self.statusBar.setStatus

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -16,9 +16,9 @@ import nw
 
 from os import path
 
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QIcon, QPixmap, QColor
-from PyQt5.QtWidgets import (
+from PySide2.QtCore import Qt, QTimer
+from PySide2.QtGui import QIcon, QPixmap, QColor
+from PySide2.QtWidgets import (
     qApp, QMainWindow, QVBoxLayout, QFrame, QSplitter, QFileDialog, QShortcut,
     QMessageBox, QProgressDialog, QDialog
 )
@@ -55,7 +55,7 @@ class GuiMain(QMainWindow):
         logger.info("Qt5 Version: %s (%d)" % (
             self.mainConf.verQtString, self.mainConf.verQtValue)
         )
-        logger.info("PyQt5 Version: %s (%d)" % (
+        logger.info("PySide2 Version: %s (%d)" % (
             self.mainConf.verPyQtString, self.mainConf.verPyQtValue)
         )
         logger.info("Python Version: %s (0x%x)" % (

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -152,17 +152,17 @@ class GuiMain(QMainWindow):
 
         # Shortcuts and Actions
         self._connectMenuActions()
-        QShortcut(
-            Qt.Key_Return,
-            self.treeView,
-            context=Qt.WidgetShortcut,
-            activated=self._treeKeyPressReturn
-        )
-        QShortcut(
-            Qt.Key_Escape,
-            self,
-            activated=self._keyPressEscape
-        )
+        # QShortcut(
+        #     Qt.Key_Return,
+        #     self.treeView,
+        #     context=Qt.WidgetShortcut,
+        #     activated=self._treeKeyPressReturn
+        # )
+        # QShortcut(
+        #     Qt.Key_Escape,
+        #     self,
+        #     activated=self._keyPressEscape
+        # )
 
         # Forward Functions
         self.setStatus = self.statusBar.setStatus

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyqt5
+pyside2
 appdirs
 lxml
 pyenchant

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -6,7 +6,7 @@ import nw, pytest, sys
 from nwtools import *
 
 from os import path, unlink
-from PyQt5.QtCore import Qt
+from PySide2.QtCore import Qt
 
 from nw.gui.dialogs.projecteditor import GuiProjectEditor
 from nw.gui.dialogs.timelineview  import GuiTimeLineView


### PR DESCRIPTION
This PR replaces PyQt5 with PySide2 as the main Python integration tool. This is due to PySide2 now being maintained by the Qt Company, and therefore is the official way to integrate from Python, and the tool more likely to be maintained in the future.