### PR TITLE
Minor Fixes

### DIFF
--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -25,7 +25,9 @@
  along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from nw.constants.enum import nwItemClass, nwItemLayout, nwOutline
+from nw.constants.enum import (
+    nwItemClass, nwItemLayout, nwItemType, nwOutline
+)
 
 class nwConst():
 
@@ -42,6 +44,9 @@ class nwConst():
     # Spell Check Providers
     SP_INTERNAL = "internal"
     SP_ENCHANT  = "enchant"
+
+    # Check Lists
+    REG_TYPES = {nwItemType.ROOT, nwItemType.FOLDER, nwItemType.FILE}
 
 # END Class nwConst
 

--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -149,9 +149,9 @@ class NWDoc():
             docMeta = ""
         else:
             docMeta = (
-                f"%%~name: {self._theItem.itemName:s}\n"
-                f"%%~path: {self._theItem.itemParent:s}/{self._theItem.itemHandle:s}\n"
-                f"%%~kind: {self._theItem.itemClass.name:s}/{self._theItem.itemLayout.name:s}\n"
+                f"%%~name: {self._theItem.itemName}\n"
+                f"%%~path: {self._theItem.itemParent}/{self._theItem.itemHandle}\n"
+                f"%%~kind: {self._theItem.itemClass.name}/{self._theItem.itemLayout.name}\n"
             )
 
         try:

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -687,9 +687,11 @@ class GuiProjectTree(QTreeWidget):
         selItem = self.itemAt(clickPos)
         if isinstance(selItem, QTreeWidgetItem):
             tHandle = selItem.data(self.C_NAME, Qt.UserRole)
-            tItem   = self.theProject.projTree[tHandle]
-            self.setSelectedHandle(tHandle) # Just to be safe
+            if tHandle is None:
+                return
 
+            self.setSelectedHandle(tHandle) # Just to be safe
+            tItem = self.theProject.projTree[tHandle]
             if self.ctxMenu.filterActions(tItem):
                 # Only open menu if any actions remain after filter
                 self.ctxMenu.exec_(self.viewport().mapToGlobal(clickPos))
@@ -718,6 +720,9 @@ class GuiProjectTree(QTreeWidget):
                 return
 
             tHandle = selItem.data(self.C_NAME, Qt.UserRole)
+            if tHandle is None:
+                return
+
             tItem = self.theProject.projTree[tHandle]
             if tItem is None:
                 return
@@ -909,16 +914,16 @@ class GuiProjectTree(QTreeWidget):
         """
         if self.orphRoot is None:
             newItem = QTreeWidgetItem([""]*4)
-            newItem.setText(self.C_NAME,   "Orphaned Files")
-            newItem.setText(self.C_COUNT,  "")
+            newItem.setText(self.C_NAME, "Orphaned Files")
+            newItem.setData(self.C_NAME, Qt.UserRole, None)
+            newItem.setIcon(self.C_NAME, self.theTheme.getIcon("proj_orphan"))
+            newItem.setText(self.C_COUNT, "")
+            newItem.setData(self.C_COUNT, Qt.UserRole, 0)
             newItem.setText(self.C_EXPORT, "")
-            newItem.setText(self.C_FLAGS,  "")
+            newItem.setText(self.C_FLAGS, "")
             self.addTopLevelItem(newItem)
             self.orphRoot = newItem
             newItem.setExpanded(True)
-            newItem.setData(self.C_NAME, Qt.UserRole, "")
-            newItem.setData(self.C_COUNT, Qt.UserRole, 0)
-            newItem.setIcon(self.C_NAME, self.theTheme.getIcon("proj_orphan"))
 
         return
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -47,7 +47,7 @@ from nw.gui import (
     GuiTheme, GuiWritingStats
 )
 from nw.core import NWProject, NWDoc, NWIndex
-from nw.constants import nwItemType, nwItemClass, nwAlert
+from nw.constants import nwItemType, nwItemClass, nwAlert, nwConst
 from nw.common import getGuiItem
 
 logger = logging.getLogger(__name__)
@@ -722,6 +722,12 @@ class GuiMain(QMainWindow):
             logger.warning("No item selected")
             return
 
+        tItem = self.theProject.projTree[tHandle]
+        if tItem is None:
+            return
+        if tItem.itemType not in nwConst.REG_TYPES:
+            return
+
         logger.verbose("Requesting change to item %s" % tHandle)
         dlgProj = GuiItemEditor(self, self.theProject, tHandle)
         dlgProj.exec_()
@@ -1312,6 +1318,9 @@ class GuiMain(QMainWindow):
         we open it. Otherwise, we do nothing.
         """
         tHandle = tItem.data(self.treeView.C_NAME, Qt.UserRole)
+        if tHandle is None:
+            return
+
         logger.verbose("User double clicked tree item with handle %s" % tHandle)
         nwItem = self.theProject.projTree[tHandle]
         if nwItem is not None:
@@ -1320,6 +1329,7 @@ class GuiMain(QMainWindow):
                 self.openDocument(tHandle, changeFocus=False, doScroll=False)
             else:
                 logger.verbose("Requested item %s is a folder" % tHandle)
+
         return
 
     def _treeKeyPressReturn(self):


### PR DESCRIPTION
Another round of minor fixes after more testing.

* Don't allow the edit item dialog for Trash and Orphaned Files special root folders.
* Orphaned Files root folder handle should be set to None, and various handler added to block actions on it.
* Remove enforced string format on assembling document meta data lines as they must be able to handle NoneType.