### PR TITLE
Replace Quotes and Undo History Behaviour

### DIFF
--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -229,10 +229,12 @@ class nwUnicode:
     U_EMDASH = "\u2014" # Long dash
     U_HELLIP = "\u2026" # Ellipsis
 
-    ## Spaces
+    ## Spaces and Lines
     U_NBSP   = "\u00a0" # Non-breaking space
     U_THNSP  = "\u2009" # Thin space
     U_THNBSP = "\u202f" # Thin non-breaking space
+    U_LSEP   = "\u2028" # Line separator
+    U_PSEP   = "\u2029" # Paragraph separator
 
     ## Symbols
     U_CHECK  = "\u2714" # Heavy check mark

--- a/nw/constants/enum.py
+++ b/nw/constants/enum.py
@@ -93,6 +93,8 @@ class nwDocAction(Enum):
     BLOCK_H4   = 22
     BLOCK_COM  = 23
     BLOCK_TXT  = 24
+    REPL_SNG   = 25
+    REPL_DBL   = 26
 
 # END Enum nwDocAction
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -80,9 +80,6 @@ class GuiDocEditor(QTextEdit):
         self.doReplace = False
         self.nonWord   = "\"'"
 
-        # Document State
-        self.hasSelection = False
-
         # Typography
         self.typDQOpen  = self.mainConf.fmtDoubleQuotes[0]
         self.typDQClose = self.mainConf.fmtDoubleQuotes[1]
@@ -160,8 +157,6 @@ class GuiDocEditor(QTextEdit):
         self.lastEdit  = 0
         self.bigDoc    = False
         self.doReplace = False
-
-        self.hasSelection = False
 
         self.setDocumentChanged(False)
         self.docHeader.setTitleFromHandle(self.theHandle)

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -577,7 +577,7 @@ class GuiMainMenu(QMenuBar):
         self.aFmtSQuote.triggered.connect(lambda: self._docAction(nwDocAction.S_QUOTE))
         self.fmtMenu.addAction(self.aFmtSQuote)
 
-        # Edit > Separator
+        # Format > Separator
         self.fmtMenu.addSeparator()
 
         # Format > Header 1
@@ -621,6 +621,21 @@ class GuiMainMenu(QMenuBar):
         self.aFmtNoFormat.setShortcuts(["Ctrl+0","Ctrl+Shift+/"])
         self.aFmtNoFormat.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_TXT))
         self.fmtMenu.addAction(self.aFmtNoFormat)
+
+        # Format > Separator
+        self.fmtMenu.addSeparator()
+
+        # Format > Replace Single Quotes
+        self.aFmtReplSng = QAction("Replace Single Quotes", self)
+        self.aFmtReplSng.setStatusTip("Replace all straight single quotes in selected text")
+        self.aFmtReplSng.triggered.connect(lambda: self._docAction(nwDocAction.REPL_SNG))
+        self.fmtMenu.addAction(self.aFmtReplSng)
+
+        # Format > Replace Double Quotes
+        self.aFmtReplDbl = QAction("Replace Double Quotes", self)
+        self.aFmtReplDbl.setStatusTip("Replace all straight double quotes in selected text")
+        self.aFmtReplDbl.triggered.connect(lambda: self._docAction(nwDocAction.REPL_DBL))
+        self.fmtMenu.addAction(self.aFmtReplDbl)
 
         return
 


### PR DESCRIPTION
This PR addresses Issue #312 by adding a function in the doc editor class that will replace all straight quotes on a selected piece of text.

It also addresses Issue #320. The solution here was in part to capture the internal undo action before it could trigger the actual undo, and redirect it around into the `docAction` function which temporarily disables auto-replace when performing these actions. It then calls the undo() programmatically, preventing the loop reported in the issue.

In addition, the PR now adds multiple places where auto-replace is temporarily blocked, and it also only calls the auto-replace function when a single new character is added. Any valid key combination for auto-replace is only one character.