### PR TITLE
Update install.py with correct paths

### DIFF
--- a/install.py
+++ b/install.py
@@ -63,8 +63,8 @@ else:
 instOpt = [
     "--name=novelWriter",
     "--onefile",
-    "--add-data=%s%s%s" % (os.path.join("nw", "themes"),  dotDot,"themes"),
-    "--add-data=%s%s%s" % (os.path.join("nw", "graphics"),dotDot,"graphics"),
+    "--add-data=%s%s%s" % (os.path.join("nw", "assets", "themes"),   dotDot,"themes"),
+    "--add-data=%s%s%s" % (os.path.join("nw", "assets", "graphics"), dotDot,"graphics"),
     "--icon=%s" % os.path.join("nw", "assets", "icons", "novelWriter.ico"),
 ]
 if buildWindowed:


### PR DESCRIPTION
Update install.py with correct joined paths for the `themes` folder and the `graphics` folder. This bug prevented pyInstaller from building successfully under Windows.