### PR TITLE
Export Icon Column

### DIFF
--- a/nw/assets/icons/fallback/check-dark.svg
+++ b/nw/assets/icons/fallback/check-dark.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="tick.svg"
+   id="svg896"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata902">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs900" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg896"
+     inkscape:window-maximized="1"
+     inkscape:window-y="1"
+     inkscape:window-x="2560"
+     inkscape:cy="13.298248"
+     inkscape:cx="11.288366"
+     inkscape:zoom="34.117902"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview898"
+     inkscape:window-height="1370"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="stroke-width:1.3846;fill:#aeaeae;fill-opacity:1"
+     id="path894"
+     d="M 19.576035,3.3487939 C 18.237131,2.6038813 16.550693,3.0884898 15.809935,4.4246248 L 10.66893,13.676495 7.726664,10.734229 c -1.0813694,-1.0813704 -2.8342677,-1.0813704 -3.9156371,0 -1.0813693,1.081369 -1.0813693,2.834267 0,3.915637 l 5.538383,5.538383 c 0.523378,0.524762 1.2295221,0.812758 1.9578191,0.812758 l 0.383533,-0.02769 c 0.859834,-0.12046 1.614439,-0.636914 2.03674,-1.397057 L 20.650482,7.1148966 C 21.39401,5.777375 20.91217,4.0923218 19.576035,3.3487939 Z" />
+</svg>

--- a/nw/assets/icons/fallback/check.svg
+++ b/nw/assets/icons/fallback/check.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="tick.svg"
+   id="svg896"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata902">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs900" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg896"
+     inkscape:window-maximized="1"
+     inkscape:window-y="1"
+     inkscape:window-x="2560"
+     inkscape:cy="13.298248"
+     inkscape:cx="11.288366"
+     inkscape:zoom="34.117902"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview898"
+     inkscape:window-height="1370"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="stroke-width:1.3846;fill:#000000;fill-opacity:0.77999997"
+     id="path894"
+     d="M 19.576035,3.3487939 C 18.237131,2.6038813 16.550693,3.0884898 15.809935,4.4246248 L 10.66893,13.676495 7.726664,10.734229 c -1.0813694,-1.0813704 -2.8342677,-1.0813704 -3.9156371,0 -1.0813693,1.081369 -1.0813693,2.834267 0,3.915637 l 5.538383,5.538383 c 0.523378,0.524762 1.2295221,0.812758 1.9578191,0.812758 l 0.383533,-0.02769 c 0.859834,-0.12046 1.614439,-0.636914 2.03674,-1.397057 L 20.650482,7.1148966 C 21.39401,5.777375 20.91217,4.0923218 19.576035,3.3487939 Z" />
+</svg>

--- a/nw/assets/icons/fallback/cross-dark.svg
+++ b/nw/assets/icons/fallback/cross-dark.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.2"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg8936"
+   sodipodi:docname="times.svg"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)">
+  <metadata
+     id="metadata8942">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8940" />
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1344"
+     id="namedview8938"
+     showgrid="false"
+     inkscape:zoom="38.125"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8936" />
+  <path
+     d="m 19.0412,4.9586375 c -1.014432,-1.0157327 -2.663535,-1.0157327 -3.677967,0 L 12.000001,8.3218703 8.6367669,4.9586375 c -1.0144323,-1.0157327 -2.663535,-1.0157327 -3.6779673,0 -1.0157327,1.0157328 -1.0157327,2.6622343 0,3.6779673 L 8.3207319,11.999838 4.9587996,15.36307 c -1.0157327,1.015733 -1.0157327,2.662235 0,3.677968 0.5072161,0.508516 1.1730998,0.762124 1.8389836,0.762124 0.6658835,0 1.3317669,-0.253608 1.8389837,-0.762124 l 3.3632341,-3.363233 3.363232,3.363233 c 0.507216,0.508516 1.173099,0.762124 1.838984,0.762124 0.665882,0 1.331765,-0.253608 1.838983,-0.762124 1.015733,-1.015733 1.015733,-2.662235 0,-3.677968 L 15.679268,11.999838 19.0412,8.6366048 c 1.015733,-1.015733 1.015733,-2.6622345 0,-3.6779673 z"
+     id="path8934"
+     inkscape:connector-curvature="0"
+     style="fill:#aeaeae;fill-opacity:1;stroke-width:1.30056" />
+</svg>

--- a/nw/assets/icons/fallback/cross.svg
+++ b/nw/assets/icons/fallback/cross.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   sodipodi:docname="times.svg"
+   id="svg8936"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8942">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8940" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg8936"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="12"
+     inkscape:cx="12"
+     inkscape:zoom="38.125"
+     showgrid="false"
+     id="namedview8938"
+     inkscape:window-height="1344"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#000000;fill-opacity:0.78;stroke-width:1.30056"
+     inkscape:connector-curvature="0"
+     id="path8934"
+     d="m 19.0412,4.9586375 c -1.014432,-1.0157327 -2.663535,-1.0157327 -3.677967,0 L 12.000001,8.3218703 8.6367669,4.9586375 c -1.0144323,-1.0157327 -2.663535,-1.0157327 -3.6779673,0 -1.0157327,1.0157328 -1.0157327,2.6622343 0,3.6779673 L 8.3207319,11.999838 4.9587996,15.36307 c -1.0157327,1.015733 -1.0157327,2.662235 0,3.677968 0.5072161,0.508516 1.1730998,0.762124 1.8389836,0.762124 0.6658835,0 1.3317669,-0.253608 1.8389837,-0.762124 l 3.3632341,-3.363233 3.363232,3.363233 c 0.507216,0.508516 1.173099,0.762124 1.838984,0.762124 0.665882,0 1.331765,-0.253608 1.838983,-0.762124 1.015733,-1.015733 1.015733,-2.662235 0,-3.677968 L 15.679268,11.999838 19.0412,8.6366048 c 1.015733,-1.015733 1.015733,-2.6622345 0,-3.6779673 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_dark/icons.conf
+++ b/nw/assets/icons/typicons_colour_dark/icons.conf
@@ -37,3 +37,5 @@ search-replace = search-replace.svg
 clear          = backspace.svg
 save           = download.svg
 edit           = pencil.svg
+check          = tick.svg
+cross          = times.svg

--- a/nw/assets/icons/typicons_colour_dark/tick.svg
+++ b/nw/assets/icons/typicons_colour_dark/tick.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="tick.svg"
+   id="svg896"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata902">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs900" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg896"
+     inkscape:window-maximized="1"
+     inkscape:window-y="1"
+     inkscape:window-x="2560"
+     inkscape:cy="13.298248"
+     inkscape:cx="11.288366"
+     inkscape:zoom="34.117902"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview898"
+     inkscape:window-height="1370"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="stroke-width:1.3846;fill:#99cc99;fill-opacity:1"
+     id="path894"
+     d="M 19.576035,3.3487939 C 18.237131,2.6038813 16.550693,3.0884898 15.809935,4.4246248 L 10.66893,13.676495 7.726664,10.734229 c -1.0813694,-1.0813704 -2.8342677,-1.0813704 -3.9156371,0 -1.0813693,1.081369 -1.0813693,2.834267 0,3.915637 l 5.538383,5.538383 c 0.523378,0.524762 1.2295221,0.812758 1.9578191,0.812758 l 0.383533,-0.02769 c 0.859834,-0.12046 1.614439,-0.636914 2.03674,-1.397057 L 20.650482,7.1148966 C 21.39401,5.777375 20.91217,4.0923218 19.576035,3.3487939 Z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_light/icons.conf
+++ b/nw/assets/icons/typicons_colour_light/icons.conf
@@ -37,3 +37,5 @@ search-replace = search-replace.svg
 clear          = backspace.svg
 save           = download.svg
 edit           = pencil.svg
+check          = tick.svg
+cross          = times.svg

--- a/nw/assets/icons/typicons_colour_light/tick.svg
+++ b/nw/assets/icons/typicons_colour_light/tick.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="tick.svg"
+   id="svg896"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata902">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs900" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg896"
+     inkscape:window-maximized="1"
+     inkscape:window-y="1"
+     inkscape:window-x="2560"
+     inkscape:cy="13.298248"
+     inkscape:cx="11.288366"
+     inkscape:zoom="34.117902"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview898"
+     inkscape:window-height="1370"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="stroke-width:1.3846;fill:#718c00;fill-opacity:1"
+     id="path894"
+     d="M 19.576035,3.3487939 C 18.237131,2.6038813 16.550693,3.0884898 15.809935,4.4246248 L 10.66893,13.676495 7.726664,10.734229 c -1.0813694,-1.0813704 -2.8342677,-1.0813704 -3.9156371,0 -1.0813693,1.081369 -1.0813693,2.834267 0,3.915637 l 5.538383,5.538383 c 0.523378,0.524762 1.2295221,0.812758 1.9578191,0.812758 l 0.383533,-0.02769 c 0.859834,-0.12046 1.614439,-0.636914 2.03674,-1.397057 L 20.650482,7.1148966 C 21.39401,5.777375 20.91217,4.0923218 19.576035,3.3487939 Z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_dark/icons.conf
+++ b/nw/assets/icons/typicons_grey_dark/icons.conf
@@ -36,3 +36,5 @@ search-replace = search-replace.svg
 clear          = backspace.svg
 save           = download.svg
 edit           = pencil.svg
+check          = tick.svg
+cross          = times.svg

--- a/nw/assets/icons/typicons_grey_dark/tick.svg
+++ b/nw/assets/icons/typicons_grey_dark/tick.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="tick.svg"
+   id="svg896"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata902">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs900" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg896"
+     inkscape:window-maximized="1"
+     inkscape:window-y="1"
+     inkscape:window-x="2560"
+     inkscape:cy="13.298248"
+     inkscape:cx="11.288366"
+     inkscape:zoom="34.117902"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview898"
+     inkscape:window-height="1370"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="stroke-width:1.3846;fill:#aeaeae;fill-opacity:1"
+     id="path894"
+     d="M 19.576035,3.3487939 C 18.237131,2.6038813 16.550693,3.0884898 15.809935,4.4246248 L 10.66893,13.676495 7.726664,10.734229 c -1.0813694,-1.0813704 -2.8342677,-1.0813704 -3.9156371,0 -1.0813693,1.081369 -1.0813693,2.834267 0,3.915637 l 5.538383,5.538383 c 0.523378,0.524762 1.2295221,0.812758 1.9578191,0.812758 l 0.383533,-0.02769 c 0.859834,-0.12046 1.614439,-0.636914 2.03674,-1.397057 L 20.650482,7.1148966 C 21.39401,5.777375 20.91217,4.0923218 19.576035,3.3487939 Z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_light/icons.conf
+++ b/nw/assets/icons/typicons_grey_light/icons.conf
@@ -36,3 +36,5 @@ search-replace = search-replace.svg
 clear          = backspace.svg
 save           = download.svg
 edit           = pencil.svg
+check          = tick.svg
+cross          = times.svg

--- a/nw/assets/icons/typicons_grey_light/tick.svg
+++ b/nw/assets/icons/typicons_grey_light/tick.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="tick.svg"
+   id="svg896"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata902">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs900" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg896"
+     inkscape:window-maximized="1"
+     inkscape:window-y="1"
+     inkscape:window-x="2560"
+     inkscape:cy="13.298248"
+     inkscape:cx="11.288366"
+     inkscape:zoom="34.117902"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview898"
+     inkscape:window-height="1370"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="stroke-width:1.3846;fill:#000000;fill-opacity:0.77999997"
+     id="path894"
+     d="M 19.576035,3.3487939 C 18.237131,2.6038813 16.550693,3.0884898 15.809935,4.4246248 L 10.66893,13.676495 7.726664,10.734229 c -1.0813694,-1.0813704 -2.8342677,-1.0813704 -3.9156371,0 -1.0813693,1.081369 -1.0813693,2.834267 0,3.915637 l 5.538383,5.538383 c 0.523378,0.524762 1.2295221,0.812758 1.9578191,0.812758 l 0.383533,-0.02769 c 0.859834,-0.12046 1.614439,-0.636914 2.03674,-1.397057 L 20.650482,7.1148966 C 21.39401,5.777375 20.91217,4.0923218 19.576035,3.3487939 Z" />
+</svg>

--- a/nw/gui/elements/docdetails.py
+++ b/nw/gui/elements/docdetails.py
@@ -55,10 +55,11 @@ class GuiDocDetails(QFrame):
         self.setLayout(self.mainBox)
 
         self.pS = 0.9*self.theTheme.fontPointSize
-        self.iS = self.theTheme.textIconSize
+        self.iPx = self.theTheme.textIconSize
+        self.sPx = int(round(0.8*self.theTheme.textIconSize))
 
-        self.expCheck = self.theTheme.getPixmap("check", (self.iS, self.iS))
-        self.expCross = self.theTheme.getPixmap("cross", (self.iS, self.iS))
+        self.expCheck = self.theTheme.getPixmap("check", (self.iPx, self.iPx))
+        self.expCross = self.theTheme.getPixmap("cross", (self.iPx, self.iPx))
 
         self.fntLabel = QFont()
         self.fntLabel.setPointSize(10)
@@ -230,7 +231,7 @@ class GuiDocDetails(QFrame):
                     self.labelFlag.setPixmap(self.expCross)
             else:
                 self.labelFlag.setPixmap(QPixmap(1,1))
-            self.statusFlag.setPixmap(flagIcon.pixmap(0.9*self.iS, 0.9*self.iS))
+            self.statusFlag.setPixmap(flagIcon.pixmap(self.sPx, self.sPx))
             self.classFlag.setText(nwLabels.CLASS_FLAG[nwItem.itemClass])
             if nwItem.itemLayout == nwItemLayout.NO_LAYOUT:
                 self.layoutFlag.setText("-")

--- a/nw/gui/elements/docdetails.py
+++ b/nw/gui/elements/docdetails.py
@@ -29,7 +29,7 @@ import logging
 import nw
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont, QIcon, QPixmap
+from PyQt5.QtGui import QFont, QIcon, QPixmap, QFontMetrics
 from PyQt5.QtWidgets import QFrame, QGridLayout, QLabel
 
 from nw.constants import (
@@ -77,7 +77,6 @@ class GuiDocDetails(QFrame):
         self.labelName.setAlignment(Qt.AlignLeft | Qt.AlignBaseline)
 
         self.labelFlag = QLabel("")
-        # self.labelFlag.setFont(self.fntFixed)
         self.labelFlag.setAlignment(Qt.AlignRight | Qt.AlignBaseline)
 
         self.labelData = QLabel("")
@@ -178,7 +177,12 @@ class GuiDocDetails(QFrame):
         self.mainBox.setColumnStretch(2,1)
         self.mainBox.setColumnStretch(3,0)
         self.mainBox.setColumnStretch(4,0)
-        self.mainBox.setColumnMinimumWidth(1, 20)
+
+        # Make sure the columns for flags and counts don't resize too often
+        flagWidth = QFontMetrics(self.fntFixed).boundingRect("Mm").width()
+        countWidth = QFontMetrics(self.fntValue).boundingRect("99,999").width()
+        self.mainBox.setColumnMinimumWidth(1, flagWidth)
+        self.mainBox.setColumnMinimumWidth(4, countWidth)
 
         logger.debug("DocDetails initialisation complete")
 

--- a/nw/gui/elements/docdetails.py
+++ b/nw/gui/elements/docdetails.py
@@ -29,7 +29,7 @@ import logging
 import nw
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont
+from PyQt5.QtGui import QFont, QIcon, QPixmap
 from PyQt5.QtWidgets import QFrame, QGridLayout, QLabel
 
 from nw.constants import (
@@ -47,30 +47,37 @@ class GuiDocDetails(QFrame):
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
         self.theProject = theProject
+        self.theTheme   = theParent.theTheme
 
         self.mainBox = QGridLayout(self)
         self.mainBox.setVerticalSpacing(1)
         self.mainBox.setHorizontalSpacing(6)
         self.setLayout(self.mainBox)
 
+        self.pS = 0.9*self.theTheme.fontPointSize
+        self.iS = self.theTheme.textIconSize
+
+        self.expCheck = self.theTheme.getPixmap("check", (self.iS, self.iS))
+        self.expCross = self.theTheme.getPixmap("cross", (self.iS, self.iS))
+
         self.fntLabel = QFont()
         self.fntLabel.setPointSize(10)
-        self.fntLabel.setBold(True)
+        self.fntLabel.setPointSizeF(self.pS)
 
         self.fntFixed = QFont()
         self.fntFixed.setFamily("Monospace")
-        self.fntFixed.setPointSize(10)
+        self.fntFixed.setPointSizeF(self.pS)
 
         self.fntValue = QFont()
-        self.fntValue.setPointSize(10)
+        self.fntValue.setPointSizeF(self.pS)
 
         # Label
-        self.labelName = QLabel("Label   ")
+        self.labelName = QLabel("Label")
         self.labelName.setFont(self.fntLabel)
         self.labelName.setAlignment(Qt.AlignLeft | Qt.AlignBaseline)
 
         self.labelFlag = QLabel("")
-        self.labelFlag.setFont(self.fntFixed)
+        # self.labelFlag.setFont(self.fntFixed)
         self.labelFlag.setAlignment(Qt.AlignRight | Qt.AlignBaseline)
 
         self.labelData = QLabel("")
@@ -79,12 +86,11 @@ class GuiDocDetails(QFrame):
         self.labelData.setWordWrap(True)
 
         # Status
-        self.statusName = QLabel("Status   ")
+        self.statusName = QLabel("Status")
         self.statusName.setFont(self.fntLabel)
         self.statusName.setAlignment(Qt.AlignLeft)
 
         self.statusFlag = QLabel("")
-        self.statusFlag.setFont(self.fntFixed)
         self.statusFlag.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
 
         self.statusData = QLabel("")
@@ -92,7 +98,7 @@ class GuiDocDetails(QFrame):
         self.statusData.setAlignment(Qt.AlignLeft)
 
         # Class
-        self.className = QLabel("Class   ")
+        self.className = QLabel("Class")
         self.className.setFont(self.fntLabel)
         self.className.setAlignment(Qt.AlignLeft)
 
@@ -105,7 +111,7 @@ class GuiDocDetails(QFrame):
         self.classData.setAlignment(Qt.AlignLeft)
 
         # Layout
-        self.layoutName = QLabel("Layout   ")
+        self.layoutName = QLabel("Layout")
         self.layoutName.setFont(self.fntLabel)
         self.layoutName.setAlignment(Qt.AlignLeft)
 
@@ -172,6 +178,7 @@ class GuiDocDetails(QFrame):
         self.mainBox.setColumnStretch(2,1)
         self.mainBox.setColumnStretch(3,0)
         self.mainBox.setColumnStretch(4,0)
+        self.mainBox.setColumnMinimumWidth(1, 20)
 
         logger.debug("DocDetails initialisation complete")
 
@@ -214,14 +221,12 @@ class GuiDocDetails(QFrame):
 
             if nwItem.itemType == nwItemType.FILE:
                 if nwItem.isExported:
-                    exportFlag = nwUnicode.U_CHECK
+                    self.labelFlag.setPixmap(self.expCheck)
                 else:
-                    exportFlag = " "
+                    self.labelFlag.setPixmap(self.expCross)
             else:
-                exportFlag = "-"
-
-            self.labelFlag.setText(exportFlag)
-            self.statusFlag.setPixmap(flagIcon.pixmap(10, 10))
+                self.labelFlag.setPixmap(QPixmap(1,1))
+            self.statusFlag.setPixmap(flagIcon.pixmap(0.9*self.iS, 0.9*self.iS))
             self.classFlag.setText(nwLabels.CLASS_FLAG[nwItem.itemClass])
             if nwItem.itemLayout == nwItemLayout.NO_LAYOUT:
                 self.layoutFlag.setText("-")

--- a/nw/gui/elements/docdetails.py
+++ b/nw/gui/elements/docdetails.py
@@ -62,7 +62,7 @@ class GuiDocDetails(QFrame):
         self.expCross = self.theTheme.getPixmap("cross", (self.iPx, self.iPx))
 
         self.fntLabel = QFont()
-        self.fntLabel.setPointSize(10)
+        self.fntLabel.setBold(True)
         self.fntLabel.setPointSizeF(self.pS)
 
         self.fntFixed = QFont()

--- a/nw/gui/elements/doctitlebar.py
+++ b/nw/gui/elements/doctitlebar.py
@@ -52,19 +52,20 @@ class GuiDocTitleBar(QLabel):
         self.setText("")
         self.setIndent(0)
         self.setMargin(0)
-        self.setContentsMargins(0,0,0,0)
+        self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
         self.setAlignment(Qt.AlignCenter)
         self.setWordWrap(True)
         self.setFrameShape(QFrame.NoFrame)
         self.setLineWidth(0)
+
         lblPalette = self.palette()
         lblPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
         lblPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
         self.setPalette(lblPalette)
 
         lblFont = self.font()
-        lblFont.setPointSizeF(0.9*self.theTheme.defFontSize)
+        lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
         self.setFont(lblFont)
 
         logger.debug("DocTitleBar initialisation complete")

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -29,7 +29,7 @@ import logging
 import nw
 
 from PyQt5.QtCore import Qt, QSize
-from PyQt5.QtGui import QFont, QColor
+from PyQt5.QtGui import QFont, QColor, QIcon
 from PyQt5.QtWidgets import (
     qApp, QTreeWidget, QTreeWidgetItem, QAbstractItemView, QMessageBox
 )
@@ -45,8 +45,9 @@ class GuiDocTree(QTreeWidget):
 
     C_NAME   = 0
     C_COUNT  = 1
-    C_FLAGS  = 2
-    C_HANDLE = 3
+    C_EXPORT = 2
+    C_FLAGS  = 3
+    C_HANDLE = 4
 
     def __init__(self, theParent, theProject):
         QTreeWidget.__init__(self, theParent)
@@ -64,15 +65,19 @@ class GuiDocTree(QTreeWidget):
         self.clearTree()
 
         # Build GUI
-        self.setIconSize(QSize(13,13))
+        self.setIconSize(QSize(13, 13))
         self.setExpandsOnDoubleClick(True)
         self.setIndentation(13)
-        self.setColumnCount(4)
-        self.setHeaderLabels(["Label","Words","Flags","Handle"])
+        self.setColumnCount(5)
+        self.setHeaderLabels(["Label","Words","Inc","Flags","Handle"])
         self.hideColumn(self.C_HANDLE)
 
         treeHead = self.headerItem()
-        treeHead.setTextAlignment(self.C_COUNT,Qt.AlignRight)
+        treeHead.setTextAlignment(self.C_COUNT, Qt.AlignRight)
+        treeHead.setToolTip(self.C_NAME, "Item label")
+        treeHead.setToolTip(self.C_COUNT, "Word count")
+        treeHead.setToolTip(self.C_EXPORT, "Include in build")
+        treeHead.setToolTip(self.C_FLAGS, "Status, class, and layout flags")
 
         # Allow Move by Drag & Drop
         self.setDragEnabled(True)
@@ -88,10 +93,14 @@ class GuiDocTree(QTreeWidget):
         # self.setSelectionBehavior(QAbstractItemView.SelectRows)
 
         for colN in range(len(self.mainConf.treeColWidth)):
-            self.setColumnWidth(colN,self.mainConf.treeColWidth[colN])
+            self.setColumnWidth(colN, self.mainConf.treeColWidth[colN])
 
-        self.fontFlags = QFont("Monospace",10)
-        self.fontCount = QFont("Monospace",10)
+        self.resizeColumnToContents(self.C_EXPORT)
+        self.resizeColumnToContents(self.C_FLAGS)
+
+        self.fntFixed = QFont()
+        self.fntFixed.setFamily("Monospace")
+        self.fntFixed.setPointSizeF(0.9*self.theTheme.fontPointSize)
 
         logger.debug("DocTree initialisation complete")
 
@@ -271,7 +280,6 @@ class GuiDocTree(QTreeWidget):
         retVals = [
             self.columnWidth(0),
             self.columnWidth(1),
-            self.columnWidth(2),
         ]
         return retVals
 
@@ -422,30 +430,30 @@ class GuiDocTree(QTreeWidget):
         tHandle = nwItem.itemHandle
         pHandle = nwItem.parHandle
 
-        stExport = " "
-        stClass  = nwLabels.CLASS_FLAG[nwItem.itemClass]
-        stLayout = ""
+        expIcon = QIcon()
 
+        stClass = nwLabels.CLASS_FLAG[nwItem.itemClass]
+        stLayout = ""
         if nwItem.itemType == nwItemType.FILE:
             stLayout = "."+nwLabels.LAYOUT_FLAG[nwItem.itemLayout]
             if nwItem.isExported:
-                stExport = nwUnicode.U_CHECK
-        else:
-            stExport = "-"
-
-        tStatus = stExport+" "+stClass+stLayout
+                expIcon = self.theTheme.getIcon("check")
+            else:
+                expIcon = self.theTheme.getIcon("cross")
+        tStatus = stClass+stLayout
 
         iStatus = nwItem.itemStatus
         if tClass == nwItemClass.NOVEL:
-            iStatus  = self.theProject.statusItems.checkEntry(iStatus) # Make sure it's valid
+            iStatus = self.theProject.statusItems.checkEntry(iStatus) # Make sure it's valid
             flagIcon = self.theParent.statusIcons[iStatus]
         else:
-            iStatus  = self.theProject.importItems.checkEntry(iStatus) # Make sure it's valid
+            iStatus = self.theProject.importItems.checkEntry(iStatus) # Make sure it's valid
             flagIcon = self.theParent.importIcons[iStatus]
 
         trItem.setText(self.C_NAME, tName)
-        trItem.setText(self.C_FLAGS,tStatus)
-        trItem.setIcon(self.C_FLAGS,flagIcon)
+        trItem.setIcon(self.C_EXPORT, expIcon)
+        trItem.setText(self.C_FLAGS, tStatus)
+        trItem.setIcon(self.C_FLAGS, flagIcon)
 
         return
 
@@ -569,12 +577,14 @@ class GuiDocTree(QTreeWidget):
 
         newItem.setText(self.C_NAME,   "")
         newItem.setText(self.C_COUNT,  "0")
+        newItem.setText(self.C_EXPORT, "")
         newItem.setText(self.C_FLAGS,  "")
         newItem.setText(self.C_HANDLE, tHandle)
 
         # newItem.setForeground(self.C_COUNT,QColor(*self.theParent.theTheme.treeWCount))
         newItem.setTextAlignment(self.C_COUNT, Qt.AlignRight)
-        newItem.setFont(self.C_FLAGS, self.fontFlags)
+        # newItem.setTextAlignment(self.C_EXPORT, Qt.AlignHCenter)
+        newItem.setFont(self.C_FLAGS, self.fntFixed)
 
         self.theMap[tHandle] = newItem
         if pHandle is None:
@@ -627,6 +637,7 @@ class GuiDocTree(QTreeWidget):
             newItem = QTreeWidgetItem([""]*4)
             newItem.setText(self.C_NAME,   "Orphaned Files")
             newItem.setText(self.C_COUNT,  "")
+            newItem.setText(self.C_EXPORT, "")
             newItem.setText(self.C_FLAGS,  "")
             newItem.setText(self.C_HANDLE, "")
             self.addTopLevelItem(newItem)

--- a/nw/gui/elements/doctree.py
+++ b/nw/gui/elements/doctree.py
@@ -65,11 +65,12 @@ class GuiDocTree(QTreeWidget):
         self.clearTree()
 
         # Build GUI
-        self.setIconSize(QSize(13, 13))
+        iPx = self.theTheme.textIconSize
+        self.setIconSize(QSize(iPx, iPx))
         self.setExpandsOnDoubleClick(True)
-        self.setIndentation(13)
+        self.setIndentation(iPx)
         self.setColumnCount(5)
-        self.setHeaderLabels(["Label","Words","Inc","Flags","Handle"])
+        self.setHeaderLabels(["Label", "Words", "Inc", "Flags", "Handle"])
         self.hideColumn(self.C_HANDLE)
 
         treeHead = self.headerItem()
@@ -92,8 +93,8 @@ class GuiDocTree(QTreeWidget):
         # self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         # self.setSelectionBehavior(QAbstractItemView.SelectRows)
 
-        for colN in range(len(self.mainConf.treeColWidth)):
-            self.setColumnWidth(colN, self.mainConf.treeColWidth[colN])
+        for colN, colW in enumerate(self.mainConf.treeColWidth):
+            self.setColumnWidth(colN, colW)
 
         self.resizeColumnToContents(self.C_EXPORT)
         self.resizeColumnToContents(self.C_FLAGS)

--- a/nw/gui/icons.py
+++ b/nw/gui/icons.py
@@ -93,6 +93,8 @@ class GuiIcons:
         "clear"          : (QStyle.SP_LineEditClearButton, "clear_left"),
         "save"           : (QStyle.SP_DialogSaveButton,    "document-save"),
         "edit"           : (None,                          None),
+        "check"          : (None,                          None),
+        "cross"          : (None,                          None),
 
         ## Other Icons
         "warning"        : (QStyle.SP_MessageBoxWarning,   "dialog-warning"),

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -65,7 +65,7 @@ class GuiMainStatus(QStatusBar):
         colTrue  = QColor(*self.theTheme.statUnsaved)
         colFalse = QColor(*self.theTheme.statSaved)
 
-        iPx = int(round(self.theTheme.baseIconSize))
+        iPx = self.theTheme.textIconSize
 
         # Permanent Widgets
         # =================
@@ -73,7 +73,7 @@ class GuiMainStatus(QStatusBar):
         ## The Spell Checker Language
         self.langIcon = QLabel("")
         self.langText = QLabel("None")
-        self.langIcon.setPixmap(self.theTheme.getPixmap("status_lang"  ,(iPx, iPx)))
+        self.langIcon.setPixmap(self.theTheme.getPixmap("status_lang", (iPx, iPx)))
         self.langIcon.setContentsMargins(0, 0, 0, 0)
         self.langText.setContentsMargins(0, 0, 8, 0)
         self.addPermanentWidget(self.langIcon)

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -48,6 +48,7 @@ class GuiMainStatus(QStatusBar):
 
         self.mainConf  = nw.CONFIG
         self.theParent = theParent
+        self.theTheme  = theParent.theTheme
         self.refTime   = None
 
         self.charCount = 0
@@ -56,11 +57,15 @@ class GuiMainStatus(QStatusBar):
         self.projWords = 0
         self.sessWords = 0
 
-        self.monoFont = QFont("Monospace",10)
+        self.fntFixed = QFont()
+        self.fntFixed.setFamily("Monospace")
+        self.fntFixed.setPointSizeF(self.theTheme.fontPointSize)
 
-        colNone  = QColor(*self.theParent.theTheme.statNone)
-        colTrue  = QColor(*self.theParent.theTheme.statUnsaved)
-        colFalse = QColor(*self.theParent.theTheme.statSaved)
+        colNone  = QColor(*self.theTheme.statNone)
+        colTrue  = QColor(*self.theTheme.statUnsaved)
+        colFalse = QColor(*self.theTheme.statSaved)
+
+        iPx = int(round(self.theTheme.baseIconSize))
 
         # Permanent Widgets
         # =================
@@ -68,14 +73,14 @@ class GuiMainStatus(QStatusBar):
         ## The Spell Checker Language
         self.langIcon = QLabel("")
         self.langText = QLabel("None")
-        self.langIcon.setPixmap(self.theParent.theTheme.getPixmap("status_lang",(14,14)))
+        self.langIcon.setPixmap(self.theTheme.getPixmap("status_lang"  ,(iPx, iPx)))
         self.langIcon.setContentsMargins(0, 0, 0, 0)
         self.langText.setContentsMargins(0, 0, 8, 0)
         self.addPermanentWidget(self.langIcon)
         self.addPermanentWidget(self.langText)
 
         ## The Editor Status
-        self.docIcon = StatusLED(colNone, colTrue, colFalse, 14, 14, self)
+        self.docIcon = StatusLED(colNone, colTrue, colFalse, iPx, iPx, self)
         self.docText = QLabel("Editor")
         self.docIcon.setContentsMargins(0, 0, 0, 0)
         self.docText.setContentsMargins(0, 0, 8, 0)
@@ -83,7 +88,7 @@ class GuiMainStatus(QStatusBar):
         self.addPermanentWidget(self.docText)
 
         ## The Project Status
-        self.projIcon = StatusLED(colNone, colTrue, colFalse, 14, 14, self)
+        self.projIcon = StatusLED(colNone, colTrue, colFalse, iPx, iPx, self)
         self.projText = QLabel("Project")
         self.projIcon.setContentsMargins(0, 0, 0, 0)
         self.projText.setContentsMargins(0, 0, 8, 0)
@@ -93,7 +98,7 @@ class GuiMainStatus(QStatusBar):
         ## The Project and Session Stats
         self.statsIcon = QLabel()
         self.statsText = QLabel("")
-        self.statsIcon.setPixmap(self.theParent.theTheme.getPixmap("status_stats",(14,14)))
+        self.statsIcon.setPixmap(self.theTheme.getPixmap("status_stats", (iPx, iPx)))
         self.statsIcon.setContentsMargins(0, 0, 0, 0)
         self.statsText.setContentsMargins(0, 0, 8, 0)
         self.addPermanentWidget(self.statsIcon)
@@ -102,10 +107,10 @@ class GuiMainStatus(QStatusBar):
         ## The Session Clock
         self.timeIcon = QLabel()
         self.timeText = QLabel("")
-        self.timeIcon.setPixmap(self.theParent.theTheme.getPixmap("status_time",(14,14)))
+        self.timeIcon.setPixmap(self.theTheme.getPixmap("status_time", (iPx, iPx)))
         self.timeText.setToolTip("Session Time")
         self.timeText.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
-        self.timeText.setFont(self.monoFont)
+        self.timeText.setFont(self.fntFixed)
         self.timeIcon.setContentsMargins(0, 0, 0, 0)
         self.timeText.setContentsMargins(0, 0, 0, 0)
         self.addPermanentWidget(self.timeIcon)

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -59,7 +59,7 @@ class GuiMainStatus(QStatusBar):
 
         self.fntFixed = QFont()
         self.fntFixed.setFamily("Monospace")
-        self.fntFixed.setPointSizeF(self.theTheme.fontPointSize)
+        self.fntFixed.setPointSizeF(0.95*self.theTheme.fontPointSize)
 
         colNone  = QColor(*self.theTheme.statNone)
         colTrue  = QColor(*self.theTheme.statUnsaved)

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -32,7 +32,7 @@ import nw
 from os import path, listdir
 
 from PyQt5.QtWidgets import qApp
-from PyQt5.QtGui import QPalette, QColor, QIcon
+from PyQt5.QtGui import QPalette, QColor, QIcon, QFontMetrics
 
 from nw.constants import nwAlert
 from nw.gui.icons import GuiIcons
@@ -119,8 +119,20 @@ class GuiTheme:
         self.loadDecoration = self.theIcons.loadDecoration
 
         # Extract Other Info
-        self.defFont = qApp.font()
-        self.defFontSize = self.defFont.pointSizeF()
+        self.guiDPI  = qApp.primaryScreen().physicalDotsPerInch()
+        self.guiFont = qApp.font()
+
+        qMetric = QFontMetrics(self.guiFont)
+        self.fontPointSize = self.guiFont.pointSizeF()
+        self.fontPixelSize = qMetric.height()
+        self.baseIconSize  = qMetric.ascent()
+        self.textIconSize  = qMetric.ascent() + qMetric.leading()
+
+        logger.verbose("GUI Font Family: %s" % self.guiFont.family())
+        logger.verbose("GUI Font Point Size: %.2f" % self.fontPointSize)
+        logger.verbose("GUI Font Pixel Size: %.2f" % self.fontPixelSize)
+        logger.verbose("GUI Base Icon Size: %.2f" % self.baseIconSize)
+        logger.verbose("GUI Text Icon Size: %.2f" % self.textIconSize)
 
         return
 

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -124,15 +124,15 @@ class GuiTheme:
 
         qMetric = QFontMetrics(self.guiFont)
         self.fontPointSize = self.guiFont.pointSizeF()
-        self.fontPixelSize = qMetric.height()
-        self.baseIconSize  = qMetric.ascent()
-        self.textIconSize  = qMetric.ascent() + qMetric.leading()
+        self.fontPixelSize = int(round(qMetric.height()))
+        self.baseIconSize  = int(round(qMetric.ascent()))
+        self.textIconSize  = int(round(qMetric.ascent() + qMetric.leading()))
 
         logger.verbose("GUI Font Family: %s" % self.guiFont.family())
         logger.verbose("GUI Font Point Size: %.2f" % self.fontPointSize)
-        logger.verbose("GUI Font Pixel Size: %.2f" % self.fontPixelSize)
-        logger.verbose("GUI Base Icon Size: %.2f" % self.baseIconSize)
-        logger.verbose("GUI Text Icon Size: %.2f" % self.textIconSize)
+        logger.verbose("GUI Font Pixel Size: %d" % self.fontPixelSize)
+        logger.verbose("GUI Base Icon Size: %d" % self.baseIconSize)
+        logger.verbose("GUI Text Icon Size: %d" % self.textIconSize)
 
         return
 


### PR DESCRIPTION
Removed the project tree checkmark for exported items and instead added a new third column that displays an icon for this. The icon renders more uniformly on different platforms.

In the process, I added a bunch of font metrics calculations to ensure icons and graphic elements scale with GUI font size. Also gave the main data columns in the project tree details panel a minimum size so they don't rescale every time you switch item in the tree view.