### PR TITLE
Editor Focus and Enter Key Behaviour

### DIFF
--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -350,6 +350,7 @@ Most features are available as keyboard shortcuts. These are as follows:
    ":kbd:`Ctrl`:kbd:`Shift`:kbd:`R`",    "Close the document viewer."
    ":kbd:`Ctrl`:kbd:`Shift`:kbd:`S`",    "Save the current project."
    ":kbd:`Ctrl`:kbd:`Shift`:kbd:`W`",    "Close the current project."
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`Z`",    "Alternative sequence for redo last undo."
    ":kbd:`Ctrl`:kbd:`Shift`:kbd:`Up`",   "Move item one step up in the project tree."
    ":kbd:`Ctrl`:kbd:`Shift`:kbd:`Down`", "Move item one step down in the project tree."
    ":kbd:`F1`",                          "Open the documentation. This will either open the Qt Assistant, if available, or send you to the documentation website."

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -891,6 +891,10 @@ class GuiDocEditor(QTextEdit):
             else:
                 theCursor.insertText(self.typSQClose)
 
+        elif self.mainConf.doReplaceDash and theThree == "---":
+            theCursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor, 3)
+            theCursor.insertText(nwUnicode.U_EMDASH)
+
         elif self.mainConf.doReplaceDash and theTwo == "--":
             theCursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor, 2)
             theCursor.insertText(nwUnicode.U_ENDASH)

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -641,23 +641,35 @@ class GuiDocEditor(QTextEdit):
     def keyPressEvent(self, keyEvent):
         """Intercept key press events.
         We need to intercept a few key sequences:
-          * The return key redirects here even if the search box has
-            focus. Since we need the return key to continue search, we
-            block any further interaction here while it's in focus.
-          * The undo sequence bypasses the doAction pathway from the
-            menu, so we redirect it back from here.
-          * The default redo sequence is Ctrl+Shift+Z, which we don't
-            use, so we block it.
+          * The return and enter key redirects here even if the search
+            box has focus. Since we need these keys to continue search,
+            we block any further interaction here while it's in focus.
+          * The undo/redo sequences bypasses the doAction pathway from
+            the menu, so we redirect them back from here.
         """
-        if self.docSearch.searchBox.hasFocus():
+        isReturn  = keyEvent.key() == Qt.Key_Return
+        isReturn |= keyEvent.key() == Qt.Key_Enter
+        if isReturn and self.docSearch.searchBox.hasFocus():
             return
         elif keyEvent == QKeySequence.Redo:
-            return
+            self.docAction(nwDocAction.REDO)
         elif keyEvent == QKeySequence.Undo:
             self.docAction(nwDocAction.UNDO)
         else:
             QTextEdit.keyPressEvent(self, keyEvent)
         return
+
+    def focusNextPrevChild(self, toNext):
+        """Capture the focus request from the tab key on the text
+        editor. If the editor has focus, we do not change focus and
+        allow the editor to insert a tab. If the search bar has focus,
+        we forward the call to the search object.
+        """
+        if self.hasFocus():
+            return False
+        elif self.docSearch.isVisible():
+            return self.docSearch.cycleFocus(toNext)
+        return True
 
     def mouseReleaseEvent(self, mEvent):
         """If the mouse button is released and the control key is
@@ -1204,6 +1216,8 @@ class GuiDocEditor(QTextEdit):
         theCursor = self.textCursor()
         if theCursor.hasSelection():
             self.docSearch.setSearchText(theCursor.selectedText())
+        else:
+            self.docSearch.setSearchText(None)
         self.docSearch.setReplaceText("")
         self.updateDocMargins()
         return
@@ -1403,12 +1417,12 @@ class GuiDocEditSearch(QFrame):
 
         # Text Boxes
         # ==========
-        self.searchBox = QLineEdit()
+        self.searchBox = QLineEdit(self)
         self.searchBox.setFont(boxFont)
         self.searchBox.setPlaceholderText("Search")
         self.searchBox.returnPressed.connect(self._doSearch)
 
-        self.replaceBox = QLineEdit()
+        self.replaceBox = QLineEdit(self)
         self.replaceBox.setFont(boxFont)
         self.replaceBox.setPlaceholderText("Replace")
         self.replaceBox.returnPressed.connect(self._doSearch)
@@ -1563,6 +1577,19 @@ class GuiDocEditSearch(QFrame):
         self.docEditor.setFocus()
 
         return
+
+    def cycleFocus(self, toNext):
+        """The tab key just alternates focus between the two input
+        boxes, if the replace box is visible.
+        """
+        if self.replaceBox.isVisible():
+            if self.searchBox.hasFocus():
+                self.replaceBox.setFocus(True)
+                return True
+            elif self.replaceBox.hasFocus():
+                self.searchBox.setFocus(True)
+                return True
+        return False
 
     ##
     #  Get and Set Functions


### PR DESCRIPTION
This PR fixes a few clumsy issues with how the tab and enter keys work in the editor panel.

## Main Fix

The Qt widget itself disables the tab key as a focus changing key, which makes sense since you want to be able to type tabs. However, since the search box sits on top of the editor, the tab key would still write to the text editor even if the search box had focus.

Previously, this was solved by blocking the tab key entirely when the search box was in focus, but not the replace box. This has now been changed to block the focus change event itself when the editor is in focus, and alternate between focus and replace when it's not.

The return AND enter keys are now properly captured to move the search forward, and only those keys are blocked.

## Additional Fixes

* The alternative key sequence `Ctrl+Shift+Z` to redo last undo has been re-activated. The standard sequence is still `Ctrl+Y`.
* Adding a hyphen to two existing hyphens now also produces a long dash. Previously, this was only the case if a hyphen was added to a short dash. You sort of have to do this on purpose to even see the issue, like typing hyphen-space-hyphen, then remove the space and add a hyphen. Previously, that would result in a hyphen + short dash. 