### PR TITLE
Auto-Replace XML Format

### DIFF
--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.10.0rc1" hexVersion="0x001000c1" fileVersion="1.1" timeStamp="2020-06-26 18:36:47">
+<novelWriterXML appVersion="0.10.0rc1" hexVersion="0x001000c1" fileVersion="1.1" timeStamp="2020-06-26 19:29:32">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>587</saveCount>
+    <saveCount>589</saveCount>
     <autoCount>102</autoCount>
-    <editTime>24235</editTime>
+    <editTime>24247</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>
@@ -19,9 +19,9 @@
     <novelWordCount>606</novelWordCount>
     <notesWordCount>376</notesWordCount>
     <autoReplace>
-      <A>B</A>
-      <B>E</B>
-      <C>D</C>
+      <entry key="A">B</entry>
+      <entry key="B">E</entry>
+      <entry key="C">D</entry>
     </autoReplace>
     <titleFormat>
       <title>%title%</title>

--- a/tests/reference/gui/2_nwProject.nwx
+++ b/tests/reference/gui/2_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.8.0rc1" hexVersion="0x000800c1" fileVersion="1.1" timeStamp="2020-06-05 21:07:03">
+<novelWriterXML appVersion="0.10.0rc1" hexVersion="0x001000c1" fileVersion="1.1" timeStamp="2020-06-26 19:32:47">
   <project>
     <name>Project Name</name>
     <title>Project Title</title>
@@ -19,7 +19,7 @@
     <novelWordCount>0</novelWordCount>
     <notesWordCount>0</notesWordCount>
     <autoReplace>
-      <This>With This Stuff </This>
+      <entry key="This">With This Stuff </entry>
     </autoReplace>
     <titleFormat>
       <title>%title%</title>


### PR DESCRIPTION
This PR alters the way the auto-replace settings ares stored in the XML from:

```
 <autoReplace>
   <A>D</A>
   <B>E</B>
   <C>F</C>
 </autoReplace>
```

to:

```
 <autoReplace>
   <entry key="A">D</entry>
   <entry key="B">E</entry>
   <entry key="C">F</entry>
 </autoReplace>
```

The open project function supports both formats.