### PR TITLE
Don't Auto-Scroll Project Tree

### DIFF
--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -1815,7 +1815,7 @@ class GuiDocEditHeader(QWidget):
         """Capture a click on the title and ensure that the item is
         selected in the project tree.
         """
-        self.theParent.treeView.setSelectedHandle(self.theHandle)
+        self.theParent.treeView.setSelectedHandle(self.theHandle, doScroll=True)
         return
 
 # END Class GuiDocEditHeader

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -542,7 +542,7 @@ class GuiDocViewHeader(QWidget):
         """Capture a click on the title and ensure that the item is
         selected in the project tree.
         """
-        self.theParent.treeView.setSelectedHandle(self.theHandle)
+        self.theParent.treeView.setSelectedHandle(self.theHandle, doScroll=True)
         return
 
 # END Class GuiDocViewHeader

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -569,14 +569,14 @@ class GuiProjectTree(QTreeWidget):
                 selHandles.append(selItems[n].data(self.C_NAME, Qt.UserRole))
         return selHandles
 
-    def setSelectedHandle(self, tHandle):
+    def setSelectedHandle(self, tHandle, doScroll=False):
         """Set a specific handle as the selected item.
         """
         if tHandle in self.theMap:
             self.clearSelection()
             self.theMap[tHandle].setSelected(True)
             selItems = self.selectedIndexes()
-            if selItems:
+            if selItems and doScroll:
                 self.scrollTo(
                     selItems[0], QAbstractItemView.PositionAtCenter
                 )

--- a/tests/reference/gui/3_nwProject.nwx
+++ b/tests/reference/gui/3_nwProject.nwx
@@ -41,14 +41,14 @@
       <type>ROOT</type>
       <class>NOVEL</class>
       <status>New</status>
-      <expanded>True</expanded>
+      <expanded>False</expanded>
     </item>
     <item handle="25fc0e7096fc6" order="0" parent="73475cb40a568">
       <name>New Chapter</name>
       <type>FOLDER</type>
       <class>NOVEL</class>
       <status>New</status>
-      <expanded>True</expanded>
+      <expanded>False</expanded>
     </item>
     <item handle="31489056e0916" order="0" parent="25fc0e7096fc6">
       <name>Just a Page</name>


### PR DESCRIPTION
Don't scroll project tree every time a document is opened. This feature is only needed for when the user clicks the document tile bar.