### PR TITLE
Item Editor fixes

### DIFF
--- a/nw/constants/__init__.py
+++ b/nw/constants/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from nw.constants.iso import isoLanguage, isoCountry
 from nw.constants.constants import (
-    nwConst, nwRegEx, nwFiles, nwKeyWords, nwLabels, nwQuotes, nwUnicode
+    nwConst, nwLists, nwRegEx, nwFiles, nwKeyWords, nwLabels, nwQuotes, nwUnicode
 )
 from nw.constants.enum import (
     nwAlert, nwDocAction, nwItemClass, nwItemLayout, nwItemType, nwOutline,
@@ -11,18 +11,19 @@ from nw.constants.enum import (
 __all__ = [
     "isoCountry",
     "isoLanguage",
-    "nwAlert",
     "nwConst",
-    "nwDocAction",
-    "nwDocInsert",
+    "nwLists",
+    "nwRegEx",
     "nwFiles",
+    "nwKeyWords",
+    "nwLabels",
+    "nwQuotes",
+    "nwUnicode",
+    "nwAlert",
+    "nwDocAction",
     "nwItemClass",
     "nwItemLayout",
     "nwItemType",
-    "nwKeyWords",
-    "nwLabels",
     "nwOutline",
-    "nwQuotes",
-    "nwRegEx",
-    "nwUnicode",
+    "nwDocInsert",
 ]

--- a/nw/constants/constants.py
+++ b/nw/constants/constants.py
@@ -45,10 +45,19 @@ class nwConst():
     SP_INTERNAL = "internal"
     SP_ENCHANT  = "enchant"
 
-    # Check Lists
+# END Class nwConst
+
+class nwLists():
+    """Lists used for grouping various other constants.
+    """
+
+    # Regular user-accessible item types
     REG_TYPES = {nwItemType.ROOT, nwItemType.FOLDER, nwItemType.FILE}
 
-# END Class nwConst
+    # Item classes where the full list of novel layouts are allowed
+    CLS_NOVEL = {nwItemClass.NOVEL, nwItemClass.ARCHIVE}
+
+# END Class nwLists
 
 class nwRegEx():
 

--- a/nw/gui/itemeditor.py
+++ b/nw/gui/itemeditor.py
@@ -28,13 +28,14 @@
 import nw
 import logging
 
+from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QGridLayout, QLineEdit, QComboBox, QLabel,
     QDialogButtonBox
 )
 
 from nw.gui.custom import QSwitch
-from nw.constants import nwLabels, nwItemLayout, nwItemClass, nwItemType
+from nw.constants import nwLabels, nwItemLayout, nwItemType, nwLists
 
 logger = logging.getLogger(__name__)
 
@@ -50,14 +51,15 @@ class GuiItemEditor(QDialog):
         self.theProject = theProject
         self.theParent  = theParent
 
-        self.outerBox = QVBoxLayout()
+        ##
+        #  Build GUI
+        ##
 
         self.theItem = self.theProject.projTree[tHandle]
         if self.theItem is None:
             self._doClose()
 
         self.setWindowTitle("Item Settings")
-        self.setLayout(self.outerBox)
 
         # Item Label
         self.editName = QLineEdit()
@@ -66,7 +68,7 @@ class GuiItemEditor(QDialog):
 
         # Item Status
         self.editStatus = QComboBox()
-        if self.theItem.itemClass == nwItemClass.NOVEL:
+        if self.theItem.itemClass in nwLists.CLS_NOVEL:
             for sLabel, _, _ in self.theProject.statusItems:
                 self.editStatus.addItem(
                     self.theParent.statusIcons[sLabel], sLabel, sLabel
@@ -81,7 +83,7 @@ class GuiItemEditor(QDialog):
         self.editLayout = QComboBox()
         self.validLayouts = []
         if self.theItem.itemType == nwItemType.FILE:
-            if self.theItem.itemClass == nwItemClass.NOVEL:
+            if self.theItem.itemClass in nwLists.CLS_NOVEL:
                 self.validLayouts.append(nwItemLayout.TITLE)
                 self.validLayouts.append(nwItemLayout.BOOK)
                 self.validLayouts.append(nwItemLayout.PAGE)
@@ -109,20 +111,27 @@ class GuiItemEditor(QDialog):
             self.editExport.setEnabled(False)
             self.editExport.setChecked(False)
 
-        self.editName.setText(self.theItem.itemName)
-        statusIdx = self.editStatus.findData(self.theItem.itemStatus)
-        if statusIdx != -1:
-            self.editStatus.setCurrentIndex(statusIdx)
-        layoutIdx = self.editLayout.findData(self.theItem.itemLayout)
-        if layoutIdx != -1:
-            self.editLayout.setCurrentIndex(layoutIdx)
-
         # Buttons
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         self.buttonBox.accepted.connect(self._doSave)
         self.buttonBox.rejected.connect(self._doClose)
 
-        # Assemble
+        # Set Current Values
+        self.editName.setText(self.theItem.itemName)
+        self.editName.selectAll()
+
+        statusIdx = self.editStatus.findData(self.theItem.itemStatus)
+        if statusIdx != -1:
+            self.editStatus.setCurrentIndex(statusIdx)
+
+        layoutIdx = self.editLayout.findData(self.theItem.itemLayout)
+        if layoutIdx != -1:
+            self.editLayout.setCurrentIndex(layoutIdx)
+
+        ##
+        #  Assemble
+        ##
+
         self.mainForm = QGridLayout()
         self.mainForm.setVerticalSpacing(self.mainConf.pxInt(4))
         self.mainForm.setHorizontalSpacing(self.mainConf.pxInt(16))
@@ -135,6 +144,7 @@ class GuiItemEditor(QDialog):
         self.mainForm.addWidget(self.textExport,  3, 0, 1, 2)
         self.mainForm.addWidget(self.editExport,  3, 2, 1, 1)
 
+        self.outerBox = QVBoxLayout()
         self.outerBox.setSpacing(self.mainConf.pxInt(16))
         self.outerBox.addLayout(self.mainForm)
         self.outerBox.addStretch(1)
@@ -142,12 +152,16 @@ class GuiItemEditor(QDialog):
         self.setLayout(self.outerBox)
 
         self.rejected.connect(self._doClose)
-        self.editName.selectAll()
 
         logger.debug("GuiItemEditor initialisation complete")
 
         return
 
+    ##
+    #  Slots
+    ##
+
+    @pyqtSlot()
     def _doSave(self):
         """Save the setting to the item.
         """
@@ -170,10 +184,11 @@ class GuiItemEditor(QDialog):
 
         return
 
+    @pyqtSlot()
     def _doClose(self):
         """Close the dialog without saving the settings.
         """
-        logger.verbose("ItemEditor close button clicked")
+        logger.verbose("ItemEditor cancel button clicked")
         self.close()
         return
 

--- a/nw/gui/itemeditor.py
+++ b/nw/gui/itemeditor.py
@@ -64,7 +64,7 @@ class GuiItemEditor(QDialog):
         # Item Label
         self.editName = QLineEdit()
         self.editName.setMinimumWidth(self.mainConf.pxInt(220))
-        self.editName.setMaxLength(self.mainConf.pxInt(200))
+        self.editName.setMaxLength(200)
 
         # Item Status
         self.editStatus = QComboBox()
@@ -143,6 +143,9 @@ class GuiItemEditor(QDialog):
         self.mainForm.addWidget(self.editLayout,  2, 1, 1, 2)
         self.mainForm.addWidget(self.textExport,  3, 0, 1, 2)
         self.mainForm.addWidget(self.editExport,  3, 2, 1, 1)
+        self.mainForm.setColumnStretch(0, 0)
+        self.mainForm.setColumnStretch(1, 1)
+        self.mainForm.setColumnStretch(2, 0)
 
         self.outerBox = QVBoxLayout()
         self.outerBox.setSpacing(self.mainConf.pxInt(16))

--- a/nw/gui/itemeditor.py
+++ b/nw/gui/itemeditor.py
@@ -61,13 +61,18 @@ class GuiItemEditor(QDialog):
 
         self.setWindowTitle("Item Settings")
 
+        mVd = self.mainConf.pxInt(220)
+        mSp = self.mainConf.pxInt(16)
+        vSp = self.mainConf.pxInt(4)
+
         # Item Label
         self.editName = QLineEdit()
-        self.editName.setMinimumWidth(self.mainConf.pxInt(220))
+        self.editName.setMinimumWidth(mVd)
         self.editName.setMaxLength(200)
 
         # Item Status
         self.editStatus = QComboBox()
+        self.editStatus.setMinimumWidth(mVd)
         if self.theItem.itemClass in nwLists.CLS_NOVEL:
             for sLabel, _, _ in self.theProject.statusItems:
                 self.editStatus.addItem(
@@ -81,24 +86,24 @@ class GuiItemEditor(QDialog):
 
         # Item Layout
         self.editLayout = QComboBox()
-        self.validLayouts = []
+        self.editLayout.setMinimumWidth(mVd)
+        validLayouts = []
         if self.theItem.itemType == nwItemType.FILE:
             if self.theItem.itemClass in nwLists.CLS_NOVEL:
-                self.validLayouts.append(nwItemLayout.TITLE)
-                self.validLayouts.append(nwItemLayout.BOOK)
-                self.validLayouts.append(nwItemLayout.PAGE)
-                self.validLayouts.append(nwItemLayout.PARTITION)
-                self.validLayouts.append(nwItemLayout.UNNUMBERED)
-                self.validLayouts.append(nwItemLayout.CHAPTER)
-                self.validLayouts.append(nwItemLayout.SCENE)
-                self.validLayouts.append(nwItemLayout.NOTE)
-            else:
-                self.validLayouts.append(nwItemLayout.NOTE)
+                validLayouts.append(nwItemLayout.TITLE)
+                validLayouts.append(nwItemLayout.BOOK)
+                validLayouts.append(nwItemLayout.PAGE)
+                validLayouts.append(nwItemLayout.PARTITION)
+                validLayouts.append(nwItemLayout.UNNUMBERED)
+                validLayouts.append(nwItemLayout.CHAPTER)
+                validLayouts.append(nwItemLayout.SCENE)
+            validLayouts.append(nwItemLayout.NOTE)
         else:
-            self.validLayouts.append(nwItemLayout.NO_LAYOUT)
+            validLayouts.append(nwItemLayout.NO_LAYOUT)
+            self.editLayout.setEnabled(False)
 
         for itemLayout in nwItemLayout:
-            if itemLayout in self.validLayouts:
+            if itemLayout in validLayouts:
                 self.editLayout.addItem(nwLabels.LAYOUT_NAME[itemLayout], itemLayout)
 
         # Export Switch
@@ -133,8 +138,8 @@ class GuiItemEditor(QDialog):
         ##
 
         self.mainForm = QGridLayout()
-        self.mainForm.setVerticalSpacing(self.mainConf.pxInt(4))
-        self.mainForm.setHorizontalSpacing(self.mainConf.pxInt(16))
+        self.mainForm.setVerticalSpacing(vSp)
+        self.mainForm.setHorizontalSpacing(mSp)
         self.mainForm.addWidget(QLabel("Label"),  0, 0, 1, 1)
         self.mainForm.addWidget(self.editName,    0, 1, 1, 2)
         self.mainForm.addWidget(QLabel("Status"), 1, 0, 1, 1)
@@ -148,7 +153,7 @@ class GuiItemEditor(QDialog):
         self.mainForm.setColumnStretch(2, 0)
 
         self.outerBox = QVBoxLayout()
-        self.outerBox.setSpacing(self.mainConf.pxInt(16))
+        self.outerBox.setSpacing(mSp)
         self.outerBox.addLayout(self.mainForm)
         self.outerBox.addStretch(1)
         self.outerBox.addWidget(self.buttonBox)

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -535,36 +535,30 @@ class GuiProjectTree(QTreeWidget):
     def setTreeItemValues(self, tHandle):
         """Set the name and flag values for a tree item.
         """
-        trItem  = self._getTreeItem(tHandle)
-        nwItem  = self.theProject.projTree[tHandle]
-        tName   = nwItem.itemName
-        tClass  = nwItem.itemClass
-        tHandle = nwItem.itemHandle
+        trItem = self._getTreeItem(tHandle)
+        nwItem = self.theProject.projTree[tHandle]
 
         expIcon = QIcon()
-
-        stClass = nwLabels.CLASS_FLAG[nwItem.itemClass]
-        stLayout = ""
+        stFlags = nwLabels.CLASS_FLAG[nwItem.itemClass]
         if nwItem.itemType == nwItemType.FILE:
-            stLayout = "."+nwLabels.LAYOUT_FLAG[nwItem.itemLayout]
+            stFlags += "."+nwLabels.LAYOUT_FLAG[nwItem.itemLayout]
             if nwItem.isExported:
                 expIcon = self.theTheme.getIcon("check")
             else:
                 expIcon = self.theTheme.getIcon("cross")
-        tStatus = stClass+stLayout
 
         iStatus = nwItem.itemStatus
-        if tClass == nwItemClass.NOVEL:
+        if nwItem.itemClass == nwItemClass.NOVEL:
             iStatus = self.theProject.statusItems.checkEntry(iStatus) # Make sure it's valid
             flagIcon = self.theParent.statusIcons[iStatus]
         else:
             iStatus = self.theProject.importItems.checkEntry(iStatus) # Make sure it's valid
             flagIcon = self.theParent.importIcons[iStatus]
 
-        trItem.setText(self.C_NAME, tName)
+        trItem.setText(self.C_NAME, nwItem.itemName)
         trItem.setIcon(self.C_EXPORT, expIcon)
-        trItem.setText(self.C_FLAGS, tStatus)
         trItem.setIcon(self.C_FLAGS, flagIcon)
+        trItem.setText(self.C_FLAGS, stFlags)
 
         return
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -47,7 +47,7 @@ from nw.gui import (
     GuiTheme, GuiWritingStats
 )
 from nw.core import NWProject, NWDoc, NWIndex
-from nw.constants import nwItemType, nwItemClass, nwAlert, nwConst
+from nw.constants import nwItemType, nwItemClass, nwAlert, nwLists
 from nw.common import getGuiItem
 
 logger = logging.getLogger(__name__)
@@ -725,7 +725,7 @@ class GuiMain(QMainWindow):
         tItem = self.theProject.projTree[tHandle]
         if tItem is None:
             return
-        if tItem.itemType not in nwConst.REG_TYPES:
+        if tItem.itemType not in nwLists.REG_TYPES:
             return
 
         logger.verbose("Requesting change to item %s" % tHandle)


### PR DESCRIPTION
This PR makes a few changes to the Item Editor, and related code.

* The Archive root folder is now equal to the Novel root folder in terms of setting status and importance flags.
* Resizing the Item Editor dialog will expand the input boxes, as a user would expect, instead of increasing the empty space between label and input box.
* Some minor cleanup and removal of redundant variables in the Item Editor dialog itself, and the function that applies the changes in the Project Tree class.