### PR TITLE
Fixed sorting bug for line numbers in index

### DIFF
--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -354,7 +354,7 @@ class NWIndex():
         else:
             return False
 
-        sTitle = "T%d" % nLine
+        sTitle = "T%06d" % nLine
         self.refIndex[tHandle][sTitle] = {
             "tags"    : [],
             "updated" : time(),
@@ -384,7 +384,7 @@ class NWIndex():
         """Count text stats and save the counts to the index.
         """
         cC, wC, pC = countWords(theText)
-        sTitle = "T%d" % nTitle
+        sTitle = "T%06d" % nTitle
         if isNovel:
             if tHandle in self.novelIndex:
                 if sTitle in self.novelIndex[tHandle]:
@@ -404,7 +404,7 @@ class NWIndex():
     def _indexSynopsis(self, tHandle, isNovel, theText, nTitle):
         """Save the synopsis to the index.
         """
-        sTitle = "T%d" % nTitle
+        sTitle = "T%06d" % nTitle
         if isNovel:
             if tHandle in self.novelIndex:
                 if sTitle in self.novelIndex[tHandle]:
@@ -425,7 +425,7 @@ class NWIndex():
         if not isValid or len(theBits) == 0:
             return False
 
-        sTitle = "T%d" % nTitle
+        sTitle = "T%06d" % nTitle
         if sTitle not in self.refIndex[tHandle]:
             logger.error("Cannot save tags to file %s, no title %s" % (tHandle, sTitle))
             return False

--- a/nw/gui/elements/outline.py
+++ b/nw/gui/elements/outline.py
@@ -408,7 +408,7 @@ class GuiProjectOutline(QTreeWidget):
         newItem.setText(self.colIndex[nwOutline.HANDLE], tHandle)
         newItem.setText(self.colIndex[nwOutline.LEVEL],  novIdx["level"])
         newItem.setText(self.colIndex[nwOutline.LABEL],  nwItem.itemName)
-        newItem.setText(self.colIndex[nwOutline.LINE],   sTitle[1:])
+        newItem.setText(self.colIndex[nwOutline.LINE],   sTitle[1:].lstrip("0"))
         newItem.setText(self.colIndex[nwOutline.SYNOP],  novIdx["synopsis"])
         newItem.setText(self.colIndex[nwOutline.CCOUNT], str(novIdx["cCount"]))
         newItem.setText(self.colIndex[nwOutline.WCOUNT], str(novIdx["wCount"]))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -156,7 +156,7 @@ def testIndexCheckThese(nwTempProj):
         "@pov: Jane"
     ))
     assert str(theIndex.tagIndex) == "{'Jane': [2, '2858dcd1057d3', 'CHARACTER']}"
-    assert theIndex.novelIndex[nHandle]["T1"]["title"] == "Hello World!"
+    assert theIndex.novelIndex[nHandle]["T000001"]["title"] == "Hello World!"
 
     assert str(theIndex.checkThese(["@tag",  "Jane"], cItem)) == "[True, True]"
     assert str(theIndex.checkThese(["@tag",  "John"], cItem)) == "[True, True]"
@@ -196,10 +196,10 @@ def testIndexMeta(nwTempProj):
         "Well, not really.\n"
     ))
     assert str(theIndex.tagIndex) == "{'Jane': [2, '2858dcd1057d3', 'CHARACTER']}"
-    assert theIndex.novelIndex[nHandle]["T1"]["title"] == "Hello World!"
+    assert theIndex.novelIndex[nHandle]["T000001"]["title"] == "Hello World!"
 
     # The novel structure should contain the pointer to the novel file header
-    assert str(theIndex.getNovelStructure()) == "['41cfc0d1f2d12:T1']"
+    assert str(theIndex.getNovelStructure()) == "['41cfc0d1f2d12:T000001']"
 
     # The novel file should have the correct counts
     cC, wC, pC = theIndex.getCounts(nHandle)


### PR DESCRIPTION
With multiple headings in a file, the structure of the file sent to the Outline panel would be sorted with the text value of line numbers, like: "1", "10", "2", "21", etc. The simple fix is to just format these line keys with leading zeroes.