### PR TITLE
Line Counter

### DIFF
--- a/nw/assets/icons/fallback/status_lines-dark.svg
+++ b/nw/assets/icons/fallback/status_lines-dark.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.2"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg5291"
+   sodipodi:docname="status_lines-dark.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1344"
+     id="namedview6681"
+     showgrid="false"
+     inkscape:zoom="38.125"
+     inkscape:cx="12.065574"
+     inkscape:cy="12"
+     inkscape:window-x="2560"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5291" />
+  <metadata
+     id="metadata5297">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5295" />
+  <g
+     id="g5303"
+     transform="matrix(1.1578947,0,0,1.1578947,-1.6052627,-1.8947364)"
+     style="fill:#aeaeae;fill-opacity:1">
+    <path
+       d="m 19,17 h -7 c -1.103,0 -2,0.897 -2,2 0,1.103 0.897,2 2,2 h 7 c 1.103,0 2,-0.897 2,-2 0,-1.103 -0.897,-2 -2,-2 z m 0,-7 h -7 c -1.103,0 -2,0.897 -2,2 0,1.103 0.897,2 2,2 h 7 c 1.103,0 2,-0.897 2,-2 0,-1.103 -0.897,-2 -2,-2 z m 0,-7 h -7 c -1.103,0 -2,0.897 -2,2 0,1.103 0.897,2 2,2 h 7 C 20.103,7 21,6.103 21,5 21,3.897 20.103,3 19,3 Z"
+       id="path5283"
+       style="fill:#aeaeae;fill-opacity:1" />
+    <circle
+       cx="5"
+       cy="19"
+       r="2.5"
+       id="circle5285"
+       style="fill:#aeaeae;fill-opacity:1" />
+    <circle
+       cx="5"
+       cy="12"
+       r="2.5"
+       id="circle5287"
+       style="fill:#aeaeae;fill-opacity:1" />
+    <circle
+       cx="5"
+       cy="5"
+       r="2.5"
+       id="circle5289"
+       style="fill:#aeaeae;fill-opacity:1" />
+  </g>
+</svg>

--- a/nw/assets/icons/fallback/status_lines.svg
+++ b/nw/assets/icons/fallback/status_lines.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.2"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg5291"
+   sodipodi:docname="status_lines.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1344"
+     id="namedview7270"
+     showgrid="false"
+     inkscape:zoom="38.125"
+     inkscape:cx="12.065574"
+     inkscape:cy="12"
+     inkscape:window-x="2560"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5291" />
+  <metadata
+     id="metadata5297">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5295" />
+  <g
+     id="g5303"
+     transform="matrix(1.1578947,0,0,1.1578947,-1.6052627,-1.8947364)"
+     style="fill:#000000;fill-opacity:0.72">
+    <path
+       d="m 19,17 h -7 c -1.103,0 -2,0.897 -2,2 0,1.103 0.897,2 2,2 h 7 c 1.103,0 2,-0.897 2,-2 0,-1.103 -0.897,-2 -2,-2 z m 0,-7 h -7 c -1.103,0 -2,0.897 -2,2 0,1.103 0.897,2 2,2 h 7 c 1.103,0 2,-0.897 2,-2 0,-1.103 -0.897,-2 -2,-2 z m 0,-7 h -7 c -1.103,0 -2,0.897 -2,2 0,1.103 0.897,2 2,2 h 7 C 20.103,7 21,6.103 21,5 21,3.897 20.103,3 19,3 Z"
+       id="path5283"
+       style="fill:#000000;fill-opacity:0.72" />
+    <circle
+       cx="5"
+       cy="19"
+       r="2.5"
+       id="circle5285"
+       style="fill:#000000;fill-opacity:0.72" />
+    <circle
+       cx="5"
+       cy="12"
+       r="2.5"
+       id="circle5287"
+       style="fill:#000000;fill-opacity:0.72" />
+    <circle
+       cx="5"
+       cy="5"
+       r="2.5"
+       id="circle5289"
+       style="fill:#000000;fill-opacity:0.72" />
+  </g>
+</svg>

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -740,8 +740,9 @@ class GuiDocEditor(QTextEdit):
         elif keyEvent == QKeySequence.Undo:
             self.docAction(nwDocAction.UNDO)
         else:
-            self.docFooter.updateLineCount()
             QTextEdit.keyPressEvent(self, keyEvent)
+            self.docFooter.updateLineCount()
+
         return
 
     def focusNextPrevChild(self, toNext):
@@ -764,8 +765,10 @@ class GuiDocEditor(QTextEdit):
         if qApp.keyboardModifiers() == Qt.ControlModifier:
             theCursor = self.cursorForPosition(mEvent.pos())
             self._followTag(theCursor)
-        self.docFooter.updateLineCount()
+
         QTextEdit.mouseReleaseEvent(self, mEvent)
+        self.docFooter.updateLineCount()
+
         return
 
     def resizeEvent(self, theEvent):
@@ -2205,7 +2208,7 @@ class GuiDocEditFooter(QWidget):
         self.linesIcon.setFixedHeight(self.sPx)
         self.linesIcon.setAlignment(Qt.AlignLeft | Qt.AlignTop)
 
-        self.linesText = QLabel("Line: 0 of 0")
+        self.linesText = QLabel("Line: 0")
         self.linesText.setIndent(0)
         self.linesText.setMargin(0)
         self.linesText.setContentsMargins(0, 0, 0, 0)
@@ -2295,13 +2298,11 @@ class GuiDocEditFooter(QWidget):
         """
         if self.theItem is None:
             iLine = 0
-            nLine = 0
         else:
             theCursor = self.docEditor.textCursor()
             iLine = theCursor.blockNumber() + 1
-            nLine = self.docEditor.qDocument.blockCount()
 
-        self.linesText.setText("Line: %d of %d" % (iLine, nLine))
+        self.linesText.setText(f"Line: {iLine:n}")
 
         return
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -312,6 +312,8 @@ class GuiDocEditor(QTextEdit):
         else:
             self.setCursorLine(tLine)
 
+        self.docFooter.updateLineCount()
+
         qApp.restoreOverrideCursor()
 
         return True
@@ -462,6 +464,7 @@ class GuiDocEditor(QTextEdit):
             theCursor = self.textCursor()
             theCursor.setPosition(thePosition)
             self.setTextCursor(theCursor)
+            self.docFooter.updateLineCount()
         return True
 
     def getCursorPosition(self):
@@ -488,6 +491,7 @@ class GuiDocEditor(QTextEdit):
             theBlock = self.qDocument.findBlockByLineNumber(theLine)
             if theBlock:
                 self.setCursorPosition(theBlock.position())
+                self.docFooter.updateLineCount()
                 logger.verbose("Cursor moved to line %d" % theLine)
         return True
 
@@ -736,6 +740,7 @@ class GuiDocEditor(QTextEdit):
         elif keyEvent == QKeySequence.Undo:
             self.docAction(nwDocAction.UNDO)
         else:
+            self.docFooter.updateLineCount()
             QTextEdit.keyPressEvent(self, keyEvent)
         return
 
@@ -759,6 +764,7 @@ class GuiDocEditor(QTextEdit):
         if qApp.keyboardModifiers() == Qt.ControlModifier:
             theCursor = self.cursorForPosition(mEvent.pos())
             self._followTag(theCursor)
+        self.docFooter.updateLineCount()
         QTextEdit.mouseReleaseEvent(self, mEvent)
         return
 
@@ -2166,6 +2172,7 @@ class GuiDocEditFooter(QWidget):
         self.sPx = int(round(0.9*self.theTheme.baseIconSize))
         fPx = int(0.9*self.theTheme.fontPixelSize)
         bSp = self.mainConf.pxInt(4)
+        hSp = self.mainConf.pxInt(6)
 
         lblFont = self.font()
         lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
@@ -2191,6 +2198,23 @@ class GuiDocEditFooter(QWidget):
         self.statusText.setPalette(self.thePalette)
         self.statusText.setFont(lblFont)
 
+        # Lines
+        self.linesIcon = QLabel("")
+        self.linesIcon.setPixmap(self.theTheme.getPixmap("status_lines", (self.sPx, self.sPx)))
+        self.linesIcon.setContentsMargins(0, 0, 0, 0)
+        self.linesIcon.setFixedHeight(self.sPx)
+        self.linesIcon.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+
+        self.linesText = QLabel("Line: 0 of 0")
+        self.linesText.setIndent(0)
+        self.linesText.setMargin(0)
+        self.linesText.setContentsMargins(0, 0, 0, 0)
+        self.linesText.setAutoFillBackground(True)
+        self.linesText.setFixedHeight(fPx)
+        self.linesText.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.linesText.setPalette(self.thePalette)
+        self.linesText.setFont(lblFont)
+
         # Words
         self.wordsIcon = QLabel("")
         self.wordsIcon.setPixmap(self.theTheme.getPixmap("status_stats", (self.sPx, self.sPx)))
@@ -2214,6 +2238,9 @@ class GuiDocEditFooter(QWidget):
         self.outerBox.addWidget(self.statusIcon)
         self.outerBox.addWidget(self.statusText)
         self.outerBox.addStretch(1)
+        self.outerBox.addWidget(self.linesIcon)
+        self.outerBox.addWidget(self.linesText)
+        self.outerBox.addSpacing(hSp)
         self.outerBox.addWidget(self.wordsIcon)
         self.outerBox.addWidget(self.wordsText)
         self.setLayout(self.outerBox)
@@ -2263,8 +2290,23 @@ class GuiDocEditFooter(QWidget):
 
         return
 
+    def updateLineCount(self):
+        """Update the word count.
+        """
+        if self.theItem is None:
+            iLine = 0
+            nLine = 0
+        else:
+            theCursor = self.docEditor.textCursor()
+            iLine = theCursor.blockNumber() + 1
+            nLine = self.docEditor.qDocument.blockCount()
+
+        self.linesText.setText("Line: %d of %d" % (iLine, nLine))
+
+        return
+
     def updateCounts(self):
-        """Update the word counts.
+        """Update the word count.
         """
         if self.theItem is None:
             wCount = 0

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -529,6 +529,7 @@ class GuiIcons:
         "status_lang"     : (None, None),
         "status_time"     : (None, None),
         "status_stats"    : (None, None),
+        "status_lines"    : (None, None),
         "doc_h1"          : (QStyle.SP_FileIcon, "x-office-document"),
         "doc_h2"          : (QStyle.SP_FileIcon, "x-office-document"),
         "doc_h3"          : (QStyle.SP_FileIcon, "x-office-document"),


### PR DESCRIPTION
This PR adds a small line counter next to the word counter at the bottom of the document editor. It is sometimes convenient when comparing files between the novelWriter editor and other plain text editors.