### PR TITLE
Document Margins and DocTitle Bar

### DIFF
--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -85,7 +85,8 @@ class GuiDocEditor(QTextEdit):
 
         # Document Title
         self.docTitle = GuiDocTitleBar(self, self.theProject)
-        self.docTitle.setGeometry(0,0,self.docTitle.width(),self.docTitle.height())
+        self.docTitle.setGeometry(0, 0, self.docTitle.width(), self.docTitle.height())
+        self.setViewportMargins(0, self.docTitle.height(), 0, 0)
 
         # Syntax
         self.hLight = GuiDocHighlighter(self.qDocument, self.theParent)
@@ -336,13 +337,17 @@ class GuiDocEditor(QTextEdit):
         tB = self.lineWidth()
         tW = self.width() - 2*tB
         tH = self.docTitle.height()
+        tT = tM - tH
         self.docTitle.setGeometry(tB, tB, tW, tH)
+        self.setViewportMargins(0, tH, 0, 0)
 
         docFormat = self.qDocument.rootFrame().frameFormat()
         docFormat.setLeftMargin(tM)
         docFormat.setRightMargin(tM)
-        if docFormat.topMargin() < tH:
-            docFormat.setTopMargin(tH + 2)
+        if tT > 0:
+            docFormat.setTopMargin(tT)
+        else:
+            docFormat.setTopMargin(0)
 
         # Updating root frame triggers a QTextDocument->contentsChange
         # signal, which we do not want as it re-runs the syntax

--- a/nw/gui/elements/docviewer.py
+++ b/nw/gui/elements/docviewer.py
@@ -59,7 +59,8 @@ class GuiDocViewer(QTextBrowser):
 
         # Document Title
         self.docTitle = GuiDocTitleBar(self, self.theProject)
-        self.docTitle.setGeometry(0,0,self.docTitle.width(),self.docTitle.height())
+        self.docTitle.setGeometry(0, 0, self.docTitle.width(), self.docTitle.height())
+        self.setViewportMargins(0, self.docTitle.height(), 0, 0)
 
         theOpt = QTextOption()
         if self.mainConf.doJustify:
@@ -218,11 +219,19 @@ class GuiDocViewer(QTextBrowser):
         tB = self.lineWidth()
         tW = self.width() - 2*tB
         tH = self.docTitle.height()
+        tT = self.mainConf.textMargin - tH
         self.docTitle.setGeometry(tB, tB, tW, tH)
+        self.setViewportMargins(0, tH, 0, 0)
 
         docFormat = self.qDocument.rootFrame().frameFormat()
-        if docFormat.topMargin() < tH:
-            docFormat.setTopMargin(tH + 2)
+        if tT > 0:
+            docFormat.setTopMargin(tT)
+        else:
+            docFormat.setTopMargin(0)
+
+        self.qDocument.blockSignals(True)
+        self.qDocument.rootFrame().setFrameFormat(docFormat)
+        self.qDocument.blockSignals(False)
 
         return
 


### PR DESCRIPTION
The text of the document editor and viewer flows underneath the document title bar, but the margin is always kept larger than the bar, so it generally isn't a problem, but when the text is scrolled by code, it doesn't considered this hidden area. This PR adjusts the viewport margin to accomodate the title bar, meaning no part of the document is behind the title bar.