### PR TITLE
Scrolling Options

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -398,6 +398,12 @@ class Config:
         self.isFullScreen = self._parseLine(
             cnfParse, cnfSec, "fullscreen", self.CNF_BOOL, self.isFullScreen
         )
+        self.hideVScroll = self._parseLine(
+            cnfParse, cnfSec, "hidevscroll", self.CNF_BOOL, self.hideVScroll
+        )
+        self.hideHScroll = self._parseLine(
+            cnfParse, cnfSec, "hidehscroll", self.CNF_BOOL, self.hideHScroll
+        )
 
         ## Project
         cnfSec = "Project"
@@ -454,6 +460,12 @@ class Config:
         )
         self.doReplaceDots = self._parseLine(
             cnfParse, cnfSec, "repdots", self.CNF_BOOL, self.doReplaceDots
+        )
+        self.scrollPastEnd = self._parseLine(
+            cnfParse, cnfSec, "scrollpastend", self.CNF_BOOL, self.scrollPastEnd
+        )
+        self.scollWithCursor = self._parseLine(
+            cnfParse, cnfSec, "scollwithcursor", self.CNF_BOOL, self.scollWithCursor
         )
         self.fmtSingleQuotes = self._parseLine(
             cnfParse, cnfSec, "fmtsinglequote", self.CNF_LIST, self.fmtSingleQuotes
@@ -572,6 +584,8 @@ class Config:
         cnfParse.set(cnfSec, "viewpane",    self._packList(self.viewPanePos))
         cnfParse.set(cnfSec, "outlinepane", self._packList(self.outlnPanePos))
         cnfParse.set(cnfSec, "fullscreen",  str(self.isFullScreen))
+        cnfParse.set(cnfSec, "hidevscroll", str(self.hideVScroll))
+        cnfParse.set(cnfSec, "hidehscroll", str(self.hideHScroll))
 
         ## Project
         cnfSec = "Project"
@@ -597,6 +611,8 @@ class Config:
         cnfParse.set(cnfSec, "repdquotes",      str(self.doReplaceDQuote))
         cnfParse.set(cnfSec, "repdash",         str(self.doReplaceDash))
         cnfParse.set(cnfSec, "repdots",         str(self.doReplaceDots))
+        cnfParse.set(cnfSec, "scrollpastend",   str(self.scrollPastEnd))
+        cnfParse.set(cnfSec, "scollwithcursor", str(self.scollWithCursor))
         cnfParse.set(cnfSec, "fmtsinglequote",  self._packList(self.fmtSingleQuotes))
         cnfParse.set(cnfSec, "fmtdoublequote",  self._packList(self.fmtDoubleQuotes))
         cnfParse.set(cnfSec, "spelltool",       str(self.spellTool))

--- a/nw/config.py
+++ b/nw/config.py
@@ -126,7 +126,8 @@ class Config:
         self.doReplaceDQuote = True
         self.doReplaceDash   = True
         self.doReplaceDots   = True
-        self.extendScroll    = True
+        self.scrollPastEnd   = True
+        self.scollWithCursor = False
 
         self.wordCountTimer  = 5.0
         self.showTabsNSpaces = False

--- a/nw/config.py
+++ b/nw/config.py
@@ -102,6 +102,10 @@ class Config:
         self.outlnPanePos = [500, 150]
         self.isFullScreen = False
 
+        ## Features
+        self.hideVScroll = False # Hide vertical scroll bars on main widgets
+        self.hideHScroll = False # Hide horizontal scroll bars on main widgets
+
         ## Project
         self.autoSaveProj = 60
         self.autoSaveDoc  = 30

--- a/nw/config.py
+++ b/nw/config.py
@@ -122,6 +122,8 @@ class Config:
         self.doReplaceDQuote = True
         self.doReplaceDash   = True
         self.doReplaceDots   = True
+        self.extendScroll    = True
+
         self.wordCountTimer  = 5.0
         self.showTabsNSpaces = False
         self.showLineEndings = False

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -452,10 +452,16 @@ class GuiBuildNovel(QDialog):
         self.toolsArea.setMinimumWidth(self.mainConf.pxInt(250))
         self.toolsArea.setWidgetResizable(True)
         self.toolsArea.setWidget(self.toolsWidget)
+
         if self.mainConf.hideVScroll:
             self.toolsArea.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.toolsArea.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
         if self.mainConf.hideHScroll:
             self.toolsArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.toolsArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         # Tools and Buttons Layout
         self.innerBox = QVBoxLayout()
@@ -1121,8 +1127,13 @@ class GuiBuildNovelDocView(QTextBrowser):
         # Scroll bars
         if self.mainConf.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
         if self.mainConf.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         docPalette = self.palette()
         docPalette.setColor(QPalette.Base, QColor(255, 255, 255))

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -450,10 +450,12 @@ class GuiBuildNovel(QDialog):
         # Tool Box Scroll Area
         self.toolsArea = QScrollArea()
         self.toolsArea.setMinimumWidth(self.mainConf.pxInt(250))
-        self.toolsArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        self.toolsArea.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.toolsArea.setWidgetResizable(True)
         self.toolsArea.setWidget(self.toolsWidget)
+        if self.mainConf.hideVScroll:
+            self.toolsArea.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        if self.mainConf.hideHScroll:
+            self.toolsArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
         # Tools and Buttons Layout
         self.innerBox = QVBoxLayout()
@@ -1115,6 +1117,12 @@ class GuiBuildNovelDocView(QTextBrowser):
             self.setTabStopDistance(self.mainConf.getTabWidth())
         else:
             self.setTabStopWidth(self.mainConf.getTabWidth())
+
+        # Scroll bars
+        if self.mainConf.hideVScroll:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        if self.mainConf.hideHScroll:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
         docPalette = self.palette()
         docPalette.setColor(QPalette.Base, QColor(255, 255, 255))

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -377,6 +377,7 @@ class GuiDocEditor(QTextEdit):
         just ensure the margins are set correctly.
         """
         wW = self.width()
+        wH = self.height()
         cM = self.mainConf.getTextMargin()
 
         vBar = self.verticalScrollBar()
@@ -400,7 +401,7 @@ class GuiDocEditor(QTextEdit):
         tW = wW - 2*tB - sW
         tH = self.docHeader.height()
         fH = self.docFooter.height()
-        fY = self.height() - fH - tB - sH
+        fY = wH - fH - tB - sH
         self.docHeader.setGeometry(tB, tB, tW, tH)
         self.docFooter.setGeometry(tB, fY, tW, fH)
 
@@ -412,7 +413,14 @@ class GuiDocEditor(QTextEdit):
         else:
             rH = 0
 
-        self.setViewportMargins(tM, max(cM, tH, rH), tM, max(cM, fH))
+        uM = max(cM, tH, rH)
+        lM = max(cM, fH)
+        self.setViewportMargins(tM, uM, tM, lM)
+
+        if self.mainConf.extendScroll:
+            docFrame = self.qDocument.rootFrame().frameFormat()
+            docFrame.setBottomMargin(wH - uM - lM - self.theTheme.fontPixelSize)
+            self.qDocument.rootFrame().setFrameFormat(docFrame)
 
         return
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -47,7 +47,7 @@ from PyQt5.QtGui import (
 from PyQt5.QtWidgets import (
     qApp, QTextEdit, QAction, QMenu, QShortcut, QMessageBox, QWidget, QLabel,
     QToolBar, QToolButton, QHBoxLayout, QGridLayout, QLineEdit, QPushButton,
-    QFrame, QAbstractSlider
+    QFrame
 )
 
 from nw.core import NWDoc, NWSpellCheck, NWSpellSimple, countWords
@@ -231,8 +231,13 @@ class GuiDocEditor(QTextEdit):
         # Scroll bars
         if self.mainConf.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
         if self.mainConf.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         # Refresh the tab stops
         if self.mainConf.verQtValue >= 51000:
@@ -479,11 +484,14 @@ class GuiDocEditor(QTextEdit):
         """
         if not isinstance(thePosition, int):
             return False
+
         if thePosition >= 0:
             theCursor = self.textCursor()
             theCursor.setPosition(thePosition)
             self.setTextCursor(theCursor)
             self.docFooter.updateLineCount()
+            self.cursorLast = self.cursorRect().center().y()
+
         return True
 
     def getCursorPosition(self):

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -430,7 +430,7 @@ class GuiDocEditor(QTextEdit):
 
         if self.mainConf.scrollPastEnd:
             docFrame = self.qDocument.rootFrame().frameFormat()
-            docFrame.setBottomMargin(wH - uM - lM - self.theTheme.fontPixelSize)
+            docFrame.setBottomMargin(wH - uM - lM - 4*tB - self.theTheme.fontPixelSize)
             self.qDocument.rootFrame().setFrameFormat(docFrame)
 
         return

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -224,6 +224,12 @@ class GuiDocEditor(QTextEdit):
 
         self.qDocument.setDefaultTextOption(theOpt)
 
+        # Scroll bars
+        if self.mainConf.hideVScroll:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        if self.mainConf.hideHScroll:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
         # Refresh the tab stops
         if self.mainConf.verQtValue >= 51000:
             self.setTabStopDistance(self.mainConf.getTabWidth())

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -127,8 +127,13 @@ class GuiDocViewer(QTextBrowser):
         # Scroll bars
         if self.mainConf.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
         if self.mainConf.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         # Refresh the tab stops
         if self.mainConf.verQtValue >= 51000:

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -124,6 +124,12 @@ class GuiDocViewer(QTextBrowser):
             theOpt.setAlignment(Qt.AlignJustify)
         self.qDocument.setDefaultTextOption(theOpt)
 
+        # Scroll bars
+        if self.mainConf.hideVScroll:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        if self.mainConf.hideHScroll:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
         # Refresh the tab stops
         if self.mainConf.verQtValue >= 51000:
             self.setTabStopDistance(self.mainConf.getTabWidth())

--- a/nw/gui/outline.py
+++ b/nw/gui/outline.py
@@ -118,10 +118,22 @@ class GuiOutline(QTreeWidget):
         self.colIndex  = {}
         self.treeNCols = 0
 
+        self.initOutline()
         self.clearOutline()
         self.headerMenu.setHiddenState(self.colHidden)
 
         logger.debug("GuiOutline initialisation complete")
+
+        return
+
+    def initOutline(self):
+        """Set or update outline settings.
+        """
+        # Scroll bars
+        if self.mainConf.hideVScroll:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        if self.mainConf.hideHScroll:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
         return
 

--- a/nw/gui/outline.py
+++ b/nw/gui/outline.py
@@ -132,8 +132,13 @@ class GuiOutline(QTreeWidget):
         # Scroll bars
         if self.mainConf.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
         if self.mainConf.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         return
 

--- a/nw/gui/outlinedetails.py
+++ b/nw/gui/outlinedetails.py
@@ -236,8 +236,13 @@ class GuiOutlineDetails(QScrollArea):
         # Scroll bars
         if self.mainConf.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
         if self.mainConf.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         return
 

--- a/nw/gui/outlinedetails.py
+++ b/nw/gui/outlinedetails.py
@@ -224,7 +224,20 @@ class GuiOutlineDetails(QScrollArea):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.setWidgetResizable(True)
 
+        self.initDetails()
+
         logger.debug("GuiOutlineDetails initialisation complete")
+
+        return
+
+    def initDetails(self):
+        """Set or update outline settings.
+        """
+        # Scroll bars
+        if self.mainConf.hideVScroll:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        if self.mainConf.hideHScroll:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
         return
 

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -225,7 +225,24 @@ class GuiConfigEditGeneralTab(QWidget):
         self.showFullPath.setChecked(self.mainConf.showFullPath)
         self.mainForm.addRow(
             "Show full path in document header",
-            self.showFullPath
+            self.showFullPath,
+            "Shows the document title and parent folder names."
+        )
+
+        self.hideVScroll = QSwitch()
+        self.hideVScroll.setChecked(self.mainConf.hideVScroll)
+        self.mainForm.addRow(
+            "Hide vertical scroll bars in main windows",
+            self.hideVScroll,
+            "Scrolling with mouse wheel and keys only."
+        )
+
+        self.hideHScroll = QSwitch()
+        self.hideHScroll.setChecked(self.mainConf.hideHScroll)
+        self.mainForm.addRow(
+            "Hide horizontal scroll bars in main windows",
+            self.hideHScroll,
+            "Scrolling with mouse wheel and keys only."
         )
 
         return
@@ -242,6 +259,8 @@ class GuiConfigEditGeneralTab(QWidget):
         guiFont      = self.guiFont.text()
         guiFontSize  = self.guiFontSize.value()
         showFullPath = self.showFullPath.isChecked()
+        hideVScroll  = self.hideVScroll.isChecked()
+        hideHScroll  = self.hideHScroll.isChecked()
 
         # Check if restart is needed
         needsRestart |= self.mainConf.guiTheme != guiTheme
@@ -255,6 +274,8 @@ class GuiConfigEditGeneralTab(QWidget):
         self.mainConf.guiFont      = guiFont
         self.mainConf.guiFontSize  = guiFontSize
         self.mainConf.showFullPath = showFullPath
+        self.mainConf.hideVScroll  = hideVScroll
+        self.mainConf.hideHScroll  = hideHScroll
 
         self.mainConf.confChanged = True
 
@@ -534,6 +555,24 @@ class GuiConfigEditLayoutTab(QWidget):
             theUnit="px"
         )
 
+        ## Scroll Past End
+        self.scrollPastEnd = QSwitch()
+        self.scrollPastEnd.setChecked(self.mainConf.scrollPastEnd)
+        self.mainForm.addRow(
+            "Scroll past end of the document",
+            self.scrollPastEnd,
+            "Allows scrolling until last line is at the top."
+        )
+
+        ## Typewriter Scrolling
+        self.scollWithCursor = QSwitch()
+        self.scollWithCursor.setChecked(self.mainConf.scollWithCursor)
+        self.mainForm.addRow(
+            "Typewriter style scrolling",
+            self.scollWithCursor,
+            "Scrolls up when the cursor moves to a new line."
+        )
+
         return
 
     def saveValues(self):
@@ -551,6 +590,8 @@ class GuiConfigEditLayoutTab(QWidget):
         doJustify       = self.textJustify.isChecked()
         textMargin      = self.textMargin.value()
         tabWidth        = self.tabWidth.value()
+        scrollPastEnd   = self.scrollPastEnd.isChecked()
+        scollWithCursor = self.scollWithCursor.isChecked()
 
         self.mainConf.textFont        = textFont
         self.mainConf.textSize        = textSize
@@ -561,6 +602,8 @@ class GuiConfigEditLayoutTab(QWidget):
         self.mainConf.doJustify       = doJustify
         self.mainConf.textMargin      = textMargin
         self.mainConf.tabWidth        = tabWidth
+        self.mainConf.scrollPastEnd   = scrollPastEnd
+        self.mainConf.scollWithCursor = scollWithCursor
 
         self.mainConf.confChanged = True
 

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -115,10 +115,24 @@ class GuiProjectTree(QTreeWidget):
         # The last column should just auto-scale
         self.resizeColumnToContents(self.C_FLAGS)
 
+        # Set custom settings
+        self.initTree()
+
         logger.debug("GuiProjectTree initialisation complete")
 
         # Internal Mapping
         self.makeAlert = self.theParent.makeAlert
+
+        return
+
+    def initTree(self):
+        """Set or update tree widget settings.
+        """
+        # Scroll bars
+        if self.mainConf.hideVScroll:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        if self.mainConf.hideHScroll:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
         return
 

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -131,8 +131,13 @@ class GuiProjectTree(QTreeWidget):
         # Scroll bars
         if self.mainConf.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
         if self.mainConf.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        else:
+            self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         return
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -790,6 +790,9 @@ class GuiMain(QMainWindow):
             self.saveDocument()
             self.docEditor.initEditor()
             self.docViewer.initViewer()
+            self.treeView.initTree()
+            self.projView.initOutline()
+            self.projMeta.initDetails()
 
         return
 

--- a/tests/reference/novelwriter.conf
+++ b/tests/reference/novelwriter.conf
@@ -1,5 +1,5 @@
 [Main]
-timestamp = 2020-06-29 17:34:15
+timestamp = 2020-10-11 18:29:34
 theme = default
 syntax = default_light
 icons = typicons_colour_light
@@ -16,6 +16,8 @@ docpane = 400, 400
 viewpane = 500, 150
 outlinepane = 500, 150
 fullscreen = False
+hidevscroll = False
+hidehscroll = False
 
 [Project]
 autosaveproject = 60
@@ -37,6 +39,8 @@ repsquotes = True
 repdquotes = True
 repdash = True
 repdots = True
+scrollpastend = True
+scollwithcursor = False
 fmtsinglequote = ‘, ’
 fmtdoublequote = “, ”
 spelltool = internal

--- a/tests/reference/novelwriter_prefs.conf
+++ b/tests/reference/novelwriter_prefs.conf
@@ -16,6 +16,8 @@ docpane = 400, 400
 viewpane = 500, 150
 outlinepane = 500, 150
 fullscreen = False
+hidevscroll = False
+hidehscroll = False
 
 [Project]
 autosaveproject = 40
@@ -37,6 +39,8 @@ repsquotes = True
 repdquotes = True
 repdash = True
 repdots = True
+scrollpastend = True
+scollwithcursor = False
 fmtsinglequote = ‘, ’
 fmtdoublequote = “, ”
 spelltool = internal

--- a/tests/reference/novelwriter_prefs.conf
+++ b/tests/reference/novelwriter_prefs.conf
@@ -16,8 +16,8 @@ docpane = 400, 400
 viewpane = 500, 150
 outlinepane = 500, 150
 fullscreen = False
-hidevscroll = False
-hidehscroll = False
+hidevscroll = True
+hidehscroll = True
 
 [Project]
 autosaveproject = 40
@@ -39,8 +39,8 @@ repsquotes = True
 repdquotes = True
 repdash = True
 repdots = True
-scrollpastend = True
-scollwithcursor = False
+scrollpastend = False
+scollwithcursor = True
 fmtsinglequote = ‘, ’
 fmtdoublequote = “, ”
 spelltool = internal

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1057,6 +1057,7 @@ def testPreferences(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp, nwRef, tmpC
     nwGUI.mainConf = tmpConf
     nwPrefs.mainConf = tmpConf
     nwPrefs.tabGeneral.mainConf = tmpConf
+    nwPrefs.tabProjects.mainConf = tmpConf
     nwPrefs.tabLayout.mainConf = tmpConf
     nwPrefs.tabEditing.mainConf = tmpConf
     nwPrefs.tabAutoRep.mainConf = tmpConf
@@ -1065,7 +1066,6 @@ def testPreferences(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp, nwRef, tmpC
     qtbot.wait(keyDelay)
     tabGeneral = nwPrefs.tabGeneral
     nwPrefs._tabBox.setCurrentWidget(tabGeneral)
-    tabGeneral.backupPath = "no/where"
 
     qtbot.wait(keyDelay)
     assert not tabGeneral.preferDarkIcons.isChecked()
@@ -1077,27 +1077,35 @@ def testPreferences(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp, nwRef, tmpC
     qtbot.mouseClick(tabGeneral.showFullPath, Qt.LeftButton)
     assert not tabGeneral.showFullPath.isChecked()
 
-    # Check Browse button
-    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *args, **kwargs: "")
-    assert not tabGeneral._backupFolder()
-    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *args, **kwargs: "some/dir")
-    qtbot.mouseClick(tabGeneral.backupGetPath, Qt.LeftButton)
-
     # Check font button
     monkeypatch.setattr(QFontDialog, "getFont", lambda font, obj: (font, True))
     qtbot.mouseClick(tabGeneral.fontButton, Qt.LeftButton)
 
     qtbot.wait(keyDelay)
-    assert not tabGeneral.backupOnClose.isChecked()
-    qtbot.mouseClick(tabGeneral.backupOnClose, Qt.LeftButton)
-    assert tabGeneral.backupOnClose.isChecked()
+    tabGeneral.guiFontSize.setValue(12)
+
+    # Projects Settings
+    qtbot.wait(keyDelay)
+    tabProjects = nwPrefs.tabProjects
+    nwPrefs._tabBox.setCurrentWidget(tabProjects)
+    tabProjects.backupPath = "no/where"
 
     qtbot.wait(keyDelay)
-    tabGeneral.guiFontSize.setValue(12)
-    tabGeneral.autoSaveDoc.setValue(20)
-    tabGeneral.autoSaveProj.setValue(40)
+    assert not tabProjects.backupOnClose.isChecked()
+    qtbot.mouseClick(tabProjects.backupOnClose, Qt.LeftButton)
+    assert tabProjects.backupOnClose.isChecked()
 
-    # Text Layour Settings
+    # Check Browse button
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *args, **kwargs: "")
+    assert not tabProjects._backupFolder()
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *args, **kwargs: "some/dir")
+    qtbot.mouseClick(tabProjects.backupGetPath, Qt.LeftButton)
+
+    qtbot.wait(keyDelay)
+    tabProjects.autoSaveDoc.setValue(20)
+    tabProjects.autoSaveProj.setValue(40)
+
+    # Text Layout Settings
     qtbot.wait(keyDelay)
     tabLayout = nwPrefs.tabLayout
     nwPrefs._tabBox.setCurrentWidget(tabLayout)

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1198,7 +1198,7 @@ def testPreferences(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp, nwRef, tmpC
     ignoreLines = [
         2,                          # Timestamp
         11, 12, 13, 14, 15, 16, 17, # Window sizes
-        7, 25,                      # Fonts (depends on system default)
+        7, 27,                      # Fonts (depends on system default)
     ]
     assert cmpFiles(testConf, refConf, ignoreLines)
 

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1077,6 +1077,16 @@ def testPreferences(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp, nwRef, tmpC
     qtbot.mouseClick(tabGeneral.showFullPath, Qt.LeftButton)
     assert not tabGeneral.showFullPath.isChecked()
 
+    qtbot.wait(keyDelay)
+    assert not tabGeneral.hideVScroll.isChecked()
+    qtbot.mouseClick(tabGeneral.hideVScroll, Qt.LeftButton)
+    assert tabGeneral.hideVScroll.isChecked()
+
+    qtbot.wait(keyDelay)
+    assert not tabGeneral.hideHScroll.isChecked()
+    qtbot.mouseClick(tabGeneral.hideHScroll, Qt.LeftButton)
+    assert tabGeneral.hideHScroll.isChecked()
+
     # Check font button
     monkeypatch.setattr(QFontDialog, "getFont", lambda font, obj: (font, True))
     qtbot.mouseClick(tabGeneral.fontButton, Qt.LeftButton)
@@ -1134,6 +1144,16 @@ def testPreferences(qtbot, monkeypatch, yesToAll, nwMinimal, nwTemp, nwRef, tmpC
     assert tabLayout.textJustify.isChecked()
     qtbot.mouseClick(tabLayout.textJustify, Qt.LeftButton)
     assert not tabLayout.textJustify.isChecked()
+
+    qtbot.wait(keyDelay)
+    assert tabLayout.scrollPastEnd.isChecked()
+    qtbot.mouseClick(tabLayout.scrollPastEnd, Qt.LeftButton)
+    assert not tabLayout.scrollPastEnd.isChecked()
+
+    qtbot.wait(keyDelay)
+    assert not tabLayout.scollWithCursor.isChecked()
+    qtbot.mouseClick(tabLayout.scollWithCursor, Qt.LeftButton)
+    assert tabLayout.scollWithCursor.isChecked()
 
     # Editor Settings
     qtbot.wait(keyDelay)

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -23,7 +23,7 @@ from nw.gui import (
     GuiProjectLoad, GuiPreferences
 )
 from nw.gui.custom import QuotesDialog
-from nw.constants import nwItemType, nwItemLayout, nwItemClass, nwFiles
+from nw.constants import nwItemLayout, nwItemClass, nwFiles
 
 keyDelay = 2
 typeDelay = 1

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -228,6 +228,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
     # Create new, save, close project
     nwGUI.theProject.projTree.setSeed(42)
     assert nwGUI.newProject({"projPath": nwFuncTemp})
+    qtbot.wait(200)
     assert nwGUI.saveProject()
     assert nwGUI.closeProject()
     qtbot.wait(stepDelay)
@@ -236,11 +237,12 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
     nwGUI.mainMenu.aWritingStats.activate(QAction.Trigger)
     assert getGuiItem("GuiWritingStats") is None
 
+    # Add some text to the scene file
     assert nwGUI.openProject(nwFuncTemp)
     qtbot.wait(stepDelay)
 
-    # Add some text to the scene file
     assert nwGUI.openDocument("0e17daca5f3e1")
+    nwGUI.docEditor.clear()
     assert nwGUI.docEditor.insertText(
         "# Scene One\n\n"
         "It was the best of times, it was the worst of times, it was the age of wisdom, it was "
@@ -252,10 +254,18 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
         "insisted on its being received, for good or for evil, in the superlative degree of "
         "comparison only.\n\n"
     )
+    qtbot.wait(stepDelay)
     assert nwGUI.saveDocument()
+    qtbot.wait(200) # Ensures that the session length is > 0
+
+    assert nwGUI.saveProject()
+    assert nwGUI.closeProject()
+    qtbot.wait(stepDelay)
 
     # Add a note file with some text
-    nwGUI.setFocus(1)
+    assert nwGUI.openProject(nwFuncTemp)
+    qtbot.wait(stepDelay)
+
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("71ee45a3c0db9").setSelected(True)
     nwGUI.treeView.newTreeItem(nwItemType.FILE, None)
@@ -264,8 +274,9 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
         "# Jane Doe\n\n"
         "All about Jane.\n\n"
     )
+    qtbot.wait(stepDelay)
     assert nwGUI.saveDocument()
-    qtbot.wait(500) # Ensures that the session length is > 0
+    qtbot.wait(200) # Ensures that the session length is > 0
 
     assert nwGUI.saveProject()
     assert nwGUI.closeProject()
@@ -296,11 +307,12 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.loads(inFile.read())
 
-    assert len(jsonData) == 2
+    qtbot.wait(stepDelay)
+    assert len(jsonData) == 3
     assert jsonData[1]["length"] >= 0
-    assert jsonData[1]["newWords"] == 126
-    assert jsonData[1]["novelWords"] == 127
-    assert jsonData[1]["noteWords"] == 5
+    assert jsonData[1]["newWords"] == 119
+    assert jsonData[1]["novelWords"] == 125
+    assert jsonData[1]["noteWords"] == 0
 
     # No Novel Files
     qtbot.mouseClick(sessLog.incNovel, Qt.LeftButton)
@@ -315,7 +327,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
     assert len(jsonData) == 1
     assert jsonData[0]["length"] >= 0
     assert jsonData[0]["newWords"] == 5
-    assert jsonData[0]["novelWords"] == 127
+    assert jsonData[0]["novelWords"] == 125
     assert jsonData[0]["noteWords"] == 5
 
     # No Note Files
@@ -331,9 +343,9 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
 
     assert len(jsonData) == 2
     assert jsonData[1]["length"] >= 0
-    assert jsonData[1]["newWords"] == 121
-    assert jsonData[1]["novelWords"] == 127
-    assert jsonData[1]["noteWords"] == 5
+    assert jsonData[1]["newWords"] == 119
+    assert jsonData[1]["novelWords"] == 125
+    assert jsonData[1]["noteWords"] == 0
 
     # No Negative Entries
     qtbot.mouseClick(sessLog.incNotes, Qt.LeftButton)
@@ -346,7 +358,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.loads(inFile.read())
 
-    assert len(jsonData) == 2
+    assert len(jsonData) == 3
 
     # Un-hide Zero Entries
     qtbot.mouseClick(sessLog.hideNegative, Qt.LeftButton)
@@ -359,7 +371,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.loads(inFile.read())
 
-    assert len(jsonData) == 2
+    assert len(jsonData) == 3
 
     # Group by Day
     qtbot.mouseClick(sessLog.groupByDay, Qt.LeftButton)


### PR DESCRIPTION
This PR adds 4 new settings:

* Hide vertical scroll bars on the main GUI and the Build Novel Project tool. Scrolling can still be done with keys and mouse wheel.
* Hide horizontal scroll bars, like above, but doesn't scroll with wheel.
* Scroll past end of document. That is, allows scrolling until the last line of the document is at the top of the editor window.
* Typewriter scrolling when typing. Meaning that when a the cursor moves to a new line while typing, the editor will try to keep the cursor at the same vertical position as before and instead scroll the document. This keeps the cursor vertically stationary, like on a typewriter. The effect only applies to the vertical axis.

This fulfils feature request #467 This PR also fixes issue #465 