### PR TITLE
Emphasis instead of Italic, Bold, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ It allows for a minimal set of formatting needed for writing text documents for 
 These are currently limited to:
 
 * Headings level 1 to 4 using the `#` syntax only.
-* Bold, italic and strikethrough text.
+* Emphasised, strongly emphasised, and very strongly emphasised text. These are rendered as italicised, bold, and bold italicised text, respectively.
+* Strikethrough text.
 * Hard line breaks using two or more spaces at the end of a line.
 
 That is it.
@@ -124,7 +125,7 @@ pip install lxml
 pip install pyenchant
 ```
 
-PyQt/Qt should be at least 5.2.1, but ideally 5.10 or higher for nearly all features to work.
+PyQt/Qt should be at least 5.3, but ideally 5.10 or higher for nearly all features to work.
 Exporting to markdown requires PyQt/Qt 5.14.
 There are no known minimum for lxml, but the code was originally written with 4.2.
 The optional spell check library must be at least 3.0.0 to work with Windows.

--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -48,18 +48,18 @@ The editor also has a minimal set of keywords used for setting tags and referenc
    "``## Title``",            "Heading level two. The space after the # is mandatory."
    "``### Title``",           "Heading level three. The space after the # is mandatory."
    "``#### Title``",          "Heading level four. The space after the # is mandatory."
-   "``*text*``",              "The text is rendered as italicised text."
-   "``**text**``",            "The text is rendered as bold text."
-   "``***text***``",          "The text is rendered as bold italicised text."
-   "``_text_``",              "Alternative format for italicised text."
-   "``__text__``",            "Alternative format for bold text."
+   "``*text*``",              "The text is rendered as emphasised text (italicised)."
+   "``**text**``",            "The text is rendered as strongly emphasised text (bold)."
+   "``***text***``",          "The text is rendered as very strongly emphasised text (italicised, bold)."
+   "``_text_``",              "Alternative format for emphasised text."
+   "``__text__``",            "Alternative format for strongly emphasised text."
    "``~~text~~``",            "Strikethrough text."
    "``% text...``",           "A comment. The text is not exported by default, seen in viewer, or counted towards word counts."
    "``% Synopsis: text...``", "A synopsis comment. Shows up in the Synopsis column of the Outline View, but is otherwise treated as a comment."
    "``@keyword: value``",     "A keyword argument followed by a value, or a comma separated list of values."
 
 .. note::
-   The bold/italic/strikethrough formatting tags do not allow spaces between the words and the tag itself.
+   The emphasis and strikethrough formatting tags do not allow spaces between the words and the tag itself.
    That is, ``**text**`` is valid, ``**text **`` is not.
 
 The editor and viewer also supports markdown standard hard line breaks, and preserves non-breaking spaces.
@@ -126,14 +126,14 @@ These are as following:
    ":kbd:`Ctrl-3`",          "Change block format to header level 3."
    ":kbd:`Ctrl-4`",          "Change block format to header level 4."
    ":kbd:`Ctrl-A`",          "Select all text in document."
-   ":kbd:`Ctrl-B`",          "Format selected text, or word under cursor, as bold."
+   ":kbd:`Ctrl-B`",          "Format selected text, or word under cursor, with strong emphasis (bold)."
    ":kbd:`Ctrl-C`",          "Copy selected text to clipboard."
    ":kbd:`Ctrl-D`",          "Wrap selected text, or word under cursor, in double quotes."
    ":kbd:`Ctrl-E`",          "If in tree view, edit a document or folder settings. (Same as :kbd:`F2`)"
    ":kbd:`Ctrl-F`",          "Open the search bar and search for selected word, if any is selected."
    ":kbd:`Ctrl-G`",          "Find next occurrence of word in current document. (Same as :kbd:`F3`)"
    ":kbd:`Ctrl-H`",          "Open the search and replace bar and search for selected word, if any is selected. (On Mac, this is :kbd:`Cmd-=`)"
-   ":kbd:`Ctrl-I`",          "Format selected text, or word under cursor, as italic."
+   ":kbd:`Ctrl-I`",          "Format selected text, or word under cursor, with emphasis (italic)."
    ":kbd:`Ctrl-N`",          "Create new document."
    ":kbd:`Ctrl-O`",          "Open selected document."
    ":kbd:`Ctrl-Q`",          "Exit novelWriter."
@@ -152,7 +152,7 @@ These are as following:
    ":kbd:`Ctrl-Shift-/`",    "Remove block formatting for block under cursor."
    ":kbd:`Ctrl-Shift-1`",    "Replace occurrence of word in current document, and search for next occurrence."
    ":kbd:`Ctrl-Shift-A`",    "Select all text in current paragraph."
-   ":kbd:`Ctrl-Shift-B`",    "Format selected text, or word under cursor, as bold and italic."
+   ":kbd:`Ctrl-Shift-B`",    "Format selected text, or word under cursor, with very strong emphasis (bold and italic)."
    ":kbd:`Ctrl-Shift-D`",    "Wrap selected text, or word under cursor, in single quotes."
    ":kbd:`Ctrl-Shift-G`",    "Find previous occurrence of word in current document. (Same as :kbd:`Shift-F3`"
    ":kbd:`Ctrl-Shift-I`",    "Import text to the current document from a text file."

--- a/nw/constants/enum.py
+++ b/nw/constants/enum.py
@@ -74,9 +74,9 @@ class nwDocAction(Enum):
     CUT        = 3
     COPY       = 4
     PASTE      = 5
-    ITALIC     = 6
-    BOLD       = 7
-    BOLDITALIC = 8
+    ENPH       = 6
+    STRONG     = 7
+    STRONGEMPH = 8
     STRIKE     = 9
     S_QUOTE    = 10
     D_QUOTE    = 11

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -514,11 +514,11 @@ class GuiDocEditor(QTextEdit):
             self.copy()
         elif theAction == nwDocAction.PASTE:
             self.paste()
-        elif theAction == nwDocAction.ITALIC:
+        elif theAction == nwDocAction.ENPH:
             self._toggleEmph(1)
-        elif theAction == nwDocAction.BOLD:
+        elif theAction == nwDocAction.STRONG:
             self._toggleEmph(2)
-        elif theAction == nwDocAction.BOLDITALIC:
+        elif theAction == nwDocAction.STRONGEMPH:
             self._toggleEmph(3)
         elif theAction == nwDocAction.STRIKE:
             self._toggleStrike()

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -526,30 +526,30 @@ class GuiMainMenu(QMenuBar):
         # Format
         self.fmtMenu = self.addMenu("&Format")
 
-        # Format > Italic Text
-        self.aFmtItalic = QAction("Italic Text", self)
-        self.aFmtItalic.setStatusTip("Make selected text italic")
-        self.aFmtItalic.setShortcut("Ctrl+I")
-        self.aFmtItalic.triggered.connect(lambda: self._docAction(nwDocAction.ITALIC))
-        self.fmtMenu.addAction(self.aFmtItalic)
+        # Format > Emphasis
+        self.aFmtEmph = QAction("Emphasis", self)
+        self.aFmtEmph.setStatusTip("Add emphasis to selected text (italic)")
+        self.aFmtEmph.setShortcut("Ctrl+I")
+        self.aFmtEmph.triggered.connect(lambda: self._docAction(nwDocAction.ENPH))
+        self.fmtMenu.addAction(self.aFmtEmph)
 
-        # Format > Bold Text
-        self.aFmtBold = QAction("Bold Text", self)
-        self.aFmtBold.setStatusTip("Make selected text bold")
-        self.aFmtBold.setShortcut("Ctrl+B")
-        self.aFmtBold.triggered.connect(lambda: self._docAction(nwDocAction.BOLD))
-        self.fmtMenu.addAction(self.aFmtBold)
+        # Format > Strong Emphasis
+        self.aFmtStrong = QAction("Strong Emphasis", self)
+        self.aFmtStrong.setStatusTip("Add strong emphasis to selected text (bold)")
+        self.aFmtStrong.setShortcut("Ctrl+B")
+        self.aFmtStrong.triggered.connect(lambda: self._docAction(nwDocAction.STRONG))
+        self.fmtMenu.addAction(self.aFmtStrong)
 
-        # Format > Underline Text
-        self.aFmtBoldIt = QAction("Bold Italic Text", self)
-        self.aFmtBoldIt.setStatusTip("Make selected text bold and italic")
-        self.aFmtBoldIt.setShortcut("Ctrl+Shift+B")
-        self.aFmtBoldIt.triggered.connect(lambda: self._docAction(nwDocAction.BOLDITALIC))
-        self.fmtMenu.addAction(self.aFmtBoldIt)
+        # Format > Very Strong Emphasis
+        self.aFmtStrongEmph = QAction("Very Strong Emphasis", self)
+        self.aFmtStrongEmph.setStatusTip("Add very strong emphasis to selected text (bold and italic)")
+        self.aFmtStrongEmph.setShortcut("Ctrl+Shift+B")
+        self.aFmtStrongEmph.triggered.connect(lambda: self._docAction(nwDocAction.STRONGEMPH))
+        self.fmtMenu.addAction(self.aFmtStrongEmph)
 
         # Format > Strikethrough
-        self.aFmtStrike = QAction("Strikethrough Text", self)
-        self.aFmtStrike.setStatusTip("Strikethrough selected text")
+        self.aFmtStrike = QAction("Strikethrough", self)
+        self.aFmtStrike.setStatusTip("Add strikethrough to selected text")
         self.aFmtStrike.setShortcut("Ctrl+-")
         self.aFmtStrike.triggered.connect(lambda: self._docAction(nwDocAction.STRIKE))
         self.fmtMenu.addAction(self.aFmtStrike)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1003,9 +1003,10 @@ class GuiMain(QMainWindow):
         self.addAction(self.mainMenu.aInsThinNBSpace)
 
         # Format
-        self.addAction(self.mainMenu.aFmtItalic)
-        self.addAction(self.mainMenu.aFmtBold)
-        self.addAction(self.mainMenu.aFmtBoldIt)
+        self.addAction(self.mainMenu.aFmtEmph)
+        self.addAction(self.mainMenu.aFmtStrong)
+        self.addAction(self.mainMenu.aFmtStrongEmph)
+        self.addAction(self.mainMenu.aFmtStrike)
         self.addAction(self.mainMenu.aFmtDQuote)
         self.addAction(self.mainMenu.aFmtSQuote)
         self.addAction(self.mainMenu.aFmtHead1)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -764,26 +764,26 @@ def testDocAction(qtbot, nwTempGUI, nwLipsum, nwRef, nwTemp):
     cleanText = nwGUI.docEditor.getText()[27:74]
 
     # Bold
-    assert nwGUI.passDocumentAction(nwDocAction.BOLD)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONG)
     assert nwGUI.docEditor.getText()[27:78] == "**Pellentesque** nec erat ut nulla posuere commodo."
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.BOLD)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONG)
     assert nwGUI.docEditor.getText()[27:74] == cleanText
     qtbot.wait(stepDelay)
 
     # Italic
-    assert nwGUI.passDocumentAction(nwDocAction.ITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.ENPH)
     assert nwGUI.docEditor.getText()[27:76] == "*Pellentesque* nec erat ut nulla posuere commodo."
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.ITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.ENPH)
     assert nwGUI.docEditor.getText()[27:74] == cleanText
     qtbot.wait(stepDelay)
 
     # Bold-Italic
-    assert nwGUI.passDocumentAction(nwDocAction.BOLDITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONGEMPH)
     assert nwGUI.docEditor.getText()[27:80] == "***Pellentesque*** nec erat ut nulla posuere commodo."
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.BOLDITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONGEMPH)
     assert nwGUI.docEditor.getText()[27:74] == cleanText
     qtbot.wait(stepDelay)
 
@@ -796,22 +796,22 @@ def testDocAction(qtbot, nwTempGUI, nwLipsum, nwRef, nwTemp):
     qtbot.wait(stepDelay)
 
     # Should get us back to plain
-    assert nwGUI.passDocumentAction(nwDocAction.BOLD)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONG)
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.ITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.ENPH)
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.ITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.ENPH)
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.BOLD)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONG)
     assert nwGUI.docEditor.getText()[27:74] == cleanText
     qtbot.wait(stepDelay)
 
     # Equivalent of the above
-    assert nwGUI.passDocumentAction(nwDocAction.BOLDITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONGEMPH)
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.ITALIC)
+    assert nwGUI.passDocumentAction(nwDocAction.ENPH)
     qtbot.wait(stepDelay)
-    assert nwGUI.passDocumentAction(nwDocAction.BOLD)
+    assert nwGUI.passDocumentAction(nwDocAction.STRONG)
     assert nwGUI.docEditor.getText()[27:74] == cleanText
     qtbot.wait(stepDelay)
 


### PR DESCRIPTION
This PR changes the wording to the more accurate name for emphasised text according to Markdown and HTML5. It doesn't change how it's renderred.