### PR TITLE
Project Load Updates (++)

### DIFF
--- a/nw/gui/itemdetails.py
+++ b/nw/gui/itemdetails.py
@@ -56,8 +56,8 @@ class GuiItemDetails(QWidget):
         self.setLayout(self.mainBox)
 
         self.pS = 0.9*self.theTheme.fontPointSize
-        self.iPx = self.theTheme.textIconSize
-        self.sPx = int(round(0.8*self.theTheme.textIconSize))
+        self.iPx = self.theTheme.baseIconSize
+        self.sPx = int(round(0.8*self.theTheme.baseIconSize))
 
         self.expCheck = self.theTheme.getPixmap("check", (self.iPx, self.iPx))
         self.expCross = self.theTheme.getPixmap("cross", (self.iPx, self.iPx))

--- a/nw/gui/outline.py
+++ b/nw/gui/outline.py
@@ -102,7 +102,7 @@ class GuiOutline(QTreeWidget):
         self.itemDoubleClicked.connect(self._treeDoubleClick)
         self.itemSelectionChanged.connect(self._itemSelected)
 
-        iPx = self.theTheme.textIconSize
+        iPx = self.theTheme.baseIconSize
         self.setIconSize(QSize(iPx, iPx))
         self.setIndentation(iPx)
 

--- a/nw/gui/projload.py
+++ b/nw/gui/projload.py
@@ -66,7 +66,8 @@ class GuiProjectLoad(QDialog):
         self.openPath  = None
 
         sPx = self.mainConf.pxInt(16)
-        iPx = self.mainConf.pxInt(96)
+        nPx = self.mainConf.pxInt(96)
+        iPx = self.theTheme.baseIconSize
 
         self.outerBox = QVBoxLayout()
         self.innerBox = QHBoxLayout()
@@ -78,13 +79,12 @@ class GuiProjectLoad(QDialog):
         self.setMinimumHeight(self.mainConf.pxInt(400))
         self.setModal(True)
 
-        self.guiDeco = self.theTheme.loadDecoration("nwicon", (iPx, iPx))
+        self.guiDeco = self.theTheme.loadDecoration("nwicon", (nPx, nPx))
         self.innerBox.addWidget(self.guiDeco, 0, Qt.AlignTop)
 
         self.projectForm = QGridLayout()
         self.projectForm.setContentsMargins(0, 0, 0, 0)
 
-        iPx = self.theTheme.textIconSize
         self.listBox = QTreeWidget()
         self.listBox.setSelectionMode(QAbstractItemView.SingleSelection)
         self.listBox.setDragDropMode(QAbstractItemView.NoDragDrop)

--- a/nw/gui/projsettings.py
+++ b/nw/gui/projsettings.py
@@ -282,7 +282,7 @@ class GuiProjectEditStatus(QWidget):
         self.colChanged = False
         self.selColour  = None
 
-        self.iPx = self.theTheme.textIconSize
+        self.iPx = self.theTheme.baseIconSize
 
         self.outerBox = QVBoxLayout()
         self.mainBox  = QHBoxLayout()

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -61,7 +61,7 @@ class GuiMainStatus(QStatusBar):
         colTrue  = QColor(*self.theTheme.statUnsaved)
         colFalse = QColor(*self.theTheme.statSaved)
 
-        iPx = self.theTheme.textIconSize
+        iPx = self.theTheme.baseIconSize
 
         # Permanent Widgets
         # =================

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -143,7 +143,6 @@ class GuiTheme:
         self.fontPointSize = self.guiFont.pointSizeF()
         self.fontPixelSize = int(round(qMetric.height()))
         self.baseIconSize  = int(round(qMetric.ascent()))
-        self.textIconSize  = int(round(qMetric.ascent() + qMetric.leading()))
         self.textNHeight   = qMetric.boundingRect("N").height()
         self.textNWidth    = qMetric.boundingRect("N").width()
 
@@ -151,7 +150,6 @@ class GuiTheme:
         logger.verbose("GUI Font Point Size: %.2f" % self.fontPointSize)
         logger.verbose("GUI Font Pixel Size: %d" % self.fontPixelSize)
         logger.verbose("GUI Base Icon Size: %d" % self.baseIconSize)
-        logger.verbose("GUI Text Icon Size: %d" % self.textIconSize)
         logger.verbose("Text 'N' Height: %d" % self.textNHeight)
         logger.verbose("Text 'N' Width: %d" % self.textNWidth)
 


### PR DESCRIPTION
Deleting a recent projects entry should open a dialog box first.

This PR also drops the duplicate icon size variable. Only one is needed, and the same should always be used for consistency.