### PR TITLE
Change Document Meta Format

### DIFF
--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -230,10 +230,10 @@ class NWDoc():
         %%~ that may contain meta data.
         """
         if metaLine.startswith("%%~name:"):
-            self._docMeta["name"] = metaLine[9:].strip()
+            self._docMeta["name"] = metaLine[8:].strip()
 
         elif metaLine.startswith("%%~path:"):
-            metaVal = metaLine[9:].strip()
+            metaVal = metaLine[8:].strip()
             metaBits = metaVal.split("/")
             if len(metaBits) == 2:
                 if isHandle(metaBits[0]):
@@ -242,7 +242,7 @@ class NWDoc():
                     self._docMeta["handle"] = metaBits[1]
 
         elif metaLine.startswith("%%~kind:"):
-            metaVal = metaLine[9:].strip()
+            metaVal = metaLine[8:].strip()
             metaBits = metaVal.split("/")
             if len(metaBits) == 2:
                 if metaBits[0] in nwItemClass.__members__:

--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -250,7 +250,9 @@ class NWDoc():
                 if metaBits[1] in nwItemLayout.__members__:
                     self._docMeta["layout"] = nwItemLayout[metaBits[1]]
 
-        # print(self._docMeta)
+        else:
+            logger.debug("Ignoring meta data: '%s'" % metaLine)
+
         return
 
 # END Class NWDoc

--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -30,7 +30,7 @@ import os
 
 from nw.constants import nwAlert
 from nw.common import isHandle
-from nw.constants import nwItemLayout, nwItemClass, nwConst
+from nw.constants import nwItemLayout, nwItemClass
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class NWDoc():
         self._theItem   = None # The currently open item
         self._docHandle = None # The handle of the currently open item
         self._fileLoc   = None # The file location of the currently open item
-        self._docMeta   = ""   # The meta string of the currently open item
+        self._docMeta   = {}   # The meta data of the currently open item
 
         # Internal Mapping
         self.makeAlert = self.theParent.makeAlert
@@ -62,7 +62,7 @@ class NWDoc():
         self._theItem   = None
         self._docHandle = None
         self._fileLoc   = None
-        self._docMeta   = ""
+        self._docMeta   = {}
         return
 
     def openDocument(self, tHandle, showStatus=True, isOrphan=False):
@@ -94,16 +94,21 @@ class NWDoc():
         self._fileLoc = docPath
 
         theText = ""
-        self._docMeta = ""
+        self._docMeta = {}
         if os.path.isfile(docPath):
             try:
                 with open(docPath, mode="r", encoding="utf8") as inFile:
-                    fstLine = inFile.readline()
-                    if fstLine.startswith("%%~ "):
-                        # This is the meta line
-                        self._docMeta = fstLine[4:].strip()
-                    else:
-                        theText = fstLine
+
+                    # Check the first <= 10 lines for metadata
+                    for i in range(10):
+                        inLine = inFile.readline()
+                        if inLine.startswith(r"%%~"):
+                            self._parseMeta(inLine)
+                        else:
+                            theText = inLine
+                            break
+
+                    # Load the rest of the file
                     theText += inFile.read()
 
             except Exception as e:
@@ -118,8 +123,6 @@ class NWDoc():
             # document and initialise an empty text string.
             logger.debug("The requested document does not exist.")
             return ""
-
-        logger.verbose("DocMeta: '%s'" % self._docMeta)
 
         if showStatus and not isOrphan:
             self.theParent.setStatus("Opened Document: %s" % self._theItem.itemName)
@@ -145,14 +148,10 @@ class NWDoc():
         if self._theItem is None:
             docMeta = ""
         else:
-            itemPath = self.theProject.projTree.getItemPath(self._docHandle)
             docMeta = (
-                "%%~ {handlepath:s}:{itemclass:s}:{itemlayout:s}:{itemname:s}\n"
-            ).format(
-                handlepath = ":".join(itemPath),
-                itemclass  = self._theItem.itemClass.name,
-                itemlayout = self._theItem.itemLayout.name,
-                itemname   = self._theItem.itemName,
+                f"%%~name: {self._theItem.itemName:s}\n"
+                f"%%~path: {self._theItem.itemParent:s}/{self._theItem.itemHandle:s}\n"
+                f"%%~kind: {self._theItem.itemClass.name:s}/{self._theItem.itemLayout.name:s}\n"
             )
 
         try:
@@ -215,39 +214,43 @@ class NWDoc():
         """Parses the document meta tag and returns the path and name as
         a list and a string.
         """
-        if len(self._docMeta) < 14:
-            # Not enough information
-            return "", [], None, None
+        theName = self._docMeta.get("name", "")
+        theParent = self._docMeta.get("parent", None)
+        theClass = self._docMeta.get("class", None)
+        theLayout = self._docMeta.get("layout", None)
 
-        theMeta = self._docMeta
+        return theName, theParent, theClass, theLayout
 
-        # Scan for handles
-        thePath = []
-        for n in range(nwConst.maxDepth + 5):
-            if len(theMeta) < 14:
-                break
-            if theMeta[13] == ":":
-                theHandle = theMeta[:13]
-                if isHandle(theHandle):
-                    thePath.append(theHandle)
-                    theMeta = theMeta[14:]
-                else:
-                    break
-            else:
-                break
+    ##
+    #  Internal Functions
+    ##
 
-        theClass = nwItemClass.NO_CLASS
-        for aClass in nwItemClass:
-            if theMeta.startswith(aClass.name):
-                theClass = aClass
-                theMeta = theMeta[len(aClass.name)+1:]
+    def _parseMeta(self, metaLine):
+        """Parse a line from the document statting with the characters
+        %%~ that may contain meta data.
+        """
+        if metaLine.startswith("%%~name:"):
+            self._docMeta["name"] = metaLine[9:].strip()
 
-        theLayout = nwItemLayout.NO_LAYOUT
-        for aLayout in nwItemLayout:
-            if theMeta.startswith(aLayout.name):
-                theLayout = aLayout
-                theMeta = theMeta[len(aLayout.name)+1:]
+        elif metaLine.startswith("%%~path:"):
+            metaVal = metaLine[9:].strip()
+            metaBits = metaVal.split("/")
+            if len(metaBits) == 2:
+                if isHandle(metaBits[0]):
+                    self._docMeta["parent"] = metaBits[0]
+                if isHandle(metaBits[1]):
+                    self._docMeta["handle"] = metaBits[1]
 
-        return theMeta, thePath, theClass, theLayout
+        elif metaLine.startswith("%%~kind:"):
+            metaVal = metaLine[9:].strip()
+            metaBits = metaVal.split("/")
+            if len(metaBits) == 2:
+                if metaBits[0] in nwItemClass.__members__:
+                    self._docMeta["class"] = nwItemClass[metaBits[0]]
+                if metaBits[1] in nwItemLayout.__members__:
+                    self._docMeta["layout"] = nwItemLayout[metaBits[1]]
+
+        # print(self._docMeta)
+        return
 
 # END Class NWDoc

--- a/sample/content/14298de4d9524.nwd
+++ b/sample/content/14298de4d9524.nwd
@@ -1,4 +1,6 @@
-%%~ 14298de4d9524:f7e2d9f330615:f6622b4617424:CHARACTER:NOTE:John Smith
+%%~name: John Smith
+%%~path: f7e2d9f330615/14298de4d9524
+%%~kind: CHARACTER/NOTE
 # John Smith
 
 @tag: John

--- a/sample/content/53b69b83cdafc.nwd
+++ b/sample/content/53b69b83cdafc.nwd
@@ -1,4 +1,6 @@
-%%~ 53b69b83cdafc:7031beac91f75:NOVEL:TITLE:Title Page
+%%~name: Title Page
+%%~path: 7031beac91f75/53b69b83cdafc
+%%~kind: NOVEL/TITLE
 # My Novel
 
 **By Jane Doh**

--- a/sample/content/5eaea4e8cdee8.nwd
+++ b/sample/content/5eaea4e8cdee8.nwd
@@ -1,4 +1,6 @@
-%%~ 5eaea4e8cdee8:15c4492bd5107:WORLD:NOTE:Mars
+%%~name: Mars
+%%~path: 15c4492bd5107/5eaea4e8cdee8
+%%~kind: WORLD/NOTE
 # Mars
 
 @tag: Mars

--- a/sample/content/636b6aa9b697b.nwd
+++ b/sample/content/636b6aa9b697b.nwd
@@ -1,7 +1,6 @@
 %%~name: Making a Scene
 %%~path: e7ded148d6e4a/636b6aa9b697b
 %%~kind: NOVEL/SCENE
-%%~
 ### Making a Scene
 
 @pov: Jane

--- a/sample/content/636b6aa9b697b.nwd
+++ b/sample/content/636b6aa9b697b.nwd
@@ -1,4 +1,7 @@
-%%~ 636b6aa9b697b:e7ded148d6e4a:7031beac91f75:NOVEL:SCENE:Making a Scene
+%%~name: Making a Scene
+%%~path: e7ded148d6e4a/636b6aa9b697b
+%%~kind: NOVEL/SCENE
+%%~
 ### Making a Scene
 
 @pov: Jane

--- a/sample/content/6a2d6d5f4f401.nwd
+++ b/sample/content/6a2d6d5f4f401.nwd
@@ -1,4 +1,6 @@
-%%~ 6a2d6d5f4f401:e7ded148d6e4a:7031beac91f75:NOVEL:CHAPTER:Chapter One
+%%~name: Chapter One
+%%~path: e7ded148d6e4a/6a2d6d5f4f401
+%%~kind: NOVEL/CHAPTER
 ## So it Begins
 
 @pov: Jane

--- a/sample/content/88706ddc78b1b.nwd
+++ b/sample/content/88706ddc78b1b.nwd
@@ -1,4 +1,6 @@
-%%~ 88706ddc78b1b:e7ded148d6e4a:7031beac91f75:NOVEL:CHAPTER:Chapter Two
+%%~name: Chapter Two
+%%~path: e7ded148d6e4a/88706ddc78b1b
+%%~kind: NOVEL/CHAPTER
 ## Where has John Gone?
 
 @pov: Jane

--- a/sample/content/8a5deb88c0e97.nwd
+++ b/sample/content/8a5deb88c0e97.nwd
@@ -1,4 +1,6 @@
-%%~ 8a5deb88c0e97:6827118336ac1:NOVEL:SCENE:Old File
+%%~name: Old File
+%%~path: ae9bf3c3ea159/8a5deb88c0e97
+%%~kind: NOVEL/SCENE
 ### Discarded Scene
 
 If you have files you no longer want in your main project, you can move them to the “Outtakes” folder. This is equivalent to turning off the “Include when building project” switch, just that you also put the file away, although the switch can be ignored when building the project, this folder cannot.

--- a/sample/content/96b68994dfa3d.nwd
+++ b/sample/content/96b68994dfa3d.nwd
@@ -1,4 +1,6 @@
-%%~ 96b68994dfa3d:e7ded148d6e4a:7031beac91f75:NOVEL:NOTE:A Note on Structure
+%%~name: A Note on Structure
+%%~path: e7ded148d6e4a/96b68994dfa3d
+%%~kind: NOVEL/NOTE
 # A Note on Structure
 
 This file is just a note. You can save notes anywhere you like in the project tree. Notes can be filtered out when you export the project.

--- a/sample/content/974e400180a99.nwd
+++ b/sample/content/974e400180a99.nwd
@@ -1,4 +1,6 @@
-%%~ 974e400180a99:7031beac91f75:NOVEL:PAGE:Page
+%%~name: Page
+%%~path: 7031beac91f75/974e400180a99
+%%~kind: NOVEL/PAGE
 This is a plain page with some text on it.
 
 This file should receive no special formatting, but the text will always be left aligned and the content will always start on a fresh page when the project is exported.

--- a/sample/content/ae7339df26ded.nwd
+++ b/sample/content/ae7339df26ded.nwd
@@ -1,4 +1,6 @@
-%%~ ae7339df26ded:e7ded148d6e4a:7031beac91f75:NOVEL:SCENE:We Found John!
+%%~name: We Found John!
+%%~path: e7ded148d6e4a/ae7339df26ded
+%%~kind: NOVEL/SCENE
 ### We Found John!
 
 @pov: John

--- a/sample/content/b3e74dbc1f584.nwd
+++ b/sample/content/b3e74dbc1f584.nwd
@@ -1,4 +1,6 @@
-%%~ b3e74dbc1f584:15c4492bd5107:WORLD:NOTE:Earth
+%%~name: Earth
+%%~path: 15c4492bd5107/b3e74dbc1f584
+%%~kind: WORLD/NOTE
 # Earth
 
 @tag: Earth

--- a/sample/content/b8136a5a774a0.nwd
+++ b/sample/content/b8136a5a774a0.nwd
@@ -1,4 +1,6 @@
-%%~ b8136a5a774a0:98acd8c76c93a:NOVEL:SCENE:Delete Me!
+%%~name: Delete Me!
+%%~path: 98acd8c76c93a/b8136a5a774a0
+%%~kind: NOVEL/SCENE
 ### Delete Me!
 
 This scene is trash.

--- a/sample/content/ba8a28a246524.nwd
+++ b/sample/content/ba8a28a246524.nwd
@@ -1,4 +1,6 @@
-%%~ ba8a28a246524:e7ded148d6e4a:7031beac91f75:NOVEL:UNNUMBERED:Interlude
+%%~name: Interlude
+%%~path: e7ded148d6e4a/ba8a28a246524
+%%~kind: NOVEL/UNNUMBERED
 ## Interlude
 
 % Notice that this is a file with the flag ‘N.Un’. The ‘N’ means it’s a novel file, and the ‘Un’ means it’s an unnumbered chapter. Unnumbered chapters can be treated separately from numbered chapters during export. Perfect for when you want to add an interlude, or for a prologue or epilogue.

--- a/sample/content/bb2c23b3c42cc.nwd
+++ b/sample/content/bb2c23b3c42cc.nwd
@@ -1,4 +1,6 @@
-%%~ bb2c23b3c42cc:f7e2d9f330615:f6622b4617424:CHARACTER:NOTE:Jane Smith
+%%~name: Jane Smith
+%%~path: f7e2d9f330615/bb2c23b3c42cc
+%%~kind: CHARACTER/NOTE
 # Jane Smith
 
 @tag: Jane

--- a/sample/content/bc0cbd2a407f3.nwd
+++ b/sample/content/bc0cbd2a407f3.nwd
@@ -1,4 +1,6 @@
-%%~ bc0cbd2a407f3:e7ded148d6e4a:7031beac91f75:NOVEL:SCENE:Another Scene
+%%~name: Another Scene
+%%~path: e7ded148d6e4a/bc0cbd2a407f3
+%%~kind: NOVEL/SCENE
 ### Another Scene
 
 @pov: John

--- a/sample/content/edca4be2fcaf8.nwd
+++ b/sample/content/edca4be2fcaf8.nwd
@@ -1,4 +1,6 @@
-%%~ edca4be2fcaf8:7031beac91f75:NOVEL:PARTITION:Part One
+%%~name: Part One
+%%~path: 7031beac91f75/edca4be2fcaf8
+%%~kind: NOVEL/PARTITION
 # Part One
 
 The first part.

--- a/sample/content/f1471bef9f2ae.nwd
+++ b/sample/content/f1471bef9f2ae.nwd
@@ -1,4 +1,6 @@
-%%~ f1471bef9f2ae:15c4492bd5107:WORLD:NOTE:Space
+%%~name: Space
+%%~path: 15c4492bd5107/f1471bef9f2ae
+%%~kind: WORLD/NOTE
 # Space
 
 @tag: Space

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.0b4" hexVersion="0x010000b4" fileVersion="1.2" timeStamp="2020-10-11 15:12:57">
+<novelWriterXML appVersion="1.0b5" hexVersion="0x010000b5" fileVersion="1.2" timeStamp="2020-10-24 18:57:05">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>765</saveCount>
+    <saveCount>766</saveCount>
     <autoCount>148</autoCount>
-    <editTime>37663</editTime>
+    <editTime>37687</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>

--- a/tests/lipsum/content/04468803b92e1.nwd
+++ b/tests/lipsum/content/04468803b92e1.nwd
@@ -1,4 +1,6 @@
-%%~ 04468803b92e1:60bdf227455cc:WORLD:NOTE:Ancient Europe
+%%~name: Ancient Europe
+%%~path: 60bdf227455cc/04468803b92e1
+%%~kind: WORLD/NOTE
 # Ancient Europe
 
 @tag: Europe

--- a/tests/lipsum/content/2426c6f0ca922.nwd
+++ b/tests/lipsum/content/2426c6f0ca922.nwd
@@ -1,4 +1,6 @@
-%%~ 2426c6f0ca922:6c6afb1247750:PLOT:NOTE:Main
+%%~name: Main
+%%~path: 6c6afb1247750/2426c6f0ca922
+%%~kind: PLOT/NOTE
 # Main Plot
 
 @tag: Main

--- a/tests/lipsum/content/441420a886d82.nwd
+++ b/tests/lipsum/content/441420a886d82.nwd
@@ -1,4 +1,6 @@
-%%~ 441420a886d82:6bd935d2490cd:b3643d0f92e32:NOVEL:CHAPTER:Chapter Two
+%%~name: Chapter Two
+%%~path: 6bd935d2490cd/441420a886d82
+%%~kind: NOVEL/CHAPTER
 ## Chapter Two
 
 @pov: Bod

--- a/tests/lipsum/content/47666c91c7ccf.nwd
+++ b/tests/lipsum/content/47666c91c7ccf.nwd
@@ -1,4 +1,6 @@
-%%~ 47666c91c7ccf:6bd935d2490cd:b3643d0f92e32:NOVEL:SCENE:Scene Five
+%%~name: Scene Five
+%%~path: 6bd935d2490cd/47666c91c7ccf
+%%~kind: NOVEL/SCENE
 ### Scene Five
 
 @pov: Bod

--- a/tests/lipsum/content/4c4f28287af27.nwd
+++ b/tests/lipsum/content/4c4f28287af27.nwd
@@ -1,4 +1,6 @@
-%%~ 4c4f28287af27:67a8707f2f249:CHARACTER:NOTE:Mr. Nobody
+%%~name: Mr. Nobody
+%%~path: 67a8707f2f249/4c4f28287af27
+%%~kind: CHARACTER/NOTE
 # Nobody Owens
 
 @tag: Bod

--- a/tests/lipsum/content/7a992350f3eb6.nwd
+++ b/tests/lipsum/content/7a992350f3eb6.nwd
@@ -1,4 +1,6 @@
-%%~ 7a992350f3eb6:b3643d0f92e32:NOVEL:TITLE:Lorem Ipusm
+%%~name: Lorem Ipsum
+%%~path: b3643d0f92e32/7a992350f3eb6
+%%~kind: NOVEL/TITLE
 # Lorem Ipsum
 
 **By lipsum.com**

--- a/tests/lipsum/content/846352075de7d.nwd
+++ b/tests/lipsum/content/846352075de7d.nwd
@@ -1,4 +1,6 @@
-%%~ 846352075de7d:b3643d0f92e32:NOVEL:BOOK:Interlude
+%%~name: Interlude
+%%~path: b3643d0f92e32/846352075de7d
+%%~kind: NOVEL/BOOK
 ## Why do we use it?
 
 % Exctracted from the lipsum.com website.

--- a/tests/lipsum/content/88243afbe5ed8.nwd
+++ b/tests/lipsum/content/88243afbe5ed8.nwd
@@ -1,4 +1,6 @@
-%%~ 88243afbe5ed8:45e6b01ca35c1:b3643d0f92e32:NOVEL:SCENE:Scene One
+%%~name: Scene One
+%%~path: 45e6b01ca35c1/88243afbe5ed8
+%%~kind: NOVEL/SCENE
 ### Scene One
 
 @pov: Bod

--- a/tests/lipsum/content/88d59a277361b.nwd
+++ b/tests/lipsum/content/88d59a277361b.nwd
@@ -1,4 +1,6 @@
-%%~ 88d59a277361b:b3643d0f92e32:NOVEL:UNNUMBERED:Prologue
+%%~name: Prologue
+%%~path: b3643d0f92e32/88d59a277361b
+%%~kind: NOVEL/UNNUMBERED
 ## Prologue
 
 % Synopsis:Explanation from the lipsum.com website.

--- a/tests/lipsum/content/8c58a65414c23.nwd
+++ b/tests/lipsum/content/8c58a65414c23.nwd
@@ -1,4 +1,6 @@
-%%~ 8c58a65414c23:b3643d0f92e32:NOVEL:PAGE:Front Matter
+%%~name: Front Matter
+%%~path: b3643d0f92e32/8c58a65414c23
+%%~kind: NOVEL/PAGE
 % Exctracted from the lipsum.com website.
 
 Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of “de Finibus Bonorum et Malorum” (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, “Lorem ipsum dolor sit amet..”, comes from a line in section 1.10.32.

--- a/tests/lipsum/content/db7e733775d4d.nwd
+++ b/tests/lipsum/content/db7e733775d4d.nwd
@@ -1,4 +1,6 @@
-%%~ db7e733775d4d:b3643d0f92e32:NOVEL:PARTITION:Act One
+%%~name: Act One
+%%~path: b3643d0f92e32/db7e733775d4d
+%%~kind: NOVEL/PARTITION
 # Act One
 
 “Fusce maximus felis libero”

--- a/tests/lipsum/content/eb103bc70c90c.nwd
+++ b/tests/lipsum/content/eb103bc70c90c.nwd
@@ -1,4 +1,6 @@
-%%~ eb103bc70c90c:6bd935d2490cd:b3643d0f92e32:NOVEL:SCENE:Scene Three
+%%~name: Scene Three
+%%~path: 6bd935d2490cd/eb103bc70c90c
+%%~kind: NOVEL/SCENE
 ### Scene Three
 
 @pov: Bod

--- a/tests/lipsum/content/f8c0562e50f1b.nwd
+++ b/tests/lipsum/content/f8c0562e50f1b.nwd
@@ -1,4 +1,6 @@
-%%~ f8c0562e50f1b:6bd935d2490cd:b3643d0f92e32:NOVEL:SCENE:Scene Four
+%%~name: Scene Four
+%%~path: 6bd935d2490cd/f8c0562e50f1b
+%%~kind: NOVEL/SCENE
 ### Scene Four
 
 @pov: Bod

--- a/tests/lipsum/content/f96ec11c6a3da.nwd
+++ b/tests/lipsum/content/f96ec11c6a3da.nwd
@@ -1,4 +1,6 @@
-%%~ f96ec11c6a3da:45e6b01ca35c1:b3643d0f92e32:NOVEL:SCENE:Scene Two
+%%~name: Scene Two
+%%~path: 45e6b01ca35c1/f96ec11c6a3da
+%%~kind: NOVEL/SCENE
 ### Scene Two
 
 @pov: Bod

--- a/tests/lipsum/content/fb609cd8319dc.nwd
+++ b/tests/lipsum/content/fb609cd8319dc.nwd
@@ -1,4 +1,6 @@
-%%~ fb609cd8319dc:45e6b01ca35c1:b3643d0f92e32:NOVEL:CHAPTER:Chapter One
+%%~name: Chapter One
+%%~path: 45e6b01ca35c1/fb609cd8319dc
+%%~kind: NOVEL/CHAPTER
 ## Chapter One
 
 @pov: Bod

--- a/tests/lipsum/nwProject.nwx
+++ b/tests/lipsum/nwProject.nwx
@@ -1,19 +1,19 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.0b3" hexVersion="0x010000b3" fileVersion="1.2" timeStamp="2020-10-04 19:00:34">
+<novelWriterXML appVersion="1.0b5" hexVersion="0x010000b5" fileVersion="1.2" timeStamp="2020-10-24 18:43:56">
   <project>
     <name>Lorem Ipsum</name>
     <title>Lorem Ipsum</title>
     <author>lipsum.com</author>
-    <saveCount>9</saveCount>
+    <saveCount>10</saveCount>
     <autoCount>22</autoCount>
-    <editTime>1552</editTime>
+    <editTime>1571</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>
     <spellCheck>False</spellCheck>
     <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
-    <lastEdited>846352075de7d</lastEdited>
+    <lastEdited>04468803b92e1</lastEdited>
     <lastViewed>None</lastViewed>
     <lastWordCount>3847</lastWordCount>
     <novelWordCount>3109</novelWordCount>

--- a/tests/minimal/content/8c659a11cd429.nwd
+++ b/tests/minimal/content/8c659a11cd429.nwd
@@ -1,3 +1,5 @@
-%%~ 8c659a11cd429:a6d311a93600a:a508bb932959c:NOVEL:SCENE:New Scene
+%%~name: New Scene
+%%~path: a6d311a93600a/8c659a11cd429
+%%~kind: NOVEL/SCENE
 ### New Scene
 

--- a/tests/minimal/content/a35baf2e93843.nwd
+++ b/tests/minimal/content/a35baf2e93843.nwd
@@ -1,4 +1,6 @@
-%%~ a35baf2e93843:a508bb932959c:NOVEL:TITLE:Title Page
+%%~name: Title Page
+%%~path: a508bb932959c/a35baf2e93843
+%%~kind: NOVEL/TITLE
 # Minimal
 
 By Jane Doe, John Doh

--- a/tests/minimal/content/f5ab3e30151e1.nwd
+++ b/tests/minimal/content/f5ab3e30151e1.nwd
@@ -1,3 +1,5 @@
-%%~ f5ab3e30151e1:a6d311a93600a:a508bb932959c:NOVEL:CHAPTER:New Chapter
+%%~name: New Chapter
+%%~path: a6d311a93600a/f5ab3e30151e1
+%%~kind: NOVEL/CHAPTER
 ## New Chapter
 

--- a/tests/minimal/nwProject.nwx
+++ b/tests/minimal/nwProject.nwx
@@ -1,17 +1,18 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="0.12.1" hexVersion="0x001201f0" fileVersion="1.2" timeStamp="2020-08-28 11:36:45">
+<novelWriterXML appVersion="1.0b5" hexVersion="0x010000b5" fileVersion="1.2" timeStamp="2020-10-24 18:55:14">
   <project>
     <name>Test Minimal</name>
     <title>Minimal</title>
     <author>Jane Doe</author>
     <author>John Doh</author>
-    <saveCount>1</saveCount>
+    <saveCount>3</saveCount>
     <autoCount>1</autoCount>
-    <editTime>8</editTime>
+    <editTime>33</editTime>
   </project>
   <settings>
     <doBackup>True</doBackup>
     <spellCheck>False</spellCheck>
+    <spellLang>None</spellLang>
     <autoOutline>True</autoOutline>
     <lastEdited>None</lastEdited>
     <lastViewed>None</lastViewed>
@@ -57,7 +58,7 @@
       <charCount>28</charCount>
       <wordCount>6</wordCount>
       <paraCount>1</paraCount>
-      <cursorPos>0</cursorPos>
+      <cursorPos>33</cursorPos>
     </item>
     <item handle="a6d311a93600a" order="1" parent="a508bb932959c">
       <name>New Chapter</name>
@@ -76,7 +77,7 @@
       <charCount>11</charCount>
       <wordCount>2</wordCount>
       <paraCount>0</paraCount>
-      <cursorPos>0</cursorPos>
+      <cursorPos>16</cursorPos>
     </item>
     <item handle="8c659a11cd429" order="1" parent="a6d311a93600a">
       <name>New Scene</name>
@@ -88,7 +89,7 @@
       <charCount>9</charCount>
       <wordCount>2</wordCount>
       <paraCount>0</paraCount>
-      <cursorPos>0</cursorPos>
+      <cursorPos>15</cursorPos>
     </item>
     <item handle="7695ce551d265" order="1" parent="None">
       <name>Plot</name>

--- a/tests/reference/gui/1_031b4af5197ec.nwd
+++ b/tests/reference/gui/1_031b4af5197ec.nwd
@@ -1,4 +1,6 @@
-%%~ 031b4af5197ec:44cb730c42048:PLOT:NOTE:New File
+%%~name: New File
+%%~path: 44cb730c42048/031b4af5197ec
+%%~kind: PLOT/NOTE
 # Main Plot
 
 @tag: MainPlot

--- a/tests/reference/gui/1_0e17daca5f3e1.nwd
+++ b/tests/reference/gui/1_0e17daca5f3e1.nwd
@@ -1,4 +1,6 @@
-%%~ 0e17daca5f3e1:31489056e0916:73475cb40a568:NOVEL:SCENE:New Scene
+%%~name: New Scene
+%%~path: 31489056e0916/0e17daca5f3e1
+%%~kind: NOVEL/SCENE
 # Novel
 
 ## Chapter

--- a/tests/reference/gui/1_1a6562590ef19.nwd
+++ b/tests/reference/gui/1_1a6562590ef19.nwd
@@ -1,4 +1,6 @@
-%%~ 1a6562590ef19:71ee45a3c0db9:CHARACTER:NOTE:New File
+%%~name: New File
+%%~path: 71ee45a3c0db9/1a6562590ef19
+%%~kind: CHARACTER/NOTE
 # Jane Doe
 
 @tag: Jane

--- a/tests/reference/gui/1_41cfc0d1f2d12.nwd
+++ b/tests/reference/gui/1_41cfc0d1f2d12.nwd
@@ -1,4 +1,6 @@
-%%~ 41cfc0d1f2d12:811786ad1ae74:WORLD:NOTE:New File
+%%~name: New File
+%%~path: 811786ad1ae74/41cfc0d1f2d12
+%%~kind: WORLD/NOTE
 # Main Location
 
 @tag: Home

--- a/tests/reference/gui/4_73475cb40a568.nwd
+++ b/tests/reference/gui/4_73475cb40a568.nwd
@@ -1,4 +1,6 @@
-%%~ 73475cb40a568:b3643d0f92e32:NOVEL:SCENE:Chapter One
+%%~name: Chapter One
+%%~path: b3643d0f92e32/73475cb40a568
+%%~kind: NOVEL/SCENE
 ## Chapter One
 
 @pov: Bod

--- a/tests/reference/gui/5_031b4af5197ec.nwd
+++ b/tests/reference/gui/5_031b4af5197ec.nwd
@@ -1,4 +1,6 @@
-%%~ 031b4af5197ec:0e17daca5f3e1:b3643d0f92e32:NOVEL:SCENE:Scene One
+%%~name: Scene One
+%%~path: 0e17daca5f3e1/031b4af5197ec
+%%~kind: NOVEL/SCENE
 ### Scene One
 
 @pov: Bod

--- a/tests/reference/gui/5_25fc0e7096fc6.nwd
+++ b/tests/reference/gui/5_25fc0e7096fc6.nwd
@@ -1,4 +1,6 @@
-%%~ 25fc0e7096fc6:811786ad1ae74:b3643d0f92e32:NOVEL:CHAPTER:Chapter One
+%%~name: Chapter One
+%%~path: 811786ad1ae74/25fc0e7096fc6
+%%~kind: NOVEL/CHAPTER
 ## Chapter One
 
 @pov: Bod

--- a/tests/reference/gui/5_2858dcd1057d3.nwd
+++ b/tests/reference/gui/5_2858dcd1057d3.nwd
@@ -1,4 +1,6 @@
-%%~ 2858dcd1057d3:0e17daca5f3e1:b3643d0f92e32:NOVEL:SCENE:Scene Two
+%%~name: Scene Two
+%%~path: 0e17daca5f3e1/2858dcd1057d3
+%%~kind: NOVEL/SCENE
 ### Scene Two
 
 @pov: Bod

--- a/tests/reference/gui/5_2fca346db6561.nwd
+++ b/tests/reference/gui/5_2fca346db6561.nwd
@@ -1,4 +1,6 @@
-%%~ 2fca346db6561:0e17daca5f3e1:b3643d0f92e32:NOVEL:SCENE:Scene Two, Section Two
+%%~name: Scene Two, Section Two
+%%~path: 0e17daca5f3e1/2fca346db6561
+%%~kind: NOVEL/SCENE
 #### Scene Two, Section Two
 
 Suspendisse potenti. Fusce tempus lorem nec laoreet suscipit. Fusce vulputate nisl ac diam tincidunt, nec malesuada quam pellentesque. Maecenas congue, tellus quis commodo rutrum, magna leo egestas arcu, quis suscipit ex risus id ligula. Suspendisse potenti. Morbi blandit lacus vitae laoreet vulputate. Donec vitae tellus eleifend, lobortis eros eu, tincidunt enim. Nullam et ullamcorper nisi. Vivamus tellus ex, lobortis quis rutrum ut, dapibus sit amet turpis. Phasellus pellentesque metus diam, commodo tristique ante commodo ac. Ut mollis ipsum nec diam blandit sollicitudin. Duis bibendum lacus nec commodo dapibus. Sed condimentum luctus ante, id ultricies urna varius nec. Nam convallis magna nec bibendum ultrices. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed auctor pharetra quam, vitae porta ex bibendum eu.

--- a/tests/reference/gui/5_31489056e0916.nwd
+++ b/tests/reference/gui/5_31489056e0916.nwd
@@ -1,4 +1,6 @@
-%%~ 31489056e0916:811786ad1ae74:b3643d0f92e32:NOVEL:SCENE:Scene One
+%%~name: Scene One
+%%~path: 811786ad1ae74/31489056e0916
+%%~kind: NOVEL/SCENE
 ### Scene One
 
 @pov: Bod

--- a/tests/reference/gui/5_41cfc0d1f2d12.nwd
+++ b/tests/reference/gui/5_41cfc0d1f2d12.nwd
@@ -1,4 +1,6 @@
-%%~ 41cfc0d1f2d12:0e17daca5f3e1:b3643d0f92e32:NOVEL:SCENE:Scene One, Section Two
+%%~name: Scene One, Section Two
+%%~path: 0e17daca5f3e1/41cfc0d1f2d12
+%%~kind: NOVEL/SCENE
 #### Scene One, Section Two
 
 Integer vel libero ipsum. Donec varius aliquam libero, sit amet commodo urna hendrerit non. Nullam quis erat mollis nunc viverra volutpat tincidunt in odio. Nam vitae quam sem. Aliquam suscipit nulla non lorem pharetra semper. Ut suscipit erat eu ligula accumsan ultrices. Phasellus nisl tellus, placerat sed laoreet id, consectetur nec dolor. Sed fringilla ipsum id dapibus posuere. Aenean finibus pharetra tincidunt. Ut molestie malesuada nulla, id posuere lorem tincidunt eu. Aliquam tempor eros a est vulputate, scelerisque pulvinar ipsum fermentum. In hac habitasse platea dictumst.

--- a/tests/reference/gui/5_98010bd9270f9.nwd
+++ b/tests/reference/gui/5_98010bd9270f9.nwd
@@ -1,4 +1,6 @@
-%%~ 98010bd9270f9:811786ad1ae74:b3643d0f92e32:NOVEL:SCENE:Scene Two
+%%~name: Scene Two
+%%~path: 811786ad1ae74/98010bd9270f9
+%%~kind: NOVEL/SCENE
 ### Scene Two
 
 @pov: Bod

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -640,7 +640,7 @@ def testMergeSplitTools(qtbot, monkeypatch, yesToAll, nwTempGUI, nwLipsum, nwRef
     testFile = os.path.join(nwTempGUI, "4_71ee45a3c0db9.nwd")
     refFile  = os.path.join(nwRef, "gui", "4_73475cb40a568.nwd")
     copyfile(projFile, testFile)
-    assert cmpFiles(testFile, refFile, [1])
+    assert cmpFiles(testFile, refFile, [1, 2, 3])
 
     # Split By Scene
     assert nwGUI.treeView.setSelectedHandle("73475cb40a568")
@@ -702,7 +702,7 @@ def testMergeSplitTools(qtbot, monkeypatch, yesToAll, nwTempGUI, nwLipsum, nwRef
     testFile = os.path.join(nwTempGUI, "5_25fc0e7096fc6.nwd")
     refFile  = os.path.join(nwRef, "gui", "5_25fc0e7096fc6.nwd")
     copyfile(projFile, testFile)
-    assert cmpFiles(testFile, refFile, [1])
+    assert cmpFiles(testFile, refFile, [1, 2, 3])
 
     projFile = os.path.join(nwLipsum, "content", "031b4af5197ec.nwd")
     testFile = os.path.join(nwTempGUI, "5_031b4af5197ec.nwd")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -684,16 +684,6 @@ def testProjectTree(qtbot, yesToAll, nwMinimal, nwTemp):
     orItem = nwTree._getTreeItem("1234567890abc")
     assert orItem.text(nwTree.C_NAME) == "Orphaned File 1"
 
-    # Move it to the Plot folder
-    # plItem = nwTree._getTreeItem("7695ce551d265")
-    # orRect = nwTree.visualItemRect(orItem)
-    # plRect = nwTree.visualItemRect(plItem)
-
-    # qtbot.mouseMove(nwTree.viewport(), pos=orRect.center(), delay=1000)
-    # qtbot.mousePress(nwTree.viewport(), Qt.LeftButton, pos=orRect.center(), delay=1000)
-    # qtbot.mouseMove(nwTree.viewport(), pos=plRect.center(), delay=1000)
-    # qtbot.mouseRelease(nwTree.viewport(), Qt.LeftButton, pos=plRect.center(), delay=1000)
-
     # qtbot.stopForInteraction()
     nwGUI.closeMain()
     nwGUI.close()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -335,20 +335,17 @@ def testDocMeta(nwDummy, nwLipsum):
 
     aDoc = NWDoc(theProject, nwDummy)
     assert aDoc.openDocument("47666c91c7ccf")
-    theMeta, thePath, theClass, theLayout = aDoc.getMeta()
+    theName, theParent, theClass, theLayout = aDoc.getMeta()
 
-    assert theMeta == "Scene Five"
-    assert len(thePath) == 3
-    assert thePath[0] == "47666c91c7ccf"
-    assert thePath[1] == "6bd935d2490cd"
-    assert thePath[2] == "b3643d0f92e32"
+    assert theName == "Scene Five"
+    assert theParent == "6bd935d2490cd"
     assert theClass == nwItemClass.NOVEL
     assert theLayout == nwItemLayout.SCENE
 
-    aDoc._docMeta = "too_short"
-    theMeta, thePath, theClass, theLayout = aDoc.getMeta()
-    assert theMeta == ""
-    assert thePath == []
+    aDoc._docMeta = {"stuff": None}
+    theName, theParent, theClass, theLayout = aDoc.getMeta()
+    assert theName == ""
+    assert theParent is None
     assert theClass is None
     assert theLayout is None
 
@@ -488,7 +485,9 @@ def testProjectOrphanedFiles(nwDummy, nwLipsum):
     # First Item with Meta Data
     orphPath = os.path.join(nwLipsum, "content", "636b6aa9b697b.nwd")
     with open(orphPath, mode="w", encoding="utf8") as outFile:
-        outFile.write(r"%%~ 5eaea4e8cdee8:15c4492bd5107:WORLD:NOTE:Mars")
+        outFile.write("%%~name:Mars\n")
+        outFile.write("%%~path:5eaea4e8cdee8/636b6aa9b697b\n")
+        outFile.write("%%~kind:WORLD/NOTE\n")
         outFile.write("\n")
 
     # Second Item without Meta Data

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -488,6 +488,7 @@ def testProjectOrphanedFiles(nwDummy, nwLipsum):
         outFile.write("%%~name:Mars\n")
         outFile.write("%%~path:5eaea4e8cdee8/636b6aa9b697b\n")
         outFile.write("%%~kind:WORLD/NOTE\n")
+        outFile.write("%%~invalid\n")
         outFile.write("\n")
 
     # Second Item without Meta Data


### PR DESCRIPTION
This PR changes the format of the meta data written to the top of document files.

The point of the change is to make the format easier to parse and extend. Currently, the single line is getting a bit information dense and there are a few pitfalls and limitations to parsing it. Especially since it contains user controlled data (the document label).

The new format changes the format to a label/value style where the first N characters can be checked, and the remainder of the line be treated as the value, regardless of content.

The previous format was:
```
%%~ 6a2d6d5f4f401:e7ded148d6e4a:7031beac91f75:NOVEL:CHAPTER:Chapter One
```

The new format is:
```
%%~name: Chapter One
%%~path: e7ded148d6e4a/6a2d6d5f4f401
%%~kind: NOVEL/CHAPTER
```

Any line starting with `%%~` will not be loaded as text (although only the first 10 lines are considered). Also, any line that does start with those characters, but don't match any of the above keywords, like `%%~name:`, will be discarded.

As a bonus, the new format is also more human readable.