### PR TITLE
Bugfix: Text of large document not always visible in editor

### DIFF
--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -937,10 +937,12 @@ class NWProject():
         for oHandle in orphanFiles:
 
             # Look for meta data
+            oName = ""
             if aDoc.openDocument(oHandle, showStatus=False, isOrphan=True):
                 oName, oPath = aDoc.getMeta()
                 aDoc.clearDocument()
-            else:
+
+            if oName == "":
                 nOrph += 1
                 oName = "Orphaned File %d" % nOrph
 

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -59,9 +59,10 @@ class GuiConfigEditor(QDialog):
 
         self.setWindowTitle("Preferences")
         self.guiDeco = self.theParent.theTheme.loadDecoration("settings", (64,64))
+        self.outerBox.setSpacing(16)
+
         self.outerBox.addWidget(self.guiDeco, 0, Qt.AlignTop)
         self.outerBox.addLayout(self.innerBox)
-        self.outerBox.setSpacing(16)
         self.setLayout(self.outerBox)
 
         self.tabGeneral = GuiConfigEditGeneralTab(self.theParent)

--- a/nw/gui/dialogs/itemeditor.py
+++ b/nw/gui/dialogs/itemeditor.py
@@ -54,15 +54,11 @@ class GuiItemEditor(QDialog):
         self.innerBox = QVBoxLayout()
 
         self.setWindowTitle("Item Settings")
-        self.guiDeco = QLabel()
-        self.guiDeco.setPixmap(
-            self.theParent.theTheme.getPixmap(
-                nwLabels.CLASS_ICON[self.theItem.itemClass], (64,64)
-            )
-        )
+        self.guiDeco = self.theParent.theTheme.loadDecoration("settings", (64,64))
+        self.outerBox.setSpacing(16)
+
         self.outerBox.addWidget(self.guiDeco, 0, Qt.AlignTop)
         self.outerBox.addLayout(self.innerBox)
-        self.outerBox.setSpacing(16)
         self.setLayout(self.outerBox)
 
         self.mainGroup = QGroupBox("Item Settings")

--- a/nw/gui/dialogs/projecteditor.py
+++ b/nw/gui/dialogs/projecteditor.py
@@ -56,13 +56,11 @@ class GuiProjectEditor(QDialog):
         self.innerBox = QVBoxLayout()
 
         self.setWindowTitle("Project Settings")
-        self.guiDeco = QLabel()
-        self.guiDeco.setPixmap(
-            self.theParent.theTheme.getPixmap("cls_novel", (64,64))
-        )
+        self.guiDeco = self.theParent.theTheme.loadDecoration("settings", (64,64))
+        self.outerBox.setSpacing(16)
+
         self.outerBox.addWidget(self.guiDeco, 0, Qt.AlignTop)
         self.outerBox.addLayout(self.innerBox)
-        self.outerBox.setSpacing(16)
         self.setLayout(self.outerBox)
 
         self.theProject.countStatus()

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -289,7 +289,9 @@ class GuiDocEditor(QTextEdit):
         return
 
     def saveText(self):
-
+        """Save the text currently in the editor to the NWDoc object,
+        and update the NWItem meta data.
+        """
         if self.nwDocument.theItem is None:
             return False
 
@@ -348,7 +350,11 @@ class GuiDocEditor(QTextEdit):
         self.qDocument.blockSignals(True)
         self.qDocument.rootFrame().setFrameFormat(docFormat)
         self.qDocument.blockSignals(False)
-        self.qDocument.contentsChange.emit(0,0,0)
+
+        # The line below causes issues with large documents as it
+        # triggers an early repaint that seems to only render a part of
+        # the document. Leaving it here as a warning for now.
+        # self.qDocument.contentsChange.emit(0,0,0)
 
         return
 


### PR DESCRIPTION
This PR fixes a bug where only a part of a text file would render in the document editor if the document frame itself changed during loading of the text. The text was still in the buffer, and no damage was done to the file, it just looked truncated.