### PR TITLE
Gui Fixes

### DIFF
--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import sys

--- a/nw/additions/qconfiglayout.py
+++ b/nw/additions/qconfiglayout.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/additions/qswitch.py
+++ b/nw/additions/qswitch.py
@@ -8,12 +8,8 @@
  File History:
  Created: 2020-05-03 [0.4.5]
 
- This class is based on Stack Overflow code by Stefan Scherfke, based
- again on contribution by IMAN4K, published under license CC BY-SA 4.0.
- https://stackoverflow.com/a/51825815/5825851
-
- The above code has been modified to integrate with novelWriter, and
- re-released under compatible GPLv3 (see creativecommons.org).
+ The core code of this class is based on Stack Overflow example by
+ Stefan Scherfke: https://stackoverflow.com/a/51825815/5825851
 
  This file is a part of novelWriter
  Copyright 2020, Veronica Berglyd Olsen
@@ -50,55 +46,9 @@ class QSwitch(QAbstractButton):
 
         self.setCheckable(True)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-
-        self._trackRadius = 10
-        self._thumbRadius = 8
-
-        self._margin = max(0, self._thumbRadius - self._trackRadius)
-        self._baseOffset = max(self._thumbRadius, self._trackRadius)
-        self._endOffset = {
-            True: lambda: self.width() - self._baseOffset,
-            False: lambda: self._baseOffset,
-        }
-        self._offset = self._baseOffset
-
-        palette = self.palette()
-        if self._thumbRadius > self._trackRadius:
-            self._trackColor = {
-                True: palette.highlight(),
-                False: palette.dark(),
-            }
-            self._thumbColor = {
-                True: palette.highlight(),
-                False: palette.light(),
-            }
-            self._textColor = {
-                True: palette.highlightedText().color(),
-                False: palette.dark().color(),
-            }
-            self._thumbText = {
-                True: '',
-                False: '',
-            }
-            self._trackOpacity = 0.5
-        else:
-            self._thumbColor = {
-                True: palette.highlightedText(),
-                False: palette.light(),
-            }
-            self._trackColor = {
-                True: palette.highlight(),
-                False: palette.dark(),
-            }
-            self._textColor = {
-                True: palette.highlight().color(),
-                False: palette.dark().color(),
-            }
-            self._thumbText = {
-                True: nwUnicode.U_CHECK,
-                False: nwUnicode.U_MULT,
-            }
-            self._trackOpacity = 1.0
+        self.setFixedWidth(40)
+        self.setFixedHeight(20)
+        self._offset = 10
 
         return
 
@@ -111,8 +61,8 @@ class QSwitch(QAbstractButton):
         return self._offset
 
     @offset.setter
-    def offset(self, value):
-        self._offset = value
+    def offset(self, theOffset):
+        self._offset = theOffset
         self.update()
         return
 
@@ -120,114 +70,85 @@ class QSwitch(QAbstractButton):
     #  Getters and Setters
     ##
 
-    def trackRadius(self):
-        return self._trackRadius
-
-    def setTrackRadius(self, theValue):
-        if isinstance(theValue, int):
-            if theValue > 0:
-                self._trackRadius = theValue
-                return
-        raise ValueError("trackRadius must be an integer > 0")
-        self.update()
+    def setChecked(self, isChecked):
+        """Overload setChecked to also alter the offset.
+        """
+        super().setChecked(isChecked)
+        if isChecked:
+            self.offset = 30
+        else:
+            self.offset = 10
         return
-
-    def thumbRadius(self):
-        return self._thumbRadius
-
-    def setThumbRadius(self, theValue):
-        if isinstance(theValue, int):
-            if theValue > 0:
-                self._thumbRadius = theValue
-                return
-        raise ValueError("thumbRadius must be an integer > 0")
-        self.update()
-        return
-
-    def setChecked(self, checked):
-        super().setChecked(checked)
-        self.offset = self._endOffset[checked]()
-
-    def sizeHint(self):
-        return QSize(
-            4 * self._trackRadius + 2 * self._margin,
-            2 * self._trackRadius + 2 * self._margin,
-        )
 
     ##
     #  Events
     ##
 
-    def resizeEvent(self, event):
+    def resizeEvent(self, theEvent):
         """Overload resize to ensure correct offset.
         """
-        super().resizeEvent(event)
-        self.offset = self._endOffset[self.isChecked()]()
+        super().resizeEvent(theEvent)
+        if self.isChecked():
+            self.offset = 30
+        else:
+            self.offset = 10
         return
 
     def paintEvent(self, event):
         """Drawing the switch itself.
         """
+
         qPaint = QPainter(self)
         qPaint.setRenderHint(QPainter.Antialiasing, True)
         qPaint.setPen(Qt.NoPen)
-        trackOpacity = self._trackOpacity
-        thumbOpacity = 1.0
-        textOpacity = 1.0
-        if self.isEnabled():
-            trackBrush = self._trackColor[self.isChecked()]
-            thumbBrush = self._thumbColor[self.isChecked()]
-            textColor = self._textColor[self.isChecked()]
+
+        qPalette = self.palette()
+        if self.isChecked():
+            trackBrush = qPalette.highlight()
+            thumbBrush = qPalette.highlightedText()
+            textColor = qPalette.highlight().color()
+            thumbText = nwUnicode.U_CHECK
         else:
-            trackOpacity *= 0.8
-            trackBrush = self.palette().shadow()
-            thumbBrush = self.palette().mid()
-            textColor = self.palette().shadow().color()
+            trackBrush = qPalette.dark()
+            thumbBrush = qPalette.light()
+            textColor = qPalette.dark().color()
+            thumbText = nwUnicode.U_MULT
+
+        if self.isEnabled():
+            trackOpacity = 1.0
+        else:
+            trackOpacity = 0.6
 
         qPaint.setBrush(trackBrush)
         qPaint.setOpacity(trackOpacity)
-        qPaint.drawRoundedRect(
-            self._margin,
-            self._margin,
-            self.width() - 2*self._margin,
-            self.height() - 2*self._margin,
-            self._trackRadius,
-            self._trackRadius,
-        )
+        qPaint.drawRoundedRect(0, 0, 40, 20, 10, 10)
+
         qPaint.setBrush(thumbBrush)
-        qPaint.setOpacity(thumbOpacity)
-        qPaint.drawEllipse(
-            self.offset - self._thumbRadius,
-            self._baseOffset - self._thumbRadius,
-            2*self._thumbRadius,
-            2*self._thumbRadius,
-        )
-        qPaint.setPen(textColor)
-        qPaint.setOpacity(textOpacity)
+        qPaint.drawEllipse(self.offset - 8, 2, 16, 16)
+
         theFont = qPaint.font()
-        theFont.setPixelSize(1.5*self._thumbRadius)
+        theFont.setPixelSize(12)
+        qPaint.setPen(textColor)
         qPaint.setFont(theFont)
         qPaint.drawText(
-            QRectF(
-                self.offset - self._thumbRadius,
-                self._baseOffset - self._thumbRadius,
-                2*self._thumbRadius,
-                2*self._thumbRadius,
-            ),
-            Qt.AlignCenter,
-            self._thumbText[self.isChecked()],
+            QRectF(self.offset - 8, 2, 16, 16),
+            Qt.AlignCenter, thumbText
         )
+
         return
 
     def mouseReleaseEvent(self, event):
-        """Animate the switch.
+        """Animate the switch on mouse release.
         """
         super().mouseReleaseEvent(event)
         if event.button() == Qt.LeftButton:
             doAnim = QPropertyAnimation(self, b'offset', self)
             doAnim.setDuration(120)
             doAnim.setStartValue(self.offset)
-            doAnim.setEndValue(self._endOffset[self.isChecked()]())
+            if self.isChecked():
+                doAnim.setEndValue(30)
+            else:
+                doAnim.setEndValue(10)
             doAnim.start()
         return
 

--- a/nw/additions/qswitch.py
+++ b/nw/additions/qswitch.py
@@ -106,18 +106,21 @@ class QSwitch(QAbstractButton):
         if self.isChecked():
             trackBrush = qPalette.highlight()
             thumbBrush = qPalette.highlightedText()
-            textColor = qPalette.highlight().color()
-            thumbText = nwUnicode.U_CHECK
+            textColor  = qPalette.highlight().color()
+            thumbText  = nwUnicode.U_CHECK
         else:
             trackBrush = qPalette.dark()
             thumbBrush = qPalette.light()
-            textColor = qPalette.dark().color()
-            thumbText = nwUnicode.U_MULT
+            textColor  = qPalette.dark().color()
+            thumbText  = nwUnicode.U_MULT
 
         if self.isEnabled():
             trackOpacity = 1.0
         else:
             trackOpacity = 0.6
+            trackBrush = qPalette.shadow()
+            thumbBrush = qPalette.mid()
+            textColor  = qPalette.shadow().color()
 
         qPaint.setBrush(trackBrush)
         qPaint.setOpacity(trackOpacity)

--- a/nw/additions/qswitch.py
+++ b/nw/additions/qswitch.py
@@ -25,7 +25,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/common.py
+++ b/nw/common.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/config.py
+++ b/nw/config.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -237,10 +237,14 @@ class nwUnicode:
     U_MULT   = "\u2715" # Multiplication x
 
     ## Arrows
-    U_UTRI   = "\u2bc5" # Up-pointing triangle
-    U_DTRI   = "\u2bc6" # Down-pointing triangle
-    U_LTRI   = "\u2bc7" # Left-pointing triangle
-    U_RTRI   = "\u2bc8" # Right-pointing triangle
+    U_UTRI   = "\u25b2" # Up-pointing triangle
+    U_UTRIS  = "\u25b4" # Up-pointing triangle, small
+    U_RTRI   = "\u25b6" # Right-pointing triangle
+    U_RTRIS  = "\u25b8" # Right-pointing triangle, small
+    U_DTRI   = "\u25bc" # Down-pointing triangle
+    U_DTRIS  = "\u25be" # Down-pointing triangle, small
+    U_LTRI   = "\u25c0" # Left-pointing triangle
+    U_LTRIS  = "\u25c2" # Left-pointing triangle, small
 
     # HTML Equivalents
 
@@ -276,9 +280,13 @@ class nwUnicode:
     H_MULT   = "&#10005;"
 
     ## Arrows
-    H_UTRI   = "&#11205;"
-    H_DTRI   = "&#11206;"
-    H_LTRI   = "&#11207;"
-    H_RTRI   = "&#11208;"
+    H_UTRI   = "&#9650;"
+    H_UTRIS  = "&#9652;"
+    H_RTRI   = "&#9654;"
+    H_RTRIS  = "&#9656;"
+    H_DTRI   = "&#9660;"
+    H_DTRIS  = "&#9662;"
+    H_LTRI   = "&#9664;"
+    H_LTRIS  = "&#9666;"
 
 # END Class nwUnicode

--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from nw.constants.enum import nwItemClass, nwItemLayout, nwOutline

--- a/nw/constants/enum.py
+++ b/nw/constants/enum.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from enum import Enum

--- a/nw/constants/iso.py
+++ b/nw/constants/iso.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/file/concat.py
+++ b/nw/convert/file/concat.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/file/html.py
+++ b/nw/convert/file/html.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/file/latex.py
+++ b/nw/convert/file/latex.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/file/markdown.py
+++ b/nw/convert/file/markdown.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/file/text.py
+++ b/nw/convert/file/text.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/text/tohtml.py
+++ b/nw/convert/text/tohtml.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/text/tolatex.py
+++ b/nw/convert/text/tolatex.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/convert/text/tomarkdown.py
+++ b/nw/convert/text/tomarkdown.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import textwrap

--- a/nw/convert/text/totext.py
+++ b/nw/convert/text/totext.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import textwrap

--- a/nw/convert/tokenizer.py
+++ b/nw/convert/tokenizer.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -120,7 +120,7 @@ class GuiConfigEditor(QDialog):
             msgBox = QMessageBox()
             msgBox.information(
                 self, "Preferences",
-                "Some changes will not be applied until<br>%s has been restarted" % nw.__package__
+                "Some changes will not be applied until %s has been restarted." % nw.__package__
             )
 
         if validEntries:
@@ -257,8 +257,10 @@ class GuiConfigEditGeneralTab(QWidget):
         )
 
         ## Ask before backup
+        ## Only enabled when "Run when closing" is checked
         self.askBeforeBackup = QSwitch()
         self.askBeforeBackup.setChecked(self.mainConf.askBeforeBackup)
+        self.askBeforeBackup.setEnabled(self.mainConf.backupOnClose)
         self.mainForm.addRow(
             "Ask before running backup",
             self.askBeforeBackup
@@ -393,7 +395,7 @@ class GuiConfigEditLayoutTab(QWidget):
         self.zenDocWidth.setSingleStep(10)
         self.zenDocWidth.setValue(self.mainConf.zenWidth)
         self.mainForm.addRow(
-            "Maximum text width in Zen mode",
+            "Maximum text width in distraction free mode",
             self.zenDocWidth,
             theUnit="px"
         )
@@ -402,9 +404,9 @@ class GuiConfigEditLayoutTab(QWidget):
         self.textFlowFixed = QSwitch()
         self.textFlowFixed.setChecked(not self.mainConf.textFixedW)
         self.mainForm.addRow(
-            "Disable maximum text width in Normal mode",
+            "Disable maximum text width in normal mode",
             self.textFlowFixed,
-            "Only fixed margins are applied to the document"
+            "Only horizontal margins are applied to the document"
         )
 
         ## Justify Text
@@ -658,6 +660,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         ## Auto-Replace Single Quotes
         self.autoReplaceSQ = QSwitch()
         self.autoReplaceSQ.setChecked(self.mainConf.doReplaceSQuote)
+        self.autoReplaceSQ.setEnabled(self.mainConf.doReplace)
         self.mainForm.addRow(
             "Auto-replace single quotes",
             self.autoReplaceSQ,
@@ -667,6 +670,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         ## Auto-Replace Double Quotes
         self.autoReplaceDQ = QSwitch()
         self.autoReplaceDQ.setChecked(self.mainConf.doReplaceDQuote)
+        self.autoReplaceDQ.setEnabled(self.mainConf.doReplace)
         self.mainForm.addRow(
             "Auto-replace double quotes",
             self.autoReplaceDQ,
@@ -676,6 +680,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         ## Auto-Replace Hyphens
         self.autoReplaceDash = QSwitch()
         self.autoReplaceDash.setChecked(self.mainConf.doReplaceDash)
+        self.autoReplaceDash.setEnabled(self.mainConf.doReplace)
         self.mainForm.addRow(
             "Auto-replace dashes",
             self.autoReplaceDash,
@@ -685,6 +690,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         ## Auto-Replace Dots
         self.autoReplaceDots = QSwitch()
         self.autoReplaceDots.setChecked(self.mainConf.doReplaceDots)
+        self.autoReplaceDots.setEnabled(self.mainConf.doReplace)
         self.mainForm.addRow(
             "Auto-replace dots",
             self.autoReplaceDots,

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -166,7 +166,7 @@ class GuiConfigEditGeneralTab(QWidget):
         self.mainForm.addRow(
             "Main GUI theme",
             self.selectTheme,
-            "Changing this requires restarting %s" % nw.__package__
+            "Changing this requires restarting %s." % nw.__package__
         )
 
         ## Syntax Highlighting
@@ -190,7 +190,7 @@ class GuiConfigEditGeneralTab(QWidget):
         self.mainForm.addRow(
             "Prefer icons for dark backgrounds",
             self.preferDarkIcons,
-            "May improve the look of icons on dark themes"
+            "This may improve the look of icons on dark themes."
         )
 
         # GUI Settings
@@ -253,7 +253,7 @@ class GuiConfigEditGeneralTab(QWidget):
         self.mainForm.addRow(
             "Run backup when closing project",
             self.backupOnClose,
-            "This option can be overridden in project settings"
+            "This option can be overridden in project settings."
         )
 
         ## Ask before backup
@@ -357,7 +357,7 @@ class GuiConfigEditLayoutTab(QWidget):
         self.mainForm.addRow(
             "Font family",
             self.textStyleFont,
-            "For the document editor and viewer"
+            "Font for the document editor and viewer."
         )
 
         ## Font Size
@@ -383,7 +383,7 @@ class GuiConfigEditLayoutTab(QWidget):
         self.textFlowMax.setSingleStep(10)
         self.textFlowMax.setValue(self.mainConf.textWidth)
         self.mainForm.addRow(
-            "Maximum text width in Normal mode",
+            "Maximum text width in \"Normal Mode\"",
             self.textFlowMax,
             theUnit="px"
         )
@@ -395,7 +395,7 @@ class GuiConfigEditLayoutTab(QWidget):
         self.zenDocWidth.setSingleStep(10)
         self.zenDocWidth.setValue(self.mainConf.zenWidth)
         self.mainForm.addRow(
-            "Maximum text width in distraction free mode",
+            "Maximum text width in \"Zen Mode\"",
             self.zenDocWidth,
             theUnit="px"
         )
@@ -404,9 +404,9 @@ class GuiConfigEditLayoutTab(QWidget):
         self.textFlowFixed = QSwitch()
         self.textFlowFixed.setChecked(not self.mainConf.textFixedW)
         self.mainForm.addRow(
-            "Disable maximum text width in normal mode",
+            "Disable maximum text width in \"Normal Mode\"",
             self.textFlowFixed,
-            "Only horizontal margins are applied to the document"
+            "If disabled, minimum text width is defined by the margin setting."
         )
 
         ## Justify Text
@@ -426,7 +426,7 @@ class GuiConfigEditLayoutTab(QWidget):
         self.mainForm.addRow(
             "Document text margin",
             self.textMargin,
-            "The minimum horizontal text margin if max with is enabled",
+            "If max width is enabled, this is the minimum margin.",
             theUnit="px"
         )
 
@@ -439,7 +439,7 @@ class GuiConfigEditLayoutTab(QWidget):
         self.mainForm.addRow(
             "Editor tab width",
             self.tabWidth,
-            "This feature requires Qt 5.9 or later",
+            "This feature requires Qt 5.9 or later.",
             theUnit="px"
         )
 
@@ -538,7 +538,7 @@ class GuiConfigEditEditingTab(QWidget):
         self.mainForm.addRow(
             "Spell check provider",
             self.spellToolList,
-            "Note that the internal spell check tool is quite slow"
+            "Note that the internal spell check tool is quite slow."
         )
         self.mainForm.addRow(
             "Spell check language",
@@ -554,7 +554,7 @@ class GuiConfigEditEditingTab(QWidget):
         self.mainForm.addRow(
             "Big document limit",
             self.bigDocLimit,
-            "Disables full spell checking over the size limit",
+            "Disables full spell checking over the size limit.",
             theUnit="kb"
         )
 
@@ -640,7 +640,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Auto-select word under cursor",
             self.autoSelect,
-            "Apply formatting to word under cursor if no selection is made"
+            "Apply formatting to word under cursor if no selection is made."
         )
 
         ## Auto-Replace as You Type Main Switch
@@ -650,7 +650,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Auto-replace text as you type",
             self.autoReplaceMain,
-            "Apply formatting to word under cursor if no selection is made"
+            "Apply formatting to word under cursor if no selection is made."
         )
 
         # Auto-Replace
@@ -664,7 +664,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Auto-replace single quotes",
             self.autoReplaceSQ,
-            "The feature will try to guess opening or closing single quote"
+            "The feature will try to guess opening or closing single quote."
         )
 
         ## Auto-Replace Double Quotes
@@ -674,7 +674,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Auto-replace double quotes",
             self.autoReplaceDQ,
-            "The feature will try to guess opening or closing quote quote"
+            "The feature will try to guess opening or closing quote quote."
         )
 
         ## Auto-Replace Hyphens
@@ -684,7 +684,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Auto-replace dashes",
             self.autoReplaceDash,
-            "Auto-replace double and triple hyphens with short and long dash"
+            "Auto-replace double and triple hyphens with short and long dash."
         )
 
         ## Auto-Replace Dots
@@ -694,7 +694,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Auto-replace dots",
             self.autoReplaceDots,
-            "Auto-replace three dots with ellipsis"
+            "Auto-replace three dots with ellipsis."
         )
 
         # Quotation Style
@@ -710,7 +710,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Single quote open style",
             self.quoteSingleStyleO,
-            "Auto-replaces apostrophe before words"
+            "Auto-replaces apostrophe before words."
         )
 
         self.quoteSingleStyleC = QLineEdit()
@@ -721,7 +721,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Single quote close style",
             self.quoteSingleStyleC,
-            "Auto-replaces apostrophe after words"
+            "Auto-replaces apostrophe after words."
         )
 
         ## Double Quote Style
@@ -733,7 +733,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Double quote open style",
             self.quoteDoubleStyleO,
-            "Auto-replaces straight quotes before words"
+            "Auto-replaces straight quotes before words."
         )
 
         self.quoteDoubleStyleC = QLineEdit()
@@ -744,7 +744,7 @@ class GuiConfigEditAutoReplaceTab(QWidget):
         self.mainForm.addRow(
             "Double quote close style",
             self.quoteDoubleStyleC,
-            "Auto-replaces straight quotes after words"
+            "Auto-replaces straight quotes after words."
         )
 
         return

--- a/nw/gui/dialogs/docmerge.py
+++ b/nw/gui/dialogs/docmerge.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/docsplit.py
+++ b/nw/gui/dialogs/docsplit.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/export.py
+++ b/nw/gui/dialogs/export.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/itemeditor.py
+++ b/nw/gui/dialogs/itemeditor.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/projecteditor.py
+++ b/nw/gui/dialogs/projecteditor.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/projectload.py
+++ b/nw/gui/dialogs/projectload.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/dialogs/sessionlog.py
+++ b/nw/gui/dialogs/sessionlog.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/docdetails.py
+++ b/nw/gui/elements/docdetails.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/doctitlebar.py
+++ b/nw/gui/elements/doctitlebar.py
@@ -58,7 +58,6 @@ class GuiDocTitleBar(QLabel):
         self.setWordWrap(True)
         self.setFrameShape(QFrame.NoFrame)
         self.setLineWidth(0)
-        self.setTextFormat(Qt.RichText)
         lblPalette = self.palette()
         lblPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
         lblPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
@@ -93,7 +92,7 @@ class GuiDocTitleBar(QLabel):
                 nwItem = self.theProject.getItem(aHandle)
                 if nwItem is not None:
                     tTitle.append(nwItem.itemName)
-            sSep = " %s " % nwUnicode.H_RTRIS
+            sSep = "  %s  " % nwUnicode.U_RSAQUO
             self.setText(sSep.join(tTitle))
         else:
             nwItem = self.theProject.getItem(tHandle)

--- a/nw/gui/elements/doctitlebar.py
+++ b/nw/gui/elements/doctitlebar.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/doctitlebar.py
+++ b/nw/gui/elements/doctitlebar.py
@@ -58,6 +58,7 @@ class GuiDocTitleBar(QLabel):
         self.setWordWrap(True)
         self.setFrameShape(QFrame.NoFrame)
         self.setLineWidth(0)
+        self.setTextFormat(Qt.RichText)
         lblPalette = self.palette()
         lblPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
         lblPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
@@ -92,7 +93,7 @@ class GuiDocTitleBar(QLabel):
                 nwItem = self.theProject.getItem(aHandle)
                 if nwItem is not None:
                     tTitle.append(nwItem.itemName)
-            sSep = " %s " % nwUnicode.U_RTRI
+            sSep = " %s " % nwUnicode.H_RTRIS
             self.setText(sSep.join(tTitle))
         else:
             nwItem = self.theProject.getItem(tHandle)

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/docviewer.py
+++ b/nw/gui/elements/docviewer.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/noticebar.py
+++ b/nw/gui/elements/noticebar.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/outline.py
+++ b/nw/gui/elements/outline.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/searchbar.py
+++ b/nw/gui/elements/searchbar.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/elements/viewdetails.py
+++ b/nw/gui/elements/viewdetails.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/icons.py
+++ b/nw/gui/icons.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/tools/dochighlight.py
+++ b/nw/gui/tools/dochighlight.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/gui/tools/wordcounter.py
+++ b/nw/gui/tools/wordcounter.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/project/backup.py
+++ b/nw/project/backup.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/project/backup.py
+++ b/nw/project/backup.py
@@ -46,16 +46,25 @@ class NWBackup():
 
     def zipIt(self):
 
-        if self.mainConf.backupPath is None:
-            self.theParent.makeAlert(
-                "Cannot backup project because no backup path is set.",nwAlert.WARN
-            )
+        if self.mainConf.backupPath is None or self.mainConf.backupPath == "":
+            self.theParent.makeAlert((
+                "Cannot backup project because no backup path is set. "
+                "Please set a valid backup location in Tools > Preferences."
+            ), nwAlert.WARN)
             return False
 
-        if self.theProject.projName is None:
-            self.theParent.makeAlert(
-                "Cannot backup project because no project name is set.",nwAlert.WARN
-            )
+        if self.theProject.projName is None or self.theProject.projName == "":
+            self.theParent.makeAlert((
+                "Cannot backup project because no project name is set. "
+                "Please set a Working Title in Project > Project Settings."
+            ), nwAlert.WARN)
+            return False
+
+        if not path.isdir(self.mainConf.backupPath):
+            self.theParent.makeAlert((
+                "Cannot backup project because the backup path does not exist. "
+                "Please set a valid backup location in Tools > Preferences."
+            ), nwAlert.WARN)
             return False
 
         logger.info("Backing up project")
@@ -75,6 +84,7 @@ class NWBackup():
             self.theProject._clearLockFile()
             make_archive(baseName, "zip", self.theProject.projPath, ".")
             self.theProject._writeLockFile()
+            logger.info("Backup written to: %s" % archName)
         except Exception as e:
             self.theParent.makeAlert(
                 ["Could not write backup archive.",str(e)],

--- a/nw/project/document.py
+++ b/nw/project/document.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/project/index.py
+++ b/nw/project/index.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/project/item.py
+++ b/nw/project/item.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/project/project.py
+++ b/nw/project/project.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/project/status.py
+++ b/nw/project/status.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/analyse.py
+++ b/nw/tools/analyse.py
@@ -21,7 +21,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/legacy.py
+++ b/nw/tools/legacy.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/optionstate.py
+++ b/nw/tools/optionstate.py
@@ -23,7 +23,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/spellcheck.py
+++ b/nw/tools/spellcheck.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/spellenchant.py
+++ b/nw/tools/spellenchant.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/spellsimple.py
+++ b/nw/tools/spellsimple.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/translate.py
+++ b/nw/tools/translate.py
@@ -22,7 +22,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/nw/tools/wordcount.py
+++ b/nw/tools/wordcount.py
@@ -23,7 +23,7 @@
  General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program. If not, see https://www.gnu.org/licenses/.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging


### PR DESCRIPTION
Some fixes and updates for the previous couple of PRs. Addresses issue #194 as well.

* The path separator in the document title bar now uses the right single angle quote symbol, same as Google search results uses. This symbol should exist in all fonts that contain latin characters.
* Fix some minor issues with the backup class. It wouldn't check if a backup path was specified, and would write the backup archive in the source folder if no path was set. Now it properly triggers an error.
* Trimmed down the source code for the new GUI switch object. No need to have all the customisation options in the class when novelWriter uses a fixed style for these. All dimensions are now hard coded. 