### PR TITLE
Issue #438: Editor cut/copy/paste

### DIFF
--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -245,6 +245,7 @@ class nwUnicode:
     ## Symbols
     U_CHECK  = "\u2714" # Heavy check mark
     U_MULT   = "\u2715" # Multiplication x
+    U_BULL   = "\u2022" # List bullet
 
     ## Arrows
     U_UTRI   = "\u25b2" # Up-pointing triangle
@@ -294,6 +295,7 @@ class nwUnicode:
     ## Symbols
     H_CHECK  = "&#10004;"
     H_MULT   = "&#10005;"
+    H_BULL   = "&bull;"
 
     ## Arrows
     H_UTRI   = "&#9650;"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -398,7 +398,7 @@ def testProjectEditor(qtbot, nwFuncTemp, nwTempGUI, nwRef, nwTemp):
     testFile = path.join(nwTempGUI, "2_nwProject.nwx")
     refFile  = path.join(nwRef, "gui", "2_nwProject.nwx")
     copyfile(projFile, testFile)
-    assert cmpFiles(testFile, refFile, [2, 6, 7, 8])
+    assert cmpFiles(testFile, refFile, [2, 8, 9, 10])
 
     # qtbot.stopForInteraction()
     nwGUI.closeMain()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -10,6 +10,7 @@ from nwtools import cmpFiles
 
 from os import path
 from PyQt5.QtCore import Qt, QPoint
+from PyQt5.QtGui import QTextCursor
 from PyQt5.QtWidgets import QAction, QDialogButtonBox, QTreeWidgetItem
 
 from nw.gui import (
@@ -1109,6 +1110,58 @@ def testDocAction(qtbot, nwLipsum, nwTemp):
     assert nwGUI.passDocumentAction(nwDocAction.REDO)
     assert nwGUI.docEditor.getText()[27:74] == cleanText
     qtbot.wait(stepDelay)
+
+    # Editor Context Menu
+    theCursor = nwGUI.docEditor.textCursor()
+    theCursor.setPosition(100)
+    nwGUI.docEditor.setTextCursor(theCursor)
+    theRect = nwGUI.docEditor.cursorRect()
+
+    nwGUI.docEditor._openContextMenu(theRect.bottomRight())
+    qtbot.mouseClick(nwGUI.docEditor, Qt.LeftButton, pos=theRect.topLeft())
+
+    nwGUI.docEditor._makePosSelection(QTextCursor.WordUnderCursor, theRect.center())
+    theCursor = nwGUI.docEditor.textCursor()
+    assert theCursor.selectedText() == "imperdiet"
+
+    nwGUI.docEditor._makePosSelection(QTextCursor.BlockUnderCursor, theRect.center())
+    theCursor = nwGUI.docEditor.textCursor()
+    assert theCursor.selectedText() == (
+        "Pellentesque nec erat ut nulla posuere commodo. Curabitur nisi augue, imperdiet et porta "
+        "imperdiet, efficitur id leo. Cras finibus arcu at nibh commodo congue. Proin suscipit "
+        "placerat condimentum. Aenean ante enim, cursus id lorem a, blandit venenatis nibh. "
+        "Maecenas suscipit porta elit, sit amet porta felis porttitor eu. Sed a dui nibh. "
+        "Phasellus sed faucibus dui. Pellentesque felis nulla, ultrices non efficitur quis, "
+        "rutrum id mi. Mauris tempus auctor nisl, in bibendum enim pellentesque sit amet. Proin "
+        "nunc lacus, imperdiet nec posuere ac, interdum non lectus."
+    )
+
+    # Viewer Context Menu
+    assert nwGUI.viewDocument("4c4f28287af27")
+
+    theCursor = nwGUI.docViewer.textCursor()
+    theCursor.setPosition(100)
+    nwGUI.docViewer.setTextCursor(theCursor)
+    theRect = nwGUI.docViewer.cursorRect()
+
+    nwGUI.docViewer._openContextMenu(theRect.bottomRight())
+    qtbot.mouseClick(nwGUI.docViewer, Qt.LeftButton, pos=theRect.topLeft())
+
+    nwGUI.docViewer._makePosSelection(QTextCursor.WordUnderCursor, theRect.center())
+    theCursor = nwGUI.docViewer.textCursor()
+    assert theCursor.selectedText() == "imperdiet"
+
+    nwGUI.docEditor._makePosSelection(QTextCursor.BlockUnderCursor, theRect.center())
+    theCursor = nwGUI.docEditor.textCursor()
+    assert theCursor.selectedText() == (
+        "Pellentesque nec erat ut nulla posuere commodo. Curabitur nisi augue, imperdiet et porta "
+        "imperdiet, efficitur id leo. Cras finibus arcu at nibh commodo congue. Proin suscipit "
+        "placerat condimentum. Aenean ante enim, cursus id lorem a, blandit venenatis nibh. "
+        "Maecenas suscipit porta elit, sit amet porta felis porttitor eu. Sed a dui nibh. "
+        "Phasellus sed faucibus dui. Pellentesque felis nulla, ultrices non efficitur quis, "
+        "rutrum id mi. Mauris tempus auctor nisl, in bibendum enim pellentesque sit amet. Proin "
+        "nunc lacus, imperdiet nec posuere ac, interdum non lectus."
+    )
 
     # qtbot.stopForInteraction()
     nwGUI.closeMain()


### PR DESCRIPTION
This PR adds:

**Document Editor**
* Cut and Copy to the context menu when a user has made a selection.
* Paste, Select All, Select Word and Select Paragraph to the context menu.
* Spell checking is added to the same menu if any suggestions are available.
* Select Word and Paragraph selects the word/paragraph under the pointer, not the cursor as the equivalent main menu entries do.

**Document Viewer**
* Removes the built-in context menu and replaces it with the Paste, Select All, Select Word and Select Paragraph features from the document editor context menu.

These changes makes them consistent (the built-in menu looks different than the other menus) and the editor and viewer are now consistent in features and functionality with each other.

Tests have been added to check that the selection functions work in both panels and the context menu can be built without crashing (no other functionality checks are made on the context menu itself).