### PR TITLE
Added project root path to sys.path for test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,10 @@
 """novelWriter Test Config
 """
 
-import pytest, shutil
+import sys, pytest, shutil
 from os import path, mkdir
+
+sys.path.insert(1, path.abspath(path.join(path.dirname(__file__), path.pardir)))
 
 @pytest.fixture(scope="session")
 def nwTemp():


### PR DESCRIPTION
A convenient fix I made in a different project after copying the test config code from novelWriter.