### PR TITLE
Saving of Dialog Options

### DIFF
--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -26,10 +26,6 @@ class nwFiles():
     SESS_INFO  = "sessionInfo.log"
     INDEX_FILE = "tagsIndex.json"
     OPTS_FILE  = "guiOptions.json"
-    EXPORT_OPT = "exportOptions.json"
-    TLINE_OPT  = "timelineOptions.json"
-    SLOG_OPT   = "sessionLogOptions.json"
-    MERGE_OPT  = "docMergeOptions.json"
 
 # END Class nwFiles
 

--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -25,6 +25,7 @@ class nwFiles():
     PROJ_DICT  = "wordlist.txt"
     SESS_INFO  = "sessionInfo.log"
     INDEX_FILE = "tagsIndex.json"
+    OPTS_FILE  = "guiOptions.json"
     EXPORT_OPT = "exportOptions.json"
     TLINE_OPT  = "timelineOptions.json"
     SLOG_OPT   = "sessionLogOptions.json"

--- a/nw/gui/dialogs/docsplit.py
+++ b/nw/gui/dialogs/docsplit.py
@@ -33,6 +33,7 @@ class GuiDocSplit(QDialog):
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
         self.theProject = theProject
+        self.optState   = self.theProject.optState
         self.sourceItem = None
 
         self.outerBox = QHBoxLayout()
@@ -56,7 +57,11 @@ class GuiDocSplit(QDialog):
         self.splitLevel.addItem("Split up to Header Level 2 (Chapter)", 2)
         self.splitLevel.addItem("Split up to Header Level 3 (Scene)",   3)
         self.splitLevel.addItem("Split up to Header Level 4 (Section)", 4)
-        self.splitLevel.setCurrentIndex(2)
+        spIndex = self.splitLevel.findData(
+            self.optState.getInt("GuiDocSplit", "spLevel", 3)
+        )
+        if spIndex != -1:
+            self.splitLevel.setCurrentIndex(spIndex)
         self.splitLevel.currentIndexChanged.connect(self._populateList)
 
         self.splitButton = QPushButton("Split")
@@ -172,6 +177,7 @@ class GuiDocSplit(QDialog):
         """Close the dialog window without doing anything.
         """
         logger.verbose("GuiDocSplit close button clicked")
+        self.optState.saveSettings()
         self.close()
         return
 
@@ -206,6 +212,7 @@ class GuiDocSplit(QDialog):
         theText = theDoc.openDocument(self.sourceItem, False)
 
         spLevel = self.splitLevel.currentData()
+        self.optState.setValue("GuiDocSplit", "spLevel", spLevel)
         logger.debug("Scanning document %s for headings level <= %d" % (self.sourceItem, spLevel))
 
         lineNo = 0

--- a/nw/gui/dialogs/export.py
+++ b/nw/gui/dialogs/export.py
@@ -24,7 +24,7 @@ from PyQt5.QtWidgets import (
 )
 
 from nw.convert import TextFile, HtmlFile, MarkdownFile, LaTeXFile, ConcatFile
-from nw.tools import OptLastState
+from nw.tools import OptionState
 from nw.common import packageRefURL
 from nw.constants import nwFiles, nwItemType, nwAlert
 
@@ -40,8 +40,7 @@ class GuiExport(QDialog):
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
         self.theProject = theProject
-        self.optState   = ExportLastState(self.theProject,nwFiles.EXPORT_OPT)
-        self.optState.loadSettings()
+        self.optState   = self.theProject.optState
 
         self.outerBox   = QHBoxLayout()
         self.innerBox   = QVBoxLayout()
@@ -50,8 +49,8 @@ class GuiExport(QDialog):
 
         self.guiDeco = self.theParent.theTheme.loadDecoration("export",(64,64))
 
-        self.tabMain   = GuiExportMain(self.theParent, self.theProject, self.optState)
-        self.tabPandoc = GuiExportPandoc(self.theParent, self.theProject, self.optState)
+        self.tabMain   = GuiExportMain(self.theParent, self.theProject)
+        self.tabPandoc = GuiExportPandoc(self.theParent, self.theProject)
 
         self.tabWidget = QTabWidget()
         self.tabWidget.addTab(self.tabMain,   "Settings")
@@ -290,24 +289,24 @@ class GuiExport(QDialog):
         if saveTo.startswith("~"):
             saveTo = path.expanduser(saveTo)
 
-        self.optState.setSetting("wNovel",   wNovel)
-        self.optState.setSetting("wNotes",   wNotes)
-        self.optState.setSetting("eFormat",  eFormat)
-        self.optState.setSetting("fixWidth", fixWidth)
-        self.optState.setSetting("wComments",wComments)
-        self.optState.setSetting("wKeywords",wKeywords)
-        self.optState.setSetting("chFormat", chFormat)
-        self.optState.setSetting("unFormat", unFormat)
-        self.optState.setSetting("scFormat", scFormat)
-        self.optState.setSetting("seFormat", seFormat)
-        self.optState.setSetting("saveTo",   saveTo)
-        self.optState.setSetting("hScene",   hScene)
-        self.optState.setSetting("hSection", hSection)
+        self.optState.setValue("GuiExport", "wNovel",    wNovel)
+        self.optState.setValue("GuiExport", "wNotes",    wNotes)
+        self.optState.setValue("GuiExport", "eFormat",   eFormat)
+        self.optState.setValue("GuiExport", "fixWidth",  fixWidth)
+        self.optState.setValue("GuiExport", "wComments", wComments)
+        self.optState.setValue("GuiExport", "wKeywords", wKeywords)
+        self.optState.setValue("GuiExport", "chFormat",  chFormat)
+        self.optState.setValue("GuiExport", "unFormat",  unFormat)
+        self.optState.setValue("GuiExport", "scFormat",  scFormat)
+        self.optState.setValue("GuiExport", "seFormat",  seFormat)
+        self.optState.setValue("GuiExport", "saveTo",    saveTo)
+        self.optState.setValue("GuiExport", "hScene",    hScene)
+        self.optState.setValue("GuiExport", "hSection",  hSection)
 
         # Pandoc Settings
         pFormat   = self.tabPandoc.outputFormat.currentData()
 
-        self.optState.setSetting("pFormat",  pFormat)
+        self.optState.setValue("GuiExport", "pFormat",  pFormat)
 
         self.optState.saveSettings()
         self.close()
@@ -362,14 +361,14 @@ class GuiExportMain(QWidget):
         ),
     }
 
-    def __init__(self, theParent, theProject, optState):
+    def __init__(self, theParent, theProject):
         QWidget.__init__(self, theParent)
 
         self.theParent  = theParent
         self.theProject = theProject
         self.theTheme   = theParent.theTheme
         self.outerBox   = QGridLayout()
-        self.optState   = optState
+        self.optState   = self.theProject.optState
         self.currFormat = self.FMT_TXT
 
         # Select Files
@@ -378,19 +377,27 @@ class GuiExportMain(QWidget):
         self.guiFiles.setLayout(self.guiFilesForm)
 
         self.expNovel = QCheckBox("Novel files",self)
-        self.expNovel.setChecked(self.optState.getSetting("wNovel"))
+        self.expNovel.setChecked(
+            self.optState.getBool("GuiExport", "wNovel", True)
+        )
         self.expNovel.setToolTip("Include all novel files in the exported document")
 
         self.expNotes = QCheckBox("Note files",self)
-        self.expNotes.setChecked(self.optState.getSetting("wNotes"))
+        self.expNotes.setChecked(
+            self.optState.getBool("GuiExport", "wNotes", False)
+        )
         self.expNotes.setToolTip("Include all note files in the exported document")
 
         self.expComments = QCheckBox("Comments",self)
-        self.expComments.setChecked(self.optState.getSetting("wComments"))
+        self.expComments.setChecked(
+            self.optState.getBool("GuiExport", "wComments", False)
+        )
         self.expComments.setToolTip("Export comments from all files")
 
         self.expKeywords = QCheckBox("Keywords",self)
-        self.expKeywords.setChecked(self.optState.getSetting("wKeywords"))
+        self.expKeywords.setChecked(
+            self.optState.getBool("GuiExport", "wKeywords", False)
+        )
         self.expKeywords.setToolTip("Export @keywords from all files")
 
         self.guiFilesForm.addWidget(self.expNovel,    0, 1)
@@ -406,13 +413,17 @@ class GuiExportMain(QWidget):
 
         self.chapterFormat = QLineEdit()
         self.chapterFormat.setMaxLength(200)
-        self.chapterFormat.setText(self.optState.getSetting("chFormat"))
+        self.chapterFormat.setText(
+            self.optState.getString("GuiExport", "chFormat", "Chapter %numword%")
+        )
         self.chapterFormat.setToolTip("Available formats: %num%, %numword%, %title%")
         self.chapterFormat.setMinimumWidth(250)
 
         self.unnumFormat = QLineEdit()
         self.unnumFormat.setMaxLength(200)
-        self.unnumFormat.setText(self.optState.getSetting("unFormat"))
+        self.unnumFormat.setText(
+            self.optState.getString("GuiExport", "unFormat", "%title%")
+        )
         self.unnumFormat.setToolTip("Available formats: %title%")
         self.unnumFormat.setMinimumWidth(250)
 
@@ -428,22 +439,30 @@ class GuiExportMain(QWidget):
 
         self.sceneFormat = QLineEdit()
         self.sceneFormat.setMaxLength(200)
-        self.sceneFormat.setText(self.optState.getSetting("scFormat"))
+        self.sceneFormat.setText(
+            self.optState.getString("GuiExport", "scFormat", "* * *")
+        )
         self.sceneFormat.setToolTip("Available formats: %title%")
         self.sceneFormat.setMinimumWidth(100)
 
         self.sectionFormat = QLineEdit()
         self.sectionFormat.setMaxLength(200)
-        self.sectionFormat.setText(self.optState.getSetting("seFormat"))
+        self.sectionFormat.setText(
+            self.optState.getString("GuiExport", "seFormat", "")
+        )
         self.sectionFormat.setToolTip("Available formats: %title%")
         self.sectionFormat.setMinimumWidth(100)
 
         self.hideScene = QCheckBox("Skip",self)
-        self.hideScene.setChecked(self.optState.getSetting("hScene"))
+        self.hideScene.setChecked(
+            self.optState.getBool("GuiExport", "hScene", False)
+        )
         self.hideScene.setToolTip("Skip scene titles in export")
 
         self.hideSection = QCheckBox("Skip",self)
-        self.hideSection.setChecked(self.optState.getSetting("hSection"))
+        self.hideSection.setChecked(
+            self.optState.getBool("GuiExport", "hSection", False)
+        )
         self.hideSection.setToolTip("Skip section titles in export")
 
         self.guiScenesForm.addWidget(QLabel("Scenes"),   0, 0)
@@ -458,8 +477,9 @@ class GuiExportMain(QWidget):
         self.exportToForm = QGridLayout(self)
         self.exportTo.setLayout(self.exportToForm)
 
-        self.exportPath = QLineEdit(self.optState.getSetting("saveTo"))
-
+        self.exportPath = QLineEdit(
+            self.optState.getString("GuiExport", "saveTo", "")
+        )
         self.exportGetPath = QPushButton(self.theTheme.getIcon("folder"),"")
         self.exportGetPath.clicked.connect(self._exportFolder)
 
@@ -486,7 +506,9 @@ class GuiExportMain(QWidget):
         self.outputFormat.addItem("Pandoc via Markdown or HTML", self.FMT_PDOC)
         self.outputFormat.currentIndexChanged.connect(self._updateFormat)
 
-        optIdx = self.outputFormat.findData(self.optState.getSetting("eFormat"))
+        optIdx = self.outputFormat.findData(
+            self.optState.getInt("GuiExport", "eFormat", 1)
+        )
         if optIdx == -1:
             self.outputFormat.setCurrentIndex(1)
             self._updateFormat(1)
@@ -508,7 +530,9 @@ class GuiExportMain(QWidget):
         self.fixedWidth.setMinimum(0)
         self.fixedWidth.setMaximum(999)
         self.fixedWidth.setSingleStep(1)
-        self.fixedWidth.setValue(self.optState.getSetting("fixWidth"))
+        self.fixedWidth.setValue(
+            self.optState.getInt("GuiExport", "fixWidth", 80)
+        )
         self.fixedWidth.setToolTip(
             "Applies to .txt and .md files. A value of '0' disables the feature."
         )
@@ -609,13 +633,13 @@ class GuiExportPandoc(QWidget):
         FMT_ZIM   : "markdown",
     }
 
-    def __init__(self, theParent, theProject, optState):
+    def __init__(self, theParent, theProject):
         QWidget.__init__(self, theParent)
 
         self.theParent  = theParent
         self.theProject = theProject
         self.outerBox   = QGridLayout()
-        self.optState   = optState
+        self.optState   = self.theProject.optState
 
         try:
             import pypandoc
@@ -659,7 +683,9 @@ class GuiExportPandoc(QWidget):
         self.outputFormat.addItem("ePUB eBook v3 (.epub3)",      self.FMT_EPUB3)
         self.outputFormat.addItem("Zim Wiki (.txt)",             self.FMT_ZIM)
 
-        optIdx = self.outputFormat.findData(self.optState.getSetting("pFormat"))
+        optIdx = self.outputFormat.findData(
+            self.optState.getInt("GuiExport", "pFormat", 1)
+        )
         if optIdx == -1:
             self.outputFormat.setCurrentIndex(1)
         else:
@@ -678,30 +704,3 @@ class GuiExportPandoc(QWidget):
         return
 
 # END Class GuiExportPandoc
-
-class ExportLastState(OptLastState):
-
-    def __init__(self, theProject, theFile):
-        OptLastState.__init__(self, theProject, theFile)
-        self.theState   = {
-            "wNovel"    : True,
-            "wNotes"    : False,
-            "eFormat"   : 1,
-            "pFormat"   : 1,
-            "fixWidth"  : 80,
-            "wComments" : False,
-            "wKeywords" : False,
-            "chFormat"  : "Chapter %numword%",
-            "unFormat"  : "%title%",
-            "scFormat"  : "* * *",
-            "seFormat"  : "",
-            "saveTo"    : "",
-            "hScene"    : False,
-            "hSection"  : False,
-        }
-        self.stringOpt = ("chFormat","unFormat","scFormat","seFormat","saveTo")
-        self.boolOpt   = ("wNovel","wNotes","wComments","wKeywords","hScene","hSection")
-        self.intOpt    = ("eFormat","pFormat","fixWidth")
-        return
-
-# END Class ExportLastState

--- a/nw/gui/dialogs/export.py
+++ b/nw/gui/dialogs/export.py
@@ -24,7 +24,6 @@ from PyQt5.QtWidgets import (
 )
 
 from nw.convert import TextFile, HtmlFile, MarkdownFile, LaTeXFile, ConcatFile
-from nw.tools import OptionState
 from nw.common import packageRefURL
 from nw.constants import nwFiles, nwItemType, nwAlert
 

--- a/nw/gui/dialogs/sessionlog.py
+++ b/nw/gui/dialogs/sessionlog.py
@@ -24,7 +24,6 @@ from PyQt5.QtWidgets import (
 )
 
 from nw.constants import nwConst, nwFiles, nwAlert
-from nw.tools import OptionState
 
 logger = logging.getLogger(__name__)
 

--- a/nw/gui/dialogs/sessionlog.py
+++ b/nw/gui/dialogs/sessionlog.py
@@ -24,7 +24,7 @@ from PyQt5.QtWidgets import (
 )
 
 from nw.constants import nwConst, nwFiles, nwAlert
-from nw.tools import OptLastState
+from nw.tools import OptionState
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +38,7 @@ class GuiSessionLogView(QDialog):
         self.mainConf   = nw.CONFIG
         self.theProject = theProject
         self.theParent  = theParent
-        self.optState   = SessionLogLastState(self.theProject,nwFiles.SLOG_OPT)
-        self.optState.loadSettings()
+        self.optState   = self.theProject.optState
 
         self.timeFilter = 0.0
         self.timeTotal  = 0.0
@@ -52,13 +51,13 @@ class GuiSessionLogView(QDialog):
         self.setMinimumHeight(400)
 
         widthCol0 = self.optState.validIntRange(
-            self.optState.getSetting("widthCol0"), 30, 999, 180
+            self.optState.getInt("GuiSession", "widthCol0", 180), 30, 999, 180
         )
         widthCol1 = self.optState.validIntRange(
-            self.optState.getSetting("widthCol1"), 30, 999, 80
+            self.optState.getInt("GuiSession", "widthCol1", 80), 30, 999, 80
         )
         widthCol2 = self.optState.validIntRange(
-            self.optState.getSetting("widthCol2"), 30, 999, 80
+            self.optState.getInt("GuiSession", "widthCol2", 80), 30, 999, 80
         )
 
         self.listBox = QTreeWidget()
@@ -77,10 +76,11 @@ class GuiSessionLogView(QDialog):
 
         sortValid = (Qt.AscendingOrder, Qt.DescendingOrder)
         sortCol = self.optState.validIntRange(
-            self.optState.getSetting("sortCol"), 0, 2, 0
+            self.optState.getInt("GuiSession", "sortCol", 0), 0, 2, 0
         )
         sortOrder = self.optState.validIntTuple(
-            self.optState.getSetting("sortOrder"), sortValid, Qt.DescendingOrder
+            self.optState.getInt("GuiSession", "sortOrder", Qt.DescendingOrder),
+            sortValid, Qt.DescendingOrder
         )
 
         self.listBox.sortByColumn(sortCol, sortOrder)
@@ -110,11 +110,15 @@ class GuiSessionLogView(QDialog):
         self.filterBox.setLayout(self.filterBoxForm)
 
         self.hideZeros = QCheckBox("Hide zero word count", self)
-        self.hideZeros.setChecked(self.optState.getSetting("hideZeros"))
+        self.hideZeros.setChecked(
+            self.optState.getBool("GuiSession", "hideZeros", True)
+        )
         self.hideZeros.stateChanged.connect(self._doHideZeros)
 
         self.hideNegative = QCheckBox("Hide negative word count", self)
-        self.hideNegative.setChecked(self.optState.getSetting("hideNegative"))
+        self.hideNegative.setChecked(
+            self.optState.getBool("GuiSession", "hideNegative", False)
+        )
         self.hideNegative.stateChanged.connect(self._doHideNegative)
 
         self.filterBoxForm.addWidget(self.hideZeros,    0, 0)
@@ -208,13 +212,13 @@ class GuiSessionLogView(QDialog):
         hideZeros    = self.hideZeros.isChecked()
         hideNegative = self.hideNegative.isChecked()
 
-        self.optState.setSetting("widthCol0",   widthCol0)
-        self.optState.setSetting("widthCol1",   widthCol1)
-        self.optState.setSetting("widthCol2",   widthCol2)
-        self.optState.setSetting("sortCol",     sortCol)
-        self.optState.setSetting("sortOrder",   sortOrder)
-        self.optState.setSetting("hideZeros",   hideZeros)
-        self.optState.setSetting("hideNegative",hideNegative)
+        self.optState.setValue("GuiSession", "widthCol0",    widthCol0)
+        self.optState.setValue("GuiSession", "widthCol1",    widthCol1)
+        self.optState.setValue("GuiSession", "widthCol2",    widthCol2)
+        self.optState.setValue("GuiSession", "sortCol",      sortCol)
+        self.optState.setValue("GuiSession", "sortOrder",    sortOrder)
+        self.optState.setValue("GuiSession", "hideZeros",    hideZeros)
+        self.optState.setValue("GuiSession", "hideNegative", hideNegative)
 
         self.optState.saveSettings()
         self.close()
@@ -237,23 +241,3 @@ class GuiSessionLogView(QDialog):
         return "%02d:%02d:%02d" % (tH,tM,tS)
 
 # END Class GuiSessionLogView
-
-class SessionLogLastState(OptLastState):
-
-    def __init__(self, theProject, theFile):
-        OptLastState.__init__(self, theProject, theFile)
-        self.theState  = {
-            "widthCol0"    : 180,
-            "widthCol1"    : 80,
-            "widthCol2"    : 80,
-            "sortCol"      : 0,
-            "sortOrder"    : Qt.DescendingOrder,
-            "hideZeros"    : True,
-            "hideNegative" : False,
-        }
-        self.stringOpt = ()
-        self.boolOpt   = ("hideZeros","hideNegative")
-        self.intOpt    = ("widthCol0","widthCol1","widthCol2","sortCol","sortOrder")
-        return
-
-# END Class SessionLogLastState

--- a/nw/gui/dialogs/timelineview.py
+++ b/nw/gui/dialogs/timelineview.py
@@ -22,7 +22,6 @@ from PyQt5.QtWidgets import (
 )
 
 from nw.constants import nwFiles, nwItemClass
-from nw.tools import OptionState
 
 logger = logging.getLogger(__name__)
 

--- a/nw/gui/dialogs/timelineview.py
+++ b/nw/gui/dialogs/timelineview.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
 )
 
 from nw.constants import nwFiles, nwItemClass
-from nw.tools import OptLastState
+from nw.tools import OptionState
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,7 @@ class GuiTimeLineView(QDialog):
         self.theProject = theProject
         self.theParent  = theParent
         self.theIndex   = theIndex
-        self.optState   = TimeLineLastState(self.theProject,nwFiles.TLINE_OPT)
-        self.optState.loadSettings()
+        self.optState   = self.theProject.optState
 
         self.theMatrix = {}
         self.numRows   = 0
@@ -54,10 +53,10 @@ class GuiTimeLineView(QDialog):
         self.setMinimumHeight(400)
 
         winWidth = self.optState.validIntRange(
-            self.optState.getSetting("winWidth"),  700, 10000, 700
+            self.optState.getInt("GuiTimeLine", "winWidth", 700), 700, 10000, 700
         )
         winHeight = self.optState.validIntRange(
-            self.optState.getSetting("winHeight"), 400, 10000, 400
+            self.optState.getInt("GuiTimeLine", "winHeight", 400), 400, 10000, 400
         )
         self.resize(winWidth,winHeight)
 
@@ -79,27 +78,39 @@ class GuiTimeLineView(QDialog):
         self.optFilter.setLayout(self.optFilterGrid)
 
         self.filterPlot = QCheckBox("Plot tags", self)
-        self.filterPlot.setChecked(self.optState.getSetting("fPlot"))
+        self.filterPlot.setChecked(
+            self.optState.getBool("GuiTimeLine", "fPlot", True)
+        )
         self.filterPlot.stateChanged.connect(self._filterChange)
 
         self.filterChar = QCheckBox("Character tags", self)
-        self.filterChar.setChecked(self.optState.getSetting("fChar"))
+        self.filterChar.setChecked(
+            self.optState.getBool("GuiTimeLine", "fChar", True)
+        )
         self.filterChar.stateChanged.connect(self._filterChange)
 
         self.filterWorld = QCheckBox("Location tags", self)
-        self.filterWorld.setChecked(self.optState.getSetting("fWorld"))
+        self.filterWorld.setChecked(
+            self.optState.getBool("GuiTimeLine", "fWorld", True)
+        )
         self.filterWorld.stateChanged.connect(self._filterChange)
 
         self.filterTime = QCheckBox("Timeline tags", self)
-        self.filterTime.setChecked(self.optState.getSetting("fTime"))
+        self.filterTime.setChecked(
+            self.optState.getBool("GuiTimeLine", "fTime", True)
+        )
         self.filterTime.stateChanged.connect(self._filterChange)
 
         self.filterObject = QCheckBox("Object tags", self)
-        self.filterObject.setChecked(self.optState.getSetting("fObject"))
+        self.filterObject.setChecked(
+            self.optState.getBool("GuiTimeLine", "fObject", True)
+        )
         self.filterObject.stateChanged.connect(self._filterChange)
 
         self.filterCustom = QCheckBox("Custom tags", self)
-        self.filterCustom.setChecked(self.optState.getSetting("fCustom"))
+        self.filterCustom.setChecked(
+            self.optState.getBool("GuiTimeLine", "fCustom", True)
+        )
         self.filterCustom.stateChanged.connect(self._filterChange)
 
         self.optFilterGrid.addWidget(self.filterPlot,   0, 1)
@@ -114,7 +125,9 @@ class GuiTimeLineView(QDialog):
         self.optHide.setLayout(self.optHideGrid)
 
         self.hideUnused = QCheckBox("Hide unused", self)
-        self.hideUnused.setChecked(self.optState.getSetting("hUnused"))
+        self.hideUnused.setChecked(
+            self.optState.getBool("GuiTimeLine", "hUnused", True)
+        )
         self.hideUnused.stateChanged.connect(self._filterChange)
 
         self.optHideGrid.addWidget(self.hideUnused, 0, 1)
@@ -227,15 +240,15 @@ class GuiTimeLineView(QDialog):
         fCustom   = self.filterCustom.isChecked()
         hUnused   = self.hideUnused.isChecked()
 
-        self.optState.setSetting("winWidth", winWidth)
-        self.optState.setSetting("winHeight",winHeight)
-        self.optState.setSetting("fPlot",    fPlot)
-        self.optState.setSetting("fChar",    fChar)
-        self.optState.setSetting("fWorld",   fWorld)
-        self.optState.setSetting("fTime",    fTime)
-        self.optState.setSetting("fObject",  fObject)
-        self.optState.setSetting("fCustom",  fCustom)
-        self.optState.setSetting("hUnused",  hUnused)
+        self.optState.setValue("GuiTimeLine", "winWidth",  winWidth)
+        self.optState.setValue("GuiTimeLine", "winHeight", winHeight)
+        self.optState.setValue("GuiTimeLine", "fPlot",     fPlot)
+        self.optState.setValue("GuiTimeLine", "fChar",     fChar)
+        self.optState.setValue("GuiTimeLine", "fWorld",    fWorld)
+        self.optState.setValue("GuiTimeLine", "fTime",     fTime)
+        self.optState.setValue("GuiTimeLine", "fObject",   fObject)
+        self.optState.setValue("GuiTimeLine", "fCustom",   fCustom)
+        self.optState.setValue("GuiTimeLine", "hUnused",   hUnused)
 
         self.optState.saveSettings()
         self.close()
@@ -247,25 +260,3 @@ class GuiTimeLineView(QDialog):
         return
 
 # END Class GuiTimeLineView
-
-class TimeLineLastState(OptLastState):
-
-    def __init__(self, theProject, theFile):
-        OptLastState.__init__(self, theProject, theFile)
-        self.theState  = {
-            "winWidth"  : 700,
-            "winHeight" : 400,
-            "fPlot"     : True,
-            "fChar"     : True,
-            "fWorld"    : True,
-            "fTime"     : True,
-            "fObject"   : True,
-            "fCustom"   : True,
-            "hUnused"   : True,
-        }
-        self.stringOpt = ()
-        self.boolOpt   = ("fPlot","fChar","fWorld","fTime","fObject","fCustom","hUnused")
-        self.intOpt    = ("winWidth","winHeight")
-        return
-
-# END Class TimeLineLastState

--- a/nw/project/project.py
+++ b/nw/project/project.py
@@ -21,7 +21,7 @@ from time import time
 
 from nw.project.status import NWStatus
 from nw.project.item import NWItem
-from nw.tools import projectMaintenance
+from nw.tools import projectMaintenance, OptionState
 from nw.common import checkString, checkBool, checkInt
 from nw.constants import (
     nwFiles, nwConst, nwItemType, nwItemClass, nwItemLayout, nwAlert
@@ -36,6 +36,7 @@ class NWProject():
         # Internal
         self.theParent   = theParent
         self.mainConf    = self.theParent.mainConf
+        self.optState    = OptionState(self)
         self.projOpened  = None # The time stamp of when the project file was opened
         self.projChanged = None # The project has unsaved changes
         self.projAltered = None # The project has been altered this session
@@ -295,6 +296,7 @@ class NWProject():
                         nwItem.setFromTag(xValue.tag,xValue.text)
                     self._appendItem(tHandle,pHandle,nwItem)
 
+        self.optState.loadSettings()
         self.mainConf.setRecent(self.projPath)
         self.theParent.setStatus("Opened Project: %s" % self.projName)
 
@@ -384,6 +386,7 @@ class NWProject():
             rename(saveFile, backFile)
         rename(tempFile, saveFile)
 
+        self.optState.saveSettings()
         self.mainConf.setRecent(self.projPath)
         self.theParent.setStatus("Saved Project: %s" % self.projName)
         self.setProjectChanged(False)

--- a/nw/tools/__init__.py
+++ b/nw/tools/__init__.py
@@ -2,7 +2,7 @@
 
 from nw.tools.analyse import TextAnalysis
 from nw.tools.legacy import projectMaintenance
-from nw.tools.optlaststate import OptLastState
+from nw.tools.optionstate import OptionState
 from nw.tools.spellcheck import NWSpellCheck
 from nw.tools.spellenchant import NWSpellEnchant
 from nw.tools.spellsimple import NWSpellSimple
@@ -12,7 +12,7 @@ from nw.tools.wordcount import countWords
 __all__ = [
     "TextAnalysis",
     "projectMaintenance",
-    "OptLastState",
+    "OptionState",
     "NWSpellCheck",
     "NWSpellEnchant",
     "NWSpellSimple",

--- a/nw/tools/legacy.py
+++ b/nw/tools/legacy.py
@@ -44,4 +44,20 @@ def projectMaintenance(theProject):
             except Exception as e:
                 logger.error(str(e))
 
+    # Remove no longer used meta files
+    rmList = []
+    rmList.append(path.join(theProject.projMeta, "mainOptions.json"))
+    rmList.append(path.join(theProject.projMeta, "exportOptions.json"))
+    rmList.append(path.join(theProject.projMeta, "outlineOptions.json"))
+    rmList.append(path.join(theProject.projMeta, "timelineOptions.json"))
+    rmList.append(path.join(theProject.projMeta, "docMergeOptions.json"))
+    rmList.append(path.join(theProject.projMeta, "sessionLogOptions.json"))
+    for rmFile in rmList:
+        if path.isfile(rmFile):
+            logger.info("Deleting: %s" % rmFile)
+            try:
+                unlink(rmFile)
+            except Exception as e:
+                logger.error(str(e))
+
     return

--- a/nw/tools/optionstate.py
+++ b/nw/tools/optionstate.py
@@ -129,74 +129,22 @@ class OptionState():
                     return defaultValue
         return defaultValue
 
-# END Class OptionState
-
-class OptLastState():
-
-    def __init__(self, theProject, theFile):
-        self.theProject = theProject
-        self.theFile    = theFile
-        self.theState   = {}
-        self.stringOpt  = ()
-        self.boolOpt    = ()
-        self.intOpt     = ()
-        return
-
-    def loadSettings(self):
-        stateFile = path.join(self.theProject.projMeta,self.theFile)
-        theState  = {}
-        if path.isfile(stateFile):
-            logger.debug("Loading options file")
-            try:
-                with open(stateFile,mode="r",encoding="utf8") as inFile:
-                    theJson = inFile.read()
-                theState = json.loads(theJson)
-            except Exception as e:
-                logger.error("Failed to load options file")
-                logger.error(str(e))
-                return False
-        for anOpt in theState:
-            self.theState[anOpt] = theState[anOpt]
-        return True
-
-    def saveSettings(self):
-        stateFile = path.join(self.theProject.projMeta,self.theFile)
-        logger.debug("Saving options file")
-        try:
-            with open(stateFile,mode="w+",encoding="utf8") as outFile:
-                outFile.write(json.dumps(self.theState, indent=2))
-        except Exception as e:
-            logger.error("Failed to save options file")
-            logger.error(str(e))
-            return False
-        return True
-
-    def setSetting(self, setName, setValue):
-        if setName in self.theState:
-            self.theState[setName] = setValue
-        else:
-            return False
-        return True
-
-    def getSetting(self, setName):
-        if setName in self.stringOpt:
-            return checkString(self.theState[setName],self.theState[setName],False)
-        elif setName in self.boolOpt:
-            return checkBool(self.theState[setName],self.theState[setName],False)
-        elif setName in self.intOpt:
-            return checkInt(self.theState[setName],self.theState[setName],False)
-        return None
-
     def validIntRange(self, theValue, intA, intB, intDefault):
+        """Check that an int is in a given range. If it isn't, return
+        the default value.
+        """
         if isinstance(theValue, int):
             if theValue >= intA and theValue <= intB:
                 return theValue
         return intDefault
 
     def validIntTuple(self, theValue, theTuple, intDefault):
+        """Check that an int is an element of a tuple. If it isn't,
+        return the default value.
+        """
         if isinstance(theValue, int):
             if theValue in theTuple:
                 return theValue
         return intDefault
 
-# END Class OptLastState
+# END Class OptionState

--- a/nw/tools/optlaststate.py
+++ b/nw/tools/optlaststate.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-"""novelWriter Options Last State
+"""novelWriter Options State
 
- novelWriter – Options Last State
-==================================
+ novelWriter – Options State
+=============================
  Class holding the last state of GUI options
 
  File History:
- Created: 2019-10-21 [0.3.1]
+ Created: 2019-10-21 [0.3.1] - Original version meant to be sub classed
+ Created: 2020-02-19 [0.4.5] - Rewritten from superclass to single file tool
 
 """
 
@@ -17,8 +18,118 @@ import nw
 from os import path
 
 from nw.common import checkString, checkBool, checkInt
+from nw.constants import nwFiles
 
 logger = logging.getLogger(__name__)
+
+class OptionState():
+
+    def __init__(self, theProject):
+
+        self.theProject = theProject
+        self.theState   = {}
+        self.stringOpt  = ()
+        self.boolOpt    = ()
+        self.intOpt     = ()
+
+        return
+
+    def loadSettings(self):
+        """Load the options dictionary from the project settings file.
+        """
+
+        stateFile = path.join(self.theProject.projMeta, nwFiles.OPTS_FILE)
+        theState  = {}
+
+        if path.isfile(stateFile):
+            logger.debug("Loading GUI options file")
+            try:
+                with open(stateFile,mode="r",encoding="utf8") as inFile:
+                    theJson = inFile.read()
+                theState = json.loads(theJson)
+            except Exception as e:
+                logger.error("Failed to load GUI options file")
+                logger.error(str(e))
+                return False
+        for anOpt in theState:
+            self.theState[anOpt] = theState[anOpt]
+
+        return True
+
+    def saveSettings(self):
+        """Save the options dictionary to the project settings file.
+        """
+
+        stateFile = path.join(self.theProject.projMeta, nwFiles.OPTS_FILE)
+        logger.debug("Saving GUI options file")
+
+        try:
+            with open(stateFile,mode="w+",encoding="utf8") as outFile:
+                outFile.write(json.dumps(self.theState, indent=2))
+        except Exception as e:
+            logger.error("Failed to save GUI options file")
+            logger.error(str(e))
+            return False
+
+        return True
+
+    def setValue(self, setGroup, setName, setValue):
+        """Saves a value, with a given group and name.
+        """
+        if not setGroup in self.theState:
+            self.theState[setGroup] = {}
+        self.theState[setGroup][setName] = setValue
+        return True
+
+    def getString(self, getGroup, getName, defaultValue):
+        """Return the value as a string, if it exists. Otherwise, return
+        the default value.
+        """
+        if getGroup in self.theState:
+            if getName in self.theState[getGroup]:
+                try:
+                    return str(self.theState[getGroup][getName])
+                except:
+                    return defaultValue
+        return defaultValue
+
+    def getInt(self, getGroup, getName, defaultValue):
+        """Return the value as an int, if it exists. Otherwise, return
+        the default value.
+        """
+        if getGroup in self.theState:
+            if getName in self.theState[getGroup]:
+                try:
+                    return int(self.theState[getGroup][getName])
+                except:
+                    return defaultValue
+        return defaultValue
+
+    def getFloat(self, getGroup, getName, defaultValue):
+        """Return the value as a float, if it exists. Otherwise, return
+        the default value.
+        """
+        if getGroup in self.theState:
+            if getName in self.theState[getGroup]:
+                try:
+                    return float(self.theState[getGroup][getName])
+                except:
+                    return defaultValue
+        return defaultValue
+
+    def getBool(self, getGroup, getName, defaultValue):
+        """Return the value as a bool, if it exists. Otherwise, return
+        the default value.
+        """
+        if getGroup in self.theState:
+            if getName in self.theState[getGroup]:
+                try:
+                    return bool(self.theState[getGroup][getName])
+                except:
+                    return defaultValue
+        return defaultValue
+
+# END Class OptionState
 
 class OptLastState():
 

--- a/sample/sampleNovel/nwProject.nwx
+++ b/sample/sampleNovel/nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.4.1" fileVersion="1.0" timeStamp="2019-11-16 12:31:19">
+<novelWriterXML appVersion="0.4.5" fileVersion="1.0" timeStamp="2020-02-19 19:55:13">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
@@ -82,7 +82,7 @@
       <charCount>1199</charCount>
       <wordCount>216</wordCount>
       <paraCount>7</paraCount>
-      <cursorPos>949</cursorPos>
+      <cursorPos>19</cursorPos>
     </item>
     <item handle="bc0cbd2a407f3" order="2" parent="e7ded148d6e4a">
       <name>Another Scene</name>


### PR DESCRIPTION
Changing the way the various dialog options are saved on a per project basis. They are no longer saved as separate files per dialog, but as a single file.

This change should not affect the user, aside from all options being reset to the default value the first time a project is opened after updating to this version of the code.