### PR TITLE
Fixed bug in loading of dictionary without enchant installed

### DIFF
--- a/nw/tools/spellenchant.py
+++ b/nw/tools/spellenchant.py
@@ -26,12 +26,18 @@
 """
 
 import logging
-import enchant
 import nw
+try:
+    import enchant
+except:
+    # No need to do anything
+    # setLanguage will fall back to dummy dictionary
+    pass
 
 from nw.tools.spellcheck import NWSpellCheck
 
 logger = logging.getLogger(__name__)
+
 
 class NWSpellEnchant(NWSpellCheck):
 

--- a/nw/tools/spellenchant.py
+++ b/nw/tools/spellenchant.py
@@ -38,7 +38,6 @@ from nw.tools.spellcheck import NWSpellCheck
 
 logger = logging.getLogger(__name__)
 
-
 class NWSpellEnchant(NWSpellCheck):
 
     def __init__(self):


### PR DESCRIPTION
This bug is back. Since the __init__ file lists everything, the enchant class fails to load when enchant isn't installed. Adding an extra try/except on the import fixes this.