### PR TITLE
Hide docFooter in Zen Mode

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -112,6 +112,7 @@ class Config:
         self.textMargin      = 40
         self.tabWidth        = 40
         self.zenWidth        = 800
+        self.hideZenFooter   = False
         self.doJustify       = False
         self.autoSelect      = True
         self.doReplace       = True
@@ -417,6 +418,9 @@ class Config:
         self.zenWidth = self._parseLine(
             cnfParse, cnfSec, "zenwidth", self.CNF_INT, self.zenWidth
         )
+        self.hideZenFooter = self._parseLine(
+            cnfParse, cnfSec, "hidezenfooter", self.CNF_BOOL, self.hideZenFooter
+        )
         self.doJustify = self._parseLine(
             cnfParse, cnfSec, "justify", self.CNF_BOOL, self.doJustify
         )
@@ -569,6 +573,7 @@ class Config:
         cnfParse.set(cnfSec,"margin",          str(self.textMargin))
         cnfParse.set(cnfSec,"tabwidth",        str(self.tabWidth))
         cnfParse.set(cnfSec,"zenwidth",        str(self.zenWidth))
+        cnfParse.set(cnfSec,"hidezenfooter",   str(self.hideZenFooter))
         cnfParse.set(cnfSec,"justify",         str(self.doJustify))
         cnfParse.set(cnfSec,"autoselect",      str(self.autoSelect))
         cnfParse.set(cnfSec,"autoreplace",     str(self.doReplace))

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -452,6 +452,14 @@ class GuiConfigEditLayoutTab(QWidget):
             "If disabled, minimum text width is defined by the margin setting."
         )
 
+        ## Zen Mode Footer
+        self.hideZenFooter = QSwitch()
+        self.hideZenFooter.setChecked(self.mainConf.hideZenFooter)
+        self.mainForm.addRow(
+            "Hide document footer in \"Zen Mode\"",
+            self.hideZenFooter
+        )
+
         ## Justify Text
         self.textJustify = QSwitch()
         self.textJustify.setChecked(self.mainConf.textFixedW)
@@ -538,6 +546,7 @@ class GuiConfigEditLayoutTab(QWidget):
         textWidth       = self.textFlowMax.value()
         zenWidth        = self.zenDocWidth.value()
         textFixedW      = not self.textFlowFixed.isChecked()
+        hideZenFooter   = self.hideZenFooter.isChecked()
         doJustify       = self.textJustify.isChecked()
         textMargin      = self.textMargin.value()
         tabWidth        = self.tabWidth.value()
@@ -551,6 +560,7 @@ class GuiConfigEditLayoutTab(QWidget):
         self.mainConf.textWidth       = textWidth
         self.mainConf.zenWidth        = zenWidth
         self.mainConf.textFixedW      = textFixedW
+        self.mainConf.hideZenFooter   = hideZenFooter
         self.mainConf.doJustify       = doJustify
         self.mainConf.textMargin      = textMargin
         self.mainConf.tabWidth        = tabWidth

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -942,6 +942,9 @@ class GuiMain(QMainWindow):
         self.mainMenu.setVisible(isVisible)
         self.tabWidget.tabBar().setVisible(isVisible)
 
+        hideDocFooter = self.isZenMode and self.mainConf.hideZenFooter
+        self.docEditor.docFooter.setVisible(not hideDocFooter)
+
         if self.splitView.isVisible():
             self.splitView.setVisible(False)
         elif self.docViewer.theHandle is not None:

--- a/tests/reference/novelwriter.conf
+++ b/tests/reference/novelwriter.conf
@@ -1,5 +1,5 @@
 [Main]
-timestamp = 2020-06-17 19:45:53
+timestamp = 2020-06-27 21:21:19
 theme = default
 syntax = default_light
 icons = typicons_colour_light
@@ -29,6 +29,7 @@ width = 600
 margin = 40
 tabwidth = 40
 zenwidth = 800
+hidezenfooter = False
 justify = False
 autoselect = True
 autoreplace = True


### PR DESCRIPTION
Added the Preferences option to hide the document footer bar when in distraction free mode.

This partially addresses issue #301.