### PR TITLE
Outline Fixes

### DIFF
--- a/nw/gui/elements/outline.py
+++ b/nw/gui/elements/outline.py
@@ -130,7 +130,7 @@ class GuiProjectOutline(QTreeWidget):
         """
 
         # If it's the first time, we always build
-        if self.firstView or overRide:
+        if self.firstView or self.firstView and overRide:
             self._loadHeaderState()
             self._populateTree()
             self.firstView = False
@@ -176,6 +176,7 @@ class GuiProjectOutline(QTreeWidget):
         of the columns.
         """
         self.treeOrder.insert(newVisualIdx, self.treeOrder.pop(oldVisualIdx))
+        self._saveHeaderState()
         return
 
     def _menuColumnToggled(self, isChecked, theItem):
@@ -185,6 +186,7 @@ class GuiProjectOutline(QTreeWidget):
         logger.verbose("User toggled Outline column '%s'" % theItem.name)
         if theItem in self.colIndex:
             self.setColumnHidden(self.colIndex[theItem], not isChecked)
+            self._saveHeaderState()
         return
 
     ##
@@ -282,21 +284,23 @@ class GuiProjectOutline(QTreeWidget):
         """Build the tree based on the project index.
         """
 
-        theLabels = []
-        for i, hItem in enumerate(self.treeOrder):
-            theLabels.append(nwLabels.OUTLINE_COLS[hItem])
-            self.colIndex[hItem] = i
-
         self.clear()
-        self.setHeaderLabels(theLabels)
-        for hItem in self.treeOrder:
-            self.setColumnWidth(self.colIndex[hItem], self.colWidth[hItem])
-            self.setColumnHidden(self.colIndex[hItem], self.colHidden[hItem])
 
-        headItem = self.headerItem()
-        headItem.setTextAlignment(self.colIndex[nwOutline.CCOUNT], Qt.AlignRight)
-        headItem.setTextAlignment(self.colIndex[nwOutline.WCOUNT], Qt.AlignRight)
-        headItem.setTextAlignment(self.colIndex[nwOutline.PCOUNT], Qt.AlignRight)
+        if self.firstView:
+            theLabels = []
+            for i, hItem in enumerate(self.treeOrder):
+                theLabels.append(nwLabels.OUTLINE_COLS[hItem])
+                self.colIndex[hItem] = i
+
+            self.setHeaderLabels(theLabels)
+            for hItem in self.treeOrder:
+                self.setColumnWidth(self.colIndex[hItem], self.colWidth[hItem])
+                self.setColumnHidden(self.colIndex[hItem], self.colHidden[hItem])
+
+            headItem = self.headerItem()
+            headItem.setTextAlignment(self.colIndex[nwOutline.CCOUNT], Qt.AlignRight)
+            headItem.setTextAlignment(self.colIndex[nwOutline.WCOUNT], Qt.AlignRight)
+            headItem.setTextAlignment(self.colIndex[nwOutline.PCOUNT], Qt.AlignRight)
 
         currTitle   = None
         currChapter = None

--- a/sample/sampleNovel/data_6/a2d6d5f4f401_main.nwd
+++ b/sample/sampleNovel/data_6/a2d6d5f4f401_main.nwd
@@ -4,3 +4,4 @@
 @location: Earth
 
 %synopsis: We can add a chapter file, but keep the scene files separate. In the chapter file we can set the meta data that applies to the whole chapter if we wish to.
+

--- a/sample/sampleNovel/nwProject.nwx
+++ b/sample/sampleNovel/nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.4.5" fileVersion="1.0" saveCount="31" autoCount="5" timeStamp="2020-04-13 15:55:18">
+<novelWriterXML appVersion="0.4.5" fileVersion="1.0" saveCount="38" autoCount="8" timeStamp="2020-04-13 16:55:55">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
@@ -71,7 +71,7 @@
       <charCount>12</charCount>
       <wordCount>3</wordCount>
       <paraCount>0</paraCount>
-      <cursorPos>15</cursorPos>
+      <cursorPos>214</cursorPos>
     </item>
     <item handle="636b6aa9b697b" order="1" parent="e7ded148d6e4a">
       <name>Making a Scene</name>


### PR DESCRIPTION
This PR fixes a bug where the Outline column header settings from last session were restored when the Outline was updated. This was due to the header being rebuilt every time the tree was updated. This is only necessary when on first build after a project is opened.