### PR TITLE
GUI Font Size Settings

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -36,7 +36,6 @@ from time import time
 
 from PyQt5.Qt import PYQT_VERSION_STR
 from PyQt5.QtCore import QT_VERSION_STR, QStandardPaths, QSysInfo
-from PyQt5.QtWidgets import QErrorMessage
 
 from nw.constants import nwFiles, nwUnicode
 from nw.common import splitVersionNumber, formatTimeStamp
@@ -82,11 +81,12 @@ class Config:
         self.confChanged = False
 
         ## General
-        self.guiTheme  = "default"
-        self.guiSyntax = "default_light"
-        self.guiIcons  = "typicons_grey_light"
-        self.guiDark   = False
-        self.guiLang   = "en" # Hardcoded for now
+        self.guiTheme    = "default"
+        self.guiSyntax   = "default_light"
+        self.guiIcons    = "typicons_grey_light"
+        self.guiDark     = False
+        self.guiLang     = "en" # Hardcoded for now
+        self.guiFontSize = 12
 
         ## Sizes
         self.winGeometry  = [1100, 650]
@@ -202,7 +202,6 @@ class Config:
         """Initialise the config class. The manual setting of confPath
         and dataPath is mainly intended for the test suite.
         """
-
         if confPath is None:
             confRoot = QStandardPaths.writableLocation(QStandardPaths.ConfigLocation)
             self.confPath = path.join(path.abspath(confRoot), self.appHandle)
@@ -317,6 +316,9 @@ class Config:
         )
         self.guiDark = self._parseLine(
             cnfParse, cnfSec, "guidark", self.CNF_BOOL, self.guiDark
+        )
+        self.guiFontSize = self._parseLine(
+            cnfParse, cnfSec, "guifontsize", self.CNF_INT, self.guiFontSize
         )
 
         ## Sizes
@@ -464,11 +466,12 @@ class Config:
         ## Main
         cnfSec = "Main"
         cnfParse.add_section(cnfSec)
-        cnfParse.set(cnfSec,"timestamp", formatTimeStamp(time()))
-        cnfParse.set(cnfSec,"theme",     str(self.guiTheme))
-        cnfParse.set(cnfSec,"syntax",    str(self.guiSyntax))
-        cnfParse.set(cnfSec,"icons",     str(self.guiIcons))
-        cnfParse.set(cnfSec,"guidark",   str(self.guiDark))
+        cnfParse.set(cnfSec,"timestamp",   formatTimeStamp(time()))
+        cnfParse.set(cnfSec,"theme",       str(self.guiTheme))
+        cnfParse.set(cnfSec,"syntax",      str(self.guiSyntax))
+        cnfParse.set(cnfSec,"icons",       str(self.guiIcons))
+        cnfParse.set(cnfSec,"guidark",     str(self.guiDark))
+        cnfParse.set(cnfSec,"guifontsize", str(self.guiFontSize))
 
         ## Sizes
         cnfSec = "Sizes"

--- a/nw/gui/dialogs/preferences.py
+++ b/nw/gui/dialogs/preferences.py
@@ -183,6 +183,19 @@ class GuiConfigEditGeneralTab(QWidget):
             "This may improve the look of icons on dark themes."
         )
 
+        ## Font Size
+        self.guiFontSize = QSpinBox(self)
+        self.guiFontSize.setMinimum(8)
+        self.guiFontSize.setMaximum(60)
+        self.guiFontSize.setSingleStep(1)
+        self.guiFontSize.setValue(self.mainConf.guiFontSize)
+        self.mainForm.addRow(
+            "Font size",
+            self.guiFontSize,
+            "Changing this requires restarting %s." % nw.__package__,
+            theUnit="pt"
+        )
+
         # GUI Settings
         # ============
         self.mainForm.addGroupLabel("GUI Settings")
@@ -266,6 +279,7 @@ class GuiConfigEditGeneralTab(QWidget):
         guiTheme        = self.selectTheme.currentData()
         guiIcons        = self.selectIcons.currentData()
         guiDark         = self.preferDarkIcons.isChecked()
+        guiFontSize     = self.guiFontSize.value()
         showFullPath    = self.showFullPath.isChecked()
         autoSaveDoc     = self.autoSaveDoc.value()
         autoSaveProj    = self.autoSaveProj.value()
@@ -276,10 +290,12 @@ class GuiConfigEditGeneralTab(QWidget):
         # Check if restart is needed
         needsRestart |= self.mainConf.guiTheme != guiTheme
         needsRestart |= self.mainConf.guiIcons != guiIcons
+        needsRestart |= self.mainConf.guiFontSize != guiFontSize
 
         self.mainConf.guiTheme        = guiTheme
         self.mainConf.guiIcons        = guiIcons
         self.mainConf.guiDark         = guiDark
+        self.mainConf.guiFontSize     = guiFontSize
         self.mainConf.showFullPath    = showFullPath
         self.mainConf.autoSaveDoc     = autoSaveDoc
         self.mainConf.autoSaveProj    = autoSaveProj
@@ -353,8 +369,8 @@ class GuiConfigEditLayoutTab(QWidget):
 
         ## Font Size
         self.textStyleSize = QSpinBox(self)
-        self.textStyleSize.setMinimum(5)
-        self.textStyleSize.setMaximum(120)
+        self.textStyleSize.setMinimum(8)
+        self.textStyleSize.setMaximum(60)
         self.textStyleSize.setSingleStep(1)
         self.textStyleSize.setValue(self.mainConf.textSize)
         self.mainForm.addRow(

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -111,6 +111,11 @@ class GuiTheme:
         self.confFile   = None
         self.cssFile    = None
 
+        # Set Font Size and Theme
+        self.guiFont = qApp.font()
+        self.guiFont.setPointSizeF(self.mainConf.guiFontSize)
+        qApp.setFont(self.guiFont)
+
         self.updateTheme()
         self.theIcons.updateTheme()
 
@@ -119,8 +124,7 @@ class GuiTheme:
         self.loadDecoration = self.theIcons.loadDecoration
 
         # Extract Other Info
-        self.guiDPI  = qApp.primaryScreen().physicalDotsPerInch()
-        self.guiFont = qApp.font()
+        self.guiDPI = qApp.primaryScreen().physicalDotsPerInch()
 
         qMetric = QFontMetrics(self.guiFont)
         self.fontPointSize = self.guiFont.pointSizeF()

--- a/tests/reference/novelwriter.conf
+++ b/tests/reference/novelwriter.conf
@@ -4,6 +4,7 @@ theme = default
 syntax = default_light
 icons = typicons_grey_light
 guidark = False
+guifontsize = 12
 
 [Sizes]
 geometry = 1100, 650


### PR DESCRIPTION
Added the option to change the font size of the GUI font.

I've noticed that for instance Ubuntu 16.04 renders the GUI with a very large font, and Windows 10 with a very small one, by default. It now defaults to 12 points on all platforms, but can be changed in Preferences between 8 and 60.