### PR TITLE
Session Log Fixes and Project File Version Bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Version 0.10.0 RC1 [2020-xx-xx]
 
+Note: If the project file is opened by this version of novelWriter, the project file can no longer be read by an earlier version due to the change of how autoReplace settings are stored.
+
+**User Interface**
+
+* The Session Log dialog has been redesigned and now has a few more filter options. The filters now also update the filtered time count properly. The dialog now shows a histogram of words added in a given session, or optionally, on a given date. The filtered log data can also be saved as a JSON or CSV file, the latter suitable for importing to a spread sheet. The new dialog tool required a new session log file format, so the new session log has been given a new file name. The old log file will be left untouched in the project's `meta` folder. For projects created prior to this change, the log will record a word count offset that will be subtracted from the first entry such that the first word diff will always be 0 instead of the total word count of the entire project. Such a large word diff would otherwise saturate the histogram. PR #339.
+
+**Other Changes**
+
+* The way the auto-replace settings are stored in the project XML file has been changed in order to be more consistent with other features, and to avoid a potential pitfall in defining the tag name from a user-entered string. The project class retains its ability to read the old format of the file, and will save in the new format. PR #344.
+
 
 ## Version 0.9.2 [2020-06-26]
 

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -356,6 +356,15 @@ class NWProject():
         # Check Project Storage Version
         # =============================
 
+        # Changes:
+        # 1.0 : Original file format.
+        # 1.1 : Changes the way documents are structure in the project
+        #       folder from data_X, where X is the first hex value of
+        #       the handle, to a single content folder.
+        # 1.2 : Changes the way autoReplace entries are stored. The 1.1
+        #       parser will lose the autoReplace settings if allowed to
+        #       read the file. Introduced in version 0.10.
+
         if fileVersion == "1.0":
             msgBox = QMessageBox()
             msgRes = msgBox.question(self.theParent, "Old Project Version", (
@@ -369,10 +378,10 @@ class NWProject():
             if msgRes != QMessageBox.Yes:
                 return False
 
-        elif fileVersion != "1.1":
+        elif fileVersion != "1.1" and fileVersion != "1.2":
             self.makeAlert((
-                "Unknown or unsupported %s project format. "
-                "The project cannot be opened by this version of %s."
+                "Unknown or unsupported %s project file format. "
+                "The project cannot be opened by this version of %s. "
             ) % (
                 nw.__package__, nw.__package__
             ), nwAlert.ERROR)
@@ -512,7 +521,7 @@ class NWProject():
         nwXML = etree.Element("novelWriterXML", attrib={
             "appVersion"  : str(nw.__version__),
             "hexVersion"  : str(nw.__hexversion__),
-            "fileVersion" : "1.1",
+            "fileVersion" : "1.2",
             "timeStamp"   : formatTimeStamp(saveTime),
         })
 

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -380,11 +380,12 @@ class NWProject():
 
         elif fileVersion != "1.1" and fileVersion != "1.2":
             self.makeAlert((
-                "Unknown or unsupported %s project file format. "
-                "The project cannot be opened by this version of %s. "
-                "The file was saved with novelWriter version %s."
-            ) % (
-                nw.__package__, nw.__package__, appVersion
+                "Unknown or unsupported {nw:s} project file format. "
+                "The project cannot be opened by this version of {nw:s}. "
+                "The file was saved with {nw:s} version {vers:s}."
+            ).format(
+                nw = nw.__package__,
+                vers = appVersion,
             ), nwAlert.ERROR)
             return False
 

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -382,8 +382,9 @@ class NWProject():
             self.makeAlert((
                 "Unknown or unsupported %s project file format. "
                 "The project cannot be opened by this version of %s. "
+                "The file was saved with novelWriter version %s."
             ) % (
-                nw.__package__, nw.__package__
+                nw.__package__, nw.__package__, appVersion
             ), nwAlert.ERROR)
             return False
 

--- a/nw/gui/sessionlog.py
+++ b/nw/gui/sessionlog.py
@@ -497,15 +497,16 @@ class GuiSessionLog(QDialog):
                 wcTotal += wcNotes
 
             dwTotal = wcTotal - pcTotal
+            if isFirst:
+                # Subtract the offset from the first list entry
+                dwTotal -= self.wordOffset
+                dwTotal = max(dwTotal, 0) # But don't go negative
+                isFirst = False
+
             if hideZeros and dwTotal == 0:
                 continue
             if hideNegative and dwTotal < 0:
                 continue
-
-            if isFirst:
-                # Subtract the offset from the first list entry
-                dwTotal -= self.wordOffset
-                isFirst = False
 
             if groupByDay:
                 sStart = dStart.strftime(nwConst.dStampFmt)

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.10.0rc1" hexVersion="0x001000c1" fileVersion="1.1" timeStamp="2020-06-26 19:29:32">
+<novelWriterXML appVersion="0.10.0rc1" hexVersion="0x001000c1" fileVersion="1.1" timeStamp="2020-06-27 17:00:02">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>589</saveCount>
-    <autoCount>102</autoCount>
-    <editTime>24247</editTime>
+    <saveCount>591</saveCount>
+    <autoCount>103</autoCount>
+    <editTime>24557</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.10.0rc1" hexVersion="0x001000c1" fileVersion="1.1" timeStamp="2020-06-27 17:00:02">
+<novelWriterXML appVersion="0.10.0rc1" hexVersion="0x001000c1" fileVersion="1.2" timeStamp="2020-06-27 17:29:20">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>591</saveCount>
+    <saveCount>593</saveCount>
     <autoCount>103</autoCount>
-    <editTime>24557</editTime>
+    <editTime>24563</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>


### PR DESCRIPTION
This PR fixes a couple of minor things with the Session Log dialog. The first line will now no longer show negative counts if you filter out novel or note files, and will properly remove the first line if hide zeros is enabled and the line has 0 word diff.

In addition, the project XML has been given a version bump to 1.2. This means that if a project is opened and saved after this point, it cannot be opened by an older version of novelWriter without losing the auto-replace settings.

If needed, the user can bypass this check by changing the fileVersion setting on line 2 of the project XML file `nwProject.nwx` from `1.2` to `1.1`. However, any auto-replace setting will be lost. No other settings will be affected.