### PR TITLE
High DPI Header & Footer Scaling

### DIFF
--- a/nw/gui/custom.py
+++ b/nw/gui/custom.py
@@ -59,8 +59,9 @@ class QConfigLayout(QGridLayout):
 
         self._itemMap = {}
 
-        self.setHorizontalSpacing(8)
-        self.setVerticalSpacing(8)
+        wSp = nw.CONFIG.pxInt(8)
+        self.setHorizontalSpacing(wSp)
+        self.setVerticalSpacing(wSp)
 
         return
 
@@ -107,11 +108,12 @@ class QConfigLayout(QGridLayout):
             qLabel = None
             raise ValueError("theLabel must be a QLabel")
 
-        qLabel.setContentsMargins(0, 4, 0, 4)
+        hM = nw.CONFIG.pxInt(4)
+        qLabel.setContentsMargins(0, hM, 0, hM)
         self.addWidget(qLabel, self._nextRow, 0, 1, 2, Qt.AlignLeft)
 
         self.setRowStretch(self._nextRow, 0)
-        self.setRowStretch(self._nextRow+1, 1)
+        self.setRowStretch(self._nextRow + 1, 1)
 
         self._nextRow += 1
 
@@ -140,10 +142,11 @@ class QConfigLayout(QGridLayout):
             qWidget = None
             raise ValueError("theWidget must be a QWidget")
 
-        qLabel.setIndent(8)
+        wSp = nw.CONFIG.pxInt(8)
+        qLabel.setIndent(wSp)
         if helpText is not None:
             qHelp = QHelpLabel(str(helpText), self._helpCol, self._fontScale)
-            qHelp.setIndent(8)
+            qHelp.setIndent(wSp)
 
             labelBox = QVBoxLayout()
             labelBox.addWidget(qLabel)
@@ -160,13 +163,13 @@ class QConfigLayout(QGridLayout):
             controlBox = QHBoxLayout()
             controlBox.addWidget(qWidget, 0, Qt.AlignVCenter)
             controlBox.addWidget(QLabel(theUnit), 0, Qt.AlignVCenter)
-            controlBox.setSpacing(8)
+            controlBox.setSpacing(wSp)
             self.addLayout(controlBox, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignVCenter)
         elif theButton is not None:
             controlBox = QHBoxLayout()
             controlBox.addWidget(qWidget, 0, Qt.AlignVCenter)
             controlBox.addWidget(theButton, 0, Qt.AlignVCenter)
-            controlBox.setSpacing(8)
+            controlBox.setSpacing(wSp)
             self.addLayout(controlBox, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignVCenter)
         else:
             self.addWidget(qWidget, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignVCenter)

--- a/nw/gui/custom.py
+++ b/nw/gui/custom.py
@@ -218,11 +218,19 @@ class QHelpLabel(QLabel):
 
 class QSwitch(QAbstractButton):
 
-    def __init__(self, parent=None, width=40, height=20):
+    def __init__(self, parent=None, width=None, height=None):
         super().__init__(parent=parent)
 
-        self._xW = int(nw.CONFIG.guiScale*width)
-        self._xH = int(nw.CONFIG.guiScale*height)
+        if width is None:
+            self._xW = nw.CONFIG.pxInt(40)
+        else:
+            self._xW = width
+
+        if height is None:
+            self._xH = nw.CONFIG.pxInt(20)
+        else:
+            self._xH = height
+
         self._xR = int(self._xH*0.5)
         self._xT = int(self._xH*0.6)
         self._rB = int(nw.CONFIG.guiScale*2)

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -2157,6 +2157,13 @@ class GuiDocEditHeader(QWidget):
         self.outerBox.addWidget(self.closeButton, 0)
         self.setLayout(self.outerBox)
 
+        # Fix Margins and Size
+        # This is needed for high DPI systems. See issue #499.
+        cM = self.mainConf.pxInt(8)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.outerBox.setContentsMargins(cM, cM, cM, cM)
+        self.setMinimumHeight(fPx + 2*cM)
+
         # Fix the Colours
         self.matchColours()
 
@@ -2366,6 +2373,13 @@ class GuiDocEditFooter(QWidget):
         self.outerBox.addWidget(self.wordsIcon)
         self.outerBox.addWidget(self.wordsText)
         self.setLayout(self.outerBox)
+
+        # Fix Margins and Size
+        # This is needed for high DPI systems. See issue #499.
+        cM = self.mainConf.pxInt(8)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.outerBox.setContentsMargins(cM, cM, cM, cM)
+        self.setMinimumHeight(fPx + 2*cM)
 
         # Fix the Colours
         self.matchColours()

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -786,6 +786,13 @@ class GuiDocViewHeader(QWidget):
         self.outerBox.addWidget(self.closeButton, 0)
         self.setLayout(self.outerBox)
 
+        # Fix Margins and Size
+        # This is needed for high DPI systems. See issue #499.
+        cM = self.mainConf.pxInt(8)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.outerBox.setContentsMargins(cM, cM, cM, cM)
+        self.setMinimumHeight(fPx + 2*cM)
+
         # Fix the Colours
         self.matchColours()
 
@@ -1035,6 +1042,13 @@ class GuiDocViewFooter(QWidget):
         self.outerBox.addWidget(self.showSynopsis, 0)
         self.outerBox.addWidget(self.lblSynopsis, 0)
         self.setLayout(self.outerBox)
+
+        # Fix Margins and Size
+        # This is needed for high DPI systems. See issue #499.
+        cM = self.mainConf.pxInt(8)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.outerBox.setContentsMargins(cM, cM, cM, cM)
+        self.setMinimumHeight(fPx + 2*cM)
 
         # Fix the Colours
         self.matchColours()

--- a/nw/gui/itemeditor.py
+++ b/nw/gui/itemeditor.py
@@ -124,8 +124,8 @@ class GuiItemEditor(QDialog):
 
         # Assemble
         self.mainForm = QGridLayout()
-        self.mainForm.setVerticalSpacing(4)
-        self.mainForm.setHorizontalSpacing(16)
+        self.mainForm.setVerticalSpacing(self.mainConf.pxInt(4))
+        self.mainForm.setHorizontalSpacing(self.mainConf.pxInt(16))
         self.mainForm.addWidget(QLabel("Label"),  0, 0, 1, 1)
         self.mainForm.addWidget(self.editName,    0, 1, 1, 2)
         self.mainForm.addWidget(QLabel("Status"), 1, 0, 1, 1)


### PR DESCRIPTION
This PR is a fix to issue #499, where the headers and footers in the editor and viewer were clipped on high-DPI monitors. This was caused by the size hint of the underlying widget not scaling with the monitor. A minimum height requirement is now calculated based on the height of the label and a fixed margin that is manually scaled by the UI scale factor. This forces a minimum size that is big enough to always show the content.

In the same PR, a few scaling issues with margins on high-DPI screens in the form layouts have been fixed as well.