### PR TITLE
Editor Performance Improvements

### DIFF
--- a/nw/common.py
+++ b/nw/common.py
@@ -29,6 +29,8 @@ import logging
 
 from datetime import datetime
 
+from PyQt5.QtWidgets import qApp
+
 from nw.constants import nwConst, nwUnicode
 
 logger = logging.getLogger(__name__)
@@ -251,3 +253,11 @@ def makeFileNameSafe(theText):
         if c.isalpha() or c.isdigit() or c == " ":
             cleanName += c
     return cleanName
+
+def getGuiItem(theName):
+    """Returns a QtWidget based on its objectName.
+    """
+    for qWidget in qApp.topLevelWidgets():
+        if qWidget.objectName() == theName:
+            return qWidget
+    return None

--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -33,7 +33,9 @@ class nwConst():
     fStampFmt = "%Y-%m-%d %H.%M.%S" # FileName safe format
     dStampFmt = "%Y-%m-%d"          # Date only format
 
-    maxDepth = 30 # Maximum folder depth of a project
+    maxDepth     = 30       # Maximum folder depth of a project
+    maxDocSize   = 5000000  # Maxium size of a single document
+    maxBuildSize = 10000000 # Maxium size of a project build
 
 # END Class nwConst
 

--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -271,16 +271,16 @@ class NWIndex():
         theRoot = self.theProject.projTree.getRootItem(tHandle)
 
         if theItem is None:
-            logger.error("Not indexing unknown item %s" % tHandle)
+            logger.info("Not indexing unknown item %s" % tHandle)
             return False
         if theItem.itemType != nwItemType.FILE:
-            logger.error("Not indexing non-file item %s" % tHandle)
+            logger.info("Not indexing non-file item %s" % tHandle)
             return False
         if theItem.itemLayout == nwItemLayout.NO_LAYOUT:
-            logger.error("Not indexing no-layout item %s" % tHandle)
+            logger.info("Not indexing no-layout item %s" % tHandle)
             return False
         if theItem.parHandle is None:
-            logger.error("Not indexing orphaned item %s" % tHandle)
+            logger.info("Not indexing orphaned item %s" % tHandle)
             return False
 
         # Run word counter for the whole text
@@ -289,10 +289,10 @@ class NWIndex():
 
         # If the file is archived or trashed, we don't index the file itself
         if self.theProject.projTree.isTrashRoot(theItem.parHandle):
-            logger.error("Not indexing trash item %s" % tHandle)
+            logger.info("Not indexing trash item %s" % tHandle)
             return False
         if theRoot.itemClass == nwItemClass.ARCHIVE:
-            logger.error("Not indexing archived item %s" % tHandle)
+            logger.info("Not indexing archived item %s" % tHandle)
             return False
 
         itemClass  = theItem.itemClass

--- a/nw/core/tokenizer.py
+++ b/nw/core/tokenizer.py
@@ -33,7 +33,7 @@ from PyQt5.QtCore import QRegularExpression
 
 from nw.core.document import NWDoc
 from nw.core.tools import numberToWord, numberToRoman
-from nw.constants import nwItemLayout, nwItemType, nwRegEx
+from nw.constants import nwConst, nwItemLayout, nwItemType, nwRegEx
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +119,9 @@ class Tokenizer():
         self.isScene = False
         self.isNote  = False
         self.isNovel = False
+
+        # Error Handling
+        self.errData = []
 
         return
 
@@ -212,6 +215,14 @@ class Tokenizer():
             theDocument  = NWDoc(self.theProject, self.theParent)
             self.theText = theDocument.openDocument(theHandle)
 
+        docSize = len(self.theText)
+        if docSize > nwConst.maxDocSize:
+            errVal = "Document '%s' is too big (%.2f MB). Skipping." % (
+                self.theItem.itemName, docSize/1.0e6
+            )
+            self.theText = "# ERROR\n\n%s\n\n" % errVal
+            self.errData.append(errVal)
+
         self.isNone  = self.theItem.itemLayout == nwItemLayout.NO_LAYOUT
         self.isTitle = self.theItem.itemLayout == nwItemLayout.TITLE
         self.isBook  = self.theItem.itemLayout == nwItemLayout.BOOK
@@ -229,6 +240,11 @@ class Tokenizer():
         """Return the result from the conversion.
         """
         return self.theResult
+
+    def getResultSize(self):
+        """Return the size of the result from the conversion.
+        """
+        return len(self.theResult)
 
     def getFilteredMarkdown(self):
         """Return the novelWriter markdown after the filters have been applied.

--- a/nw/core/tools.py
+++ b/nw/core/tools.py
@@ -29,6 +29,8 @@
 
 import logging
 
+from nw.constants import nwUnicode
+
 logger = logging.getLogger(__name__)
 
 # =============================================================================================== #
@@ -43,6 +45,15 @@ def countWords(theText):
     wordCount = 0
     paraCount = 0
     prevEmpty = True
+
+    # We need to treat dashes as word separators for counting words.
+    # The check+replace apprach is much faster that direct replace for
+    # large texts, and a bit slower for small texts, but in the latter
+    # case it doesn't matter.
+    if nwUnicode.U_ENDASH in theText:
+        theText = theText.replace(nwUnicode.U_ENDASH, " ")
+    if nwUnicode.U_EMDASH in theText:
+        theText = theText.replace(nwUnicode.U_EMDASH, " ")
 
     for aLine in theText.splitlines():
 
@@ -72,8 +83,7 @@ def countWords(theText):
             charCount -= 2
             countPara = False
 
-        theBuff = aLine.replace("–", " ").replace("—", " ")
-        wordCount += len(theBuff.split())
+        wordCount += len(aLine.split())
         charCount += theLen
         if countPara and prevEmpty:
             paraCount += 1

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -288,13 +288,10 @@ class GuiDocEditor(QTextEdit):
 
         return True
 
-    def reHighLightText(self, forceBigDoc=False):
-        """Run the syntax highlighter again.
+    def updateTagHighLighting(self, forceBigDoc=False):
+        """Rerun the syntax highlighter on all meta data lines.
         """
-        if not self.bigDoc or forceBigDoc:
-            qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
-            self.hLight.rehighlight()
-            qApp.restoreOverrideCursor()
+        self.hLight.rehighlightByType(GuiDocHighlighter.BLOCK_META)
         return
 
     def redrawText(self):

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -223,20 +223,11 @@ class GuiDocEditor(QTextEdit):
         # font changed, otherwise we just clear the editor entirely,
         # which makes it read only.
         if self.theHandle is not None:
-            self.reloadText()
+            self.redrawText()
         else:
             self.clearEditor()
 
         return True
-
-    def reloadText(self):
-        """Reloads the document currently being edited.
-        """
-        if self.theHandle is not None:
-            tHandle = self.theHandle
-            self.clearEditor()
-            self.loadText(tHandle, showStatus=False)
-        return
 
     def loadText(self, tHandle, tLine=None, showStatus=True):
         """Load text from a document into the editor. If we have an io
@@ -296,6 +287,21 @@ class GuiDocEditor(QTextEdit):
             self.setTabStopWidth(self.mainConf.getTabWidth())
 
         return True
+
+    def reHighLightText(self, forceBigDoc=False):
+        """Run the syntax highlighter again.
+        """
+        if not self.bigDoc or forceBigDoc:
+            qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
+            self.hLight.rehighlight()
+            qApp.restoreOverrideCursor()
+        return
+
+    def redrawText(self):
+        """Redraw the text by marking the document content as "dirty".
+        """
+        self.qDocument.markContentsDirty(0, self.qDocument.characterCount())
+        return
 
     def replaceText(self, theText):
         """Replaces the text of the current document with the provided

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -446,7 +446,7 @@ class GuiDocEditor(QTextEdit):
         return self.textCursor().selectionEnd()
 
     def saveCursorPosition(self):
-        """Save the cursor position to the current project otem.
+        """Save the cursor position to the current project item object.
         """
         theItem = self.nwDocument.getCurrentItem()
         if theItem is not None:

--- a/nw/gui/projload.py
+++ b/nw/gui/projload.py
@@ -125,7 +125,7 @@ class GuiProjectLoad(QDialog):
 
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Open | QDialogButtonBox.Cancel)
         self.buttonBox.accepted.connect(self._doOpenRecent)
-        self.buttonBox.rejected.connect(self._doClose)
+        self.buttonBox.rejected.connect(self._doCancel)
 
         self.newButton = self.buttonBox.addButton("New", QDialogButtonBox.ActionRole)
         self.newButton.clicked.connect(self._doNewProject)
@@ -153,7 +153,7 @@ class GuiProjectLoad(QDialog):
         """Close the dialog window with a recent project selected.
         """
         logger.verbose("GuiProjectLoad open button clicked")
-        self._saveDialogState()
+        self._saveSettings()
 
         selItems = self.listBox.selectedItems()
         if selItems:
@@ -194,11 +194,12 @@ class GuiProjectLoad(QDialog):
 
         return
 
-    def _doClose(self):
+    def _doCancel(self):
         """Close the dialog window without doing anything.
         """
         logger.verbose("GuiProjectLoad close button clicked")
-        self._saveDialogState()
+        self.openPath = None
+        self.openState = self.NONE_STATE
         self.close()
         return
 
@@ -206,7 +207,7 @@ class GuiProjectLoad(QDialog):
         """Create a new project.
         """
         logger.verbose("GuiProjectLoad new project button clicked")
-        self._saveDialogState()
+        self._saveSettings()
         self.openPath = None
         self.openState = self.NEW_STATE
         self.accept()
@@ -231,10 +232,21 @@ class GuiProjectLoad(QDialog):
         return
 
     ##
+    #  Events
+    ##
+
+    def closeEvent(self, theEvent):
+        """Capture the user closing the dialog so we can save settings.
+        """
+        self._saveSettings()
+        theEvent.accept()
+        return
+
+    ##
     #  Internal Functions
     ##
 
-    def _saveDialogState(self):
+    def _saveSettings(self):
         """Save the changes made to the dialog.
         """
         colWidths = [0, 0, 0]

--- a/nw/gui/writingstats.py
+++ b/nw/gui/writingstats.py
@@ -33,7 +33,7 @@ import os
 from datetime import datetime
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPixmap
+from PyQt5.QtGui import QPixmap, QCursor
 from PyQt5.QtWidgets import (
     qApp, QDialog, QTreeWidget, QTreeWidgetItem, QDialogButtonBox, QGridLayout,
     QLabel, QGroupBox, QMenu, QAction, QFileDialog, QSpinBox, QHBoxLayout
@@ -253,10 +253,15 @@ class GuiWritingStats(QDialog):
 
         logger.debug("GuiWritingStats initialisation complete")
 
-        qApp.processEvents()
+        return
+
+    def populateGUI(self):
+        """Populate list box with data from the log file.
+        """
+        qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
         self._loadLogFile()
         self._updateListBox()
-
+        qApp.restoreOverrideCursor()
         return
 
     ##

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -48,6 +48,7 @@ from nw.gui import (
 )
 from nw.core import NWProject, NWDoc, NWIndex
 from nw.constants import nwItemType, nwItemClass, nwAlert
+from nw.common import getGuiItem
 
 logger = logging.getLogger(__name__)
 
@@ -816,9 +817,15 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return
 
-        dlgBuild = GuiBuildNovel(self, self.theProject)
+        dlgBuild = getGuiItem("GuiBuildNovel")
+        if dlgBuild is None:
+            dlgBuild = GuiBuildNovel(self, self.theProject)
+
         dlgBuild.setModal(False)
         dlgBuild.show()
+        qApp.processEvents()
+        dlgBuild.viewCachedDoc()
+
         return
 
     def showWritingStatsDialog(self):
@@ -828,9 +835,15 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return
 
-        dlgStats = GuiWritingStats(self, self.theProject)
+        dlgStats = getGuiItem("GuiWritingStats")
+        if dlgStats is None:
+            dlgStats = GuiWritingStats(self, self.theProject)
+
         dlgStats.setModal(False)
         dlgStats.show()
+        qApp.processEvents()
+        dlgStats.populateGUI()
+
         return
 
     def showAboutNWDialog(self):

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -448,6 +448,7 @@ class GuiMain(QMainWindow):
         """Close the document and clear the editor and title field.
         """
         if self.hasProject:
+            self.docEditor.saveCursorPosition()
             if self.docEditor.docChanged:
                 self.saveDocument()
             self.docEditor.clearEditor()

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -716,12 +716,11 @@ class GuiMain(QMainWindow):
 
         tEnd = time()
         self.statusBar.setStatus("Indexing completed in %.1f ms" % ((tEnd - tStart)*1000.0))
+        self.docEditor.updateTagHighLighting()
         qApp.restoreOverrideCursor()
 
         if not beQuiet:
             self.makeAlert("The project index has been successfully rebuilt.", nwAlert.INFO)
-
-        self.docEditor.reHighLightText()
 
         return True
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -716,12 +716,12 @@ class GuiMain(QMainWindow):
 
         tEnd = time()
         self.statusBar.setStatus("Indexing completed in %.1f ms" % ((tEnd - tStart)*1000.0))
-        self.docEditor.reloadText()
-
         qApp.restoreOverrideCursor()
 
         if not beQuiet:
             self.makeAlert("The project index has been successfully rebuilt.", nwAlert.INFO)
+
+        self.docEditor.reHighLightText()
 
         return True
 

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -114,7 +114,12 @@ def testProjectSettings(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTempGUI, nwR
     projEdit._doSave()
 
     # Open again, and check project settings
-    projEdit = GuiProjectSettings(nwGUI, nwGUI.theProject)
+    nwGUI.mainMenu.aProjectSettings.activate(QAction.Trigger)
+    qtbot.waitUntil(lambda: getGuiItem("GuiProjectSettings") is not None, timeout=1000)
+
+    projEdit = getGuiItem("GuiProjectSettings")
+    assert isinstance(projEdit, GuiProjectSettings)
+
     qtbot.addWidget(projEdit)
     assert projEdit.tabMain.editName.text()  == "Project Name"
     assert projEdit.tabMain.editTitle.text() == "Project Title"
@@ -582,8 +587,13 @@ def testBuildTool(qtbot, yesToAll, nwTempBuild, nwLipsum, nwRef, nwTemp):
     nwBuild._doClose()
 
     # Re-open build dialog from cahce
-    nwBuild = GuiBuildNovel(nwGUI, nwGUI.theProject)
+    nwGUI.mainMenu.aBuildProject.activate(QAction.Trigger)
+    qtbot.waitUntil(lambda: getGuiItem("GuiBuildNovel") is not None, timeout=1000)
 
+    nwBuild = getGuiItem("GuiBuildNovel")
+    assert isinstance(nwBuild, GuiBuildNovel)
+
+    assert nwBuild.viewCachedDoc()
     assert nwBuild.htmlText  == htmlText
     assert nwBuild.htmlStyle == htmlStyle
     assert nwBuild.nwdText   == nwdText
@@ -659,7 +669,11 @@ def testMergeSplitTools(qtbot, monkeypatch, yesToAll, nwTempGUI, nwLipsum, nwRef
     # Split By Scene
     assert nwGUI.treeView.setSelectedHandle("73475cb40a568")
     qtbot.wait(stepDelay)
-    nwSplit = GuiDocSplit(nwGUI, nwGUI.theProject)
+    nwGUI.mainMenu.aSplitDoc.activate(QAction.Trigger)
+    qtbot.waitUntil(lambda: getGuiItem("GuiDocSplit") is not None, timeout=1000)
+
+    nwSplit = getGuiItem("GuiDocSplit")
+    assert isinstance(nwSplit, GuiDocSplit)
     qtbot.wait(stepDelay)
     nwSplit.splitLevel.setCurrentIndex(2)
     qtbot.wait(stepDelay)
@@ -691,7 +705,11 @@ def testMergeSplitTools(qtbot, monkeypatch, yesToAll, nwTempGUI, nwLipsum, nwRef
     # Split By Section
     assert nwGUI.treeView.setSelectedHandle("73475cb40a568")
     qtbot.wait(stepDelay)
-    nwSplit = GuiDocSplit(nwGUI, nwGUI.theProject)
+    nwGUI.mainMenu.aSplitDoc.activate(QAction.Trigger)
+    qtbot.waitUntil(lambda: getGuiItem("GuiDocSplit") is not None, timeout=1000)
+
+    nwSplit = getGuiItem("GuiDocSplit")
+    assert isinstance(nwSplit, GuiDocSplit)
     qtbot.wait(stepDelay)
     nwSplit.splitLevel.setCurrentIndex(3)
     qtbot.wait(stepDelay)
@@ -945,6 +963,7 @@ def testLoadProject(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp):
     assert nwGUI.openProject(nwMinimal)
     assert nwGUI.closeProject()
 
+    qtbot.wait(stepDelay)
     monkeypatch.setattr(GuiProjectLoad, "exec_", lambda *args: None)
     monkeypatch.setattr(GuiProjectLoad, "result", lambda *args: QDialog.Accepted)
     nwGUI.mainMenu.aOpenProject.activate(QAction.Trigger)
@@ -954,36 +973,50 @@ def testLoadProject(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp):
     assert isinstance(nwLoad, GuiProjectLoad)
     nwLoad.show()
 
+    qtbot.wait(stepDelay)
     recentCount = nwLoad.listBox.topLevelItemCount()
     assert recentCount > 0
 
+    qtbot.wait(stepDelay)
     selItem = nwLoad.listBox.topLevelItem(0)
     selPath = selItem.data(nwLoad.C_NAME, Qt.UserRole)
     assert isinstance(selItem, QTreeWidgetItem)
 
+    qtbot.wait(stepDelay)
     nwLoad.selPath.setText("")
     nwLoad.listBox.setCurrentItem(selItem)
     nwLoad._doSelectRecent()
     assert nwLoad.selPath.text() == selPath
 
+    qtbot.wait(stepDelay)
     qtbot.mouseClick(nwLoad.buttonBox.button(QDialogButtonBox.Open), Qt.LeftButton)
     assert nwLoad.openPath == selPath
     assert nwLoad.openState == nwLoad.OPEN_STATE
 
     # Just create a new project load from scratch for the rest of the test
     del nwLoad
-    nwLoad = GuiProjectLoad(nwGUI)
+
+    qtbot.wait(stepDelay)
+    nwGUI.mainMenu.aOpenProject.activate(QAction.Trigger)
+    qtbot.waitUntil(lambda: getGuiItem("GuiProjectLoad") is not None, timeout=1000)
+
+    qtbot.wait(stepDelay)
+    nwLoad = getGuiItem("GuiProjectLoad")
+    assert isinstance(nwLoad, GuiProjectLoad)
     nwLoad.show()
 
+    qtbot.wait(stepDelay)
     qtbot.mouseClick(nwLoad.buttonBox.button(QDialogButtonBox.Cancel), Qt.LeftButton)
     assert nwLoad.openPath is None
     assert nwLoad.openState == nwLoad.NONE_STATE
 
+    qtbot.wait(stepDelay)
     nwLoad.show()
     qtbot.mouseClick(nwLoad.newButton, Qt.LeftButton)
     assert nwLoad.openPath is None
     assert nwLoad.openState == nwLoad.NEW_STATE
 
+    qtbot.wait(stepDelay)
     nwLoad.show()
     nwLoad._keyPressDelete()
     assert nwLoad.listBox.topLevelItemCount() == recentCount - 1


### PR DESCRIPTION
This PR makes a few improvements to the document editor that mostly affects large and very large documents.

* The syntax highlighter now remembers what type of line each line in a document is. Whether it is empty, a title, text or a meta keyword/value set. This information is then used when the index is manually updated to rehighlight the lines containing meta keywords only. Previously, this was handled by reloading the entire document. This not only resets the undo stack, which is annoying, it is also quite slow for large documents in the megabyte range.
* When preferences were changed, the document editor would also previously reload in order to update the text formats and other layout options. This again resets the undo stack, and is slow for large documents. This has now been replaced with the `markContentsDirty` feature of the `QTextDocument` which causes a refresh of the document layout. This is faster, and doesn't affect the undo stack.
* The cursor position of an open document would only be saved if the document had been changed as it was a part of the document save function. Now it is always saved even when the document is left unchanged. On next open, the cursor is put back to its previous position.
* For very large documents, in the megabyte range, the repositioning of the cursor would interfere with the generation of the document layout. This process does not block the main thread, so the Python code will move on to repositioning the cursor before the layout is complete even for medium sized documents. This probably causes some temporary race condition in the Qt library. Whatever the reason is, this causes the GUI to freeze for quite some time. For large documents this could take a couple of minutes to resolve. There are no events or signals I've found that can be used to track when the layout is complete, however there is a signal emitted every time the size of the document layout is updated. This size can in turn be used to extract the largest possible cursor position that is within reach in the document layout at its current size. For a medium or large document the reposition of the cursor is now delayed until the document layout size has reached a point where this is possible, and the cursor is then moved. This works on Linux/xorg, but has not been tested on other platforms.