### PR TITLE
Preview Edit Doc Before Selected Doc

### DIFF
--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -529,6 +529,8 @@ class GuiDocViewHeader(QWidget):
     def _refreshDocument(self):
         """Reload the content of the document.
         """
+        if self.docViewer.theHandle == self.theParent.docEditor.theHandle:
+            self.theParent.saveDocument()
         self.docViewer.reloadText()
         return
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -518,20 +518,30 @@ class GuiMain(QMainWindow):
         """Load a document for viewing in the view panel.
         """
         if tHandle is None:
-            tHandle = self.treeView.getSelectedHandle()
-        if tHandle is None:
-            logger.debug("No document selected, trying editor document")
-            tHandle = self.docEditor.theHandle
-        if tHandle is None:
-            logger.debug("No document selected, trying last viewed")
-            tHandle = self.theProject.lastViewed
-        if tHandle is None:
-            logger.debug("No document selected, giving up")
-            return False
+            logger.debug("Viewing document, but no handle provided")
+
+            if self.docEditor.hasFocus():
+                logger.verbose("Trying editor document")
+                tHandle = self.docEditor.theHandle
+
+            if tHandle is not None:
+                self.saveDocument()
+            else:
+                logger.verbose("Trying selected document")
+                tHandle = self.treeView.getSelectedHandle()
+
+            if tHandle is None:
+                logger.verbose("Trying last viewed document")
+                tHandle = self.theProject.lastViewed
+
+            if tHandle is None:
+                logger.verbose("No document to view, giving up")
+                return False
 
         # Make sure main tab is in Editor view
         self.tabWidget.setCurrentWidget(self.splitDocs)
 
+        logger.debug("Viewing document with handle %s" % tHandle)
         if self.docViewer.loadText(tHandle):
             if not self.splitView.isVisible():
                 bPos = self.splitMain.sizes()


### PR DESCRIPTION
Pressing `Ctrl+R` while editing a document (editor has focus) should trigger a preview of that document. The selected document in the project tree should be second choice, or when the editor does not have focus.

This PR changes that order, and also triggers a `saveDocument` call before updating the view, meaning it can effectively be used to refresh the view at any time. The view is generated from the saved file, not the editor content.

This resolves Issue #143.