### PR TITLE
Issue #441: Document Viewer History Navigation

### DIFF
--- a/docs/source/int_interface.rst
+++ b/docs/source/int_interface.rst
@@ -328,6 +328,8 @@ Most features are available as keyboard shortcuts. These are as follows:
    ":kbd:`Alt`:kbd:`1`",                 "Switch focus to the project tree."
    ":kbd:`Alt`:kbd:`2`",                 "Switch focus to document editor."
    ":kbd:`Alt`:kbd:`3`",                 "Switch focus to document viewer."
+   ":kbd:`Alt`:kbd:`Left`",              "Move backward in the view history of the document viewer."
+   ":kbd:`Alt`:kbd:`Right`",             "Move forward in the view history of the document viewer."
    ":kbd:`Ctrl`:kbd:`.`",                "Open menu to correct word under cursor."
    ":kbd:`Ctrl`:kbd:`,`",                "Open the :guilabel:`Preferences` dialog."
    ":kbd:`Ctrl`:kbd:`/`",                "Change block format to comment."

--- a/nw/assets/icons/fallback/backward-dark.svg
+++ b/nw/assets/icons/fallback/backward-dark.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#aeaeae;fill-opacity:1;stroke-width:1.28574"
+     id="path8978"
+     d="m 17.565474,3.7531206 c -1.002875,-1.0041608 -2.63319,-1.0041608 -3.636065,0 L 5.6814051,11.999839 13.929409,20.246558 C 14.430847,20.749281 15.089144,21 15.747442,21 c 0.658297,0 1.316595,-0.250719 1.818032,-0.753442 1.004161,-1.004161 1.004161,-2.631904 0,-3.636065 l -4.609368,-4.610654 4.609368,-4.6106535 c 1.004161,-1.0041608 1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/fallback/backward.svg
+++ b/nw/assets/icons/fallback/backward.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#000000;fill-opacity:0.78;stroke-width:1.28574"
+     id="path8978"
+     d="m 17.565474,3.7531206 c -1.002875,-1.0041608 -2.63319,-1.0041608 -3.636065,0 L 5.6814051,11.999839 13.929409,20.246558 C 14.430847,20.749281 15.089144,21 15.747442,21 c 0.658297,0 1.316595,-0.250719 1.818032,-0.753442 1.004161,-1.004161 1.004161,-2.631904 0,-3.636065 l -4.609368,-4.610654 4.609368,-4.6106535 c 1.004161,-1.0041608 1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/fallback/forward-dark.svg
+++ b/nw/assets/icons/fallback/forward-dark.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#aeaeae;fill-opacity:1;stroke-width:1.28574"
+     id="path8978"
+     d="m 6.4345258,3.7531206 c 1.002875,-1.0041608 2.63319,-1.0041608 3.6360652,0 l 8.248004,8.2467184 -8.248004,8.246719 C 9.5691528,20.749281 8.9108558,21 8.2525578,21 c -0.658297,0 -1.316595,-0.250719 -1.818032,-0.753442 -1.004161,-1.004161 -1.004161,-2.631904 0,-3.636065 L 11.043894,11.999839 6.4345258,7.3891855 c -1.004161,-1.0041608 -1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/fallback/forward.svg
+++ b/nw/assets/icons/fallback/forward.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#000000;fill-opacity:0.77999997;stroke-width:1.28574"
+     id="path8978"
+     d="m 6.4345258,3.7531206 c 1.002875,-1.0041608 2.63319,-1.0041608 3.6360652,0 l 8.248004,8.2467184 -8.248004,8.246719 C 9.5691528,20.749281 8.9108558,21 8.2525578,21 c -0.658297,0 -1.316595,-0.250719 -1.818032,-0.753442 -1.004161,-1.004161 -1.004161,-2.631904 0,-3.636065 L 11.043894,11.999839 6.4345258,7.3891855 c -1.004161,-1.0041608 -1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_dark/chevron-left.svg
+++ b/nw/assets/icons/typicons_colour_dark/chevron-left.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="stroke-width:1.28574;fill:#6699cc;fill-opacity:1"
+     id="path8978"
+     d="m 17.565474,3.7531206 c -1.002875,-1.0041608 -2.63319,-1.0041608 -3.636065,0 L 5.6814051,11.999839 13.929409,20.246558 C 14.430847,20.749281 15.089144,21 15.747442,21 c 0.658297,0 1.316595,-0.250719 1.818032,-0.753442 1.004161,-1.004161 1.004161,-2.631904 0,-3.636065 l -4.609368,-4.610654 4.609368,-4.6106535 c 1.004161,-1.0041608 1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_dark/chevron-right.svg
+++ b/nw/assets/icons/typicons_colour_dark/chevron-right.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#6699cc;fill-opacity:1;stroke-width:1.28574"
+     id="path8978"
+     d="m 6.4345258,3.7531206 c 1.002875,-1.0041608 2.63319,-1.0041608 3.6360652,0 l 8.248004,8.2467184 -8.248004,8.246719 C 9.5691528,20.749281 8.9108558,21 8.2525578,21 c -0.658297,0 -1.316595,-0.250719 -1.818032,-0.753442 -1.004161,-1.004161 -1.004161,-2.631904 0,-3.636065 L 11.043894,11.999839 6.4345258,7.3891855 c -1.004161,-1.0041608 -1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_dark/icons.conf
+++ b/nw/assets/icons/typicons_colour_dark/icons.conf
@@ -51,5 +51,7 @@ check          = tick.svg
 cross          = times.svg
 hash           = hash.svg
 reference      = at.svg
+backward       = chevron-left.svg
+forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg

--- a/nw/assets/icons/typicons_colour_light/chevron-left.svg
+++ b/nw/assets/icons/typicons_colour_light/chevron-left.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#4271ae;fill-opacity:1;stroke-width:1.28574"
+     id="path8978"
+     d="m 17.565474,3.7531206 c -1.002875,-1.0041608 -2.63319,-1.0041608 -3.636065,0 L 5.6814051,11.999839 13.929409,20.246558 C 14.430847,20.749281 15.089144,21 15.747442,21 c 0.658297,0 1.316595,-0.250719 1.818032,-0.753442 1.004161,-1.004161 1.004161,-2.631904 0,-3.636065 l -4.609368,-4.610654 4.609368,-4.6106535 c 1.004161,-1.0041608 1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_light/chevron-right.svg
+++ b/nw/assets/icons/typicons_colour_light/chevron-right.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#4271ae;fill-opacity:1;stroke-width:1.28574"
+     id="path8978"
+     d="m 6.4345258,3.7531206 c 1.002875,-1.0041608 2.63319,-1.0041608 3.6360652,0 l 8.248004,8.2467184 -8.248004,8.246719 C 9.5691528,20.749281 8.9108558,21 8.2525578,21 c -0.658297,0 -1.316595,-0.250719 -1.818032,-0.753442 -1.004161,-1.004161 -1.004161,-2.631904 0,-3.636065 L 11.043894,11.999839 6.4345258,7.3891855 c -1.004161,-1.0041608 -1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_light/icons.conf
+++ b/nw/assets/icons/typicons_colour_light/icons.conf
@@ -51,5 +51,7 @@ check          = tick.svg
 cross          = times.svg
 hash           = hash.svg
 reference      = at.svg
+backward       = chevron-left.svg
+forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg

--- a/nw/assets/icons/typicons_grey_dark/chevron-left.svg
+++ b/nw/assets/icons/typicons_grey_dark/chevron-left.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#aeaeae;fill-opacity:1;stroke-width:1.28574"
+     id="path8978"
+     d="m 17.565474,3.7531206 c -1.002875,-1.0041608 -2.63319,-1.0041608 -3.636065,0 L 5.6814051,11.999839 13.929409,20.246558 C 14.430847,20.749281 15.089144,21 15.747442,21 c 0.658297,0 1.316595,-0.250719 1.818032,-0.753442 1.004161,-1.004161 1.004161,-2.631904 0,-3.636065 l -4.609368,-4.610654 4.609368,-4.6106535 c 1.004161,-1.0041608 1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_dark/chevron-right.svg
+++ b/nw/assets/icons/typicons_grey_dark/chevron-right.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#aeaeae;fill-opacity:1;stroke-width:1.28574"
+     id="path8978"
+     d="m 6.4345258,3.7531206 c 1.002875,-1.0041608 2.63319,-1.0041608 3.6360652,0 l 8.248004,8.2467184 -8.248004,8.246719 C 9.5691528,20.749281 8.9108558,21 8.2525578,21 c -0.658297,0 -1.316595,-0.250719 -1.818032,-0.753442 -1.004161,-1.004161 -1.004161,-2.631904 0,-3.636065 L 11.043894,11.999839 6.4345258,7.3891855 c -1.004161,-1.0041608 -1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_dark/icons.conf
+++ b/nw/assets/icons/typicons_grey_dark/icons.conf
@@ -51,5 +51,7 @@ check          = tick.svg
 cross          = times.svg
 hash           = hash.svg
 reference      = at.svg
+backward       = chevron-left.svg
+forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg

--- a/nw/assets/icons/typicons_grey_light/chevron-left.svg
+++ b/nw/assets/icons/typicons_grey_light/chevron-left.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#000000;fill-opacity:0.78;stroke-width:1.28574"
+     id="path8978"
+     d="m 17.565474,3.7531206 c -1.002875,-1.0041608 -2.63319,-1.0041608 -3.636065,0 L 5.6814051,11.999839 13.929409,20.246558 C 14.430847,20.749281 15.089144,21 15.747442,21 c 0.658297,0 1.316595,-0.250719 1.818032,-0.753442 1.004161,-1.004161 1.004161,-2.631904 0,-3.636065 l -4.609368,-4.610654 4.609368,-4.6106535 c 1.004161,-1.0041608 1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_light/chevron-right.svg
+++ b/nw/assets/icons/typicons_grey_light/chevron-right.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8980"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata8986">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8984" />
+  <path
+     style="fill:#000000;fill-opacity:0.77999997;stroke-width:1.28574"
+     id="path8978"
+     d="m 6.4345258,3.7531206 c 1.002875,-1.0041608 2.63319,-1.0041608 3.6360652,0 l 8.248004,8.2467184 -8.248004,8.246719 C 9.5691528,20.749281 8.9108558,21 8.2525578,21 c -0.658297,0 -1.316595,-0.250719 -1.818032,-0.753442 -1.004161,-1.004161 -1.004161,-2.631904 0,-3.636065 L 11.043894,11.999839 6.4345258,7.3891855 c -1.004161,-1.0041608 -1.004161,-2.6319041 0,-3.6360649 z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_light/icons.conf
+++ b/nw/assets/icons/typicons_grey_light/icons.conf
@@ -51,5 +51,7 @@ check          = tick.svg
 cross          = times.svg
 hash           = hash.svg
 reference      = at.svg
+backward       = chevron-left.svg
+forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg

--- a/nw/core/tohtml.py
+++ b/nw/core/tohtml.py
@@ -189,7 +189,7 @@ class ToHtml(Tokenizer):
                 hStyle = ""
 
             if self.linkHeaders:
-                aNm = "<a name='head_%s:T%06d'></a>" % (self.theHandle, tLine)
+                aNm = "<a name='T%06d'></a>" % tLine
             else:
                 aNm = ""
 

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -475,16 +475,16 @@ class GuiMainMenu(QMenuBar):
         # View > Separator
         self.viewMenu.addSeparator()
 
-        # View > Navigate Viewer Backward
-        self.aViewPrev = QAction("Navigate Viewer Backward", self)
-        self.aViewPrev.setStatusTip("Show the previous document in the right pane")
+        # View > Go Backward
+        self.aViewPrev = QAction("Go Backward", self)
+        self.aViewPrev.setStatusTip("Move backward in the view history of the right pane")
         self.aViewPrev.setShortcut("Alt+Left")
         self.aViewPrev.triggered.connect(self.theParent.docViewer.navBackward)
         self.viewMenu.addAction(self.aViewPrev)
 
-        # View > Navigate Viewer Forward
-        self.aViewNext = QAction("Navigate Viewer Forward", self)
-        self.aViewNext.setStatusTip("Show the next document in the right pane")
+        # View > Go Forward
+        self.aViewNext = QAction("Go Forward", self)
+        self.aViewNext.setStatusTip("Move forward in the view history of the right pane")
         self.aViewNext.setShortcut("Alt+Right")
         self.aViewNext.triggered.connect(self.theParent.docViewer.navForward)
         self.viewMenu.addAction(self.aViewNext)

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -475,6 +475,23 @@ class GuiMainMenu(QMenuBar):
         # View > Separator
         self.viewMenu.addSeparator()
 
+        # View > Navigate Viewer Backward
+        self.aViewPrev = QAction("Navigate Viewer Backward", self)
+        self.aViewPrev.setStatusTip("Show the previous document in the right pane")
+        self.aViewPrev.setShortcut("Alt+Left")
+        self.aViewPrev.triggered.connect(self.theParent.docViewer.navBackward)
+        self.viewMenu.addAction(self.aViewPrev)
+
+        # View > Navigate Viewer Forward
+        self.aViewNext = QAction("Navigate Viewer Forward", self)
+        self.aViewNext.setStatusTip("Show the next document in the right pane")
+        self.aViewNext.setShortcut("Alt+Right")
+        self.aViewNext.triggered.connect(self.theParent.docViewer.navForward)
+        self.viewMenu.addAction(self.aViewNext)
+
+        # View > Separator
+        self.viewMenu.addSeparator()
+
         # View > Toggle Distraction Free Mode
         self.aFocusMode = QAction("Distraction Free Mode", self)
         self.aFocusMode.setStatusTip("Toggles distraction free mode, only showing text editor")

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -554,6 +554,8 @@ class GuiIcons:
         "minimise"       : (None, None),
         "refresh"        : (None, None),
         "reference"      : (None, None),
+        "backward"       : (None, None),
+        "forward"        : (None, None),
 
         ## Switches
         "sticky-on"  : (None, None),

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -525,7 +525,7 @@ class GuiMain(QMainWindow):
             self.docEditor.saveText()
         return True
 
-    def viewDocument(self, tHandle=None, navLink=None):
+    def viewDocument(self, tHandle=None, tAnchor=None):
         """Load a document for viewing in the view panel.
         """
         if tHandle is None:
@@ -562,7 +562,7 @@ class GuiMain(QMainWindow):
                 vPos[1] = bPos[1] - vPos[0]
                 self.splitDocs.setSizes(vPos)
                 self.viewMeta.setVisible(self.mainConf.showRefPanel)
-            self.docViewer.navigateTo(navLink)
+            self.docViewer.navigateTo(tAnchor)
 
         return True
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -346,6 +346,7 @@ class GuiMain(QMainWindow):
 
         if saveOK:
             self.closeDocument()
+            self.docViewer.clearNavHistory()
             self.projView.closeOutline()
             self.theProject.closeProject()
             self.theIndex.clearIndex()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1163,6 +1163,22 @@ def testDocAction(qtbot, nwLipsum, nwTemp):
         "nunc lacus, imperdiet nec posuere ac, interdum non lectus."
     )
 
+    # Navigation History
+    assert nwGUI.viewDocument("04468803b92e1")
+    assert nwGUI.docViewer.theHandle == "04468803b92e1"
+    assert nwGUI.docViewer.docHeader.backButton.isEnabled()
+    assert not nwGUI.docViewer.docHeader.forwardButton.isEnabled()
+
+    qtbot.mouseClick(nwGUI.docViewer.docHeader.backButton, Qt.LeftButton)
+    assert nwGUI.docViewer.theHandle == "4c4f28287af27"
+    assert not nwGUI.docViewer.docHeader.backButton.isEnabled()
+    assert nwGUI.docViewer.docHeader.forwardButton.isEnabled()
+
+    qtbot.mouseClick(nwGUI.docViewer.docHeader.forwardButton, Qt.LeftButton)
+    assert nwGUI.docViewer.theHandle == "04468803b92e1"
+    assert nwGUI.docViewer.docHeader.backButton.isEnabled()
+    assert not nwGUI.docViewer.docHeader.forwardButton.isEnabled()
+
     # qtbot.stopForInteraction()
     nwGUI.closeMain()
 


### PR DESCRIPTION
This PR adds a 20 page history to the document viewer where the user can navigate backwards and forwards in the last opened documents. The forward history is reset if the user opens a document explicitly instead of navigating back and forth. Same as a browser does, and the undo/redo stack.

The user can interact with the navigation in the following ways:
* Backward and forward navigation in the `View` menu.
* Keyboard shortcuts `Alt+Left` and `Alt+Right`.
* Navigation buttons in the top, left corner of the document view window.
* Backward and forward nav buttons on the mouse, if available.

If novelWriter is started with the `--verbose` flag, the entire history is dumped to the terminal window each time a navigation occurs. This can be used for debugging, although it is definitely verbose and may be removed at a later point.