### PR TITLE
Markdown to HTML Converter Bug

### DIFF
--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -216,6 +216,7 @@ def main(sysArgs=None):
         logger.addHandler(cHandle)
 
     logger.setLevel(debugLevel)
+    logger.info("This is %s %s" % (__package__, __version__))
 
     # Check Packages and Versions
     errorData = []

--- a/nw/core/tohtml.py
+++ b/nw/core/tohtml.py
@@ -312,23 +312,24 @@ class ToHtml(Tokenizer):
         refTags = []
         if theBits[0] in nwLabels.KEY_NAME:
             retText += "<span class='tags'>%s:</span>&nbsp;" % nwLabels.KEY_NAME[theBits[0]]
-            if theBits[0] == nwKeyWords.TAG_KEY:
-                retText += "<a name='tag_%s'>%s</a>" % (
-                    theBits[1], theBits[1]
-                )
-            else:
-                if self.genMode == self.M_PREVIEW:
-                    for tTag in theBits[1:]:
-                        refTags.append("<a href='#%s=%s'>%s</a>" % (
-                            theBits[0][1:], tTag, tTag
-                        ))
-                    retText += ", ".join(refTags)
+            if len(theBits) > 1:
+                if theBits[0] == nwKeyWords.TAG_KEY:
+                    retText += "<a name='tag_%s'>%s</a>" % (
+                        theBits[1], theBits[1]
+                    )
                 else:
-                    for tTag in theBits[1:]:
-                        refTags.append("<a href='#tag_%s'>%s</a>" % (
-                            tTag, tTag
-                        ))
-                    retText += ", ".join(refTags)
+                    if self.genMode == self.M_PREVIEW:
+                        for tTag in theBits[1:]:
+                            refTags.append("<a href='#%s=%s'>%s</a>" % (
+                                theBits[0][1:], tTag, tTag
+                            ))
+                        retText += ", ".join(refTags)
+                    else:
+                        for tTag in theBits[1:]:
+                            refTags.append("<a href='#tag_%s'>%s</a>" % (
+                                tTag, tTag
+                            ))
+                        retText += ", ".join(refTags)
 
         return "<div>%s</div>" % retText
 

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -476,22 +476,32 @@ class GuiBuildNovel(QDialog):
             noteRoot &= tItem.itemType == nwItemType.ROOT
             noteRoot &= tItem.itemClass != nwItemClass.NOVEL
 
-            if noteRoot:
-                # Add headers for root folders of notes
-                makeHtml.addRootHeading(tItem.itemHandle)
-                makeHtml.doConvert()
-                self.htmlText.append(makeHtml.getResult())
-                self.nwdText.append(makeHtml.getFilteredMarkdown())
+            try:
+                if noteRoot:
+                    # Add headers for root folders of notes
+                    makeHtml.addRootHeading(tItem.itemHandle)
+                    makeHtml.doConvert()
+                    self.htmlText.append(makeHtml.getResult())
+                    self.nwdText.append(makeHtml.getFilteredMarkdown())
 
-            elif self._checkInclude(tItem, noteFiles, novelFiles, ignoreFlag):
-                makeHtml.setText(tItem.itemHandle)
-                makeHtml.doAutoReplace()
-                makeHtml.tokenizeText()
-                makeHtml.doHeaders()
-                makeHtml.doConvert()
-                makeHtml.doPostProcessing()
-                self.htmlText.append(makeHtml.getResult())
-                self.nwdText.append(makeHtml.getFilteredMarkdown())
+                elif self._checkInclude(tItem, noteFiles, novelFiles, ignoreFlag):
+                    makeHtml.setText(tItem.itemHandle)
+                    makeHtml.doAutoReplace()
+                    makeHtml.tokenizeText()
+                    makeHtml.doHeaders()
+                    makeHtml.doConvert()
+                    makeHtml.doPostProcessing()
+                    self.htmlText.append(makeHtml.getResult())
+                    self.nwdText.append(makeHtml.getFilteredMarkdown())
+
+            except Exception as e:
+                logger.error("Failed to generate html of document '%s'" % tItem.itemHandle)
+                logger.error(str(e))
+                self.docView.setText((
+                    "Failed to generate preview. "
+                    "Document with title '%s' could not be parsed."
+                ) % tItem.itemName)
+                return False
 
             # Update progress bar, also for skipped items
             self.buildProgress.setValue(nItt+1)

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -135,11 +135,22 @@ class GuiDocViewer(QTextBrowser):
         aDoc = ToHtml(self.theProject, self.theParent)
         aDoc.setPreview(True, self.mainConf.viewComments)
         aDoc.setLinkHeaders(True)
-        aDoc.setText(tHandle)
-        aDoc.doAutoReplace()
-        aDoc.tokenizeText()
-        aDoc.doConvert()
-        aDoc.doPostProcessing()
+
+        # Be extra careful here to prevent crashes when first opening a
+        # project as a crash here leaves no way of recovering.
+        # See issue #298
+        try:
+            aDoc.setText(tHandle)
+            aDoc.doAutoReplace()
+            aDoc.tokenizeText()
+            aDoc.doConvert()
+            aDoc.doPostProcessing()
+        except Exception as e:
+            logger.error("Failed to generate preview for document with handle '%s'" % tHandle)
+            logger.error(str(e))
+            self.setText("An error occurred while generating the preview.")
+            return False
+
         self.setHtml(aDoc.theResult)
         if self.theHandle == tHandle:
             self.verticalScrollBar().setValue(sPos)


### PR DESCRIPTION
The HTML converter did not expect a `@tag:` command with no tags. The tag keyword itself is element 0 in the returned array, and the following elements are the actual tags. The converter checked for length 0, in which case it ignores the line, but in the length 1 case, it still tried to convert the tags to html anchor points. This works fine for other keywords, as `array[1:] is safe for out of bounds calls, but since tags have only one entry, it uses `array[1]`, causing an out of bounds error.

This PR adds an `if len(array) > 1` check before even entering this part of the converter. In addition, the call to the converter is wrapped in a `try/except` construct both in the document viewer and build tool to prevent parsing errors from crashing novelWriter.

This fixes Issue #298.