### PR TITLE
Issue #396: Select Paragraph Fix

### DIFF
--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -1165,7 +1165,19 @@ class GuiDocEditor(QTextEdit):
         theCursor = self.textCursor()
         theCursor.clearSelection()
         theCursor.select(selMode)
+
+        if selMode == QTextCursor.BlockUnderCursor:
+            # This selection mode also selects the preceding oaragraph
+            # separator, which we want to avoid.
+            posS = theCursor.selectionStart()
+            posE = theCursor.selectionEnd()
+            selTxt = theCursor.selectedText()
+            if selTxt.startswith(nwUnicode.U_PSEP):
+                theCursor.setPosition(posS+1, QTextCursor.MoveAnchor)
+                theCursor.setPosition(posE, QTextCursor.KeepAnchor)
+
         self.setTextCursor(theCursor)
+
         return
 
     def _beginSearch(self):


### PR DESCRIPTION
Modify the paragraph selection behaviour of Qt to not include the preceding paragraph separator in the selection.