### PR TITLE
Fix the Focus Mode checkbox not updating in the menu

### DIFF
--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -484,7 +484,7 @@ class GuiMainMenu(QMenuBar):
         self.aFocusMode.setShortcut("F8")
         self.aFocusMode.setCheckable(True)
         self.aFocusMode.setChecked(self.theParent.isFocusMode)
-        self.aFocusMode.toggled.connect(self.theParent.toggleFocusMode)
+        self.aFocusMode.triggered.connect(lambda: self.theParent.toggleFocusMode())
         self.viewMenu.addAction(self.aFocusMode)
 
         # View > Toggle Full Screen

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1079,6 +1079,7 @@ class GuiMain(QMainWindow):
             return False
 
         self.isFocusMode = not self.isFocusMode
+        self.mainMenu.aFocusMode.setChecked(self.isFocusMode)
         if self.isFocusMode:
             logger.debug("Activating Focus Mode")
             self.tabWidget.setCurrentWidget(self.splitDocs)

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.0rc2" hexVersion="0x010000c2" fileVersion="1.2" timeStamp="2020-11-21 15:35:49">
+<novelWriterXML appVersion="1.0rc2" hexVersion="0x010000c2" fileVersion="1.2" timeStamp="2020-12-13 20:09:24">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>805</saveCount>
+    <saveCount>810</saveCount>
     <autoCount>153</autoCount>
-    <editTime>39146</editTime>
+    <editTime>39261</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>


### PR DESCRIPTION
This fixes a minor issue with the checkbox next to the "Distraction free Mode" entry in the menu. The checkbox would toggle when the menu entry was clicked, but not when the document header button was used. The toggle is now handled manually by the function that handles the two modes, and the toggling of the check mark by the Qt library is bypassed.