### PR TITLE
Minor Fixes

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -119,6 +119,7 @@ class Config:
         self.showLineEndings = False
         self.bigDocLimit     = 800
         self.showFullPath    = True
+        self.highlightQuotes = True
 
         self.fmtApostrophe   = nwUnicode.U_RSQUO
         self.fmtSingleQuotes = [nwUnicode.U_LSQUO,nwUnicode.U_RSQUO]
@@ -414,6 +415,9 @@ class Config:
         self.showFullPath = self._parseLine(
             cnfParse, cnfSec, "showfullpath", self.CNF_BOOL, self.showFullPath
         )
+        self.highlightQuotes = self._parseLine(
+            cnfParse, cnfSec, "highlightquotes", self.CNF_BOOL, self.highlightQuotes
+        )
 
         ## Backup
         cnfSec = "Backup"
@@ -504,6 +508,7 @@ class Config:
         cnfParse.set(cnfSec,"showlineendings", str(self.showLineEndings))
         cnfParse.set(cnfSec,"bigdoclimit",     str(self.bigDocLimit))
         cnfParse.set(cnfSec,"showfullpath",    str(self.showFullPath))
+        cnfParse.set(cnfSec,"highlightquotes", str(self.highlightQuotes))
 
         ## Backup
         cnfSec = "Backup"

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -222,6 +222,13 @@ class GuiConfigEditGeneralTab(QWidget):
             self.showFullPath
         )
 
+        self.highlightQuotes = QSwitch()
+        self.highlightQuotes.setChecked(self.mainConf.highlightQuotes)
+        self.mainForm.addRow(
+            "Add highlighting to text in quotes",
+            self.highlightQuotes
+        )
+
         # AutoSave Settings
         # =================
         self.mainForm.addGroupLabel("Automatic Save")
@@ -296,6 +303,7 @@ class GuiConfigEditGeneralTab(QWidget):
         guiIcons        = self.selectIcons.currentData()
         guiDark         = self.preferDarkIcons.isChecked()
         showFullPath    = self.showFullPath.isChecked()
+        highlightQuotes = self.highlightQuotes.isChecked()
         autoSaveDoc     = self.autoSaveDoc.value()
         autoSaveProj    = self.autoSaveProj.value()
         backupPath      = self.backupPath
@@ -311,6 +319,7 @@ class GuiConfigEditGeneralTab(QWidget):
         self.mainConf.guiIcons        = guiIcons
         self.mainConf.guiDark         = guiDark
         self.mainConf.showFullPath    = showFullPath
+        self.mainConf.highlightQuotes = highlightQuotes
         self.mainConf.autoSaveDoc     = autoSaveDoc
         self.mainConf.autoSaveProj    = autoSaveProj
         self.mainConf.backupPath      = backupPath

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -485,6 +485,11 @@ class GuiDocTree(QTreeWidget):
         if tHandle in self.theMap:
             self.clearSelection()
             self.theMap[tHandle].setSelected(True)
+            selItems = self.selectedIndexes()
+            if selItems:
+                self.scrollTo(
+                    selItems[0], QAbstractItemView.PositionAtCenter
+                )
             return True
         return False
 

--- a/nw/gui/tools/dochighlight.py
+++ b/nw/gui/tools/dochighlight.py
@@ -159,22 +159,24 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         ))
 
         # Quoted Strings
-        self.hRules.append((
-            "{:s}(.+?){:s}".format('"','"'), {
-                0 : self.hStyles["dialogue1"],
-            }
-        ))
-        self.hRules.append((
-            "{:s}(.+?){:s}".format(*self.mainConf.fmtDoubleQuotes), {
-                0 : self.hStyles["dialogue2"],
-            }
-        ))
-        self.hRules.append((
-            "{:s}(.+?){:s}".format(*self.mainConf.fmtSingleQuotes), {
-                0 : self.hStyles["dialogue3"],
-            }
-        ))
+        if self.mainConf.highlightQuotes:
+            self.hRules.append((
+                "{:s}(.+?){:s}".format('"','"'), {
+                    0 : self.hStyles["dialogue1"],
+                }
+            ))
+            self.hRules.append((
+                "{:s}(.+?){:s}".format(*self.mainConf.fmtDoubleQuotes), {
+                    0 : self.hStyles["dialogue2"],
+                }
+            ))
+            self.hRules.append((
+                "{:s}(.+?){:s}".format(*self.mainConf.fmtSingleQuotes), {
+                    0 : self.hStyles["dialogue3"],
+                }
+            ))
 
+        # Auto-Replace Tags
         self.hRules.append((
             r"<(\S+?)>", {
                 0 : self.hStyles["replace"],

--- a/tests/reference/novelwriter.conf
+++ b/tests/reference/novelwriter.conf
@@ -1,5 +1,5 @@
 [Main]
-timestamp = 2020-05-01 21:28:25
+timestamp = 2020-05-21 14:52:36
 theme = default
 syntax = default_light
 icons = typicons_grey_light
@@ -40,6 +40,7 @@ showtabsnspaces = False
 showlineendings = False
 bigdoclimit = 800
 showfullpath = True
+highlightquotes = True
 
 [Backup]
 backuppath = 


### PR DESCRIPTION
Two minor changes:
* Clicking the document header selects the file in the project tree, but now it also makes sure the selected item is visible. If the folder it's in is collapsed, it's expanded, and scrolled into view.
* It is now possible to disable syntax highlighting of text in quotes  from the Preferences > General tab.