### PR TITLE
Adding Tests for Project Load and Outline View

### DIFF
--- a/nw/gui/outlinedetails.py
+++ b/nw/gui/outlinedetails.py
@@ -249,8 +249,8 @@ class GuiOutlineDetails(QScrollArea):
         self.itemValue.setText(nwItem.itemStatus)
 
         self.cCValue.setText("{:n}".format(checkInt(novIdx["cCount"], 0)))
-        self.wCValue.setText("{:n}".format(checkInt(novIdx["pCount"], 0)))
-        self.pCValue.setText("{:n}".format(checkInt(novIdx["wCount"], 0)))
+        self.wCValue.setText("{:n}".format(checkInt(novIdx["wCount"], 0)))
+        self.pCValue.setText("{:n}".format(checkInt(novIdx["pCount"], 0)))
 
         self.synopValue.setText(novIdx["synopsis"])
 

--- a/tests/lipsum/nwProject.nwx
+++ b/tests/lipsum/nwProject.nwx
@@ -48,7 +48,7 @@
       <expanded>True</expanded>
     </item>
     <item handle="7a992350f3eb6" order="0" parent="b3643d0f92e32">
-      <name>Lorem Ipusm</name>
+      <name>Lorem Ipsum</name>
       <type>FILE</type>
       <class>NOVEL</class>
       <status>Finished</status>

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1168,6 +1168,7 @@ def testOutline(qtbot, nwTempBuild, nwLipsum, nwTemp):
 
     # Click POV Link
     qtbot.mouseClick(nwGUI.projMeta.povKeyValue, Qt.LeftButton)
+    qtbot.wait(500)
     assert nwGUI.docViewer.theHandle == "4c4f28287af27"
 
     # qtbot.stopForInteraction()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1167,8 +1167,8 @@ def testOutline(qtbot, nwTempBuild, nwLipsum, nwTemp):
     assert nwGUI.projMeta.itemValue.text() == "Finished"
 
     # Click POV Link
-    qtbot.mouseClick(nwGUI.projMeta.povKeyValue, Qt.LeftButton)
-    qtbot.wait(500)
+    assert nwGUI.projMeta.povKeyValue.text() == "<a href='#pov=Bod'>Bod</a>"
+    nwGUI.projMeta._tagClicked("#pov=Bod")
     assert nwGUI.docViewer.theHandle == "4c4f28287af27"
 
     # qtbot.stopForInteraction()


### PR DESCRIPTION
This PR adds tests for:

* The Open Project dialog,
* The Outline View.

It also fixes the following issues:

* The count values for word and paragraph counts were swapped in the details panel of the Outline View.