### PR TITLE
Help Menu Improvements

### DIFF
--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -362,8 +362,9 @@ Most features are available as keyboard shortcuts. These are as follows:
    ":kbd:`F9`",                          "Re-build the project index."
    ":kbd:`F10`",                         "Re-build the project outline."
    ":kbd:`F11`",                         "Activate full screen mode."
+   ":kbd:`Shift`:kbd:`F1`",              "Open the online documentation in the system default browser."
    ":kbd:`Shift`:kbd:`F3`",              "Find previous occurrence of search word in current document. (Same as :kbd:`Ctrl`:kbd:`Shift`:kbd:`G`)"
-   ":kbd:`Enter`",                       "If in the project tree, open a document for editing."
+   ":kbd:`Return`",                      "If in the project tree, open a document for editing."
 
 .. note::
    On macOS, replace :kbd:`Ctrl` with :kbd:`Cmd`.

--- a/nw/config.py
+++ b/nw/config.py
@@ -321,6 +321,7 @@ class Config:
         # Check if local help files exist
         self.helpPath = path.join(self.assetPath, "help", "novelWriter.qhc")
         self.hasHelp  = path.isfile(self.helpPath)
+        self.hasHelp &= path.isfile(path.join(self.assetPath, "help", "novelWriter.qch"))
 
         logger.debug("Config initialisation complete")
 

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -169,12 +169,14 @@ class GuiMainMenu(QMenuBar):
         """Open the documentation in Qt Assistant.
         """
         if not self.mainConf.hasHelp:
+            self._openWebsite(nw.__docurl__)
             return False
 
         self.assistProc = QProcess(self)
         self.assistProc.start("assistant", ["-collectionFile", self.mainConf.helpPath])
 
         if not self.assistProc.waitForStarted(10000):
+            self._openWebsite(nw.__docurl__)
             return False
 
         return True
@@ -864,15 +866,21 @@ class GuiMainMenu(QMenuBar):
         self.helpMenu.addSeparator()
 
         # Document > Documentation
-        self.aHelp = QAction("Documentation", self)
         if self.mainConf.hasHelp and self.mainConf.hasAssistant:
-            self.aHelp.setStatusTip("View local documentation with Qt Assistant")
-            self.aHelp.triggered.connect(self._openAssistant)
+            self.aHelpLoc = QAction("Documentation (Local)", self)
+            self.aHelpLoc.setStatusTip("View local documentation with Qt Assistant")
+            self.aHelpLoc.triggered.connect(self._openAssistant)
+            self.aHelpLoc.setShortcut("F1")
+            self.helpMenu.addAction(self.aHelpLoc)
+
+        self.aHelpWeb = QAction("Documentation (Online)", self)
+        self.aHelpWeb.setStatusTip("View online documentation")
+        self.aHelpWeb.triggered.connect(lambda: self._openWebsite(nw.__docurl__))
+        if self.mainConf.hasHelp and self.mainConf.hasAssistant:
+            self.aHelpWeb.setShortcut("Shift+F1")
         else:
-            self.aHelp.setStatusTip("View online documentation")
-            self.aHelp.triggered.connect(lambda: self._openWebsite(nw.__docurl__))
-        self.aHelp.setShortcut("F1")
-        self.helpMenu.addAction(self.aHelp)
+            self.aHelpWeb.setShortcuts(["F1","Shift+F1"])
+        self.helpMenu.addAction(self.aHelpWeb)
 
         # Document > Go to Website
         self.aWebsite = QAction("Open the novelWriter Website", self)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1034,7 +1034,9 @@ class GuiMain(QMainWindow):
         self.addAction(self.mainMenu.aPreferences)
 
         # Help
-        self.addAction(self.mainMenu.aHelp)
+        if self.mainConf.hasHelp and self.mainConf.hasAssistant:
+            self.addAction(self.mainMenu.aHelpLoc)
+        self.addAction(self.mainMenu.aHelpWeb)
 
         return True
 


### PR DESCRIPTION
The online documentation is still better than the local copy, so this PR ensures that the Help menu entry for online documentation is always available, even when the local one is as well. The online one is connected to `Shift+F1`. If the local is available, the `F1` key defaults to the local one, otherwise it too direct to the online version.