### PR TITLE
Header and Footer Buttons (Edit, Search, Comments, Synopsis)

### DIFF
--- a/nw/assets/icons/fallback/bullet-off-dark.svg
+++ b/nw/assets/icons/fallback/bullet-off-dark.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg11603"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata11609">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11607" />
+  <path
+     style="stroke-width:1.5;fill:#aeaeae;fill-opacity:1"
+     id="path11601"
+     d="m 12,6 c 3.3075,0 6,2.691 6,6 0,3.309 -2.6925,6 -6,6 C 8.6925,18 6,15.309 6,12 6,8.691 8.6925,6 12,6 m 0,-3 c -4.971,0 -9,4.029 -9,9 0,4.968 4.029,9 9,9 4.968,0 9,-4.032 9,-9 0,-4.971 -4.032,-9 -9,-9 z" />
+</svg>

--- a/nw/assets/icons/fallback/bullet-off.svg
+++ b/nw/assets/icons/fallback/bullet-off.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg11603"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata11609">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11607" />
+  <path
+     style="stroke-width:1.5;fill:#000000;fill-opacity:0.78039217"
+     id="path11601"
+     d="m 12,6 c 3.3075,0 6,2.691 6,6 0,3.309 -2.6925,6 -6,6 C 8.6925,18 6,15.309 6,12 6,8.691 8.6925,6 12,6 m 0,-3 c -4.971,0 -9,4.029 -9,9 0,4.968 4.029,9 9,9 4.968,0 9,-4.032 9,-9 0,-4.971 -4.032,-9 -9,-9 z" />
+</svg>

--- a/nw/assets/icons/fallback/bullet-on-dark.svg
+++ b/nw/assets/icons/fallback/bullet-on-dark.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg10879"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata10885">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10883" />
+  <path
+     style="stroke-width:1.5;fill:#aeaeae;fill-opacity:1"
+     id="path10877"
+     d="M 21,12 C 21,9.5145 19.992,7.2645 18.3645,5.6355 16.7355,4.008 14.4855,3 12,3 9.516,3 7.266,4.008 5.637,5.6355 4.008,7.2645 3,9.5145 3,12 3,14.484 4.008,16.734 5.637,18.363 7.266,19.992 9.516,21 12,21 14.4855,21 16.7355,19.992 18.3645,18.363 19.992,16.734 21,14.484 21,12 Z" />
+</svg>

--- a/nw/assets/icons/fallback/bullet-on.svg
+++ b/nw/assets/icons/fallback/bullet-on.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg10879"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata10885">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10883" />
+  <path
+     style="stroke-width:1.5;fill:#000000;fill-opacity:0.78039217"
+     id="path10877"
+     d="M 21,12 C 21,9.5145 19.992,7.2645 18.3645,5.6355 16.7355,4.008 14.4855,3 12,3 9.516,3 7.266,4.008 5.637,5.6355 4.008,7.2645 3,9.5145 3,12 3,14.484 4.008,16.734 5.637,18.363 7.266,19.992 9.516,21 12,21 14.4855,21 16.7355,19.992 18.3645,18.363 19.992,16.734 21,14.484 21,12 Z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_dark/icons.conf
+++ b/nw/assets/icons/typicons_colour_dark/icons.conf
@@ -55,3 +55,5 @@ backward       = chevron-left.svg
 forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg
+bullet-on      = media-record.svg
+bullet-off     = media-record-outline.svg

--- a/nw/assets/icons/typicons_colour_dark/media-record-outline.svg
+++ b/nw/assets/icons/typicons_colour_dark/media-record-outline.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg11603"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata11609">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11607" />
+  <path
+     style="stroke-width:1.5;fill:#6699cc;fill-opacity:1"
+     id="path11601"
+     d="m 12,6 c 3.3075,0 6,2.691 6,6 0,3.309 -2.6925,6 -6,6 C 8.6925,18 6,15.309 6,12 6,8.691 8.6925,6 12,6 m 0,-3 c -4.971,0 -9,4.029 -9,9 0,4.968 4.029,9 9,9 4.968,0 9,-4.032 9,-9 0,-4.971 -4.032,-9 -9,-9 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_dark/media-record.svg
+++ b/nw/assets/icons/typicons_colour_dark/media-record.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg10879"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata10885">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10883" />
+  <path
+     style="stroke-width:1.5;fill:#6699cc;fill-opacity:1"
+     id="path10877"
+     d="M 21,12 C 21,9.5145 19.992,7.2645 18.3645,5.6355 16.7355,4.008 14.4855,3 12,3 9.516,3 7.266,4.008 5.637,5.6355 4.008,7.2645 3,9.5145 3,12 3,14.484 4.008,16.734 5.637,18.363 7.266,19.992 9.516,21 12,21 14.4855,21 16.7355,19.992 18.3645,18.363 19.992,16.734 21,14.484 21,12 Z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_light/icons.conf
+++ b/nw/assets/icons/typicons_colour_light/icons.conf
@@ -55,3 +55,5 @@ backward       = chevron-left.svg
 forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg
+bullet-on      = media-record.svg
+bullet-off     = media-record-outline.svg

--- a/nw/assets/icons/typicons_colour_light/media-record-outline.svg
+++ b/nw/assets/icons/typicons_colour_light/media-record-outline.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg11603"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata11609">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11607" />
+  <path
+     style="stroke-width:1.5;fill:#4271ae;fill-opacity:1"
+     id="path11601"
+     d="m 12,6 c 3.3075,0 6,2.691 6,6 0,3.309 -2.6925,6 -6,6 C 8.6925,18 6,15.309 6,12 6,8.691 8.6925,6 12,6 m 0,-3 c -4.971,0 -9,4.029 -9,9 0,4.968 4.029,9 9,9 4.968,0 9,-4.032 9,-9 0,-4.971 -4.032,-9 -9,-9 z" />
+</svg>

--- a/nw/assets/icons/typicons_colour_light/media-record.svg
+++ b/nw/assets/icons/typicons_colour_light/media-record.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg10879"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata10885">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10883" />
+  <path
+     style="stroke-width:1.5;fill:#4271ae;fill-opacity:1"
+     id="path10877"
+     d="M 21,12 C 21,9.5145 19.992,7.2645 18.3645,5.6355 16.7355,4.008 14.4855,3 12,3 9.516,3 7.266,4.008 5.637,5.6355 4.008,7.2645 3,9.5145 3,12 3,14.484 4.008,16.734 5.637,18.363 7.266,19.992 9.516,21 12,21 14.4855,21 16.7355,19.992 18.3645,18.363 19.992,16.734 21,14.484 21,12 Z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_dark/icons.conf
+++ b/nw/assets/icons/typicons_grey_dark/icons.conf
@@ -55,3 +55,5 @@ backward       = chevron-left.svg
 forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg
+bullet-on      = media-record.svg
+bullet-off     = media-record-outline.svg

--- a/nw/assets/icons/typicons_grey_dark/media-record-outline.svg
+++ b/nw/assets/icons/typicons_grey_dark/media-record-outline.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg11603"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata11609">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11607" />
+  <path
+     style="stroke-width:1.5;fill:#aeaeae;fill-opacity:1"
+     id="path11601"
+     d="m 12,6 c 3.3075,0 6,2.691 6,6 0,3.309 -2.6925,6 -6,6 C 8.6925,18 6,15.309 6,12 6,8.691 8.6925,6 12,6 m 0,-3 c -4.971,0 -9,4.029 -9,9 0,4.968 4.029,9 9,9 4.968,0 9,-4.032 9,-9 0,-4.971 -4.032,-9 -9,-9 z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_dark/media-record.svg
+++ b/nw/assets/icons/typicons_grey_dark/media-record.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg10879"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata10885">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10883" />
+  <path
+     style="stroke-width:1.5;fill:#aeaeae;fill-opacity:1"
+     id="path10877"
+     d="M 21,12 C 21,9.5145 19.992,7.2645 18.3645,5.6355 16.7355,4.008 14.4855,3 12,3 9.516,3 7.266,4.008 5.637,5.6355 4.008,7.2645 3,9.5145 3,12 3,14.484 4.008,16.734 5.637,18.363 7.266,19.992 9.516,21 12,21 14.4855,21 16.7355,19.992 18.3645,18.363 19.992,16.734 21,14.484 21,12 Z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_light/icons.conf
+++ b/nw/assets/icons/typicons_grey_light/icons.conf
@@ -55,3 +55,5 @@ backward       = chevron-left.svg
 forward        = chevron-right.svg
 sticky-on      = pin.svg
 sticky-off     = pin-outline.svg
+bullet-on      = media-record.svg
+bullet-off     = media-record-outline.svg

--- a/nw/assets/icons/typicons_grey_light/media-record-outline.svg
+++ b/nw/assets/icons/typicons_grey_light/media-record-outline.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg11603"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata11609">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11607" />
+  <path
+     style="stroke-width:1.5;fill:#000000;fill-opacity:0.78039217"
+     id="path11601"
+     d="m 12,6 c 3.3075,0 6,2.691 6,6 0,3.309 -2.6925,6 -6,6 C 8.6925,18 6,15.309 6,12 6,8.691 8.6925,6 12,6 m 0,-3 c -4.971,0 -9,4.029 -9,9 0,4.968 4.029,9 9,9 4.968,0 9,-4.032 9,-9 0,-4.971 -4.032,-9 -9,-9 z" />
+</svg>

--- a/nw/assets/icons/typicons_grey_light/media-record.svg
+++ b/nw/assets/icons/typicons_grey_light/media-record.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg10879"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.2">
+  <metadata
+     id="metadata10885">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10883" />
+  <path
+     style="stroke-width:1.5;fill:#000000;fill-opacity:0.78039217"
+     id="path10877"
+     d="M 21,12 C 21,9.5145 19.992,7.2645 18.3645,5.6355 16.7355,4.008 14.4855,3 12,3 9.516,3 7.266,4.008 5.637,5.6355 4.008,7.2645 3,9.5145 3,12 3,14.484 4.008,16.734 5.637,18.363 7.266,19.992 9.516,21 12,21 14.4855,21 16.7355,19.992 18.3645,18.363 19.992,16.734 21,14.484 21,12 Z" />
+</svg>

--- a/nw/config.py
+++ b/nw/config.py
@@ -812,6 +812,16 @@ class Config:
         self.errData = []
         return errMessage
 
+    def setViewComments(self, viewState):
+        self.viewComments = viewState
+        self.confChanged  = True
+        return self.viewComments
+
+    def setViewSynopsis(self, viewState):
+        self.viewSynopsis = viewState
+        self.confChanged  = True
+        return self.viewSynopsis
+
     ##
     #  Getters
     ##

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -652,6 +652,15 @@ class GuiDocEditor(QTextEdit):
         self.docSearch.closeSearch()
         return self.docSearch.isVisible()
 
+    def toggleSearch(self):
+        """Toggle the visibility of the search box.
+        """
+        if self.docSearch.isVisible():
+            self.docSearch.closeSearch()
+        else:
+            self._beginSearch()
+        return
+
     ##
     #  Document Events and Maintenance
     ##
@@ -1853,7 +1862,7 @@ class GuiDocEditHeader(QWidget):
         self.buttonSize = fPx + hSp
 
         # Main Widget Settings
-        self.setContentsMargins(2*self.buttonSize, 0, 0, 0)
+        # self.setContentsMargins(2*self.buttonSize, 0, 0, 0)
         self.setAutoFillBackground(True)
         self.setPalette(self.thePalette)
 
@@ -1878,6 +1887,28 @@ class GuiDocEditHeader(QWidget):
         ).format(*self.theTheme.colText)
 
         # Buttons
+        self.editButton = QToolButton(self)
+        self.editButton.setIcon(self.theTheme.getIcon("edit"))
+        self.editButton.setContentsMargins(0, 0, 0, 0)
+        self.editButton.setIconSize(QSize(fPx, fPx))
+        self.editButton.setFixedSize(fPx, fPx)
+        self.editButton.setStyleSheet(buttonStyle)
+        self.editButton.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self.editButton.setVisible(False)
+        self.editButton.setToolTip("Edit document meta")
+        self.editButton.clicked.connect(self._editDocument)
+
+        self.searchButton = QToolButton(self)
+        self.searchButton.setIcon(self.theTheme.getIcon("search"))
+        self.searchButton.setContentsMargins(0, 0, 0, 0)
+        self.searchButton.setIconSize(QSize(fPx, fPx))
+        self.searchButton.setFixedSize(fPx, fPx)
+        self.searchButton.setStyleSheet(buttonStyle)
+        self.searchButton.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self.searchButton.setVisible(False)
+        self.searchButton.setToolTip("Search document")
+        self.searchButton.clicked.connect(self._searchDocument)
+
         self.minmaxButton = QToolButton(self)
         self.minmaxButton.setIcon(self.theTheme.getIcon("maximise"))
         self.minmaxButton.setContentsMargins(0, 0, 0, 0)
@@ -1903,6 +1934,8 @@ class GuiDocEditHeader(QWidget):
         # Assemble Layout
         self.outerBox = QHBoxLayout()
         self.outerBox.setSpacing(hSp)
+        self.outerBox.addWidget(self.editButton, 0)
+        self.outerBox.addWidget(self.searchButton, 0)
         self.outerBox.addWidget(self.theTitle, 1)
         self.outerBox.addWidget(self.minmaxButton, 0)
         self.outerBox.addWidget(self.closeButton, 0)
@@ -1923,6 +1956,8 @@ class GuiDocEditHeader(QWidget):
         self.theHandle = tHandle
         if tHandle is None:
             self.theTitle.setText("")
+            self.editButton.setVisible(False)
+            self.searchButton.setVisible(False)
             self.closeButton.setVisible(False)
             self.minmaxButton.setVisible(False)
             return True
@@ -1942,6 +1977,8 @@ class GuiDocEditHeader(QWidget):
                 return False
             self.theTitle.setText(nwItem.itemName)
 
+        self.editButton.setVisible(True)
+        self.searchButton.setVisible(True)
         self.closeButton.setVisible(True)
         self.minmaxButton.setVisible(True)
 
@@ -1951,10 +1988,24 @@ class GuiDocEditHeader(QWidget):
     #  Slots
     ##
 
+    def _editDocument(self):
+        """Open the edit item dialog from the main GUI.
+        """
+        self.theParent.editItem(self.theHandle)
+        return
+
+    def _searchDocument(self):
+        """Toggle the visibility of the search box.
+        """
+        self.docEditor.toggleSearch()
+        return
+
     def _closeDocument(self):
-        """Trigger the close editor/viewer on the main window.
+        """Trigger the close editor on the main window.
         """
         self.theParent.closeDocEditor()
+        self.editButton.setVisible(False)
+        self.searchButton.setVisible(False)
         self.closeButton.setVisible(False)
         self.minmaxButton.setVisible(False)
         return
@@ -1966,10 +2017,14 @@ class GuiDocEditHeader(QWidget):
         if self.theParent.isFocusMode:
             self.minmaxButton.setIcon(self.theTheme.getIcon("minimise"))
             self.setContentsMargins(self.buttonSize, 0, 0, 0)
+            self.editButton.setVisible(False)
+            self.searchButton.setVisible(False)
             self.closeButton.setVisible(False)
         else:
             self.minmaxButton.setIcon(self.theTheme.getIcon("maximise"))
-            self.setContentsMargins(2*self.buttonSize, 0, 0, 0)
+            self.setContentsMargins(0, 0, 0, 0)
+            self.editButton.setVisible(True)
+            self.searchButton.setVisible(True)
             self.closeButton.setVisible(True)
         return
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -1862,7 +1862,6 @@ class GuiDocEditHeader(QWidget):
         self.buttonSize = fPx + hSp
 
         # Main Widget Settings
-        # self.setContentsMargins(2*self.buttonSize, 0, 0, 0)
         self.setAutoFillBackground(True)
         self.setPalette(self.thePalette)
 

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -879,6 +879,19 @@ class GuiDocViewFooter(QWidget):
         bSp = self.mainConf.pxInt(2)
         hSp = self.mainConf.pxInt(8)
 
+        # Icons
+        stickyOn  = self.theTheme.getPixmap("sticky-on", (fPx, fPx))
+        stickyOff = self.theTheme.getPixmap("sticky-off", (fPx, fPx))
+        stickyIcon = QIcon()
+        stickyIcon.addPixmap(stickyOn, QIcon.Normal, QIcon.On)
+        stickyIcon.addPixmap(stickyOff, QIcon.Normal, QIcon.Off)
+
+        bulletOn  = self.theTheme.getPixmap("bullet-on", (fPx, fPx))
+        bulletOff = self.theTheme.getPixmap("bullet-off", (fPx, fPx))
+        bulletIcon = QIcon()
+        bulletIcon.addPixmap(bulletOn, QIcon.Normal, QIcon.On)
+        bulletIcon.addPixmap(bulletOff, QIcon.Normal, QIcon.Off)
+
         # Main Widget Settings
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
@@ -900,11 +913,6 @@ class GuiDocViewFooter(QWidget):
         self.showHide.setToolTip("Show/hide the references panel")
 
         # Sticky Button
-        stickyOn  = self.theTheme.getPixmap("sticky-on", (fPx, fPx))
-        stickyOff = self.theTheme.getPixmap("sticky-off", (fPx, fPx))
-        stickyIcon = QIcon()
-        stickyIcon.addPixmap(stickyOn, QIcon.Normal, QIcon.On)
-        stickyIcon.addPixmap(stickyOff, QIcon.Normal, QIcon.Off)
         self.stickyRefs = QToolButton(self)
         self.stickyRefs.setCheckable(True)
         self.stickyRefs.setToolButtonStyle(Qt.ToolButtonIconOnly)
@@ -916,6 +924,30 @@ class GuiDocViewFooter(QWidget):
         self.stickyRefs.setToolTip(
             "Activate to freeze the content of the references panel when changing document"
         )
+
+        # Show Comments
+        self.showComments = QToolButton(self)
+        self.showComments.setCheckable(True)
+        self.showComments.setChecked(self.mainConf.viewComments)
+        self.showComments.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self.showComments.setStyleSheet(buttonStyle)
+        self.showComments.setIcon(bulletIcon)
+        self.showComments.setIconSize(QSize(fPx, fPx))
+        self.showComments.setFixedSize(QSize(fPx, fPx))
+        self.showComments.toggled.connect(self._doToggleComments)
+        self.showComments.setToolTip("Show comments")
+
+        # Show Synopsis
+        self.showSynopsis = QToolButton(self)
+        self.showSynopsis.setCheckable(True)
+        self.showSynopsis.setChecked(self.mainConf.viewSynopsis)
+        self.showSynopsis.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self.showSynopsis.setStyleSheet(buttonStyle)
+        self.showSynopsis.setIcon(bulletIcon)
+        self.showSynopsis.setIconSize(QSize(fPx, fPx))
+        self.showSynopsis.setFixedSize(QSize(fPx, fPx))
+        self.showSynopsis.toggled.connect(self._doToggleSynopsis)
+        self.showSynopsis.setToolTip("Show synopsis comments")
 
         # Labels
         self.lblRefs = QLabel("References")
@@ -938,10 +970,32 @@ class GuiDocViewFooter(QWidget):
         self.lblSticky.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         self.lblSticky.setPalette(self.thePalette)
 
+        self.lblComments = QLabel("Comments")
+        self.lblComments.setBuddy(self.showComments)
+        self.lblComments.setIndent(0)
+        self.lblComments.setMargin(0)
+        self.lblComments.setContentsMargins(0, 0, 0, 0)
+        self.lblComments.setAutoFillBackground(True)
+        self.lblComments.setFixedHeight(fPx)
+        self.lblComments.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.lblComments.setPalette(self.thePalette)
+
+        self.lblSynopsis = QLabel("Synopsis")
+        self.lblSynopsis.setBuddy(self.showSynopsis)
+        self.lblSynopsis.setIndent(0)
+        self.lblSynopsis.setMargin(0)
+        self.lblSynopsis.setContentsMargins(0, 0, 0, 0)
+        self.lblSynopsis.setAutoFillBackground(True)
+        self.lblSynopsis.setFixedHeight(fPx)
+        self.lblSynopsis.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.lblSynopsis.setPalette(self.thePalette)
+
         lblFont = self.font()
         lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
         self.lblRefs.setFont(lblFont)
         self.lblSticky.setFont(lblFont)
+        self.lblComments.setFont(lblFont)
+        self.lblSynopsis.setFont(lblFont)
 
         # Assemble Layout
         self.outerBox = QHBoxLayout()
@@ -952,6 +1006,11 @@ class GuiDocViewFooter(QWidget):
         self.outerBox.addWidget(self.stickyRefs, 0)
         self.outerBox.addWidget(self.lblSticky, 0)
         self.outerBox.addStretch(1)
+        self.outerBox.addWidget(self.showComments, 0)
+        self.outerBox.addWidget(self.lblComments, 0)
+        self.outerBox.addSpacing(hSp)
+        self.outerBox.addWidget(self.showSynopsis, 0)
+        self.outerBox.addWidget(self.lblSynopsis, 0)
         self.setLayout(self.outerBox)
 
         logger.debug("GuiDocViewFooter initialisation complete")
@@ -976,6 +1035,20 @@ class GuiDocViewFooter(QWidget):
         self.docViewer.stickyRef = theState
         if not theState and self.docViewer.theHandle is not None:
             self.viewMeta.refreshReferences(self.docViewer.theHandle)
+        return
+
+    def _doToggleComments(self, theState):
+        """Toggle the view comment button and reload the document.
+        """
+        self.mainConf.setViewComments(not self.mainConf.viewComments)
+        self.docViewer.reloadText()
+        return
+
+    def _doToggleSynopsis(self, theState):
+        """Toggle the view synopsis button and reload the document.
+        """
+        self.mainConf.setViewSynopsis(not self.mainConf.viewSynopsis)
+        self.docViewer.reloadText()
         return
 
 # END Class GuiDocViewFooter

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -490,9 +490,8 @@ class GuiConfigEditLayoutTab(QWidget):
         self.tabWidth.setSingleStep(1)
         self.tabWidth.setValue(self.mainConf.tabWidth)
         self.mainForm.addRow(
-            "Editor tab width",
+            "Document tab width",
             self.tabWidth,
-            "This feature requires Qt 5.9 or later.",
             theUnit="px"
         )
 

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -496,26 +496,6 @@ class GuiConfigEditLayoutTab(QWidget):
             theUnit="px"
         )
 
-        # Render Options
-        # ==============
-        self.mainForm.addGroupLabel("Render Text")
-
-        ## Render Comments
-        self.viewComments = QSwitch()
-        self.viewComments.setChecked(self.mainConf.viewComments)
-        self.mainForm.addRow(
-            "Render comments in document view panel",
-            self.viewComments
-        )
-
-        ## Render Synopsis
-        self.viewSynopsis = QSwitch()
-        self.viewSynopsis.setChecked(self.mainConf.viewSynopsis)
-        self.mainForm.addRow(
-            "Render synopsis in document view panel",
-            self.viewSynopsis
-        )
-
         return
 
     def saveValues(self):
@@ -533,8 +513,6 @@ class GuiConfigEditLayoutTab(QWidget):
         doJustify       = self.textJustify.isChecked()
         textMargin      = self.textMargin.value()
         tabWidth        = self.tabWidth.value()
-        viewComments    = self.viewComments.isChecked()
-        viewSynopsis    = self.viewSynopsis.isChecked()
 
         self.mainConf.textFont        = textFont
         self.mainConf.textSize        = textSize
@@ -545,8 +523,6 @@ class GuiConfigEditLayoutTab(QWidget):
         self.mainConf.doJustify       = doJustify
         self.mainConf.textMargin      = textMargin
         self.mainConf.tabWidth        = tabWidth
-        self.mainConf.viewComments    = viewComments
-        self.mainConf.viewSynopsis    = viewSynopsis
 
         self.mainConf.confChanged = True
 

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -237,7 +237,7 @@ class GuiProjectTree(QTreeWidget):
 
         # Add the new item to the tree
         self.revealTreeItem(tHandle, nHandle)
-        self.theParent.editItem()
+        self.theParent.editItem(tHandle)
 
         return True
 

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -560,6 +560,8 @@ class GuiIcons:
         ## Switches
         "sticky-on"  : (None, None),
         "sticky-off" : (None, None),
+        "bullet-on"  : (None, None),
+        "bullet-off" : (None, None),
     }
 
     DECO_MAP = {

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -674,10 +674,11 @@ class GuiMain(QMainWindow):
 
         return True
 
-    def editItem(self):
+    def editItem(self, tHandle=None):
         """Open the edit item dialog.
         """
-        tHandle = self.treeView.getSelectedHandle()
+        if tHandle is None:
+            tHandle = self.treeView.getSelectedHandle()
         if tHandle is None:
             logger.warning("No item selected")
             return


### PR DESCRIPTION
This PR changes:

* Search and Edit buttons in the editor header.
* Show/hide comments and synopsis in the viewer footer.
* Removes the show comments and synopsis form the Layouts tab in Preferences.