### PR TITLE
Issue #368: Project language setting

### DIFF
--- a/.github/workflows/pytest_cov.yml
+++ b/.github/workflows/pytest_cov.yml
@@ -14,7 +14,9 @@ jobs:
           python-version: 3.8
           architecture: x64
       - name: Install Packages
-        run: sudo apt install xvfb libenchant-dev qt5-default
+        run: |
+          sudo apt update
+          sudo apt install xvfb libenchant-dev qt5-default
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Install Dependencies
@@ -44,7 +46,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install Packages
-        run: sudo apt install xvfb libenchant-dev qt5-default
+        run: |
+          sudo apt update
+          sudo apt install xvfb libenchant-dev qt5-default
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Install Dependencies

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -76,6 +76,7 @@ class NWProject():
         self.projCache   = None # The full path to the project's cache folder
         self.projContent = None # The full path to the project's content folder
         self.projDict    = None # The spell check dictionary
+        self.projLang    = None # The spell check language, if different than default
         self.projFile    = None # The file name of the project main XML file
 
         # Project Meta
@@ -190,6 +191,7 @@ class NWProject():
         self.projCache   = None
         self.projContent = None
         self.projDict    = None
+        self.projLang    = None
         self.projFile    = nwFiles.PROJ_FILE
         self.projName    = ""
         self.bookTitle   = ""
@@ -561,6 +563,8 @@ class NWProject():
                         self.doBackup = checkBool(xItem.text, False)
                     elif xItem.tag == "spellCheck":
                         self.spellCheck = checkBool(xItem.text, False)
+                    elif xItem.tag == "spellLang":
+                        self.projLang = checkString(xItem.text, None, True)
                     elif xItem.tag == "autoOutline":
                         self.autoOutline = checkBool(xItem.text, True)
                     elif xItem.tag == "lastEdited":
@@ -654,8 +658,8 @@ class NWProject():
 
         # Save Project Meta
         xProject = etree.SubElement(nwXML, "project")
-        self._packProjectValue(xProject, "name", self.projName,  True)
-        self._packProjectValue(xProject, "title", self.bookTitle, True)
+        self._packProjectValue(xProject, "name", self.projName)
+        self._packProjectValue(xProject, "title", self.bookTitle)
         self._packProjectValue(xProject, "author", self.bookAuthors)
         self._packProjectValue(xProject, "saveCount", str(self.saveCount))
         self._packProjectValue(xProject, "autoCount", str(self.autoCount))
@@ -665,6 +669,7 @@ class NWProject():
         xSettings = etree.SubElement(nwXML, "settings")
         self._packProjectValue(xSettings, "doBackup", self.doBackup)
         self._packProjectValue(xSettings, "spellCheck", self.spellCheck)
+        self._packProjectValue(xSettings, "spellLang", self.projLang)
         self._packProjectValue(xSettings, "autoOutline", self.autoOutline)
         self._packProjectValue(xSettings, "lastEdited", self.lastEdited)
         self._packProjectValue(xSettings, "lastViewed", self.lastViewed)
@@ -990,6 +995,12 @@ class NWProject():
             self.setProjectChanged(True)
         return True
 
+    def setSpellLang(self, theLang):
+        """Set the project-specific spell check language.
+        """
+        self.projLang = checkString(theLang, None, True)
+        return True
+
     def setAutoOutline(self, theMode):
         """Enable/disable automatic update of project outline.
         """
@@ -1240,12 +1251,10 @@ class NWProject():
         if not isinstance(theValue, list):
             theValue = [theValue]
         for aValue in theValue:
-            if not isinstance(aValue, str):
-                aValue = str(aValue)
-            if aValue == "" and not allowNone:
+            if (aValue == "" or aValue is None) and not allowNone:
                 continue
             xItem = etree.SubElement(xParent, theName)
-            xItem.text = aValue
+            xItem.text = str(aValue)
         return
 
     def _packProjectKeyValue(self, xParent, theName, theDict):

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -48,7 +48,7 @@ from PyQt5.QtWidgets import (
     QFrame
 )
 
-from nw.core import NWDoc, NWSpellSimple, countWords
+from nw.core import NWDoc, NWSpellCheck, NWSpellSimple, countWords
 from nw.gui.dochighlight import GuiDocHighlighter
 from nw.common import transferCase
 from nw.constants import (
@@ -73,6 +73,7 @@ class GuiDocEditor(QTextEdit):
         self.spellCheck = False
         self.nwDocument = NWDoc(self.theProject, self.theParent)
         self.theHandle  = None
+        self.theDict    = None
 
         # Document Variables
         self.charCount = 0
@@ -1334,7 +1335,7 @@ class GuiDocEditor(QTextEdit):
         """Create the spell checking object based on the spellTool
         setting in config.
         """
-        if self.mainConf.spellTool == "enchant":
+        if self.mainConf.spellTool == NWSpellCheck.SP_ENCHANT:
             from nw.core.spellcheck import NWSpellEnchant
             self.theDict = NWSpellEnchant()
         else:

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -448,8 +448,17 @@ class GuiDocEditor(QTextEdit):
         status bar to show the one actually loaded by the spell checker
         class.
         """
-        self.theDict.setLanguage(self.mainConf.spellLanguage, self.theProject.projDict)
+        if self.theProject.projLang is None:
+            theLang = self.mainConf.spellLanguage
+        else:
+            theLang = self.theProject.projLang
+
+        self.theDict.setLanguage(theLang, self.theProject.projDict)
         self.theParent.statusBar.setLanguage(self.theDict.spellLanguage)
+
+        if not self.bigDoc:
+            self.spellCheckDocument()
+
         return True
 
     def setSpellCheck(self, theMode):
@@ -494,6 +503,8 @@ class GuiDocEditor(QTextEdit):
             logger.debug(
                 "Document re-highlighted in %.3f milliseconds" % (1000*(afTime-bfTime))
             )
+
+            self.theParent.statusBar.showMessage("Spell check complete")
 
         return True
 

--- a/nw/gui/projsettings.py
+++ b/nw/gui/projsettings.py
@@ -33,7 +33,7 @@ from PyQt5.QtGui import QIcon, QPixmap, QColor, QBrush
 from PyQt5.QtWidgets import (
     QHBoxLayout, QVBoxLayout, QGridLayout, QLineEdit, QPlainTextEdit, QLabel,
     QWidget, QDialogButtonBox, QListWidget, QPushButton, QListWidgetItem,
-    QColorDialog, QAbstractItemView, QTreeWidget, QTreeWidgetItem
+    QColorDialog, QAbstractItemView, QTreeWidget, QTreeWidgetItem, QComboBox
 )
 
 from nw.constants import nwAlert
@@ -55,12 +55,15 @@ class GuiProjectSettings(PagedDialog):
 
         self.theProject.countStatus()
         self.setWindowTitle("Project Settings")
-        self.setMinimumWidth(self.mainConf.pxInt(570))
-        self.setMinimumHeight(self.mainConf.pxInt(355))
 
+        wW = self.mainConf.pxInt(570)
+        wH = self.mainConf.pxInt(375)
+
+        self.setMinimumWidth(wW)
+        self.setMinimumHeight(wH)
         self.resize(
-            self.mainConf.pxInt(self.optState.getInt("GuiProjectSettings", "winWidth",  570)),
-            self.mainConf.pxInt(self.optState.getInt("GuiProjectSettings", "winHeight", 355))
+            self.mainConf.pxInt(self.optState.getInt("GuiProjectSettings", "winWidth",  wW)),
+            self.mainConf.pxInt(self.optState.getInt("GuiProjectSettings", "winHeight", wH))
         )
 
         self.tabMain    = GuiProjectEditMain(self.theParent, self.theProject)
@@ -96,11 +99,13 @@ class GuiProjectSettings(PagedDialog):
         projName    = self.tabMain.editName.text()
         bookTitle   = self.tabMain.editTitle.text()
         bookAuthors = self.tabMain.editAuthors.toPlainText()
+        spellLang   = self.tabMain.spellLang.currentData()
         doBackup    = not self.tabMain.doBackup.isChecked()
 
         self.theProject.setProjectName(projName)
         self.theProject.setBookTitle(bookTitle)
         self.theProject.setBookAuthors(bookAuthors)
+        self.theProject.setSpellLang(spellLang)
         self.theProject.setProjBackup(doBackup)
 
         if self.tabStatus.colChanged:
@@ -190,6 +195,26 @@ class GuiProjectEditMain(QWidget):
             self.editAuthors,
             "One name per line."
         )
+
+        self.spellLang = QComboBox(self)
+        theDict = self.theParent.docEditor.theDict
+        self.spellLang.addItem("Default", "None")
+        if theDict is not None:
+            for spTag, spName in theDict.listDictionaries():
+                self.spellLang.addItem(spName, spTag)
+
+        self.mainForm.addRow(
+            "Spell check language",
+            self.spellLang,
+            "Overrides main preferences."
+        )
+
+        if self.theProject.projLang is None:
+            spellIdx = 0
+        else:
+            spellIdx = self.spellLang.findData(self.theProject.projLang)
+        if spellIdx != -1:
+            self.spellLang.setCurrentIndex(spellIdx)
 
         self.doBackup = QSwitch(self)
         self.doBackup.setChecked(not self.theProject.doBackup)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -803,6 +803,7 @@ class GuiMain(QMainWindow):
         if self.hasProject:
             dlgProj = GuiProjectSettings(self, self.theProject)
             dlgProj.exec_()
+            self.docEditor.setDictionaries()
             self._setWindowTitle(self.theProject.projName)
         return True
 

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,17 +1,18 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.12.1" hexVersion="0x001201f0" fileVersion="1.2" timeStamp="2020-08-16 21:12:32">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:30:17">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>723</saveCount>
-    <autoCount>140</autoCount>
-    <editTime>35485</editTime>
+    <saveCount>743</saveCount>
+    <autoCount>143</autoCount>
+    <editTime>36089</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>
-    <spellCheck>False</spellCheck>
+    <spellCheck>True</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>636b6aa9b697b</lastEdited>
     <lastViewed>636b6aa9b697b</lastViewed>
@@ -119,7 +120,7 @@
       <charCount>1811</charCount>
       <wordCount>318</wordCount>
       <paraCount>8</paraCount>
-      <cursorPos>1364</cursorPos>
+      <cursorPos>1880</cursorPos>
     </item>
     <item handle="bc0cbd2a407f3" order="2" parent="e7ded148d6e4a">
       <name>Another Scene</name>

--- a/tests/reference/gui/0_nwProject.nwx
+++ b/tests/reference/gui/0_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.11.1" hexVersion="0x001101f0" fileVersion="1.2" timeStamp="2020-08-10 21:55:04">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:31:39">
   <project>
     <name>New Project</name>
     <title></title>
@@ -10,6 +10,7 @@
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>None</lastEdited>
     <lastViewed>None</lastViewed>

--- a/tests/reference/gui/1_nwProject.nwx
+++ b/tests/reference/gui/1_nwProject.nwx
@@ -1,15 +1,16 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.11.1" hexVersion="0x001101f0" fileVersion="1.2" timeStamp="2020-08-10 22:00:16">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:34:07">
   <project>
     <name>New Project</name>
     <title></title>
-    <saveCount>5</saveCount>
+    <saveCount>4</saveCount>
     <autoCount>1</autoCount>
-    <editTime>14</editTime>
+    <editTime>8</editTime>
   </project>
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>True</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>0e17daca5f3e1</lastEdited>
     <lastViewed>None</lastViewed>

--- a/tests/reference/gui/2_nwProject.nwx
+++ b/tests/reference/gui/2_nwProject.nwx
@@ -1,17 +1,18 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.11.1" hexVersion="0x001101f0" fileVersion="1.2" timeStamp="2020-08-10 22:01:52">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:31:40">
   <project>
     <name>Project Name</name>
     <title>Project Title</title>
     <author>Jane Doe</author>
     <author>John Doh</author>
-    <saveCount>2</saveCount>
+    <saveCount>1</saveCount>
     <autoCount>1</autoCount>
     <editTime>0</editTime>
   </project>
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>None</lastEdited>
     <lastViewed>None</lastViewed>

--- a/tests/reference/gui/3_nwProject.nwx
+++ b/tests/reference/gui/3_nwProject.nwx
@@ -1,15 +1,16 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.11.1" hexVersion="0x001101f0" fileVersion="1.2" timeStamp="2020-08-10 22:03:19">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:31:40">
   <project>
     <name>New Project</name>
     <title></title>
-    <saveCount>2</saveCount>
+    <saveCount>1</saveCount>
     <autoCount>1</autoCount>
     <editTime>0</editTime>
   </project>
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>0e17daca5f3e1</lastEdited>
     <lastViewed>None</lastViewed>

--- a/tests/reference/proj/1_nwProject.nwx
+++ b/tests/reference/proj/1_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.11.1" hexVersion="0x001101f0" fileVersion="1.2" timeStamp="2020-08-10 21:26:47">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:31:43">
   <project>
     <name>New Project</name>
     <title></title>
@@ -10,6 +10,7 @@
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>None</lastEdited>
     <lastViewed>None</lastViewed>

--- a/tests/reference/proj/2_nwProject.nwx
+++ b/tests/reference/proj/2_nwProject.nwx
@@ -1,15 +1,16 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.11.1" hexVersion="0x001101f0" fileVersion="1.2" timeStamp="2020-08-10 21:28:02">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:31:43">
   <project>
     <name>New Project</name>
     <title></title>
-    <saveCount>4</saveCount>
+    <saveCount>2</saveCount>
     <autoCount>1</autoCount>
     <editTime>0</editTime>
   </project>
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>None</lastEdited>
     <lastViewed>None</lastViewed>

--- a/tests/reference/proj/3_nwProject.nwx
+++ b/tests/reference/proj/3_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.12.1" hexVersion="0x001201f0" fileVersion="1.2" timeStamp="2020-08-28 11:58:47">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:31:43">
   <project>
     <name>New Project</name>
     <title></title>
@@ -10,6 +10,7 @@
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>None</lastEdited>
     <lastViewed>None</lastViewed>

--- a/tests/reference/proj/4_nwProject.nwx
+++ b/tests/reference/proj/4_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.11.1" hexVersion="0x001101f0" fileVersion="1.2" timeStamp="2020-08-10 23:59:24">
+<novelWriterXML appVersion="1.0b1" hexVersion="0x010000b1" fileVersion="1.2" timeStamp="2020-09-05 17:31:43">
   <project>
     <name>Test Custom</name>
     <title>Test Novel</title>
@@ -12,6 +12,7 @@
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>None</lastEdited>
     <lastViewed>None</lastViewed>


### PR DESCRIPTION
This PR adds a project language setting that can be used to override the spell check language setting in preferences for a specific project. The override setting is in the Project Settings dialog.