### PR TITLE
Change Python minimal version to 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,8 @@ to make those. Feel free to submit more if you are able to make them.
 
 ## Package Dependencies
 
-It is recommended that novelWriter runs with Qt 5.10 or later, and Python 3.6 or later. Running with
-Qt as low as 5.2.1 and Python 3.4.3 has been tested, and worked in the past, but there are no
-guarantees that this will keep working as these are not a part of the test builds.
+It is recommended that novelWriter runs with Qt 5.10 or later, and requires Python 3.6 or later.
+Minimum version of Qt is 5.2.
 
 
 ### Linux
@@ -146,7 +145,6 @@ C:\...\AppData\Local\Programs\Python\Python38\python.exe novelWriter.py
 
 ### Package Versions
 
-PyQt/Qt should be at least 5.3, but ideally 5.10 or higher for nearly all features to work.
 Exporting to Markdown requires PyQt/Qt 5.14. There are no known minimum for `lxml`, but the code
 was originally written with 4.2. The optional spell check library must be at least 3.0.0 to work
 with Windows 64 bit systems. On Linux, 2.0.0 also works fine.

--- a/docs/source/int_introduction.rst
+++ b/docs/source/int_introduction.rst
@@ -46,7 +46,7 @@ than the document editor itself are hidden away.
 The colour scheme of the user interface defaults to that of the host operating system. In addition,
 a dark theme is provided, and can be enabled in :guilabel:`Preferences` from the :guilabel:`Tools`
 menu. A number of syntax highlighting themes are also available in :guilabel:`Preferences`. A set of
-icon themes in colour and greyscale are also offered. The icons are based on the Typicon_ icon set
+icon themes in colour and greyscale are also offered. The icons are based on the Typicons_ icon set
 designed by Stephen Hutchings.
 
 The main window is split in two, or optionally three, panels. The left-most contains the project
@@ -58,7 +58,7 @@ entire novel structure can be displayed, with all the tags and references listed
 you structure your novel project files, this outline can be quite different than your project tree.
 Your project tree lists files, your Outline tree lists the structure of the novel itself.
 
-.. _Typicon: https://github.com/stephenhutchings/typicons.font
+.. _Typicons: https://github.com/stephenhutchings/typicons.font
 
 
 .. _a_intro_project:

--- a/install.py
+++ b/install.py
@@ -35,7 +35,7 @@ except getopt.GetoptError:
 for inOpt, inArg in inOpts:
     if inOpt in ("-h", "--help"):
         print(helpMsg)
-        sys.exit()
+        sys.exit(0)
     elif inOpt in ("-d", "--debug"):
         buildWindowed = False
 
@@ -72,7 +72,7 @@ if buildWindowed:
 
 instOpt.append("novelWriter.py")
 
-import PyInstaller.__main__ # noqa: F401
+import PyInstaller.__main__ # noqa: E402
 PyInstaller.__main__.run(instOpt)
 
 print("")

--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -200,9 +200,9 @@ def main(sysArgs=None):
     # Check Packages and Versions
     errorData = []
     errorCode = 0
-    if sys.hexversion < 0x030403f0:
+    if sys.hexversion < 0x030600f0:
         errorData.append(
-            "At least Python 3.4.3 is required, but 3.6 is highly recommended."
+            "At least Python 3.6.0 is required, found %s." % CONFIG.verPyString
         )
         errorCode |= 4
     if CONFIG.verQtValue < 50200:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 license_files = LICENSE.md
+version = attr: nw.__version__
 
 [bdist_wheel]
 universal = 0

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ import sys
 import subprocess
 import setuptools
 
-from nw import __version__, __url__, __docurl__, __issuesurl__, __sourceurl__
-
 ##
 #  Build the Package
 ##
@@ -119,19 +117,16 @@ if len(sys.argv) == 1:
 with open("README.md", "r") as inFile:
     longDescription = inFile.read()
 
-with open("requirements.txt", "r") as inFile:
-    pkgRequirements = inFile.read().strip().splitlines()
-
 setuptools.setup(
     name = "novelWriter",
-    version = __version__,
+    # version = __version__, # Set in setup.cfg
     author = "Veronica Berglyd Olsen",
     author_email = "code@vkbo.net",
     description = "A markdown-like document editor for writing novels",
     long_description = longDescription,
     long_description_content_type = "text/markdown",
     license = "GNU General Public License v3",
-    url = __url__,
+    url = "https://novelwriter.io",
     entry_points = {
         "console_scripts" : ["novelWriter-cli=nw:main"],
         "gui_scripts" :     ["novelWriter=nw:main"],
@@ -140,9 +135,9 @@ setuptools.setup(
     include_package_data = True,
     package_data = {"": ["*.conf"]},
     project_urls = {
-        "Bug Tracker": __issuesurl__,
-        "Documentation": __docurl__,
-        "Source Code": __sourceurl__,
+        "Bug Tracker": "https://github.com/vkbo/novelWriter/issues",
+        "Documentation": "https://github.com/vkbo/novelWriter/issues",
+        "Source Code": "https://github.com/vkbo/novelWriter",
     },
     classifiers = [
         "Programming Language :: Python :: 3 :: Only",
@@ -159,5 +154,9 @@ setuptools.setup(
         "Topic :: Text Editors",
     ],
     python_requires = ">=3.6",
-    install_requires = pkgRequirements,
+    install_requires = [
+        "pyqt5>=5.2.1",
+        "lxml>=4.2.0",
+        "pyenchant>=3.0.0",
+    ],
 )


### PR DESCRIPTION
Since novelWriter is no longer compatible with Python 3.4 and 3.5, it is best to force a minimal Python version of 3.6.0. This PR ensures that, and updates the documentation.

This PR also alters the `setup.py` script to not import the main `nw` package to populate various variables. The version number is instead extracted via the `setup.cfg` file as described in the Python packaging documentation.