### PR TITLE
Drop appdirs dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ For the apt package manager on Debian systems, the following Python3 packages ar
 
 * `python3-pyqt5` for the GUI
 * `python3-pyqt5.qtsvg` may need to be installed separately
-* `python3-appdirs` for locating the system's config folder
 * `python3-lxml` for writing project files
 
 These are optional, but recommended:
@@ -88,7 +87,6 @@ in the application folder.
 You can also do them one at a time, skipping the ones you don't need:
 ```
 python3 -m pip install pyqt5
-python3 -m pip install appdirs
 python3 -m pip install lxml
 python3 -m pip install pyenchant
 python3 -m pip install latexcodec

--- a/docs/source/started.txt
+++ b/docs/source/started.txt
@@ -26,7 +26,6 @@ On some operating systems you need to use ``python3`` instead of ``python``.
 The following Python packages are required to run novelWriter:
 
 * ``pyqt5`` for the GUI
-* ``appdirs`` for locating the system's config folder
 * ``lxml`` for writing project files
 
 .. note::

--- a/novelWriter.py
+++ b/novelWriter.py
@@ -27,12 +27,6 @@ except:
     print("ERROR: Failed to load dependency python3-lxml")
     sys.exit(1)
 
-try:
-    import appdirs
-except:
-    print("ERROR: Failed to load dependency python3-appdirs")
-    sys.exit(1)
-
 if __name__ == "__main__":
     import nw
     nw.main(sys.argv[1:])

--- a/nw/config.py
+++ b/nw/config.py
@@ -16,11 +16,10 @@ import sys
 import nw
 
 from os import path, mkdir, makedirs
-from appdirs import user_config_dir
 from datetime import datetime
 
 from PyQt5.Qt import PYQT_VERSION_STR
-from PyQt5.QtCore import QT_VERSION_STR
+from PyQt5.QtCore import QT_VERSION_STR, QStandardPaths
 
 from nw.constants import nwFiles, nwUnicode
 from nw.common import splitVersionNumber
@@ -167,7 +166,8 @@ class Config:
     def initConfig(self, confPath=None):
 
         if confPath is None:
-            self.confPath = user_config_dir(self.appHandle)
+            confRoot = QStandardPaths.writableLocation(QStandardPaths.ConfigLocation)
+            self.confPath = path.join(confRoot, self.appHandle)
         else:
             logger.info("Setting config from alternative path: %s" % confPath)
             self.confPath = confPath

--- a/nw/config.py
+++ b/nw/config.py
@@ -167,7 +167,7 @@ class Config:
 
         if confPath is None:
             confRoot = QStandardPaths.writableLocation(QStandardPaths.ConfigLocation)
-            self.confPath = path.join(confRoot, self.appHandle)
+            self.confPath = path.join(path.abspath(confRoot), self.appHandle)
         else:
             logger.info("Setting config from alternative path: %s" % confPath)
             self.confPath = confPath
@@ -186,12 +186,13 @@ class Config:
 
         # If config folder does not exist, make it.
         # This assumes that the os config folder itself exists.
-        if self.osWindows:
-            if not path.isdir(self.confPath):
-                makedirs(self.confPath)
-        else:
-            if not path.isdir(self.confPath):
+        if not path.isdir(self.confPath):
+            try:
                 mkdir(self.confPath)
+            except Exception as e:
+                logger.error("Could not create folder: %s" % self.confPath)
+                logger.error(str(e))
+                return False
 
         # Check if config file exists
         if path.isfile(path.join(self.confPath,self.confFile)):

--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -116,10 +116,6 @@ class nwDependencies():
             "site" : "",
             "docs" : "",
         },
-        "appdirs"    : {
-            "site" : "",
-            "docs" : "",
-        },
         "lxml"       : {
             "site" : "",
             "docs" : "",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyqt5
-appdirs
 lxml
 pyenchant
 latexcodec

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setuptools.setup(
     python_requires = ">=3.5",
     install_requires = [
         "pyqt5",
-        "appdirs",
         "lxml",
         "pyenchant",
         "latexcodec",


### PR DESCRIPTION
The Python package `appdirs` is only needed for extracting the user's config path on various operating systems. This feature is available in Qt5 via `QStandardPaths`, so the package can be dropped.