### PR TITLE
Age of Project Build

### DIFF
--- a/nw/common.py
+++ b/nw/common.py
@@ -193,3 +193,27 @@ def transferCase(theSource, theTarget):
         theResult = theTarget.lower()
 
     return theResult
+
+def fuzzyTime(secDiff):
+    """Converts a time difference in seconds into a fuzzy time string.
+    """
+    if secDiff < 0:
+        return "in the future"
+    elif secDiff < 15:
+        return "just now"
+    elif secDiff < 45:
+        return "a few seconds ago"
+    elif secDiff < 90:
+        return "a minute ago"
+    elif secDiff < 3300: # 55 minutes
+        return "%d minutes ago" % int(round(secDiff/60))
+    elif secDiff < 5400: # 90 minutes
+        return "an hour ago"
+    elif secDiff < 84600: # 23.5 hours
+        return "%d hours ago" % int(round(secDiff/3600))
+    elif secDiff < 129600: # 1.5 days
+        return "a day ago"
+    elif secDiff < 8640000: # 100 days
+        return "%d days ago" % int(round(secDiff/86400))
+    else:
+        return "ages ago"

--- a/nw/common.py
+++ b/nw/common.py
@@ -213,7 +213,10 @@ def fuzzyTime(secDiff):
         return "%d hours ago" % int(round(secDiff/3600))
     elif secDiff < 129600: # 1.5 days
         return "a day ago"
-    elif secDiff < 8640000: # 100 days
+    elif secDiff < 31104000: # 360 days
         return "%d days ago" % int(round(secDiff/86400))
+    elif secDiff < 36288000: # 420 days
+        return "a year ago"
     else:
         return "ages ago"
+    return "beyond time and space"

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -983,7 +983,7 @@ class GuiBuildNovelDocView(QTextBrowser):
 
         # Age Timer
         self.ageTimer = QTimer()
-        self.ageTimer.setInterval(5000)
+        self.ageTimer.setInterval(10000)
         self.ageTimer.timeout.connect(self._updateBuildAge)
         self.ageTimer.start()
 
@@ -1071,7 +1071,7 @@ class GuiBuildNovelDocView(QTextBrowser):
             )
         else:
             strBuildTime = "Unknown"
-        self.theTitle.setText("Build Time: %s" % strBuildTime)
+        self.theTitle.setText("<b>Build Time:</b> %s" % strBuildTime)
 
 
     def _updateDocMargins(self):

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -40,7 +40,7 @@ from PyQt5.QtGui import (
 )
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QTextBrowser, QPushButton, QLabel,
-    QLineEdit, QGroupBox, QGridLayout, QProgressBar, QMenu, QAction, QFrame,
+    QLineEdit, QGroupBox, QGridLayout, QProgressBar, QMenu, QAction,
     QFileDialog, QFontDialog, QSpinBox
 )
 


### PR DESCRIPTION
This PR adds a header label on top of the document preview in the Build Novel project tool to make it clear when the document was generated. It includes a fuzzy time string as well so the user doesn't have to spend too much time figuring out how old it is.

This addresses Issue #331.