### PR TITLE
Drop Read Only

### DIFF
--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -39,14 +39,13 @@ class NWDoc():
 
     def __init__(self, theProject, theParent):
 
-        self.mainConf    = nw.CONFIG
-        self.theProject  = theProject
-        self.theParent   = theParent
-        self.theItem     = None
-        self.docHandle   = None
-        self.docEditable = False
-        self.fileLoc     = None
-        self.docMeta     = ""
+        self.mainConf   = nw.CONFIG
+        self.theProject = theProject
+        self.theParent  = theParent
+        self.theItem    = None
+        self.docHandle  = None
+        self.fileLoc    = None
+        self.docMeta    = ""
 
         # Internal Mapping
         self.makeAlert = self.theParent.makeAlert
@@ -60,11 +59,10 @@ class NWDoc():
     def clearDocument(self):
         """Clear the document contents.
         """
-        self.theItem     = None
-        self.docHandle   = None
-        self.docEditable = False
-        self.fileLoc     = None
-        self.docMeta     = ""
+        self.theItem   = None
+        self.docHandle = None
+        self.fileLoc   = None
+        self.docMeta   = ""
         return
 
     def openDocument(self, tHandle, showStatus=True, isOrphan=False):
@@ -86,13 +84,6 @@ class NWDoc():
         if self.theItem is None and not isOrphan:
             self.clearDocument()
             return None
-
-        # By default, the document is editable.
-        # Except for files in the trash folder.
-        self.docEditable = True
-        if self.theItem is not None:
-            if self.theItem.parHandle == self.theProject.projTree.trashRoot():
-                self.docEditable = False
 
         docFile = self.docHandle+".nwd"
         logger.debug("Opening document %s" % docFile)
@@ -137,7 +128,7 @@ class NWDoc():
         """Save the document via temp file in case of save failure, and
         in any case keep a backup of the file.
         """
-        if self.docHandle is None or not self.docEditable:
+        if self.docHandle is None:
             return False
 
         self.theProject.ensureFolderStructure()

--- a/nw/gui/__init__.py
+++ b/nw/gui/__init__.py
@@ -2,7 +2,7 @@
 
 from nw.gui.about import GuiAbout
 from nw.gui.build import GuiBuildNovel
-from nw.gui.docbars import GuiDocTitleBar, GuiNoticeBar, GuiSearchBar
+from nw.gui.docbars import GuiDocTitleBar, GuiSearchBar
 from nw.gui.docdetails import GuiDocViewDetails
 from nw.gui.doceditor import GuiDocEditor
 from nw.gui.docmerge import GuiDocMerge
@@ -25,7 +25,6 @@ __all__ = [
     "GuiAbout",
     "GuiBuildNovel",
     "GuiDocTitleBar",
-    "GuiNoticeBar",
     "GuiSearchBar",
     "GuiDocViewDetails",
     "GuiDocEditor",

--- a/nw/gui/docbars.py
+++ b/nw/gui/docbars.py
@@ -7,7 +7,6 @@
 
  File History:
  Created: 2019-09-29 [0.2.1] GuiSearchBar
- Created: 2019-10-31 [0.3.2] GuiNoticeBar
  Created: 2020-04-25 [0.4.5] GuiDocTitleBar
 
  This file is a part of novelWriter
@@ -168,59 +167,6 @@ class GuiSearchBar(QFrame):
         return True
 
 # END Class GuiSearchBar
-
-class GuiNoticeBar(QFrame):
-
-    def __init__(self, theParent):
-        QFrame.__init__(self, theParent)
-
-        logger.debug("Initialising GuiNoticeBar ...")
-
-        self.mainConf  = nw.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
-
-        self.setContentsMargins(0, 0, 0, 0)
-        self.setFrameShape(QFrame.Box)
-
-        m8 = self.mainConf.pxInt(8)
-        m2 = self.mainConf.pxInt(2)
-
-        self.mainBox = QHBoxLayout(self)
-        self.mainBox.setContentsMargins(m8, m2, m2, m2)
-
-        self.noteLabel = QLabel("")
-
-        self.closeButton = QPushButton(self.theTheme.getIcon("close"),"")
-        self.closeButton.clicked.connect(self.hideNote)
-
-        self.mainBox.addWidget(self.noteLabel)
-        self.mainBox.addWidget(self.closeButton)
-        self.mainBox.setStretch(0, 1)
-
-        self.setLayout(self.mainBox)
-
-        self.hideNote()
-
-        logger.debug("GuiNoticeBar initialisation complete")
-
-        return
-
-    def showNote(self, theNote):
-        """Show the note on the noticebar.
-        """
-        self.noteLabel.setText("<b>Note:</b> %s" % theNote)
-        self.setVisible(True)
-        return
-
-    def hideNote(self):
-        """Clear the noticebar and hide it.
-        """
-        self.noteLabel.setText("")
-        self.setVisible(False)
-        return
-
-# END Class GuiNoticeBar
 
 class GuiDocTitleBar(QLabel):
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -270,11 +270,7 @@ class GuiDocEditor(QTextEdit):
         self.setDocumentChanged(False)
         self.theHandle = tHandle
 
-        if self.nwDocument.docEditable:
-            self.setReadOnly(False)
-        else:
-            self.theParent.noticeBar.showNote("This document is read only.")
-
+        self.setReadOnly(False)
         self.docTitle.setTitleFromHandle(self.theHandle)
         self.updateDocMargins()
         self.hLight.spellCheck = spTemp

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -158,7 +158,6 @@ class GuiDocEditor(QTextEdit):
         self.hasSelection = False
 
         self.setDocumentChanged(False)
-        self.theParent.noticeBar.hideNote()
         self.docTitle.setTitleFromHandle(self.theHandle)
 
         return True

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -42,7 +42,7 @@ from PyQt5.QtWidgets import (
 from nw.gui import (
     GuiBuildNovel, GuiDocEditor, GuiDocMerge, GuiDocSplit, GuiDocViewDetails,
     GuiDocViewer, GuiItemDetails, GuiItemEditor, GuiMainMenu, GuiMainStatus,
-    GuiNoticeBar, GuiOutline, GuiOutlineDetails, GuiPreferences, GuiProjectLoad,
+    GuiOutline, GuiOutlineDetails, GuiPreferences, GuiProjectLoad,
     GuiProjectSettings, GuiProjectTree, GuiSearchBar, GuiSessionLogView, GuiTheme
 )
 from nw.core import NWProject, NWDoc, NWIndex
@@ -90,7 +90,6 @@ class GuiMain(QMainWindow):
 
         # Main GUI Elements
         self.statusBar = GuiMainStatus(self)
-        self.noticeBar = GuiNoticeBar(self)
         self.treeView  = GuiProjectTree(self)
         self.docEditor = GuiDocEditor(self)
         self.docViewer = GuiDocViewer(self)
@@ -118,7 +117,6 @@ class GuiMain(QMainWindow):
         self.docEdit.setContentsMargins(0, 0, 0, 0)
         self.docEdit.setSpacing(self.mainConf.pxInt(2))
         self.docEdit.addWidget(self.searchBar)
-        self.docEdit.addWidget(self.noticeBar)
         self.docEdit.addWidget(self.docEditor)
         self.editPane.setLayout(self.docEdit)
 


### PR DESCRIPTION
Currently, documents in Trash folder are read only. This is enforced artificially, and there really is no point to it. This PR removes this feature, and also removes the GuiNoticeBar class used for alerting the user to this. It was always an inelegant implementation.