### PR TITLE
Tree Context Menu Fix and Project Load Improvement

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,9 +10,7 @@ coverage:
     project:
       default:
         threshold: 1%
-    patch:
-      default:
-        threshold: 1%
+    patch: no
     changes: no
 
 parsers:

--- a/nw/common.py
+++ b/nw/common.py
@@ -29,7 +29,7 @@ import logging
 
 from datetime import datetime
 
-from nw.constants import nwConst
+from nw.constants import nwConst, nwUnicode
 
 logger = logging.getLogger(__name__)
 
@@ -150,11 +150,11 @@ def formatInt(theInt):
             theVal /= 1000.0
             if theVal < 1000.0:
                 if theVal < 10.0:
-                    return "%4.2f%s" % (theVal, pF)
+                    return "%4.2f%s%s" % (theVal, nwUnicode.U_THNSP, pF)
                 elif theVal < 100.0:
-                    return "%4.1f%s" % (theVal, pF)
+                    return "%4.1f%s%s" % (theVal, nwUnicode.U_THNSP, pF)
                 else:
-                    return "%3.0f%s" % (theVal, pF)
+                    return "%3.0f%s%s" % (theVal, nwUnicode.U_THNSP, pF)
 
     return "%d" % theInt
 

--- a/nw/gui/projload.py
+++ b/nw/gui/projload.py
@@ -282,6 +282,7 @@ class GuiProjectLoad(QDialog):
             newItem.setTextAlignment(self.C_NAME,  Qt.AlignLeft  | Qt.AlignVCenter)
             newItem.setTextAlignment(self.C_COUNT, Qt.AlignRight | Qt.AlignVCenter)
             newItem.setTextAlignment(self.C_TIME,  Qt.AlignRight | Qt.AlignVCenter)
+            newItem.setFont(self.C_TIME, self.theTheme.guiFontFixed)
             self.listBox.addTopLevelItem(newItem)
             if not hasSelection:
                 newItem.setSelected(True)

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -985,23 +985,26 @@ class GuiProjectTreeMenu(QMenu):
         """Update item settings from the nwItem.
         """
         self.theItem = theItem
-        trashHandle = self.theTree.theProject.projTree.trashRoot()
+        theRoot = self.theTree.theProject.projTree.getRootItem(theItem.itemHandle)
 
-        if theItem is None:
+        if theItem is None or theRoot is None:
+            logger.error("Failed to extract information to build tree context menu")
             return False
 
-        inTrash = theItem.parHandle == trashHandle
-        isTrash = theItem.itemHandle == trashHandle
+        trashHandle = self.theTree.theProject.projTree.trashRoot()
+
+        inTrash = theItem.parHandle == trashHandle and trashHandle is not None
+        isTrash = theItem.itemHandle == trashHandle and trashHandle is not None
         isFile  = theItem.itemType == nwItemType.FILE
-        isArch  = theItem.itemClass == nwItemClass.ARCHIVE
+        isArch  = theRoot.itemClass == nwItemClass.ARCHIVE
         isOrph  = isFile and theItem.parHandle is None
 
         showOpen      = isFile
         showView      = isFile
         showEdit      = not isTrash and not isOrph
-        showExport    = isFile and not inTrash and not isOrph
-        showNewFile   = not isTrash and not inTrash and not isOrph and not isArch
-        showNewFolder = not isTrash and not inTrash and not isOrph
+        showExport    = isFile
+        showNewFile   = not (isTrash or inTrash or isOrph or isArch)
+        showNewFolder = not (isTrash or inTrash or isOrph)
         showDelete    = not isTrash
         showEmpty     = isTrash
 

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -138,8 +138,8 @@ class GuiTheme:
         logger.verbose("GUI DPI: %.1f" % self.guiDPI)
         logger.verbose("GUI Scale: %.2f" % self.guiScale)
 
+        # Fonts
         self.guiFont = qApp.font()
-        self.guiFontFixed = QFontDatabase.systemFont(QFontDatabase.FixedFont)
 
         qMetric = QFontMetrics(self.guiFont)
         self.fontPointSize = self.guiFont.pointSizeF()
@@ -147,6 +147,11 @@ class GuiTheme:
         self.baseIconSize = int(round(qMetric.ascent()))
         self.textNHeight = qMetric.boundingRect("N").height()
         self.textNWidth = qMetric.boundingRect("N").width()
+
+        # Monospace Font
+        self.guiFontFixed = QFont()
+        self.guiFontFixed.setPointSizeF(0.95*self.fontPointSize)
+        self.guiFontFixed.setFamily(QFontDatabase.systemFont(QFontDatabase.FixedFont).family())
 
         logger.verbose("GUI Font Family: %s" % self.guiFont.family())
         logger.verbose("GUI Font Point Size: %.2f" % self.fontPointSize)

--- a/nw/gui/writingstats.py
+++ b/nw/gui/writingstats.py
@@ -33,7 +33,7 @@ from os import path
 from datetime import datetime
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont, QPixmap
+from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (
     qApp, QDialog, QTreeWidget, QTreeWidgetItem, QDialogButtonBox, QGridLayout,
     QLabel, QGroupBox, QMenu, QAction, QFileDialog, QSpinBox, QHBoxLayout
@@ -100,10 +100,6 @@ class GuiWritingStats(QDialog):
         hHeader.setTextAlignment(self.C_LENGTH, Qt.AlignRight)
         hHeader.setTextAlignment(self.C_COUNT, Qt.AlignRight)
 
-        self.monoFont = QFont()
-        self.monoFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
-        self.monoFont.setFamily(self.theTheme.guiFontFixed.family())
-
         sortValid = (Qt.AscendingOrder, Qt.DescendingOrder)
         sortCol = self.optState.validIntRange(
             self.optState.getInt("GuiWritingStats", "sortCol", 0), 0, 2, 0
@@ -127,23 +123,23 @@ class GuiWritingStats(QDialog):
         self.infoBox.setLayout(self.infoForm)
 
         self.labelTotal = QLabel(self._formatTime(0))
-        self.labelTotal.setFont(self.monoFont)
+        self.labelTotal.setFont(self.theTheme.guiFontFixed)
         self.labelTotal.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.labelFilter = QLabel(self._formatTime(0))
-        self.labelFilter.setFont(self.monoFont)
+        self.labelFilter.setFont(self.theTheme.guiFontFixed)
         self.labelFilter.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.novelWords = QLabel("0")
-        self.novelWords.setFont(self.monoFont)
+        self.novelWords.setFont(self.theTheme.guiFontFixed)
         self.novelWords.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.notesWords = QLabel("0")
-        self.notesWords.setFont(self.monoFont)
+        self.notesWords.setFont(self.theTheme.guiFontFixed)
         self.notesWords.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.totalWords = QLabel("0")
-        self.totalWords.setFont(self.monoFont)
+        self.totalWords.setFont(self.theTheme.guiFontFixed)
         self.totalWords.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.infoForm.addWidget(QLabel("Total Time:"),       0, 0)
@@ -559,9 +555,9 @@ class GuiWritingStats(QDialog):
             newItem.setTextAlignment(self.C_COUNT, Qt.AlignRight)
             newItem.setTextAlignment(self.C_BAR, Qt.AlignLeft | Qt.AlignVCenter)
 
-            newItem.setFont(self.C_TIME, self.monoFont)
-            newItem.setFont(self.C_LENGTH, self.monoFont)
-            newItem.setFont(self.C_COUNT, self.monoFont)
+            newItem.setFont(self.C_TIME, self.theTheme.guiFontFixed)
+            newItem.setFont(self.C_LENGTH, self.theTheme.guiFontFixed)
+            newItem.setFont(self.C_COUNT, self.theTheme.guiFontFixed)
 
             self.listBox.addTopLevelItem(newItem)
             self.timeFilter += sDiff

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -86,13 +86,13 @@ def testFormatTime():
 @pytest.mark.core
 def testFormatInt():
     assert formatInt(1000) == "1000"
-    assert formatInt(1234) == "1.23k"
-    assert formatInt(12345) == "12.3k"
-    assert formatInt(123456) == "123k"
-    assert formatInt(1234567) == "1.23M"
-    assert formatInt(12345678) == "12.3M"
-    assert formatInt(123456789) == "123M"
-    assert formatInt(1234567890) == "1.23G"
+    assert formatInt(1234) == "1.23\u2009k"
+    assert formatInt(12345) == "12.3\u2009k"
+    assert formatInt(123456) == "123\u2009k"
+    assert formatInt(1234567) == "1.23\u2009M"
+    assert formatInt(12345678) == "12.3\u2009M"
+    assert formatInt(123456789) == "123\u2009M"
+    assert formatInt(1234567890) == "1.23\u2009G"
 
 @pytest.mark.core
 def testTransferCase():


### PR DESCRIPTION
This PR does the following:

* Changes the Last Opened column of the Project Load dialog to a fixed with font, and adds a thin space between the word count and the multiplier unit in the Words column.
* Fixes a bug in the filtering of options in the Project Tree context menu. When the user right-clicks an item, the available options for that item is turned visible, and the other become invisible. However, the options that are filtered out on the Trash folders were accidentally applied to other folders if there was no Trask folder present. This is because when the Trash folder is not present, the lookup of its handle returns a None, which accidentally matches on Root folders who have a parent folder handle set to None (they are root folders without parents). The filter therefor thought they were all Trash folders. This check has now been fixed.