### PR TITLE
Document Meta Data

### DIFF
--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -929,16 +929,14 @@ class NWTree():
 
         self.theProject = theProject
 
-        self._projTree  = {} # Holds all the items of the project
-        self._treeOrder = [] # The order of the tree items on the tree view
-        self._treeRoots = [] # The root items of the tree
-        self._trashRoot = "" # The handle of the trash root folder
-
+        self._projTree    = {}    # Holds all the items of the project
+        self._treeOrder   = []    # The order of the tree items on the tree view
+        self._treeRoots   = []    # The root items of the tree
+        self._trashRoot   = None  # The handle of the trash root folder
         self._theLength   = 0     # Always the length of _treeOrder
         self._theIndex    = 0     # The current iterator index
         self._treeChanged = False # True if tree structure has changed
-
-        self._handleSeed = None # Used for generating handles for testing
+        self._handleSeed  = None  # Used for generating handles for testing
 
         return
 
@@ -952,7 +950,7 @@ class NWTree():
         self._projTree  = {}
         self._treeOrder = []
         self._treeRoots = []
-        self._trashRoot = ""
+        self._trashRoot = None
         self._theLength = 0
         self._theIndex  = 0
         self._treeChanged = False

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -257,6 +257,7 @@ class GuiDocEditor(QTextEdit):
         self.setPlainText(theDoc)
         afTime = time()
         logger.debug("Document highlighted in %.3f milliseconds" % (1000*(afTime-bfTime)))
+        self.updateDocMargins()
 
         if tLine is None:
             self.setCursorPosition(self.nwDocument.theItem.cursorPos)

--- a/sample/sampleNovel/data_1/4298de4d9524_main.nwd
+++ b/sample/sampleNovel/data_1/4298de4d9524_main.nwd
@@ -1,3 +1,4 @@
+%%~ 14298de4d9524:f7e2d9f330615:f6622b4617424:John Smith
 # John Smith
 
 @tag: John

--- a/sample/sampleNovel/data_5/3b69b83cdafc_main.nwd
+++ b/sample/sampleNovel/data_5/3b69b83cdafc_main.nwd
@@ -1,3 +1,4 @@
+%%~ 53b69b83cdafc:7031beac91f75:Title Page
 # My Novel
 
 **By Jane Doh**

--- a/sample/sampleNovel/data_5/eaea4e8cdee8_main.nwd
+++ b/sample/sampleNovel/data_5/eaea4e8cdee8_main.nwd
@@ -1,3 +1,4 @@
+%%~ 5eaea4e8cdee8:15c4492bd5107:Mars
 # Mars
 
 @tag: Mars

--- a/sample/sampleNovel/data_6/36b6aa9b697b_main.nwd
+++ b/sample/sampleNovel/data_6/36b6aa9b697b_main.nwd
@@ -1,3 +1,4 @@
+%%~ 636b6aa9b697b:e7ded148d6e4a:7031beac91f75:Making a Scene
 ### Making a Scene
 
 @pov: Jane

--- a/sample/sampleNovel/data_6/a2d6d5f4f401_main.nwd
+++ b/sample/sampleNovel/data_6/a2d6d5f4f401_main.nwd
@@ -1,3 +1,4 @@
+%%~ 6a2d6d5f4f401:e7ded148d6e4a:7031beac91f75:Chapter One
 ## So it Begins
 
 @pov: Jane

--- a/sample/sampleNovel/data_8/8706ddc78b1b_main.nwd
+++ b/sample/sampleNovel/data_8/8706ddc78b1b_main.nwd
@@ -1,3 +1,4 @@
+%%~ 88706ddc78b1b:e7ded148d6e4a:7031beac91f75:Chapter Two
 ## Where has John Gone?
 
 @pov: Jane

--- a/sample/sampleNovel/data_9/6b68994dfa3d_main.nwd
+++ b/sample/sampleNovel/data_9/6b68994dfa3d_main.nwd
@@ -1,3 +1,4 @@
+%%~ 96b68994dfa3d:e7ded148d6e4a:7031beac91f75:A Note on Structure
 # A Note on Structure
 
 This file is just a note. You can save notes anywhere you like in the project tree. Notes can be filtered out when you export the project.

--- a/sample/sampleNovel/data_a/e7339df26ded_main.nwd
+++ b/sample/sampleNovel/data_a/e7339df26ded_main.nwd
@@ -1,3 +1,4 @@
+%%~ ae7339df26ded:e7ded148d6e4a:7031beac91f75:We Found John!
 ### We Found John!
 
 @pov: John

--- a/sample/sampleNovel/data_b/3e74dbc1f584_main.nwd
+++ b/sample/sampleNovel/data_b/3e74dbc1f584_main.nwd
@@ -1,3 +1,4 @@
+%%~ b3e74dbc1f584:15c4492bd5107:Earth
 # Earth
 
 @tag: Earth

--- a/sample/sampleNovel/data_b/8136a5a774a0_main.nwd
+++ b/sample/sampleNovel/data_b/8136a5a774a0_main.nwd
@@ -1,3 +1,4 @@
+%%~ b8136a5a774a0:98acd8c76c93a:Delete Me!
 ### Delete Me!
 
 This scene is trash.

--- a/sample/sampleNovel/data_b/a8a28a246524_main.nwd
+++ b/sample/sampleNovel/data_b/a8a28a246524_main.nwd
@@ -1,3 +1,4 @@
+%%~ ba8a28a246524:e7ded148d6e4a:7031beac91f75:Interlude
 ## Interlude
 
 % Notice that this is a file with the flag ‘N.Un’. The ‘N’ means it’s a novel file, and the ‘Un’ means it’s an unnumbered chapter. Unnumbered chapters can be treated separately from numbered chapters during export. Perfect for when you want to add an interlude, or for a prologue or epilogue.

--- a/sample/sampleNovel/data_b/b2c23b3c42cc_main.nwd
+++ b/sample/sampleNovel/data_b/b2c23b3c42cc_main.nwd
@@ -1,3 +1,4 @@
+%%~ bb2c23b3c42cc:f7e2d9f330615:f6622b4617424:Jane Smith
 # Jane Smith
 
 @tag: Jane

--- a/sample/sampleNovel/data_b/c0cbd2a407f3_main.nwd
+++ b/sample/sampleNovel/data_b/c0cbd2a407f3_main.nwd
@@ -1,3 +1,4 @@
+%%~ bc0cbd2a407f3:e7ded148d6e4a:7031beac91f75:Another Scene
 ### Another Scene
 
 @pov: John

--- a/sample/sampleNovel/data_f/1471bef9f2ae_main.nwd
+++ b/sample/sampleNovel/data_f/1471bef9f2ae_main.nwd
@@ -1,3 +1,4 @@
+%%~ f1471bef9f2ae:15c4492bd5107:Space
 # Space
 
 @tag: Space

--- a/sample/sampleNovel/nwProject.nwx
+++ b/sample/sampleNovel/nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.4.5" fileVersion="1.0" saveCount="52" autoCount="8" timeStamp="2020-04-26 18:05:45">
+<novelWriterXML appVersion="0.4.5" fileVersion="1.0" saveCount="122" autoCount="15" timeStamp="2020-05-08 22:47:59">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
@@ -10,9 +10,9 @@
   <settings>
     <spellCheck>True</spellCheck>
     <autoOutline>True</autoOutline>
-    <lastEdited>6a2d6d5f4f401</lastEdited>
+    <lastEdited>636b6aa9b697b</lastEdited>
     <lastViewed>b3e74dbc1f584</lastViewed>
-    <lastWordCount>869</lastWordCount>
+    <lastWordCount>875</lastWordCount>
     <autoReplace>
       <A>B</A>
       <B>E</B>
@@ -83,7 +83,7 @@
       <charCount>1199</charCount>
       <wordCount>216</wordCount>
       <paraCount>7</paraCount>
-      <cursorPos>950</cursorPos>
+      <cursorPos>0</cursorPos>
     </item>
     <item handle="bc0cbd2a407f3" order="2" parent="e7ded148d6e4a">
       <name>Another Scene</name>
@@ -240,9 +240,9 @@
       <status>New</status>
       <expanded>False</expanded>
       <layout>SCENE</layout>
-      <charCount>0</charCount>
-      <wordCount>0</wordCount>
-      <paraCount>0</paraCount>
+      <charCount>30</charCount>
+      <wordCount>6</wordCount>
+      <paraCount>1</paraCount>
       <cursorPos>36</cursorPos>
     </item>
   </content>

--- a/tests/reference/gui/1_1489056e0916_main.nwd
+++ b/tests/reference/gui/1_1489056e0916_main.nwd
@@ -1,3 +1,4 @@
+%%~ 31489056e0916:25fc0e7096fc6:73475cb40a568:New Scene
 # Novel
 
 ## Chapter

--- a/tests/reference/gui/1_8010bd9270f9_main.nwd
+++ b/tests/reference/gui/1_8010bd9270f9_main.nwd
@@ -1,3 +1,4 @@
+%%~ 98010bd9270f9:44cb730c42048:New File
 # Jane Doe
 
 @tag: Jane

--- a/tests/reference/gui/1_a6562590ef19_main.nwd
+++ b/tests/reference/gui/1_a6562590ef19_main.nwd
@@ -1,3 +1,4 @@
+%%~ 1a6562590ef19:811786ad1ae74:New File
 # Main Location
 
 @tag: Home

--- a/tests/reference/gui/1_e17daca5f3e1_main.nwd
+++ b/tests/reference/gui/1_e17daca5f3e1_main.nwd
@@ -1,3 +1,4 @@
+%%~ 0e17daca5f3e1:71ee45a3c0db9:New File
 # Main Plot
 
 @tag: MainPlot


### PR DESCRIPTION
This PR adds a single line of meta data at the top of document files. The document class itself handles this internally, and it is stripped before any text is returned. None of the rest of the code will ever see this line. It is buffered in the docMeta variable.

Currently it isn't used for anything, but it can be used for recovering orphaned files. Mainly, it is useful to see where a file inside the project folder belongs in the project tree if one were to browse those files.

This PR also fixes a minor bug with recognising the trash folder that was introduced in one of the recent PRs, and a GUI bug with dynamic margins being ignored when a file is loaded. Neither were critical bugs.