### PR TITLE
Fix minor grammar and typo issues in documentation

### DIFF
--- a/docs/source/int_interface.rst
+++ b/docs/source/int_interface.rst
@@ -75,7 +75,7 @@ having it selected. This will open the file in the document editor. The editor u
 markdown format. The format is described in the :ref:`a_ui_md` section below. The editor has a
 maximise button (activates :guilabel:`Focus Mode`) and a close button in the top-right corner.
 
-Any document in the project tree can also be viewed in parallel in a right hand side document viewer
+Any document in the project tree can also be viewed in parallel in a right hand side document viewer.
 To view a document, press :kbd:`Ctrl`:kbd:`R`, or select :guilabel:`View Document` in the menu. The
 document viewed does not have to be the same document currently being edited. However, If you *are*
 viewing the same document, pressing :kbd:`Ctrl`:kbd:`R` again will update the document with your
@@ -188,7 +188,7 @@ A minimal set of text emphasis styles are supported.
 
 In markdown guides it is often recommended to differentiate between strong importance and emphasis
 by using ``**`` for strong and ``_`` for emphasis, although markdown generally supports also ``__``
-for strong and ``*`` fdr emphasis. However, since the differentiation makes the highlighting and
+for strong and ``*`` for emphasis. However, since the differentiation makes the highlighting and
 conversion significantly simpler and faster, in novelWriter this is a rule, not just a
 recommendation. The following is therefore the only supported formatting syntax:
 

--- a/docs/source/int_started.rst
+++ b/docs/source/int_started.rst
@@ -9,7 +9,7 @@ currently supported by the developer. Packages may also be available in other pa
 those are not managed by me.
 
 As novelWriter matures, more options for how to install it and get it running will be added. At the
-present time, the process is best suited for people used to work with Python projects from command
+present time, the process is best suited for people used to working with Python projects from command
 line.
 
 
@@ -70,7 +70,7 @@ PyQt/Qt should be at least 5.2.1, but ideally 5.10 or higher for nearly all feat
 Exporting to standard Markdown, for instance, requires PyQt/Qt 5.14. Searching using regular
 expressions requires 5.3, and for full Unicode support, 5.13.
 
-There are no known minimum version requirement for package ``lxml``, but the code was originally
+There is no known minimum version requirement for package ``lxml``, but the code was originally
 written with 4.2, which is therefore set as the minimum. It may work on lower versions. You have to
 test it.
 

--- a/docs/source/write_export.rst
+++ b/docs/source/write_export.rst
@@ -108,7 +108,7 @@ Currently, six formats are supported for exporting.
 OpenDocument Format
    This produces an open document ``.odt`` file. The document produced has very little formatting,
    and may require further editing afterwards. For a better formatted office document, you may get a
-   better result with exporting to HTML and the import that HTML document into your office word
+   better result with exporting to HTML and then import that HTML document into your office word
    processor. They are generally very good at importing HTML files.
 
 PDF Format

--- a/docs/source/write_notes.rst
+++ b/docs/source/write_notes.rst
@@ -4,14 +4,14 @@
 Supporting Files (Notes)
 ************************
 
-novelWriter doesn't have a database and compicated forms to fill in all details about plot elements,
+novelWriter doesn't have a database and complicated forms to fill in all details about plot elements,
 characters, and all sorts of additional information that isn't a part of the novel text itself.
 Instead, all such information is saved in notes. The relation between all these additional elements
 is extracted from these files by the project indexer based on the tags and references you set.
 
-These files are not required, but making at least minimal files for each such plot element, and add
+These files are not required, but making at least minimal files for each such plot element, and adding
 a tag to them, makes it possible to use the :guilabel:`Outline` feature to see how each element
-intersects with each section of the novel itself, and add clickable cross-references between
+intersects with each section of the novel itself, and adds clickable cross-references between
 documents in the editor and viewer.
 
 

--- a/docs/source/write_projects.rst
+++ b/docs/source/write_projects.rst
@@ -197,12 +197,12 @@ This is covered in the :ref:`a_export_files` section.
 Word Counts
 -----------
 
-A character, word and paragraph count is maintained for each file, as well as dor each section of a
+A character, word and paragraph count is maintained for each file, as well as for each section of a
 file defined by a header. The word count, and change of words in the current session, is displayed
 in the footer of any document open in the editor, and all stats are shown in the details panel
 below the project tree for any file selected.
 
-The word counts are not updated in real time, but runs in the background every five seconds for as
+The word counts are not updated in real time, but run in the background every five seconds for as
 long as the document is being actively edited.
 
 A total project word count is displayed in the status bar. The total count depends on the sum of
@@ -273,7 +273,7 @@ also be applied to exports.
 .. note::
    A keyword cannot contain any spaces. The angle brackets are added by default, and when used in
    the text are a part of the keyword to be replaced. This is to ensure that parts of the text
-   isn't unintentionally replaced by the content of the list.
+   aren't unintentionally replaced by the content of the list.
 
 
 .. _a_proj_backup:
@@ -282,7 +282,7 @@ Backup
 ======
 
 An automatic backup system is built into novelWriter. In order to use it, a backup path to where
-the backup files are to be stored must to be provided in :guilabel:`Preferences`.
+the backup files are to be stored must be provided in :guilabel:`Preferences`.
 
 Backups can be run automatically when a project is closed, which also implies it is run when the
 application is closed. Backups are date stamped zip files of the entire project folder, and are
@@ -290,7 +290,7 @@ stored in a subfolder of the backup path with the same name as the project :guil
 Title` set in :ref:`a_proj_settings`.
 
 The backup feature, when configured, can also be run manually from the :guilabel:`Tools` menu.
-It is also possible to dissable automated backup for a given project in :guilabel:`Project
+It is also possible to disable automated backup for a given project in :guilabel:`Project
 Settings`.
 
 .. note::

--- a/docs/source/write_structure.rst
+++ b/docs/source/write_structure.rst
@@ -7,7 +7,7 @@ Novel Structure
 This section covers the structure of a novel project.
 
 This section concerns files under the Novel type root folder only. There are some restrictions
-and features that only applies to these type of files.
+and features that only apply to these types of files.
 
 
 .. _a_struct_heads:
@@ -36,8 +36,8 @@ way:
 ``## Header2``
    Header level two signifies a chapter level partition. Each time you want to start a new chapter,
    you must add such a heading. If you choose to split your manuscript up into one file per scene,
-   you need a single chapeter file with just the heading. You can of course also add a synopsis and
-   reference keywords to the chapter file. If you want to open the chaper with a quote, this is
+   you need a single chapter file with just the heading. You can of course also add a synopsis and
+   reference keywords to the chapter file. If you want to open the chapter with a quote, this is
    also where you'd put the text for that.
 
 ``### Header3``
@@ -46,7 +46,7 @@ way:
 
 ``#### Header4``
    Header level four signifies a sub-scene level partition, usually called just a section in the
-   documentation und user interface. These can be useful if you want to change tag references
+   documentation and user interface. These can be useful if you want to change tag references
    mid-scene, like if you change the point-of-view character. You are free to use sections as you
    wish also in novel files, and can filter the titles out of the final manuscript just like with
    scene titles.
@@ -64,7 +64,7 @@ Unnumbered Chapter Headings
 If you use file layout types for your files, the automatic numbering feature for your chapters is
 controlled by whether you use the :guilabel:`Chapter` or :guilabel:`Unnumbered` layout type for your
 file. However, if you have a different file layout where this isn't practical, you can also switch
-off chapter numbering for a chapter by making the first charcater of the chapter title an ``*``.
+off chapter numbering for a chapter by making the first character of the chapter title an ``*``.
 Like so:
 
 ``## *Unnumbered Chapter Title``
@@ -195,7 +195,7 @@ Below is an overview of all available layout formats.
 
 :guilabel:`Unnumbered`
    Same as :guilabel:`Chapter`, but when exporting the files and automatic chapter numbering is
-   enabled, this file will not increment the chapeter number. It also has a separate title
+   enabled, this file will not increment the chapter number. It also has a separate title
    formatting setting. This makes the layout suitable for Prologue and Epilogue type chapters.
 
 :guilabel:`Scene`


### PR DESCRIPTION
This MR includes a number of fixes for minor typos and grammar errors.  Some of these tend towards being very nit-picky.  Some are hard to see, such as the addition of a period, or change of a single character.  Please feel free to incorporate some, all, or none of these suggested changes.

I was pleasantly surprised to find user documention which describes the novel structure with suggestions on how to use it when writing a novel.  I also appreciate reading the reasons for some of the design choices.  Because I was reading the documentation anyway, I thought I'd try to contribute some minor improvements at the same time.

Overall I like what you are doing with _novelWriter_.

I like that simple Markdown is used and that each layout type (chapter, plot, characters, etc.) is treated in a similar manner.  I also like the ability to create plain text tags and refences to link among scenes, characters, locations, etc.

I am impressed with the focus on making sure that a writer's efforts are not lost by providing features such as auto-save.  I also appreciated reading that _nW_ ensures a file is correctly saved before replacing the previous content.

One goal I have is to try to ensure that one of the export formats will work with the [eBookGenTools](https://ebookgentools.sourceforge.io/) scripts that I maintain.  As such I will start looking at the export feature next.

I look forward to seeing _nW_ progress.

Sincerely,
Curtis Gedak
