### PR TITLE
Allow creating files in the 'Outtakes' root folder

### DIFF
--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -1024,7 +1024,8 @@ class GuiProjectTreeMenu(QMenu):
         return
 
     def filterActions(self, theItem):
-        """Update item settings from the nwItem.
+        """Filter the menu entries available based on the properties of
+        the item the menu was activated on.
         """
         self.theItem = theItem
 

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -1027,9 +1027,8 @@ class GuiProjectTreeMenu(QMenu):
         """Update item settings from the nwItem.
         """
         self.theItem = theItem
-        theRoot = self.theTree.theProject.projTree.getRootItem(theItem.itemHandle)
 
-        if theItem is None or theRoot is None:
+        if theItem is None:
             logger.error("Failed to extract information to build tree context menu")
             return False
 
@@ -1038,14 +1037,13 @@ class GuiProjectTreeMenu(QMenu):
         inTrash = theItem.itemParent == trashHandle and trashHandle is not None
         isTrash = theItem.itemHandle == trashHandle and trashHandle is not None
         isFile  = theItem.itemType == nwItemType.FILE
-        isArch  = theRoot.itemClass == nwItemClass.ARCHIVE
         isOrph  = isFile and theItem.itemParent is None
 
         showOpen      = isFile
         showView      = isFile
         showEdit      = not isTrash and not isOrph
         showExport    = isFile
-        showNewFile   = not (isTrash or inTrash or isOrph or isArch)
+        showNewFile   = not (isTrash or inTrash or isOrph)
         showNewFolder = not (isTrash or inTrash or isOrph)
         showDelete    = not isTrash
         showEmpty     = isTrash


### PR DESCRIPTION
The context menu for the project tree did not have the "New File" option for the "Outtakes" folder, although a new file could be created from the main menu or through keyboard shortcut. This was inconsistent. The "New File" option has now been enabled in the context menu as well. Although there shouldn't be a reason to make a new file in Outtakes if the folder is used only for actual outtakes, the user may want to use this special folder differently.

This PR closes #517.