### PR TITLE
Project Lockfile

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -20,7 +20,7 @@ from os import path, mkdir, unlink, rename
 from datetime import datetime
 
 from PyQt5.Qt import PYQT_VERSION_STR
-from PyQt5.QtCore import QT_VERSION_STR, QStandardPaths
+from PyQt5.QtCore import QT_VERSION_STR, QStandardPaths, QSysInfo
 
 from nw.constants import nwFiles, nwUnicode
 from nw.common import splitVersionNumber
@@ -155,6 +155,10 @@ class Config:
             self.osWindows = True
         else:
             self.osUnknown = True
+
+        # Other System Info
+        self.hostName  = QSysInfo.machineHostName()
+        self.kernelVer = QSysInfo.kernelVersion()
 
         # Packages
         self.hasEnchant  = False

--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -23,6 +23,7 @@ class nwFiles():
     APP_ICON    = "novelWriter.svg"
     PROJ_FILE   = "nwProject.nwx"
     PROJ_DICT   = "wordlist.txt"
+    PROJ_LOCK   = "nwProject.lock"
     SESS_INFO   = "sessionInfo.log"
     INDEX_FILE  = "tagsIndex.json"
     OPTS_FILE   = "guiOptions.json"

--- a/nw/project/backup.py
+++ b/nw/project/backup.py
@@ -57,7 +57,9 @@ class NWBackup():
         baseName = path.join(self.mainConf.backupPath, archName)
 
         try:
+            self.theProject._clearLockFile()
             make_archive(baseName, "zip", self.theProject.projPath, ".")
+            self.theProject._writeLockFile()
         except Exception as e:
             self.theParent.makeAlert(
                 ["Could not write backup archive.",str(e)],

--- a/tests/reference/proj/2_nwProject.nwx
+++ b/tests/reference/proj/2_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.1.4" fileVersion="1.0" timeStamp="2019-06-08 20:53:03">
+<novelWriterXML appVersion="0.4.5" fileVersion="1.0" timeStamp="2020-02-26 22:05:41">
   <project>
     <name></name>
     <title></title>
@@ -72,28 +72,28 @@
       <paraCount>0</paraCount>
       <cursorPos>0</cursorPos>
     </item>
-    <item handle="39fa9ec190eee" order="None" parent="None">
+    <item handle="8722616204217" order="None" parent="None">
       <name>Timeline</name>
       <type>ROOT</type>
       <class>TIMELINE</class>
       <status>New</status>
       <expanded>False</expanded>
     </item>
-    <item handle="d029fa3a95e17" order="None" parent="None">
+    <item handle="96061e92f58e4" order="None" parent="None">
       <name>Object</name>
       <type>ROOT</type>
       <class>OBJECT</class>
       <status>New</status>
       <expanded>False</expanded>
     </item>
-    <item handle="81b8a03f97e87" order="None" parent="None">
+    <item handle="eb624dbe56eb6" order="None" parent="None">
       <name>Custom1</name>
       <type>ROOT</type>
       <class>CUSTOM</class>
       <status>New</status>
       <expanded>False</expanded>
     </item>
-    <item handle="da4ea2a5506f2" order="None" parent="None">
+    <item handle="f369cb89fc627" order="None" parent="None">
       <name>Custom2</name>
       <type>ROOT</type>
       <class>CUSTOM</class>

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -29,6 +29,7 @@ def testProjectNew(nwTempProj,nwRef,nwTemp):
     assert theProject.newProject()
     assert theProject.setProjectPath(nwTempProj)
     assert theProject.saveProject()
+    assert theProject.closeProject()
     assert cmpFiles(projFile, refFile, [2])
 
 @pytest.mark.project
@@ -41,8 +42,20 @@ def testProjectSave(nwTempProj,nwRef):
     projFile = path.join(nwTempProj,"nwProject.nwx")
     refFile  = path.join(nwRef,"proj","1_nwProject.nwx")
     assert theProject.saveProject()
+    assert theProject.closeProject()
     assert cmpFiles(projFile, refFile, [2])
     assert not theProject.projChanged
+
+@pytest.mark.project
+def testProjectOpenTwice(nwTempProj,nwRef):
+    projFile = path.join(nwTempProj,"nwProject.nwx")
+    refFile  = path.join(nwRef,"proj","1_nwProject.nwx")
+    assert theProject.openProject(projFile)
+    assert not theProject.openProject(projFile)
+    assert theProject.openProject(projFile, overrideLock=True)
+    assert theProject.saveProject()
+    assert theProject.closeProject()
+    assert cmpFiles(projFile, refFile, [2])
 
 @pytest.mark.project
 def testProjectNewRoot(nwTempProj,nwRef):
@@ -59,6 +72,7 @@ def testProjectNewRoot(nwTempProj,nwRef):
     assert isinstance(theProject.newRoot("Custom2",   nwItemClass.CUSTOM),    str)
     assert theProject.projChanged
     assert theProject.saveProject()
+    assert theProject.closeProject()
     assert cmpFiles(projFile, refFile, [2])
     assert not theProject.projChanged
 
@@ -96,6 +110,8 @@ def testIndexScanThis(nwTempProj):
     assert str(theBits) == "['@tag', 'this', 'and this']"
     assert str(thePos)  == "[0, 6, 12]"
 
+    assert theProject.closeProject()
+
 @pytest.mark.project
 def testBuildIndex(nwTempProj):
     projFile = path.join(nwTempProj,"nwProject.nwx")
@@ -117,3 +133,4 @@ def testBuildIndex(nwTempProj):
     assert theIndex.buildNovelList()
     assert str(theIndex.novelList)  == "[[1, 1, 'Novel', 'SCENE'], [3, 2, 'Chapter', 'SCENE'], [5, 3, 'Scene', 'SCENE'], [7, 4, 'Section', 'SCENE']]"
     assert str(theIndex.novelOrder) == "['31489056e0916:1', '31489056e0916:3', '31489056e0916:5', '31489056e0916:7']"
+    assert theProject.closeProject()


### PR DESCRIPTION
This PR adds a project lock file to prevent opening the same project twice. A user may, for instance, have the project open on two computers synced via a file sync tool, or on a network drive. The user will now be alerted if the lock file exists, but can override the lock if they wish.

This PR solves issue #7.