### PR TITLE
Fixes

### DIFF
--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -183,10 +183,11 @@ class nwQuotes():
 # END Class nwQuotes
 
 class nwUnicode:
-    """Suppoted unicode character constants and translation maps.
+    """Suppoted unicode character constants and translation maps for HTML.
     """
 
     # Unicode Constants
+    # =================
 
     ## Quotation Marks
     U_QUOT   = "\u0022" # Quotation mark
@@ -216,7 +217,6 @@ class nwUnicode:
 
     ## Other
     U_NBSP   = "\u00a0" # Non-breaking space
-    U_PARA   = "\u2029" # Paragraph separator
     U_CHECK  = "\u2714" # Heavy check mark
     U_MULT   = "\u2715" # Multiplication x
 
@@ -231,6 +231,7 @@ class nwUnicode:
     U_LTRIS  = "\u25c2" # Left-pointing triangle, small
 
     # HTML Equivalents
+    # ================
 
     ## Quotes
     H_QUOT   = "&quot;"

--- a/nw/gui/dialogs/configeditor.py
+++ b/nw/gui/dialogs/configeditor.py
@@ -573,7 +573,7 @@ class GuiConfigEditEditingTab(QWidget):
             "Big document limit",
             self.bigDocLimit,
             "Disables full spell checking over the size limit.",
-            theUnit="kb"
+            theUnit="kB"
         )
 
         return

--- a/nw/gui/elements/doceditor.py
+++ b/nw/gui/elements/doceditor.py
@@ -391,9 +391,13 @@ class GuiDocEditor(QTextEdit):
         uses QTextEdit->toPlainText for Qt versions lower than 5.9, and
         the QDocument->toRawText for higher version. The latter
         preserves non-breaking spaces, which the former does not.
+        We still want to get rid of page and line separators though.
+        See: https://doc.qt.io/qt-5/qtextdocument.html#toPlainText
         """
         if self.mainConf.verQtValue >= 50900:
-            theText = self.qDocument.toRawText().replace(nwUnicode.U_PARA,"\n")
+            theText = self.qDocument.toRawText()
+            theText = theText.replace("\u2028", "\n") # Line separators
+            theText = theText.replace("\u2029", "\n") # Paragraph separators
         else:
             theText = self.toPlainText()
         return theText


### PR DESCRIPTION
Two minor fixes:

* Preferences big document limit unit is `kB` not `kb`. Issue #258 
* When extracting text from the document editor, also line separators should be replaced with newline characters, as per the QTextEdit documentation.