### PR TITLE
Fix a bug in build tool for lower Qt versions

### DIFF
--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -1013,8 +1013,9 @@ class GuiBuildNovel(QDialog):
         """
         self.saveODT.setEnabled(theState)
         self.savePDF.setEnabled(theState)
-        self.saveMD.setEnabled(theState)
         self.saveTXT.setEnabled(theState)
+        if self.mainConf.verQtValue >= 51400:
+            self.saveMD.setEnabled(theState)
         return
 
     def _saveSettings(self):


### PR DESCRIPTION
This fixes issue #471

This bug is unfortunately not caught by tests as the tests run on newer versions from the pip installer. One of the test jobs should probably run on an older set of Qt libraries.