### PR TITLE
Fix Syntax Theme Switching

### DIFF
--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -206,11 +206,16 @@ class GuiDocEditor(QTextEdit):
         theFont.setPointSize(self.mainConf.textSize)
         self.setFont(theFont)
 
-        docPalette = self.palette()
-        docPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        mainPalette = self.palette()
+        mainPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        mainPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
+        mainPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        self.setPalette(mainPalette)
+
+        docPalette = self.viewport().palette()
         docPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
         docPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
-        self.setPalette(docPalette)
+        self.viewport().setPalette(docPalette)
 
         # Set default text margins
         cM = self.mainConf.getTextMargin()

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -206,6 +206,7 @@ class GuiDocEditor(QTextEdit):
         theFont.setPointSize(self.mainConf.textSize)
         self.setFont(theFont)
 
+        # Set the widget colours to match syntax theme
         mainPalette = self.palette()
         mainPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
         mainPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
@@ -216,6 +217,9 @@ class GuiDocEditor(QTextEdit):
         docPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
         docPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
         self.viewport().setPalette(docPalette)
+
+        self.docHeader.matchColours()
+        self.docFooter.matchColours()
 
         # Set default text margins
         cM = self.mainConf.getTextMargin()
@@ -2058,18 +2062,12 @@ class GuiDocEditHeader(QWidget):
         self.theTheme   = docEditor.theTheme
         self.theHandle  = None
 
-        # Make a QPalette that matches the Syntax Theme
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
-
         fPx = int(0.9*self.theTheme.fontPixelSize)
         hSp = self.mainConf.pxInt(6)
         self.buttonSize = fPx + hSp
 
         # Main Widget Settings
         self.setAutoFillBackground(True)
-        self.setPalette(self.thePalette)
 
         # Title Label
         self.theTitle = QLabel()
@@ -2080,7 +2078,6 @@ class GuiDocEditHeader(QWidget):
         self.theTitle.setAutoFillBackground(True)
         self.theTitle.setAlignment(Qt.AlignHCenter | Qt.AlignTop)
         self.theTitle.setFixedHeight(fPx)
-        self.theTitle.setPalette(self.thePalette)
 
         lblFont = self.theTitle.font()
         lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
@@ -2146,13 +2143,30 @@ class GuiDocEditHeader(QWidget):
         self.outerBox.addWidget(self.closeButton, 0)
         self.setLayout(self.outerBox)
 
+        # Fix the Colours
+        self.matchColours()
+
         logger.debug("GuiDocEditHeader initialisation complete")
 
         return
 
     ##
-    #  Setters
+    #  Methods
     ##
+
+    def matchColours(self):
+        """Update the colours of the widget to match those of the syntax
+        theme rather than the main GUI.
+        """
+        self.thePalette = QPalette()
+        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+
+        self.setPalette(self.thePalette)
+        self.theTitle.setPalette(self.thePalette)
+
+        return
 
     def setTitleFromHandle(self, tHandle):
         """Sets the document title from the handle, or alternatively,
@@ -2267,11 +2281,6 @@ class GuiDocEditFooter(QWidget):
         self.theHandle  = None
         self.theItem    = None
 
-        # Make a QPalette that matches the Syntax Theme
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
-
         self.sPx = int(round(0.9*self.theTheme.baseIconSize))
         fPx = int(0.9*self.theTheme.fontPixelSize)
         bSp = self.mainConf.pxInt(4)
@@ -2283,7 +2292,6 @@ class GuiDocEditFooter(QWidget):
         # Main Widget Settings
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
-        self.setPalette(self.thePalette)
 
         # Status
         self.statusIcon = QLabel("")
@@ -2298,7 +2306,6 @@ class GuiDocEditFooter(QWidget):
         self.statusText.setAutoFillBackground(True)
         self.statusText.setFixedHeight(fPx)
         self.statusText.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.statusText.setPalette(self.thePalette)
         self.statusText.setFont(lblFont)
 
         # Lines
@@ -2315,7 +2322,6 @@ class GuiDocEditFooter(QWidget):
         self.linesText.setAutoFillBackground(True)
         self.linesText.setFixedHeight(fPx)
         self.linesText.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.linesText.setPalette(self.thePalette)
         self.linesText.setFont(lblFont)
 
         # Words
@@ -2332,7 +2338,6 @@ class GuiDocEditFooter(QWidget):
         self.wordsText.setAutoFillBackground(True)
         self.wordsText.setFixedHeight(fPx)
         self.wordsText.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.wordsText.setPalette(self.thePalette)
         self.wordsText.setFont(lblFont)
 
         # Assemble Layout
@@ -2348,6 +2353,9 @@ class GuiDocEditFooter(QWidget):
         self.outerBox.addWidget(self.wordsText)
         self.setLayout(self.outerBox)
 
+        # Fix the Colours
+        self.matchColours()
+
         logger.debug("GuiDocEditFooter initialisation complete")
 
         return
@@ -2355,6 +2363,22 @@ class GuiDocEditFooter(QWidget):
     ##
     #  Methods
     ##
+
+    def matchColours(self):
+        """Update the colours of the widget to match those of the syntax
+        theme rather than the main GUI.
+        """
+        self.thePalette = QPalette()
+        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+
+        self.setPalette(self.thePalette)
+        self.statusText.setPalette(self.thePalette)
+        self.linesText.setPalette(self.thePalette)
+        self.wordsText.setPalette(self.thePalette)
+
+        return
 
     def setHandle(self, tHandle):
         """Set the handle that will populate the footer's data.

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -2158,13 +2158,13 @@ class GuiDocEditHeader(QWidget):
         """Update the colours of the widget to match those of the syntax
         theme rather than the main GUI.
         """
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette = QPalette()
+        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
 
-        self.setPalette(self.thePalette)
-        self.theTitle.setPalette(self.thePalette)
+        self.setPalette(thePalette)
+        self.theTitle.setPalette(thePalette)
 
         return
 
@@ -2368,15 +2368,15 @@ class GuiDocEditFooter(QWidget):
         """Update the colours of the widget to match those of the syntax
         theme rather than the main GUI.
         """
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette = QPalette()
+        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
 
-        self.setPalette(self.thePalette)
-        self.statusText.setPalette(self.thePalette)
-        self.linesText.setPalette(self.thePalette)
-        self.wordsText.setPalette(self.thePalette)
+        self.setPalette(thePalette)
+        self.statusText.setPalette(thePalette)
+        self.linesText.setPalette(thePalette)
+        self.wordsText.setPalette(thePalette)
 
         return
 

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -65,7 +65,6 @@ class GuiDocViewer(QTextBrowser):
         self.setAutoFillBackground(True)
         self.setOpenExternalLinks(False)
         self.setFocusPolicy(Qt.StrongFocus)
-        self.initViewer()
 
         # Document Header and Footer
         self.docHeader  = GuiDocViewHeader(self)
@@ -73,17 +72,14 @@ class GuiDocViewer(QTextBrowser):
         self.docHistory = GuiDocViewHistory(self)
         self.stickyRef  = False
 
-        theOpt = QTextOption()
-        if self.mainConf.doJustify:
-            theOpt.setAlignment(Qt.AlignJustify)
-        self.qDocument.setDefaultTextOption(theOpt)
-
         # Signals
         self.anchorClicked.connect(self._linkClicked)
 
         # Context Menu
         self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self._openContextMenu)
+
+        self.initViewer()
 
         logger.debug("GuiDocViewer initialisation complete")
 
@@ -112,6 +108,7 @@ class GuiDocViewer(QTextBrowser):
         theFont.setPointSize(self.mainConf.textSize)
         self.setFont(theFont)
 
+        # Set the widget colours to match syntax theme
         mainPalette = self.palette()
         mainPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
         mainPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
@@ -123,6 +120,10 @@ class GuiDocViewer(QTextBrowser):
         docPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
         self.viewport().setPalette(docPalette)
 
+        self.docHeader.matchColours()
+        self.docFooter.matchColours()
+
+        # Set default text margins
         self.qDocument.setDocumentMargin(0)
         theOpt = QTextOption()
         if self.mainConf.doJustify:
@@ -705,17 +706,11 @@ class GuiDocViewHeader(QWidget):
         self.theTheme   = docViewer.theTheme
         self.theHandle  = None
 
-        # Make a QPalette that matches the Syntax Theme
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
-
         fPx = int(0.9*self.theTheme.fontPixelSize)
         hSp = self.mainConf.pxInt(6)
 
         # Main Widget Settings
         self.setAutoFillBackground(True)
-        self.setPalette(self.thePalette)
 
         # Title Label
         self.theTitle = QLabel()
@@ -726,7 +721,6 @@ class GuiDocViewHeader(QWidget):
         self.theTitle.setAutoFillBackground(True)
         self.theTitle.setAlignment(Qt.AlignHCenter | Qt.AlignTop)
         self.theTitle.setFixedHeight(fPx)
-        self.theTitle.setPalette(self.thePalette)
 
         lblFont = self.theTitle.font()
         lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
@@ -792,13 +786,30 @@ class GuiDocViewHeader(QWidget):
         self.outerBox.addWidget(self.closeButton, 0)
         self.setLayout(self.outerBox)
 
+        # Fix the Colours
+        self.matchColours()
+
         logger.debug("GuiDocViewHeader initialisation complete")
 
         return
 
     ##
-    #  Setters
+    #  Methods
     ##
+
+    def matchColours(self):
+        """Update the colours of the widget to match those of the syntax
+        theme rather than the main GUI.
+        """
+        self.thePalette = QPalette()
+        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+
+        self.setPalette(self.thePalette)
+        self.theTitle.setPalette(self.thePalette)
+
+        return
 
     def setTitleFromHandle(self, tHandle):
         """Sets the document title from the handle, or alternatively,
@@ -892,11 +903,6 @@ class GuiDocViewFooter(QWidget):
         self.viewMeta  = docViewer.theParent.viewMeta
         self.theHandle = None
 
-        # Make a QPalette that matches the Syntax Theme
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
-
         fPx = int(0.9*self.theTheme.fontPixelSize)
         bSp = self.mainConf.pxInt(2)
         hSp = self.mainConf.pxInt(8)
@@ -917,7 +923,6 @@ class GuiDocViewFooter(QWidget):
         # Main Widget Settings
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
-        self.setPalette(self.thePalette)
 
         buttonStyle = (
             "QToolButton {{border: none; background: transparent;}} "
@@ -980,7 +985,6 @@ class GuiDocViewFooter(QWidget):
         self.lblRefs.setAutoFillBackground(True)
         self.lblRefs.setFixedHeight(fPx)
         self.lblRefs.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.lblRefs.setPalette(self.thePalette)
 
         self.lblSticky = QLabel("Sticky")
         self.lblSticky.setBuddy(self.stickyRefs)
@@ -990,7 +994,6 @@ class GuiDocViewFooter(QWidget):
         self.lblSticky.setAutoFillBackground(True)
         self.lblSticky.setFixedHeight(fPx)
         self.lblSticky.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.lblSticky.setPalette(self.thePalette)
 
         self.lblComments = QLabel("Comments")
         self.lblComments.setBuddy(self.showComments)
@@ -1000,7 +1003,6 @@ class GuiDocViewFooter(QWidget):
         self.lblComments.setAutoFillBackground(True)
         self.lblComments.setFixedHeight(fPx)
         self.lblComments.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.lblComments.setPalette(self.thePalette)
 
         self.lblSynopsis = QLabel("Synopsis")
         self.lblSynopsis.setBuddy(self.showSynopsis)
@@ -1010,7 +1012,6 @@ class GuiDocViewFooter(QWidget):
         self.lblSynopsis.setAutoFillBackground(True)
         self.lblSynopsis.setFixedHeight(fPx)
         self.lblSynopsis.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.lblSynopsis.setPalette(self.thePalette)
 
         lblFont = self.font()
         lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
@@ -1035,7 +1036,31 @@ class GuiDocViewFooter(QWidget):
         self.outerBox.addWidget(self.lblSynopsis, 0)
         self.setLayout(self.outerBox)
 
+        # Fix the Colours
+        self.matchColours()
+
         logger.debug("GuiDocViewFooter initialisation complete")
+
+        return
+
+    ##
+    #  Methods
+    ##
+
+    def matchColours(self):
+        """Update the colours of the widget to match those of the syntax
+        theme rather than the main GUI.
+        """
+        self.thePalette = QPalette()
+        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+
+        self.setPalette(self.thePalette)
+        self.lblRefs.setPalette(self.thePalette)
+        self.lblSticky.setPalette(self.thePalette)
+        self.lblComments.setPalette(self.thePalette)
+        self.lblSynopsis.setPalette(self.thePalette)
 
         return
 

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -112,11 +112,16 @@ class GuiDocViewer(QTextBrowser):
         theFont.setPointSize(self.mainConf.textSize)
         self.setFont(theFont)
 
-        docPalette = self.palette()
-        docPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        mainPalette = self.palette()
+        mainPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        mainPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
+        mainPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        self.setPalette(mainPalette)
+
+        docPalette = self.viewport().palette()
         docPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
         docPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
-        self.setPalette(docPalette)
+        self.viewport().setPalette(docPalette)
 
         self.qDocument.setDocumentMargin(0)
         theOpt = QTextOption()

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -801,13 +801,13 @@ class GuiDocViewHeader(QWidget):
         """Update the colours of the widget to match those of the syntax
         theme rather than the main GUI.
         """
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette = QPalette()
+        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
 
-        self.setPalette(self.thePalette)
-        self.theTitle.setPalette(self.thePalette)
+        self.setPalette(thePalette)
+        self.theTitle.setPalette(thePalette)
 
         return
 
@@ -1051,16 +1051,16 @@ class GuiDocViewFooter(QWidget):
         """Update the colours of the widget to match those of the syntax
         theme rather than the main GUI.
         """
-        self.thePalette = QPalette()
-        self.thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        self.thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        self.thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette = QPalette()
+        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
 
-        self.setPalette(self.thePalette)
-        self.lblRefs.setPalette(self.thePalette)
-        self.lblSticky.setPalette(self.thePalette)
-        self.lblComments.setPalette(self.thePalette)
-        self.lblSynopsis.setPalette(self.thePalette)
+        self.setPalette(thePalette)
+        self.lblRefs.setPalette(thePalette)
+        self.lblSticky.setPalette(thePalette)
+        self.lblComments.setPalette(thePalette)
+        self.lblSynopsis.setPalette(thePalette)
 
         return
 


### PR DESCRIPTION
This PR adds callable function to update the colours on document headers and footers, as well as the document background and text. This allows the user to switch syntax theme without having to restart novelWriter.