### PR TITLE
Menu Updates

### DIFF
--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -70,6 +70,7 @@ __status__     = "Beta"
 __url__        = "https://novelwriter.io"
 __sourceurl__  = "https://github.com/vkbo/novelWriter"
 __issuesurl__  = "https://github.com/vkbo/novelWriter/issues"
+__releaseurl__ = "https://github.com/vkbo/novelWriter/releases/latest"
 __domain__     = "novelwriter.io"
 __docurl__     = "https://novelwriter.readthedocs.io"
 __credits__    = [

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -598,8 +598,8 @@ class GuiMainMenu(QMenuBar):
         # Insert > Separator
         self.insertMenu.addSeparator()
 
-        # Insert > Keywords and Tags
-        self.mInsKeywords = self.insertMenu.addMenu("Keywords and Tags")
+        # Insert > Tags and References
+        self.mInsKeywords = self.insertMenu.addMenu("Tags and References")
         self.mInsKWItems = {}
         self.mInsKWItems[nwKeyWords.TAG_KEY]    = (QAction(self.mInsKeywords), "Ctrl+K, G")
         self.mInsKWItems[nwKeyWords.POV_KEY]    = (QAction(self.mInsKeywords), "Ctrl+K, V")
@@ -918,14 +918,20 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Go to Website
         self.aWebsite = QAction("Open the novelWriter Website", self)
-        self.aWebsite.setStatusTip("View the main website")
+        self.aWebsite.setStatusTip("Open the main website at %s" % nw.__url__)
         self.aWebsite.triggered.connect(lambda: self._openWebsite(nw.__url__))
         self.helpMenu.addAction(self.aWebsite)
 
         # Document > Report Issue
-        self.aIssue = QAction("Report an Issue", self)
-        self.aIssue.setStatusTip("Report a bug or issue on GitHub")
+        self.aIssue = QAction("Report an Issue (GitHub)", self)
+        self.aIssue.setStatusTip("Report a bug or issue on GitHub at %s" % nw.__issuesurl__)
         self.aIssue.triggered.connect(lambda: self._openWebsite(nw.__issuesurl__))
+        self.helpMenu.addAction(self.aIssue)
+
+        # Document > Latest Release
+        self.aIssue = QAction("Latest Release (GitHub)", self)
+        self.aIssue.setStatusTip("Open the Releases page on GitHub at %s" % nw.__releaseurl__)
+        self.aIssue.triggered.connect(lambda: self._openWebsite(nw.__releaseurl__))
         self.helpMenu.addAction(self.aIssue)
 
         return


### PR DESCRIPTION
A few minor updates to the main menu:

* Rename "Keywords and Tags" to "Tags and References"
* Add menu entry to open the GitHub releases page