### PR TITLE
Outline Feature - Step 2

### DIFF
--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -121,6 +121,7 @@ class nwLabels():
     }
     OUTLINE_COLS = {
         nwOutline.TITLE  : "Title",
+        nwOutline.HANDLE : "Handle",
         nwOutline.LEVEL  : "Level",
         nwOutline.LABEL  : "Document",
         nwOutline.LINE   : "Line",

--- a/nw/constants/enum.py
+++ b/nw/constants/enum.py
@@ -107,20 +107,21 @@ class nwAlert(Enum):
 class nwOutline(Enum):
 
     TITLE  = 0
-    LEVEL  = 1
-    LABEL  = 2
-    LINE   = 3
-    CCOUNT = 4
-    WCOUNT = 5
-    PCOUNT = 6
-    POV    = 7
-    CHAR   = 8
-    PLOT   = 9
-    TIME   = 10
-    WORLD  = 11
-    OBJECT = 12
-    ENTITY = 13
-    CUSTOM = 14
-    SYNOP  = 15
+    HANDLE = 1
+    LEVEL  = 2
+    LABEL  = 3
+    LINE   = 4
+    CCOUNT = 5
+    WCOUNT = 6
+    PCOUNT = 7
+    POV    = 8
+    CHAR   = 9
+    PLOT   = 10
+    TIME   = 11
+    WORLD  = 12
+    OBJECT = 13
+    ENTITY = 14
+    CUSTOM = 15
+    SYNOP  = 16
 
 # END Enum nwOutline

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -218,7 +218,7 @@ class GuiDocEditor(QTextEdit):
 
         return True
 
-    def loadText(self, tHandle):
+    def loadText(self, tHandle, tLine=None):
         """Load text from a document into the editor. If we have an io
         error, we must handle this and clear the editor so that we don't
         risk overwriting the file if it exists. This can for instance
@@ -249,7 +249,10 @@ class GuiDocEditor(QTextEdit):
         afTime = time()
         logger.debug("Document highlighted in %.3f milliseconds" % (1000*(afTime-bfTime)))
 
-        self.setCursorPosition(self.nwDocument.theItem.cursorPos)
+        if tLine is None:
+            self.setCursorPosition(self.nwDocument.theItem.cursorPos)
+        else:
+            self.setCursorLine(tLine)
         self.lastEdit = time()
         self._runCounter()
         self.wcTimer.start()
@@ -353,6 +356,8 @@ class GuiDocEditor(QTextEdit):
         return theText
 
     def setCursorPosition(self, thePosition):
+        """Move the cursor to a given position in the document.
+        """
         if thePosition >= 0:
             theCursor = self.textCursor()
             theCursor.setPosition(thePosition)
@@ -360,8 +365,21 @@ class GuiDocEditor(QTextEdit):
         return True
 
     def getCursorPosition(self):
+        """Find the cursor position in the document.
+        """
         theCursor = self.textCursor()
         return theCursor.position()
+
+    def setCursorLine(self, theLine):
+        """Move the cursor to a given line in the document.
+        """
+        if theLine is None:
+            return False
+        if theLine >= 0:
+            theBlock = self.qDocument.findBlockByLineNumber(theLine)
+            if theBlock:
+                self.setCursorPosition(theBlock.position())
+        return True
 
     ##
     #  Spell Checking

--- a/nw/gui/tools/dochighlight.py
+++ b/nw/gui/tools/dochighlight.py
@@ -267,11 +267,15 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             self.setFormat(4, len(theText), self.hStyles["header4"])
 
         elif theText.startswith("%"): # Comments
-            if theText.startswith("%synopsis:"):
-                self.setFormat(0, 10, self.hStyles["modifier"])
-                self.setFormat(10, len(theText), self.hStyles["hidden"])
+            toCheck = theText[1:].lstrip().lower()
+            tLen = len(theText)
+            cLen = len(toCheck)
+            cOff = tLen - cLen
+            if toCheck.startswith("synopsis:"):
+                self.setFormat(0, cOff+9, self.hStyles["modifier"])
+                self.setFormat(cOff+9, tLen, self.hStyles["hidden"])
             else:
-                self.setFormat(0, len(theText), self.hStyles["hidden"])
+                self.setFormat(0, tLen, self.hStyles["hidden"])
 
         else: # Text Paragraph
             for rX, xFmt in self.rxRules:

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -452,11 +452,13 @@ class GuiMain(QMainWindow):
             self.docEditor.clearEditor()
         return True
 
-    def openDocument(self, tHandle):
+    def openDocument(self, tHandle, tLine=None):
+        """Open a specific document, optionally at a given line.
+        """
         if self.hasProject:
             self.closeDocument()
             self.tabWidget.setCurrentWidget(self.splitView)
-            if self.docEditor.loadText(tHandle):
+            if self.docEditor.loadText(tHandle, tLine):
                 self.docEditor.setFocus()
                 self.theProject.setLastEdited(tHandle)
             else:

--- a/nw/project/index.py
+++ b/nw/project/index.py
@@ -308,9 +308,14 @@ class NWIndex():
                 self.indexNoteRef(tHandle, aLine, nLine, nTitle)
                 self.indexTag(tHandle, aLine, nLine, itemClass)
 
-            elif aLine.startswith(r"%synopsis:"):
+            elif aLine.startswith(r"%"):
                 if nTitle > 0:
-                    self.indexSynopsis(tHandle, isNovel, aLine[10:].strip(), nTitle)
+                    toCheck = aLine[1:].lstrip().lower()
+                    tLen = len(aLine)
+                    cLen = len(toCheck)
+                    cOff = tLen - cLen
+                    if toCheck.startswith("synopsis:"):
+                        self.indexSynopsis(tHandle, isNovel, aLine[cOff+9:].strip(), nTitle)
 
         # Count words for remaining text after last heading
         if nTitle > 0:

--- a/sample/sampleNovel/data_6/a2d6d5f4f401_main.nwd
+++ b/sample/sampleNovel/data_6/a2d6d5f4f401_main.nwd
@@ -3,5 +3,5 @@
 @pov: Jane
 @location: Earth
 
-%synopsis: We can add a chapter file, but keep the scene files separate. In the chapter file we can set the meta data that applies to the whole chapter if we wish to.
+% Synopsis: We can add a chapter file, but keep the scene files separate. In the chapter file we can set the meta data that applies to the whole chapter if we wish to.
 

--- a/sample/sampleNovel/nwProject.nwx
+++ b/sample/sampleNovel/nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.4.5" fileVersion="1.0" saveCount="38" autoCount="8" timeStamp="2020-04-13 16:55:55">
+<novelWriterXML appVersion="0.4.5" fileVersion="1.0" saveCount="52" autoCount="8" timeStamp="2020-04-26 18:05:45">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
@@ -71,7 +71,7 @@
       <charCount>12</charCount>
       <wordCount>3</wordCount>
       <paraCount>0</paraCount>
-      <cursorPos>214</cursorPos>
+      <cursorPos>215</cursorPos>
     </item>
     <item handle="636b6aa9b697b" order="1" parent="e7ded148d6e4a">
       <name>Making a Scene</name>
@@ -83,7 +83,7 @@
       <charCount>1199</charCount>
       <wordCount>216</wordCount>
       <paraCount>7</paraCount>
-      <cursorPos>19</cursorPos>
+      <cursorPos>950</cursorPos>
     </item>
     <item handle="bc0cbd2a407f3" order="2" parent="e7ded148d6e4a">
       <name>Another Scene</name>


### PR DESCRIPTION
This PR adds the following features:

* Double-clicking a title in the outline view will open that document for editing. If the title selected is not the first title in the document, the cursor will be moved to the correct position in the document. (See also Issue #187)
* The marker for synopsis comments has been changed a bit so that it is a bit more relaxed in identifying a comment that should be considered a synopsis. As long as the word "synopsis:" (with the following colon) is the fist word in the comment, not case sensitive, the comment is flagged as the synopsis for the file. (See also Issue #186)