### PR TITLE
Project Load Dialog Updates

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -288,7 +288,8 @@ class Config:
         return True
 
     def loadConfig(self):
-
+        """Load preferences from file and replace default settings.
+        """
         logger.debug("Loading config file")
         cnfParse = configparser.ConfigParser()
         try:
@@ -453,7 +454,8 @@ class Config:
         return True
 
     def saveConfig(self):
-
+        """Save the current preferences to file.
+        """
         logger.debug("Saving config file")
         cnfParse = configparser.ConfigParser()
 
@@ -546,7 +548,6 @@ class Config:
     def loadRecentCache(self):
         """Load the cache file for recent projects.
         """
-
         if self.dataPath is None:
             return False
 
@@ -587,7 +588,6 @@ class Config:
     def saveRecentCache(self):
         """Save the cache dictionary of recent projects.
         """
-
         if self.dataPath is None:
             return False
 
@@ -617,6 +617,18 @@ class Config:
             "time"  : int(saveTime),
             "words" : int(wordCount),
         }
+        return True
+
+    def removeFromRecentCache(self, thePath):
+        """Trying to remove a path from the recent projects cache.
+        """
+        if thePath in self.recentProj:
+            del self.recentProj[thePath]
+            logger.verbose("Removed recent: %s" % thePath)
+            self.saveRecentCache()
+        else:
+            logger.error("Unknown recent: %s" % thePath)
+            return False
         return True
 
     ##
@@ -737,7 +749,6 @@ class Config:
     def _checkOptionalPackages(self):
         """Cheks if we have the optional packages used by some features.
         """
-
         try:
             import enchant
             self.hasEnchant = True

--- a/nw/gui/dialogs/projectload.py
+++ b/nw/gui/dialogs/projectload.py
@@ -31,9 +31,10 @@ import nw
 from datetime import datetime
 
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QGridLayout, QPushButton, QTreeWidget,
-    QAbstractItemView, QTreeWidgetItem, QDialogButtonBox, QLabel
+    QAbstractItemView, QTreeWidgetItem, QDialogButtonBox, QLabel, QShortcut
 )
 
 from nw.common import formatInt
@@ -119,6 +120,10 @@ class GuiProjectLoad(QDialog):
         self._populateList()
         self._doSelectRecent()
 
+        keyDelete = QShortcut(self.listBox)
+        keyDelete.setKey(QKeySequence(Qt.Key_Delete))
+        keyDelete.activated.connect(self._keyPressDelete)
+
         logger.debug("GuiProjectLoad initialisation complete")
 
         return
@@ -177,6 +182,15 @@ class GuiProjectLoad(QDialog):
         self.openPath = None
         self.openState = self.NEW_STATE
         self.accept()
+        return
+
+    def _keyPressDelete(self):
+        """Remove an entry from the recent projects list.
+        """
+        selList = self.listBox.selectedItems()
+        if selList:
+            self.mainConf.removeFromRecentCache(selList[0].text(3))
+            self._populateList()
         return
 
     ##

--- a/nw/gui/dialogs/projectload.py
+++ b/nw/gui/dialogs/projectload.py
@@ -28,25 +28,27 @@
 import logging
 import nw
 
+from os import path
 from datetime import datetime
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QGridLayout, QPushButton, QTreeWidget,
-    QAbstractItemView, QTreeWidgetItem, QDialogButtonBox, QLabel, QShortcut
+    QAbstractItemView, QTreeWidgetItem, QDialogButtonBox, QLabel, QShortcut,
+    QFileDialog, QLineEdit
 )
 
 from nw.common import formatInt
+from nw.constants import nwFiles
 
 logger = logging.getLogger(__name__)
 
 class GuiProjectLoad(QDialog):
 
-    NONE_STATE   = 0
-    BROWSE_STATE = 1
-    NEW_STATE    = 2
-    OPEN_STATE   = 3
+    NONE_STATE = 0
+    NEW_STATE  = 1
+    OPEN_STATE = 2
 
     def __init__(self, theParent):
         QDialog.__init__(self, theParent)
@@ -88,16 +90,23 @@ class GuiProjectLoad(QDialog):
         treeHead.setTextAlignment(1, Qt.AlignRight)
         treeHead.setTextAlignment(2, Qt.AlignRight)
 
-        self.lblRecent = QLabel("<b>Recently Opened:</b>")
-        self.lblPath   = QLabel("<b>Path:</b>")
-        self.selPath   = QLabel("")
-        self.selPath.setWordWrap(True)
+        self.lblRecent = QLabel("<b>Recently Opened Projects</b>")
+        self.lblPath   = QLabel("<b>Path</b>")
+        self.selPath   = QLineEdit("")
+        self.selPath.setEnabled(False)
 
-        self.projectForm.addWidget(self.lblRecent, 0, 0, 1, 2)
-        self.projectForm.addWidget(self.listBox,   1, 0, 1, 2)
-        self.projectForm.addWidget(self.lblPath,   2, 0, 1, 1, Qt.AlignTop)
-        self.projectForm.addWidget(self.selPath,   2, 1, 1, 1, Qt.AlignTop)
+        self.browseButton = QPushButton("...")
+        self.browseButton.setMaximumWidth(30)
+        self.browseButton.clicked.connect(self._doBrowse)
+
+        self.projectForm.addWidget(self.lblRecent,    0, 0, 1, 3)
+        self.projectForm.addWidget(self.listBox,      1, 0, 1, 3)
+        self.projectForm.addWidget(self.lblPath,      2, 0, 1, 1)
+        self.projectForm.addWidget(self.selPath,      2, 1, 1, 1)
+        self.projectForm.addWidget(self.browseButton, 2, 2, 1, 1)
+        self.projectForm.setColumnStretch(0, 0)
         self.projectForm.setColumnStretch(1, 1)
+        self.projectForm.setColumnStretch(2, 0)
         self.projectForm.setVerticalSpacing(4)
         self.projectForm.setHorizontalSpacing(8)
 
@@ -109,9 +118,6 @@ class GuiProjectLoad(QDialog):
 
         self.newButton = self.buttonBox.addButton("New", QDialogButtonBox.ActionRole)
         self.newButton.clicked.connect(self._doNewProject)
-
-        self.browseButton = self.buttonBox.addButton("Browse", QDialogButtonBox.ActionRole)
-        self.browseButton.clicked.connect(self._doBrowse)
 
         self.outerBox.addLayout(self.innerBox)
         self.outerBox.addWidget(self.buttonBox)
@@ -160,10 +166,20 @@ class GuiProjectLoad(QDialog):
         project browser dialog.
         """
         logger.verbose("GuiProjectLoad browse button clicked")
-        self._saveDialogState()
-        self.openPath = None
-        self.openState = self.BROWSE_STATE
-        self.accept()
+        if self.mainConf.showGUI:
+            dlgOpt  = QFileDialog.Options()
+            dlgOpt |= QFileDialog.DontUseNativeDialog
+            projFile, _ = QFileDialog.getOpenFileName(
+                self, "Open novelWriter Project", "",
+                "novelWriter Project File (%s);;All Files (*)" % nwFiles.PROJ_FILE,
+                options=dlgOpt
+            )
+            if projFile:
+                thePath = path.abspath(path.dirname(projFile))
+                self.selPath.setText(thePath)
+                self.openPath = thePath
+                self.openState = self.OPEN_STATE
+                self.accept()
         return
 
     def _doClose(self):

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -272,7 +272,6 @@ class GuiMain(QMainWindow):
     def newProject(self, projPath=None, forceNew=False):
         """Create new project with a few default files and folders.
         """
-
         if self.hasProject:
             msgBox = QMessageBox()
             msgRes = msgBox.warning(
@@ -734,6 +733,8 @@ class GuiMain(QMainWindow):
         return None
 
     def editConfigDialog(self):
+        """Open the preferences dialog.
+        """
         dlgConf = GuiConfigEditor(self, self.theProject)
         if dlgConf.exec_() == QDialog.Accepted:
             logger.debug("Applying new preferences")
@@ -745,6 +746,8 @@ class GuiMain(QMainWindow):
         return True
 
     def editProjectDialog(self):
+        """Open the project settings dialog.
+        """
         if self.hasProject:
             dlgProj = GuiProjectEditor(self, self.theProject)
             dlgProj.exec_()
@@ -752,12 +755,16 @@ class GuiMain(QMainWindow):
         return True
 
     def buildProjectDialog(self):
+        """Open the build project dialog.
+        """
         if self.hasProject:
             dlgExport = GuiBuildNovel(self, self.theProject)
             dlgExport.exec_()
         return True
 
     def showSessionLogDialog(self):
+        """Open the session log dialog.
+        """
         if self.hasProject:
             dlgTLine = GuiSessionLogView(self, self.theProject)
             dlgTLine.exec_()
@@ -768,7 +775,6 @@ class GuiMain(QMainWindow):
         can be either a string or an array of strings. Severity level is
         0 = info, 1 = warning, and 2 = error.
         """
-
         if isinstance(theMessage, list):
             popMsg = " ".join(theMessage)
             logMsg = theMessage
@@ -812,7 +818,8 @@ class GuiMain(QMainWindow):
     ##
 
     def closeMain(self):
-
+        """Save everything, and close novelWriter.
+        """
         if self.mainConf.showGUI and self.hasProject:
             msgBox = QMessageBox()
             msgRes = msgBox.question(
@@ -865,7 +872,6 @@ class GuiMain(QMainWindow):
         """Main GUI Zen Mode hides tree, view pane and optionally also
         statusbar and menu.
         """
-
         if self.docEditor.theHandle is None:
             logger.error("No document open, so not activating Zen Mode")
             return False
@@ -897,7 +903,6 @@ class GuiMain(QMainWindow):
         if the user uses the system window manager. Currently, Qt
         doesn't have access to the exact state of the window.
         """
-
         self.setWindowState(self.windowState() ^ Qt.WindowFullScreen)
 
         winState = self.windowState() & Qt.WindowFullScreen == Qt.WindowFullScreen

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -264,8 +264,6 @@ class GuiMain(QMainWindow):
         if dlgProj.result() == QDialog.Accepted:
             if dlgProj.openState == GuiProjectLoad.OPEN_STATE:
                 self.openProject(dlgProj.openPath)
-            elif dlgProj.openState == GuiProjectLoad.BROWSE_STATE:
-                self.openProject(dlgProj.openPath)
             elif dlgProj.openState == GuiProjectLoad.NEW_STATE:
                 self.newProject()
 
@@ -354,13 +352,11 @@ class GuiMain(QMainWindow):
 
         return saveOK
 
-    def openProject(self, projFile=None):
+    def openProject(self, projFile):
         """Open a project. The parameter projFile is passed from the
-        open recent projects menu, so it can be set. If not, we pop the
-        dialog.
+        open recent projects menu, and must be set to be forwarded to
+        the project class. Otherwise, we just return.
         """
-        if projFile is None:
-            projFile = self.openProjectDialog()
         if projFile is None:
             return False
 
@@ -484,6 +480,8 @@ class GuiMain(QMainWindow):
         return True
 
     def saveDocument(self):
+        """Save the current documents.
+        """
         if self.hasProject:
             self.docEditor.saveText()
         return True
@@ -491,7 +489,6 @@ class GuiMain(QMainWindow):
     def viewDocument(self, tHandle=None):
         """Load a document for viewing in the view panel.
         """
-
         if tHandle is None:
             tHandle = self.treeView.getSelectedHandle()
         if tHandle is None:
@@ -521,7 +518,6 @@ class GuiMain(QMainWindow):
         """Import the text contained in an out-of-project text file, and
         insert the text into the currently open document.
         """
-
         lastPath = self.mainConf.lastPath
 
         extFilter = [
@@ -610,6 +606,8 @@ class GuiMain(QMainWindow):
     ##
 
     def openSelectedItem(self):
+        """Open the selected documents.
+        """
         tHandle = self.treeView.getSelectedHandle()
         if tHandle is None:
             logger.warning("No item selected")
@@ -626,6 +624,8 @@ class GuiMain(QMainWindow):
         return True
 
     def editItem(self):
+        """Open the edit item dialog.
+        """
         tHandle = self.treeView.getSelectedHandle()
         if tHandle is None:
             logger.warning("No item selected")
@@ -654,7 +654,6 @@ class GuiMain(QMainWindow):
     def rebuildIndex(self):
         """Rebuild the entire index.
         """
-
         if not self.hasProject:
             return False
 
@@ -708,19 +707,9 @@ class GuiMain(QMainWindow):
     #  Main Dialogs
     ##
 
-    def openProjectDialog(self):
-        dlgOpt  = QFileDialog.Options()
-        dlgOpt |= QFileDialog.DontUseNativeDialog
-        projFile, _ = QFileDialog.getOpenFileName(
-            self, "Open novelWriter Project", "",
-            "novelWriter Project File (%s);;All Files (*)" % nwFiles.PROJ_FILE,
-            options=dlgOpt
-        )
-        if projFile:
-            return projFile
-        return None
-
     def saveProjectDialog(self):
+        """Select where to save project.
+        """
         dlgOpt  = QFileDialog.Options()
         dlgOpt |= QFileDialog.ShowDirsOnly
         dlgOpt |= QFileDialog.DontUseNativeDialog
@@ -732,6 +721,8 @@ class GuiMain(QMainWindow):
         return None
 
     def newProjectDialog(self):
+        """Select where to save new project.
+        """
         dlgOpt  = QFileDialog.Options()
         dlgOpt |= QFileDialog.ShowDirsOnly
         dlgOpt |= QFileDialog.DontUseNativeDialog


### PR DESCRIPTION
Some minor improvements to the Load project dialog:
* Entries in the recent projects list can be deleted with the delete key.
* The browse button now sits after the path box, and is run locally in the dialog, not in the main GUI. The benefit is only that if the cancel button is pressed in the browse dialog, we return to the Project Load dialog, not the main window.
* The selected path box is now a QLineEdit, not a QLabel. It looks more reasonable, and we avoid having to consider word wrapping.