### PR TITLE
Qt Version Checking

### DIFF
--- a/.github/workflows/test_linux_3.6.yml
+++ b/.github/workflows/test_linux_3.6.yml
@@ -27,8 +27,12 @@ jobs:
           pip install PyQt5==5.9
           pip install -r requirements.txt
           pip install pytest-timeout
+          pip install pytest-cov
           pip install pytest-qt
+          pip install codecov
       - name: Run Tests
         run: |
           export QT_QPA_PLATFORM=offscreen
-          pytest -v --timeout=60
+          pytest -v --cov=nw --timeout=60
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/test_linux_3.6.yml
+++ b/.github/workflows/test_linux_3.6.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install --upgrade pip
-          pip install PyQt5==5.9
+          pip install PyQt5==5.9.2
           pip install -r requirements.txt
           pip install pytest-timeout
           pip install pytest-cov

--- a/.github/workflows/test_linux_3.6.yml
+++ b/.github/workflows/test_linux_3.6.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install --upgrade pip
-          pip install PyQt5==5.10.1
           pip install -r requirements.txt
           pip install pytest-timeout
           pip install pytest-cov

--- a/.github/workflows/test_linux_3.6.yml
+++ b/.github/workflows/test_linux_3.6.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install --upgrade pip
+          pip install PyQt5==5.9
           pip install -r requirements.txt
           pip install pytest-timeout
           pip install pytest-qt

--- a/.github/workflows/test_linux_3.6.yml
+++ b/.github/workflows/test_linux_3.6.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   testLinux36:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Python Setup
         uses: actions/setup-python@v1
@@ -24,7 +24,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install --upgrade pip
-          pip install PyQt5==5.9.2
+          pip install PyQt5==5.10.1
           pip install -r requirements.txt
           pip install pytest-timeout
           pip install pytest-cov

--- a/nw/config.py
+++ b/nw/config.py
@@ -177,6 +177,8 @@ class Config:
         self.verPyQtPatch  = verQt[2]
         self.verPyQtValue  = verQt[3]
 
+        self.verQtMin = min(self.verQtValue, self.verPyQtValue)
+
         # Check Python Version
         self.verPyString = sys.version.split()[0]
         self.verPyMajor  = sys.version_info[0]
@@ -202,7 +204,7 @@ class Config:
             self.osUnknown = True
 
         # Other System Info
-        if self.verQtValue >= 50600:
+        if self.verQtMin >= 50600:
             self.hostName  = QSysInfo.machineHostName()
             self.kernelVer = QSysInfo.kernelVersion()
         else:
@@ -251,7 +253,7 @@ class Config:
             self.confPath = confPath
 
         if dataPath is None:
-            if self.verQtValue >= 50400:
+            if self.verQtMin >= 50400:
                 dataRoot = QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)
             else:
                 dataRoot = QStandardPaths.writableLocation(QStandardPaths.DataLocation)

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -399,7 +399,7 @@ class GuiBuildNovel(QDialog):
         self.saveNWD.triggered.connect(lambda: self._saveDocument(self.FMT_NWD))
         self.saveMenu.addAction(self.saveNWD)
 
-        if self.mainConf.verQtValue >= 51400:
+        if self.mainConf.verQtMin >= 51400:
             self.saveMD = QAction("Markdown (.md)", self)
             self.saveMD.triggered.connect(lambda: self._saveDocument(self.FMT_MD))
             self.saveMenu.addAction(self.saveMD)
@@ -1014,7 +1014,7 @@ class GuiBuildNovel(QDialog):
         self.saveODT.setEnabled(theState)
         self.savePDF.setEnabled(theState)
         self.saveTXT.setEnabled(theState)
-        if self.mainConf.verQtValue >= 51400:
+        if self.mainConf.verQtMin >= 51400:
             self.saveMD.setEnabled(theState)
         return
 
@@ -1120,7 +1120,7 @@ class GuiBuildNovelDocView(QTextBrowser):
         self.setFont(theFont)
 
         # Set the tab stops
-        if self.mainConf.verQtValue >= 51000:
+        if self.mainConf.verQtMin >= 51000:
             self.setTabStopDistance(self.mainConf.getTabWidth())
         else:
             self.setTabStopWidth(self.mainConf.getTabWidth())

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -236,7 +236,7 @@ class GuiDocEditor(QTextEdit):
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         # Refresh the tab stops
-        if self.mainConf.verQtValue >= 51000:
+        if self.mainConf.verQtMin >= 51000:
             self.setTabStopDistance(self.mainConf.getTabWidth())
         else:
             self.setTabStopWidth(self.mainConf.getTabWidth())
@@ -473,7 +473,7 @@ class GuiDocEditor(QTextEdit):
         We still want to get rid of page and line separators though.
         See: https://doc.qt.io/qt-5/qtextdocument.html#toPlainText
         """
-        if self.mainConf.verQtValue >= 50900:
+        if self.mainConf.verQtMin >= 50900:
             theText = self.qDocument.toRawText()
             theText = theText.replace(nwUnicode.U_LSEP, "\n") # Line separators
             theText = theText.replace(nwUnicode.U_PSEP, "\n") # Paragraph separators
@@ -1856,7 +1856,7 @@ class GuiDocEditSearch(QFrame):
             # Using the Unicode-capable QRegularExpression class was
             # only added in Qt 5.13. Otherwise, 5.3 and up supports
             # only the QRegExp class.
-            if self.mainConf.verQtValue >= 51300:
+            if self.mainConf.verQtMin >= 51300:
                 rxOpt = QRegularExpression.UseUnicodePropertiesOption
                 if not self.isCaseSense:
                     rxOpt |= QRegularExpression.CaseInsensitiveOption
@@ -1864,7 +1864,7 @@ class GuiDocEditSearch(QFrame):
                 self._alertSearchValid(theRegEx.isValid())
                 return theRegEx
 
-            elif self.mainConf.verQtValue >= 50300:
+            elif self.mainConf.verQtMin >= 50300:
                 if self.isCaseSense:
                     rxOpt = Qt.CaseSensitive
                 else:

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -136,7 +136,7 @@ class GuiDocViewer(QTextBrowser):
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         # Refresh the tab stops
-        if self.mainConf.verQtValue >= 51000:
+        if self.mainConf.verQtMin >= 51000:
             self.setTabStopDistance(self.mainConf.getTabWidth())
         else:
             self.setTabStopWidth(self.mainConf.getTabWidth())
@@ -182,7 +182,7 @@ class GuiDocViewer(QTextBrowser):
             return False
 
         # Refresh the tab stops
-        if self.mainConf.verQtValue >= 51000:
+        if self.mainConf.verQtMin >= 51000:
             self.setTabStopDistance(self.mainConf.getTabWidth())
         else:
             self.setTabStopWidth(self.mainConf.getTabWidth())

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1084,7 +1084,7 @@ def testInsertMenu(qtbot, monkeypatch, nwFuncTemp, nwTemp):
     nwGUI.docEditor.clear()
 
     nwGUI.mainMenu.aInsNBSpace.activate(QAction.Trigger)
-    if nwGUI.mainConf.verQtValue >= 50900:
+    if nwGUI.mainConf.verQtMin >= 50900:
         assert nwGUI.docEditor.getText() == nwUnicode.U_NBSP
     else:
         assert nwGUI.docEditor.getText() == " "
@@ -1095,7 +1095,7 @@ def testInsertMenu(qtbot, monkeypatch, nwFuncTemp, nwTemp):
     nwGUI.docEditor.clear()
 
     nwGUI.mainMenu.aInsThinNBSpace.activate(QAction.Trigger)
-    if nwGUI.mainConf.verQtValue >= 50900:
+    if nwGUI.mainConf.verQtMin >= 50900:
         assert nwGUI.docEditor.getText() == nwUnicode.U_THNBSP
     else:
         assert nwGUI.docEditor.getText() == " "


### PR DESCRIPTION
The checks against Qt and PyQt versions should check against the lowest of the two.

Also, the Python 3.6 test should run on an older PyQt5 version to get those if checks covered.