### PR TITLE
Optional Colour Highlighting of Emphasised Text

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -126,6 +126,7 @@ class Config:
         self.bigDocLimit     = 800
         self.showFullPath    = True
         self.highlightQuotes = True
+        self.highlightEmph   = True
 
         self.fmtApostrophe   = nwUnicode.U_RSQUO
         self.fmtSingleQuotes = [nwUnicode.U_LSQUO, nwUnicode.U_RSQUO]
@@ -469,6 +470,9 @@ class Config:
         self.highlightQuotes = self._parseLine(
             cnfParse, cnfSec, "highlightquotes", self.CNF_BOOL, self.highlightQuotes
         )
+        self.highlightEmph = self._parseLine(
+            cnfParse, cnfSec, "highlightemph", self.CNF_BOOL, self.highlightEmph
+        )
 
         ## Backup
         cnfSec = "Backup"
@@ -590,6 +594,7 @@ class Config:
         cnfParse.set(cnfSec,"bigdoclimit",     str(self.bigDocLimit))
         cnfParse.set(cnfSec,"showfullpath",    str(self.showFullPath))
         cnfParse.set(cnfSec,"highlightquotes", str(self.highlightQuotes))
+        cnfParse.set(cnfSec,"highlightemph",   str(self.highlightEmph))
 
         ## Backup
         cnfSec = "Backup"

--- a/nw/gui/dochighlight.py
+++ b/nw/gui/dochighlight.py
@@ -82,7 +82,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         self.colHead   = QColor(*self.theTheme.colHead)
         self.colHeadH  = QColor(*self.theTheme.colHeadH)
-        self.colEmph   = QColor(*self.theTheme.colEmph)
         self.colDialN  = QColor(*self.theTheme.colDialN)
         self.colDialD  = QColor(*self.theTheme.colDialD)
         self.colDialS  = QColor(*self.theTheme.colDialS)
@@ -95,6 +94,11 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self.colMod    = QColor(*self.theTheme.colMod)
         self.colTrail  = QColor(*self.theTheme.colEmph)
         self.colTrail.setAlpha(64)
+
+        if self.mainConf.highlightEmph:
+            self.colEmph = QColor(*self.theTheme.colEmph)
+        else:
+            self.colEmph = None
 
         self.hStyles = {
             "header1"    : self._makeFormat(self.colHead,  "bold", 1.8),

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -629,7 +629,16 @@ class GuiConfigEditEditingTab(QWidget):
         self.highlightQuotes.setChecked(self.mainConf.highlightQuotes)
         self.mainForm.addRow(
             "Highlight text wrapped in quotes",
-            self.highlightQuotes
+            self.highlightQuotes,
+            helpText="Applies to single, double and straight quotes."
+        )
+
+        self.highlightEmph = QSwitch()
+        self.highlightEmph.setChecked(self.mainConf.highlightEmph)
+        self.mainForm.addRow(
+            "Add highlight colour to emphasised text",
+            self.highlightEmph,
+            helpText="Applies to emphasis, strong and strikethrough."
         )
 
         # Spell Checking
@@ -687,12 +696,14 @@ class GuiConfigEditEditingTab(QWidget):
 
         guiSyntax       = self.selectSyntax.currentData()
         highlightQuotes = self.highlightQuotes.isChecked()
+        highlightEmph   = self.highlightEmph.isChecked()
         spellTool       = self.spellToolList.currentData()
         spellLanguage   = self.spellLangList.currentData()
         bigDocLimit     = self.bigDocLimit.value()
 
         self.mainConf.guiSyntax       = guiSyntax
         self.mainConf.highlightQuotes = highlightQuotes
+        self.mainConf.highlightEmph   = highlightEmph
         self.mainConf.spellTool       = spellTool
         self.mainConf.spellLanguage   = spellLanguage
         self.mainConf.bigDocLimit     = bigDocLimit

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -494,26 +494,6 @@ class GuiConfigEditLayoutTab(QWidget):
             theUnit="px"
         )
 
-        # Writing Guides
-        # ==============
-        self.mainForm.addGroupLabel("Writing Guides")
-
-        ## Show Tabs and Spaces
-        self.showTabsNSpaces = QSwitch()
-        self.showTabsNSpaces.setChecked(self.mainConf.showTabsNSpaces)
-        self.mainForm.addRow(
-            "Show tabs and spaces",
-            self.showTabsNSpaces
-        )
-
-        ## Show Line Endings
-        self.showLineEndings = QSwitch()
-        self.showLineEndings.setChecked(self.mainConf.showLineEndings)
-        self.mainForm.addRow(
-            "Show line endings",
-            self.showLineEndings
-        )
-
         # Render Options
         # ==============
         self.mainForm.addGroupLabel("Render Text")
@@ -541,33 +521,29 @@ class GuiConfigEditLayoutTab(QWidget):
         validEntries = True
         needsRestart = False
 
-        textFont        = self.textStyleFont.text()
-        textSize        = self.textStyleSize.value()
-        textWidth       = self.textFlowMax.value()
-        zenWidth        = self.zenDocWidth.value()
-        textFixedW      = not self.textFlowFixed.isChecked()
-        hideZenFooter   = self.hideZenFooter.isChecked()
-        doJustify       = self.textJustify.isChecked()
-        textMargin      = self.textMargin.value()
-        tabWidth        = self.tabWidth.value()
-        showTabsNSpaces = self.showTabsNSpaces.isChecked()
-        showLineEndings = self.showLineEndings.isChecked()
-        viewComments    = self.viewComments.isChecked()
-        viewSynopsis    = self.viewSynopsis.isChecked()
+        textFont      = self.textStyleFont.text()
+        textSize      = self.textStyleSize.value()
+        textWidth     = self.textFlowMax.value()
+        zenWidth      = self.zenDocWidth.value()
+        textFixedW    = not self.textFlowFixed.isChecked()
+        hideZenFooter = self.hideZenFooter.isChecked()
+        doJustify     = self.textJustify.isChecked()
+        textMargin    = self.textMargin.value()
+        tabWidth      = self.tabWidth.value()
+        viewComments  = self.viewComments.isChecked()
+        viewSynopsis  = self.viewSynopsis.isChecked()
 
-        self.mainConf.textFont        = textFont
-        self.mainConf.textSize        = textSize
-        self.mainConf.textWidth       = textWidth
-        self.mainConf.zenWidth        = zenWidth
-        self.mainConf.textFixedW      = textFixedW
-        self.mainConf.hideZenFooter   = hideZenFooter
-        self.mainConf.doJustify       = doJustify
-        self.mainConf.textMargin      = textMargin
-        self.mainConf.tabWidth        = tabWidth
-        self.mainConf.showTabsNSpaces = showTabsNSpaces
-        self.mainConf.showLineEndings = showLineEndings
-        self.mainConf.viewComments    = viewComments
-        self.mainConf.viewSynopsis    = viewSynopsis
+        self.mainConf.textFont      = textFont
+        self.mainConf.textSize      = textSize
+        self.mainConf.textWidth     = textWidth
+        self.mainConf.zenWidth      = zenWidth
+        self.mainConf.textFixedW    = textFixedW
+        self.mainConf.hideZenFooter = hideZenFooter
+        self.mainConf.doJustify     = doJustify
+        self.mainConf.textMargin    = textMargin
+        self.mainConf.tabWidth      = tabWidth
+        self.mainConf.viewComments  = viewComments
+        self.mainConf.viewSynopsis  = viewSynopsis
 
         self.mainConf.confChanged = True
 
@@ -687,6 +663,26 @@ class GuiConfigEditEditingTab(QWidget):
             theUnit="kB"
         )
 
+        # Writing Guides
+        # ==============
+        self.mainForm.addGroupLabel("Writing Guides")
+
+        ## Show Tabs and Spaces
+        self.showTabsNSpaces = QSwitch()
+        self.showTabsNSpaces.setChecked(self.mainConf.showTabsNSpaces)
+        self.mainForm.addRow(
+            "Show tabs and spaces",
+            self.showTabsNSpaces
+        )
+
+        ## Show Line Endings
+        self.showLineEndings = QSwitch()
+        self.showLineEndings.setChecked(self.mainConf.showLineEndings)
+        self.mainForm.addRow(
+            "Show line endings",
+            self.showLineEndings
+        )
+
         return
 
     def saveValues(self):
@@ -700,6 +696,8 @@ class GuiConfigEditEditingTab(QWidget):
         spellTool       = self.spellToolList.currentData()
         spellLanguage   = self.spellLangList.currentData()
         bigDocLimit     = self.bigDocLimit.value()
+        showTabsNSpaces = self.showTabsNSpaces.isChecked()
+        showLineEndings = self.showLineEndings.isChecked()
 
         self.mainConf.guiSyntax       = guiSyntax
         self.mainConf.highlightQuotes = highlightQuotes
@@ -707,6 +705,8 @@ class GuiConfigEditEditingTab(QWidget):
         self.mainConf.spellTool       = spellTool
         self.mainConf.spellLanguage   = spellLanguage
         self.mainConf.bigDocLimit     = bigDocLimit
+        self.mainConf.showTabsNSpaces = showTabsNSpaces
+        self.mainConf.showLineEndings = showLineEndings
 
         self.mainConf.confChanged = True
 

--- a/tests/reference/novelwriter.conf
+++ b/tests/reference/novelwriter.conf
@@ -1,5 +1,5 @@
 [Main]
-timestamp = 2020-06-27 21:21:19
+timestamp = 2020-06-29 17:34:15
 theme = default
 syntax = default_light
 icons = typicons_colour_light
@@ -46,6 +46,7 @@ showlineendings = False
 bigdoclimit = 800
 showfullpath = True
 highlightquotes = True
+highlightemph = True
 
 [Backup]
 backuppath = 


### PR DESCRIPTION
Added an option in Preferences to enable/disable the colour added to emphasised text. The emphasis itself is still show, so italicised text is still italicised, etc. The delimiters still receive the theme colour for "hidden" text. In the context of novelWriter, it means text that isn't part of the body text, so either markup or comments.