### PR TITLE
Document Editor Tweaks

### DIFF
--- a/nw/gui/custom.py
+++ b/nw/gui/custom.py
@@ -326,7 +326,7 @@ class QSwitch(QAbstractButton):
         """
         super().mouseReleaseEvent(event)
         if event.button() == Qt.LeftButton:
-            doAnim = QPropertyAnimation(self, b'offset', self)
+            doAnim = QPropertyAnimation(self, b"offset", self)
             doAnim.setDuration(120)
             doAnim.setStartValue(self.offset)
             if self.isChecked():

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -38,7 +38,7 @@ from time import time
 
 from PyQt5.QtCore import (
     Qt, QSize, QTimer, pyqtSlot, pyqtSignal, QRegExp, QRegularExpression,
-    QPointF, QObject, QRunnable
+    QPointF, QObject, QRunnable, QPropertyAnimation
 )
 from PyQt5.QtGui import (
     QTextCursor, QTextOption, QKeySequence, QFont, QColor, QPalette,
@@ -774,11 +774,22 @@ class GuiDocEditor(QTextEdit):
         if self.mainConf.scollWithCursor:
             kMod = keyEvent.modifiers()
             if kMod == Qt.NoModifier or kMod == Qt.ShiftModifier:
+                hWid = self.viewport().height()
                 cPos = self.cursorRect().center().y()
-                mPos = self.mainConf.scollToPoint * self.viewport().height()
+                mPos = self.mainConf.scollToPoint * hWid
                 vBar = self.verticalScrollBar()
-                vBar.setValue(vBar.value() + cPos - round(mPos * 0.01))
-                self.ensureCursorVisible()
+
+                # Compute the needed scroll and duration
+                pOld = vBar.value()
+                pNew = pOld + cPos - round(mPos*0.01)
+                aDur = 150 + round(abs(pNew - pOld)/hWid*500)
+
+                if pNew >= 0:
+                    doAnim = QPropertyAnimation(vBar, b"value", self)
+                    doAnim.setDuration(aDur)
+                    doAnim.setStartValue(pOld)
+                    doAnim.setEndValue(pNew)
+                    doAnim.start()
 
         return
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -782,7 +782,7 @@ class GuiDocEditor(QTextEdit):
                 # Compute the needed scroll and duration
                 pOld = vBar.value()
                 pNew = pOld + cPos - round(mPos*0.01)
-                aDur = 150 + round(abs(pNew - pOld)/hWid*500)
+                aDur = 150 + round(min(abs(pNew - pOld)/hWid, 1.0)*500)
 
                 if pNew >= 0:
                     doAnim = QPropertyAnimation(vBar, b"value", self)
@@ -2346,11 +2346,13 @@ class GuiDocEditFooter(QWidget):
         """
         if self.theItem is None:
             iLine = 0
+            iDist = 0
         else:
             theCursor = self.docEditor.textCursor()
             iLine = theCursor.blockNumber() + 1
+            iDist = 100*iLine/self.docEditor.qDocument.blockCount()
 
-        self.linesText.setText(f"Line: {iLine:n}")
+        self.linesText.setText(f"Line: {iLine:n} ({iDist:.0f}\u202f%)")
 
         return
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -168,6 +168,13 @@ def testDocEditor(qtbot, yesToAll, nwFuncTemp, nwTempGUI, nwRef, nwTemp):
     nwGUI.mainMenu.aSpellCheck.setChecked(True)
     assert nwGUI.mainMenu._toggleSpellCheck()
 
+    # Change some settings
+    nwGUI.mainConf.hideHScroll = True
+    nwGUI.mainConf.hideVScroll = True
+    nwGUI.mainConf.scrollPastEnd = True
+    nwGUI.mainConf.scollToPoint = 80
+    nwGUI.mainConf.scollWithCursor = True
+
     # Add a Character File
     nwGUI.setFocus(1)
     nwGUI.treeView.clearSelection()


### PR DESCRIPTION
This PR makes a few minor changes to the document editor.

* The line counter in the footer now shows how many percent through the document you are. This is convenient for large documents.
* The follow cursor feature (typewriter mode) now animates the scrolling over 150 to 650 milliseconds, depending on the distance to move. This smooths the otherwise sudden jumps this feature would make when the scroll bar value was changed.
* The context menu now shows a "Follow Tag" menu entry when the menu is opened on a word on a meta keyword/value line. The spell checker is also disabled for these lines also on the context menu level. Previously, it was just blocked on the highlighter.