### PR TITLE
Minor Fixes

### DIFF
--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -471,14 +471,14 @@ class NWProject():
         #       read the file. Introduced in version 0.10.
 
         if fileVersion == "1.0":
-            msgRes = self.theParent.askQuestion("Old Project Version", (
+            msgYes = self.theParent.askQuestion("Old Project Version", (
                 "The project file and data is created by a novelWriter version "
                 "lower than 0.7. Do you want to upgrade the project to the "
                 "most recent format?<br><br>Note that after the upgrade, you "
                 "cannot open the project with an older version of novelWriter "
                 "any more, so make sure you have a recent backup."
             ))
-            if not msgRes:
+            if not msgYes:
                 self.clearProject()
                 return False
 
@@ -497,7 +497,7 @@ class NWProject():
         # =========================
 
         if int(hexVersion, 16) > int(nw.__hexversion__, 16):
-            msgRes = self.theParent.askQuestion("Version Conflict", (
+            msgYes = self.theParent.askQuestion("Version Conflict", (
                 "This project was saved by a newer version of novelWriter, version %s. "
                 "This is version %s. If you continue to open the project, some attributes "
                 "and settings may not be preserved, but the overall project should be fine. "
@@ -505,7 +505,7 @@ class NWProject():
             ) % (
                 appVersion, nw.__version__
             ))
-            if not msgRes:
+            if not msgYes:
                 self.clearProject()
                 return False
 

--- a/nw/gui/build.py
+++ b/nw/gui/build.py
@@ -1114,8 +1114,8 @@ class GuiBuildNovelDocView(QTextBrowser):
         self.qDocument.setDocumentMargin(self.mainConf.getTextMargin())
         self.setPlaceholderText(
             "This area will show the content of the document to be "
-            "exported or printed. Press the \"Build Novel Project\" "
-            "button to generate content."
+            "exported or printed. Press the \"Build Project\" button "
+            "to generate content."
         )
 
         theFont = QFont()

--- a/nw/gui/docsplit.py
+++ b/nw/gui/docsplit.py
@@ -31,7 +31,7 @@ import logging
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QComboBox, QListWidget, QAbstractItemView,
-    QListWidgetItem, QDialogButtonBox, QLabel, QMessageBox
+    QListWidgetItem, QDialogButtonBox, QLabel
 )
 
 from nw.core import NWDoc
@@ -163,15 +163,12 @@ class GuiDocSplit(QDialog):
             ), nwAlert.ERROR)
             return
 
-        msgBox = QMessageBox()
-        msgRes = msgBox.question(
-            self, "Split Document", (
-                "The document will be split into %d file(s) in a new folder. "
-                "The original document will remain intact.<br><br>"
-                "Continue with the splitting process?"
-            ) % nFiles
-        )
-        if msgRes != QMessageBox.Yes:
+        msgYes = self.theParent.askQuestion("Split Document", (
+            "The document will be split into %d file(s) in a new folder. "
+            "The original document will remain intact.<br><br>"
+            "Continue with the splitting process?"
+        ) % nFiles)
+        if not msgYes:
             return
 
         # Create the folder

--- a/nw/gui/projload.py
+++ b/nw/gui/projload.py
@@ -36,7 +36,7 @@ from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import (
     QDialog, QHBoxLayout, QVBoxLayout, QGridLayout, QPushButton, QTreeWidget,
     QAbstractItemView, QTreeWidgetItem, QDialogButtonBox, QLabel, QShortcut,
-    QFileDialog, QLineEdit, QMessageBox
+    QFileDialog, QLineEdit
 )
 
 from nw.common import formatInt
@@ -218,12 +218,11 @@ class GuiProjectLoad(QDialog):
         """
         selList = self.listBox.selectedItems()
         if selList:
-            msgBox = QMessageBox()
-            msgRes = msgBox.question(
-                self, "Remove Entry",
+            msgYes = self.theParent.askQuestion(
+                "Remove Entry",
                 "Remove the selected entry from the recent projects list?"
             )
-            if msgRes == QMessageBox.Yes:
+            if msgYes:
                 self.mainConf.removeFromRecentCache(
                     selList[0].data(self.C_NAME, Qt.UserRole)
                 )

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -32,8 +32,7 @@ import logging
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
-    qApp, QTreeWidget, QTreeWidgetItem, QAbstractItemView, QMessageBox,
-    QMenu, QAction
+    qApp, QTreeWidget, QTreeWidgetItem, QAbstractItemView, QMenu, QAction
 )
 
 from nw.core import NWDoc
@@ -391,13 +390,12 @@ class GuiProjectTree(QTreeWidget):
             self.makeAlert("The Trash folder is already empty.", nwAlert.INFO)
             return False
 
-        msgBox = QMessageBox()
-        msgRes = msgBox.question(
-            self, "Empty Trash", "Permanently delete %d file%s from Trash?" % (
+        msgYes = self.theParent.askQuestion(
+            "Empty Trash", "Permanently delete %d file%s from Trash?" % (
                 nTrash, "s" if nTrash > 1 else ""
             )
         )
-        if msgRes != QMessageBox.Yes:
+        if not msgYes:
             return False
 
         logger.verbose("Deleting %d files from Trash" % nTrash)
@@ -449,11 +447,10 @@ class GuiProjectTree(QTreeWidget):
                 # user if they want to permanently delete the file.
                 doPermanent = False
                 if not alreadyAsked:
-                    msgBox = QMessageBox()
-                    msgRes = msgBox.question(
-                        self, "Delete File", "Permanently delete file '%s'?" % nwItemS.itemName
+                    msgYes = self.theParent.askQuestion(
+                        "Delete File", "Permanently delete file '%s'?" % nwItemS.itemName
                     )
-                    if msgRes == QMessageBox.Yes:
+                    if msgYes:
                         doPermanent = True
                 else:
                     doPermanent = True
@@ -478,11 +475,10 @@ class GuiProjectTree(QTreeWidget):
                 # move it there.
                 doTrash = False
                 if askForTrash:
-                    msgBox = QMessageBox()
-                    msgRes = msgBox.question(
-                        self, "Delete File", "Move file '%s' to Trash?" % nwItemS.itemName
+                    msgYes = self.theParent.askQuestion(
+                        "Delete File", "Move file '%s' to Trash?" % nwItemS.itemName
                     )
-                    if msgRes == QMessageBox.Yes:
+                    if msgYes:
                         doTrash = True
                 else:
                     doTrash = True
@@ -1122,7 +1118,7 @@ class GuiProjectTreeMenu(QMenu):
         return
 
     def _doEmptyTrash(self):
-        """Forward the delete item call to the project tree.
+        """Forward the empty trash call to the project tree.
         """
         self.theTree.emptyTrash()
         return

--- a/nw/gui/writingstats.py
+++ b/nw/gui/writingstats.py
@@ -403,8 +403,12 @@ class GuiWritingStats(QDialog):
         ttNotes = 0
         ttTime  = 0
 
+        logFile = os.path.join(self.theProject.projMeta, nwFiles.SESS_STATS)
+        if not os.path.isfile(logFile):
+            logger.info("This project has no writing stats logfile")
+            return False
+
         try:
-            logFile = os.path.join(self.theProject.projMeta, nwFiles.SESS_STATS)
             with open(logFile, mode="r", encoding="utf8") as inFile:
                 for inLine in inFile:
                     if inLine.startswith("#"):

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -320,12 +320,11 @@ class GuiMain(QMainWindow):
             return True
 
         if not isYes:
-            msgBox = QMessageBox()
-            msgRes = msgBox.question(
-                self, "Close Project",
+            msgYes = self.askQuestion(
+                "Close Project",
                 "Close the current project?<br>Changes are saved automatically."
             )
-            if msgRes != QMessageBox.Yes:
+            if not msgYes:
                 return False
 
         if self.docEditor.docChanged:
@@ -337,11 +336,10 @@ class GuiMain(QMainWindow):
             if self.theProject.doBackup and self.mainConf.backupOnClose:
                 doBackup = True
                 if self.mainConf.askBeforeBackup:
-                    msgBox = QMessageBox()
-                    msgRes = msgBox.question(
-                        self, "Backup Project", "Backup the current project?"
+                    msgYes = self.askQuestion(
+                        "Backup Project", "Backup the current project?"
                     )
-                    if msgRes != QMessageBox.Yes:
+                    if not msgYes:
                         doBackup = False
             if doBackup:
                 self.theProject.zipIt(False)
@@ -640,12 +638,11 @@ class GuiMain(QMainWindow):
             return False
 
         if not self.docEditor.isEmpty():
-            msgBox = QMessageBox()
-            msgRes = msgBox.question(self, "Import Document", (
+            msgYes = self.askQuestion("Import Document", (
                 "Importing the file will overwrite the current content of the document. "
                 "Do you want to proceed?"
             ))
-            if msgRes != QMessageBox.Yes:
+            if not msgYes:
                 return False
 
         self.docEditor.replaceText(theText)
@@ -1007,12 +1004,11 @@ class GuiMain(QMainWindow):
         """Save everything, and close novelWriter.
         """
         if self.hasProject:
-            msgBox = QMessageBox()
-            msgRes = msgBox.question(
-                self, "Exit",
+            msgYes = self.askQuestion(
+                "Exit",
                 "Do you want to exit novelWriter?<br>Changes are saved automatically."
             )
-            if msgRes != QMessageBox.Yes:
+            if not msgYes:
                 return False
 
         logger.info("Exiting novelWriter")

--- a/tests/test_gui_writingstats.py
+++ b/tests/test_gui_writingstats.py
@@ -203,6 +203,7 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     # IOError
     # =======
     monkeypatch.setattr("builtins.open", causeOSError)
+    assert not sessLog._loadLogFile()
     assert not sessLog._saveData(sessLog.FMT_CSV)
 
     # qtbot.stopForInteraction()


### PR DESCRIPTION
This PR fixes a few minor issues.

* The placeholder text in the Build Novel Project tool was referring to the name of the build button by a previous label. It now refers to the label that is on the current button.
* When opening the Writing Stats dialog in a new project where there is no session log file yet, an error dialog would pop up to complain the file is missing. A missing file is not an error, and should just be quietly ignored.
* Add "Move Item Up" and "Move Item Down" to the project tree context menu. These connect to the same function as the same entries in the Tools menu.
* Updated various parts of the code where a question message box is opened and redirected the call to the main GUI class. This was done mostly for consistency, but the feature was added earlier to ensure that core classes do not depend on Qt libraries.