### PR TITLE
Built Time – A Few Tweaks

### DIFF
--- a/nw/common.py
+++ b/nw/common.py
@@ -199,10 +199,8 @@ def fuzzyTime(secDiff):
     """
     if secDiff < 0:
         return "in the future"
-    elif secDiff < 15:
+    elif secDiff < 30:
         return "just now"
-    elif secDiff < 45:
-        return "a few seconds ago"
     elif secDiff < 90:
         return "a minute ago"
     elif secDiff < 3300: # 55 minutes
@@ -213,10 +211,19 @@ def fuzzyTime(secDiff):
         return "%d hours ago" % int(round(secDiff/3600))
     elif secDiff < 129600: # 1.5 days
         return "a day ago"
-    elif secDiff < 31104000: # 360 days
+    elif secDiff < 561600: # 6.5 days
         return "%d days ago" % int(round(secDiff/86400))
-    elif secDiff < 36288000: # 420 days
+    elif secDiff < 907200: # 10.5 days
+        return "a week ago"
+    elif secDiff < 2419200: # 28 days
+        return "%d weeks ago" % int(round(secDiff/604800))
+    elif secDiff < 3888000: # 45 days
+        return "a month ago"
+    elif secDiff < 31104000: # 360 days
+        return "%d months ago" % int(round(secDiff/2592000))
+    elif secDiff < 47304000: # 1.5 years
         return "a year ago"
     else:
-        return "ages ago"
+        return "%d years ago" % int(round(secDiff/31557600))
+
     return "beyond time and space"

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -970,7 +970,7 @@ class GuiBuildNovelDocView(QTextBrowser):
         fPx = int(1.1*self.theTheme.fontPixelSize)
         mPx = self.mainConf.pxInt(4)
 
-        self.theTitle = QLabel("", self)
+        self.theTitle = QLabel("<b>Build Time:</b> Unknown", self)
         self.theTitle.setIndent(0)
         self.theTitle.setAutoFillBackground(True)
         self.theTitle.setAlignment(Qt.AlignCenter)
@@ -1062,7 +1062,7 @@ class GuiBuildNovelDocView(QTextBrowser):
     ##
 
     def _updateBuildAge(self):
-        """
+        """Update the build time and the fuzzy age.
         """
         if self.buildTime > 0:
             strBuildTime = "%s (%s)" % (


### PR DESCRIPTION
The document header should say something even when there is no build cache,
Also, add weeks and months to the fuzzy time converter and let it end in counting full years.