### PR TITLE
Fix Qt 5.5 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Not Yet Released
 
+**Bugfixes**
+
+* Fixed an issue with the Build Novel Project tool on Ubuntu 16.04 LTS where the dialog wouldn't open. PR #246.
+
 **User Interface**
 
 * Renamed the "Generate Preview" button on the "Build Novel Project" tool to "Build Novel Project". You must actually click this to be able to export or print. Issue #237, PR #238.
 * Added font family and font size selectors to the "Build Novel Project" tool. You may want a different print font than used in the editor itself. Issue #230, PR #238.
 * A margin of the viewport (outside the document) has been added to the document editor and viewer to make room for the document title bar. Previously, the title bar would sit on top of the document top margin, which would sometimes hide text that would otherwise be visible. PR #236.
-
 
 ## Version 0.6.1 [2020-05-25]
 

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -254,28 +254,28 @@ class GuiBuildNovel(QDialog):
         self.saveMenu = QMenu(self)
         self.btnSave.setMenu(self.saveMenu)
 
-        self.saveODT = QAction("Open Document (.odt)")
+        self.saveODT = QAction("Open Document (.odt)", self)
         self.saveODT.triggered.connect(lambda: self._saveDocument(self.FMT_ODT))
         self.saveMenu.addAction(self.saveODT)
 
-        self.savePDF = QAction("Portable Document Format (.pdf)")
+        self.savePDF = QAction("Portable Document Format (.pdf)", self)
         self.savePDF.triggered.connect(lambda: self._saveDocument(self.FMT_PDF))
         self.saveMenu.addAction(self.savePDF)
 
-        self.saveHTM = QAction("%s HTML (.htm)" % nw.__package__)
+        self.saveHTM = QAction("%s HTML (.htm)" % nw.__package__, self)
         self.saveHTM.triggered.connect(lambda: self._saveDocument(self.FMT_HTM))
         self.saveMenu.addAction(self.saveHTM)
 
         if self.mainConf.verQtValue >= 51400:
-            self.saveMD = QAction("Markdown (.md)")
+            self.saveMD = QAction("Markdown (.md)", self)
             self.saveMD.triggered.connect(lambda: self._saveDocument(self.FMT_MD))
             self.saveMenu.addAction(self.saveMD)
 
-        self.saveNWD = QAction("novelWriter Markdown (.nwd)")
+        self.saveNWD = QAction("novelWriter Markdown (.nwd)", self)
         self.saveNWD.triggered.connect(lambda: self._saveDocument(self.FMT_NWD))
         self.saveMenu.addAction(self.saveNWD)
 
-        self.saveTXT = QAction("Plain Text (.txt)")
+        self.saveTXT = QAction("Plain Text (.txt)", self)
         self.saveTXT.triggered.connect(lambda: self._saveDocument(self.FMT_TXT))
         self.saveMenu.addAction(self.saveTXT)
 


### PR DESCRIPTION
QAction must have a parent set before Qt 5.7. This PR fixes this so we're again compatible with Ubuntu 16.04 LTS. This fixes Issue #243.