### PR TITLE
Formatting with mulitple paragraphs selected

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -955,4 +955,4 @@ class Config:
 
         return
 
-# End Class Config
+# END Class Config

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -756,8 +756,8 @@ class GuiDocEditor(QTextEdit):
           * The return and enter key redirects here even if the search
             box has focus. Since we need these keys to continue search,
             we block any further interaction here while it's in focus.
-          * The undo/redo sequences bypasses the doAction pathway from
-            the menu, so we redirect them back from here.
+          * The undo/redo/select all sequences bypasses the docAction
+            pathway from the menu, so we redirect them back from here.
         """
         isReturn  = keyEvent.key() == Qt.Key_Return
         isReturn |= keyEvent.key() == Qt.Key_Enter
@@ -767,6 +767,8 @@ class GuiDocEditor(QTextEdit):
             self.docAction(nwDocAction.REDO)
         elif keyEvent == QKeySequence.Undo:
             self.docAction(nwDocAction.UNDO)
+        elif keyEvent == QKeySequence.SelectAll:
+            self.docAction(nwDocAction.SEL_ALL)
         else:
             QTextEdit.keyPressEvent(self, keyEvent)
             self.docFooter.updateLineCount()
@@ -1292,10 +1294,11 @@ class GuiDocEditor(QTextEdit):
                 reSelect = True
             if reSelect:
                 theCursor.clearSelection()
-                theCursor.setPosition(posE-1)
-                theCursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor, posE-posS-1)
+                theCursor.setPosition(posS, QTextCursor.MoveAnchor)
+                theCursor.setPosition(posE-1, QTextCursor.KeepAnchor)
 
             self.setTextCursor(theCursor)
+
         return theCursor
 
     def _toggleFormat(self, fLen, fChar):
@@ -1429,7 +1432,10 @@ class GuiDocEditor(QTextEdit):
         theCursor.clearSelection()
         theCursor.select(selMode)
 
-        if selMode == QTextCursor.BlockUnderCursor:
+        if selMode == QTextCursor.WordUnderCursor:
+            theCursor = self._autoSelect()
+
+        elif selMode == QTextCursor.BlockUnderCursor:
             # This selection mode also selects the preceding oaragraph
             # separator, which we want to avoid.
             posS = theCursor.selectionStart()

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -1237,6 +1237,11 @@ class GuiDocEditor(QTextEdit):
             posS = theCursor.selectionStart()
             posE = theCursor.selectionEnd()
 
+            blockS = self.qDocument.findBlock(posS)
+            blockE = self.qDocument.findBlock(posE)
+            if blockS != blockE:
+                posE = blockS.position() + blockS.length() - 1
+
             theCursor.clearSelection()
             theCursor.beginEditBlock()
             theCursor.setPosition(posE)
@@ -1245,8 +1250,8 @@ class GuiDocEditor(QTextEdit):
             theCursor.insertText(tBefore)
             theCursor.endEditBlock()
 
-            theCursor.setPosition(posE + len(tBefore))
-            theCursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor, posE-posS)
+            theCursor.setPosition(posE + len(tBefore), QTextCursor.MoveAnchor)
+            theCursor.setPosition(posS + len(tBefore), QTextCursor.KeepAnchor)
             self.setTextCursor(theCursor)
 
         else:

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -1299,12 +1299,24 @@ class GuiDocEditor(QTextEdit):
         return theCursor
 
     def _toggleFormat(self, fLen, fChar):
-        """Toggle strikethrough text.
+        """Toggle the formatting of a specific type for a piece of text.
+        If more than one block is selected, the formatting is applied to
+        the first block.
         """
         theCursor = self._autoSelect()
         if theCursor.hasSelection():
             posS = theCursor.selectionStart()
             posE = theCursor.selectionEnd()
+
+            blockS = self.qDocument.findBlock(posS)
+            blockE = self.qDocument.findBlock(posE)
+
+            if blockS != blockE:
+                posE = blockS.position() + blockS.length() - 1
+                theCursor.clearSelection()
+                theCursor.setPosition(posS, QTextCursor.MoveAnchor)
+                theCursor.setPosition(posE, QTextCursor.KeepAnchor)
+                self.setTextCursor(theCursor)
 
             numB = 0
             for n in range(fLen):


### PR DESCRIPTION
This is related to issue #451. This PR changes the behaviour of the formatting functions to only apply the format to the first of the selected paragraphs.