### PR TITLE
JSON File Changes

### DIFF
--- a/nw/config.py
+++ b/nw/config.py
@@ -690,8 +690,7 @@ class Config:
         if os.path.isfile(cacheFile):
             try:
                 with open(cacheFile, mode="r", encoding="utf8") as inFile:
-                    theJson = inFile.read()
-                theData = json.loads(theJson)
+                    theData = json.load(inFile)
 
                 for projPath in theData.keys():
                     theEntry  = theData[projPath]
@@ -729,7 +728,7 @@ class Config:
 
         try:
             with open(cacheTemp, mode="w+", encoding="utf8") as outFile:
-                outFile.write(json.dumps(self.recentProj, indent=2))
+                json.dump(self.recentProj, outFile, indent=2)
         except Exception as e:
             self.hasError = True
             self.errData.append("Could not save recent project cache")

--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -159,8 +159,7 @@ class NWIndex():
             logger.debug("Loading index file")
             try:
                 with open(indexFile, mode="r", encoding="utf8") as inFile:
-                    theJson = inFile.read()
-                theData = json.loads(theJson)
+                    theData = json.load(inFile)
             except Exception as e:
                 logger.error("Failed to load index file")
                 logger.error(str(e))
@@ -190,23 +189,18 @@ class NWIndex():
         """Save the current index as a json file in the project meta
         data folder.
         """
-        indexFile = os.path.join(self.theProject.projMeta, nwFiles.INDEX_FILE)
-
         logger.debug("Saving index file")
-        if self.mainConf.debugInfo:
-            nIndent = 2
-        else:
-            nIndent = None
+        indexFile = os.path.join(self.theProject.projMeta, nwFiles.INDEX_FILE)
 
         try:
             with open(indexFile, mode="w+", encoding="utf8") as outFile:
-                outFile.write(json.dumps({
+                json.dump({
                     "tagIndex"   : self.tagIndex,
                     "refIndex"   : self.refIndex,
                     "novelIndex" : self.novelIndex,
                     "noteIndex"  : self.noteIndex,
                     "textCounts" : self.textCounts,
-                }, indent=nIndent))
+                }, outFile, indent=2)
         except Exception as e:
             logger.error("Failed to save index file")
             logger.error(str(e))
@@ -218,6 +212,7 @@ class NWIndex():
         """Check that the entries in the index are valid and contain the
         elements it should.
         """
+        logger.debug("Checking index")
         self.indexBroken = False
 
         try:

--- a/nw/core/options.py
+++ b/nw/core/options.py
@@ -109,8 +109,7 @@ class OptionState():
             logger.debug("Loading GUI options file")
             try:
                 with open(stateFile, mode="r", encoding="utf8") as inFile:
-                    theJson = inFile.read()
-                theState = json.loads(theJson)
+                    theState = json.load(inFile)
             except Exception as e:
                 logger.error("Failed to load GUI options file")
                 logger.error(str(e))
@@ -137,7 +136,7 @@ class OptionState():
 
         try:
             with open(stateFile, mode="w+", encoding="utf8") as outFile:
-                outFile.write(json.dumps(self.theState, indent=2))
+                json.dump(self.theState, outFile, indent=2)
         except Exception as e:
             logger.error("Failed to save GUI options file")
             logger.error(str(e))

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -1024,7 +1024,7 @@ class NWProject():
         return True
 
     def setTreeOrder(self, newOrder):
-        """A list representing the liner/flattened order of project
+        """A list representing the linear/flattened order of project
         items in the GUI project tree. The user can rearrange the order
         by drag-and-drop. Forwarded to the NWTree class.
         """

--- a/nw/core/tree.py
+++ b/nw/core/tree.py
@@ -177,7 +177,7 @@ class NWTree():
 
             # Dump the JSON
             with open(tocJson, mode="w+", encoding="utf8") as outFile:
-                outFile.write(json.dumps(jsonData, indent=2))
+                json.dump(jsonData, outFile, indent=2)
 
         except Exception as e:
             logger.error(str(e))

--- a/nw/gui/writingstats.py
+++ b/nw/gui/writingstats.py
@@ -362,7 +362,7 @@ class GuiWritingStats(QDialog):
                             "novelWords": wA,
                             "noteWords": wB,
                         })
-                    outFile.write(json.dumps(jsonData, indent=2))
+                    json.dump(jsonData, outFile, indent=2)
                     wSuccess = True
 
                 elif dataFmt == self.FMT_CSV:

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -266,7 +266,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
 
     jsonStats = os.path.join(nwFuncTemp, "sessionStats.json")
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
-        jsonData = json.loads(inFile.read())
+        jsonData = json.load(inFile)
 
     qtbot.wait(stepDelay)
 
@@ -301,7 +301,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
 
     jsonStats = os.path.join(nwFuncTemp, "sessionStats.json")
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
-        jsonData = json.loads(inFile.read())
+        jsonData = json.load(inFile)
 
     assert len(jsonData) == 2
     assert jsonData[1]["length"] >= 14.0
@@ -318,7 +318,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
 
     jsonStats = os.path.join(nwFuncTemp, "sessionStats.json")
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
-        jsonData = json.loads(inFile.read())
+        jsonData = json.load(inFile)
 
     assert len(jsonData) == 3
 
@@ -331,7 +331,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
 
     jsonStats = os.path.join(nwFuncTemp, "sessionStats.json")
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
-        jsonData = json.loads(inFile.read())
+        jsonData = json.load(inFile)
 
     assert len(jsonData) == 4
 
@@ -343,7 +343,7 @@ def testWritingStatsExport(qtbot, monkeypatch, yesToAll, nwFuncTemp, nwTemp):
 
     jsonStats = os.path.join(nwFuncTemp, "sessionStats.json")
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
-        jsonData = json.loads(inFile.read())
+        jsonData = json.load(inFile)
 
     # Check against both 1 and 2 as this can be 2 if test was started just before midnight.
     # A failed test should in any case produce a 4

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -27,7 +27,6 @@ def testIndexBuildCheck(monkeypatch, nwLipsum, nwDummy, nwTempProj, nwRef):
     theProject.projTree.setSeed(42)
     assert theProject.openProject(nwLipsum)
 
-    theProject.mainConf.debugInfo = True
     monkeypatch.setattr("nw.core.index.time", lambda: 123.4)
 
     theIndex = NWIndex(theProject, nwDummy)
@@ -49,7 +48,7 @@ def testIndexBuildCheck(monkeypatch, nwLipsum, nwDummy, nwTempProj, nwRef):
         raise Exception
 
     # Make the save fail
-    monkeypatch.setattr(json, "dumps", doPanic)
+    monkeypatch.setattr(json, "dump", doPanic)
     assert not theIndex.saveIndex()
 
     # Make the save pass
@@ -83,7 +82,7 @@ def testIndexBuildCheck(monkeypatch, nwLipsum, nwDummy, nwTempProj, nwRef):
     assert not theIndex.textCounts
 
     # Make the load fail
-    monkeypatch.setattr(json, "loads", doPanic)
+    monkeypatch.setattr(json, "load", doPanic)
     assert not theIndex.loadIndex()
 
     # Make the load pass


### PR DESCRIPTION
Related to issues discussed in #383.

All JSON files are now indented with two spaces. Previously, the index file was only indented when running in debug mode. Indented files are easier to version control, although there isn't really any point in tracking any of the JSON files in a novelWriter project.

This PR also skips using an intermediate variable when loading and saving JSON files.