### PR TITLE
Doc and Project Modified Status

### DIFF
--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -606,10 +606,13 @@ class NWProject():
         self.theParent.setStatus("Opened Project: %s" % self.projName)
 
         self._scanProjectFolder()
-        self.setProjectChanged(False)
+
+        self.currWCount = self.lastWCount
         self.projOpened = time()
         self.projAltered = False
+
         self._writeLockFile()
+        self.setProjectChanged(False)
 
         return True
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -903,12 +903,13 @@ class GuiDocEditor(QTextEdit):
     ##
 
     @pyqtSlot(int, int, int)
-    def _docChange(self, thePos, charsRemoved, charsAdded):
+    def _docChange(self, thePos, chrRem, chrAdd):
         """Triggered by QTextDocument->contentsChanged. This also
         triggers the syntax highlighter.
         """
         self.lastEdit = time()
         self.lastFind = None
+
         if self.qDocument.characterCount() > nwConst.MAX_DOCSIZE:
             self.theParent.makeAlert((
                 "The document has grown too big and you cannot add more text to it. "
@@ -916,12 +917,16 @@ class GuiDocEditor(QTextEdit):
             ) % (nwConst.MAX_DOCSIZE/1.0e6), nwAlert.ERROR)
             self.undo()
             return
+
         if not self.docChanged:
-            self.setDocumentChanged(True)
+            self.setDocumentChanged(chrRem != 0 or chrAdd != 0)
+
         if not self.wcTimer.isActive():
             self.wcTimer.start()
-        if self.doReplace and charsAdded == 1:
+
+        if self.doReplace and chrAdd == 1:
             self._docAutoReplace(self.qDocument.findBlock(thePos))
+
         return
 
     @pyqtSlot("QPoint")

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -316,7 +316,6 @@ class GuiDocEditor(QTextEdit):
         self.lastEdit = time()
         self._runCounter()
         self.wcTimer.start()
-        self.setDocumentChanged(False)
         self.theHandle = tHandle
 
         self.setReadOnly(False)
@@ -340,6 +339,9 @@ class GuiDocEditor(QTextEdit):
 
         self.docFooter.updateLineCount()
         self.lengthLast = self.qDocument.characterCount()
+
+        qApp.processEvents()
+        self.setDocumentChanged(False)
 
         qApp.restoreOverrideCursor()
 
@@ -373,8 +375,8 @@ class GuiDocEditor(QTextEdit):
 
         qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
         self.setPlainText(theText)
-        self.setDocumentChanged(True)
         self.updateDocMargins()
+        self.setDocumentChanged(True)
         qApp.restoreOverrideCursor()
 
         return True
@@ -450,10 +452,16 @@ class GuiDocEditor(QTextEdit):
         lM = max(cM, fH)
         self.setViewportMargins(tM, uM, tM, lM)
 
+        docChanged = self.docChanged
         if self.mainConf.scrollPastEnd:
             docFrame = self.qDocument.rootFrame().frameFormat()
             docFrame.setBottomMargin(max(0, 0.6*(wH - uM - lM - 4*tB)))
             self.qDocument.rootFrame().setFrameFormat(docFrame)
+
+        # This is needed as the setFrameFormat function itself will
+        # trigger the contetsChanged signal which sets docChanged, so we
+        # set it back to whatever it was before.
+        self.setDocumentChanged(docChanged)
 
         return
 

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -179,13 +179,8 @@ class GuiMainStatus(QStatusBar):
     def setStats(self, pWC, sWC):
         """Set the current project statistics.
         """
-        self.statsText.setToolTip(
-            "Project word count (session change)"
-        )
-        self.statsText.setText(
-            f"Words: {pWC:n} ({sWC:+n})"
-        )
-
+        self.statsText.setText(f"Words: {pWC:n} ({sWC:+n})")
+        self.statsText.setToolTip("Project word count (session change)")
         return
 
     ##

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -51,9 +51,6 @@ class GuiMainStatus(QStatusBar):
         self.theTheme  = theParent.theTheme
         self.refTime   = None
 
-        self.projWords = 0
-        self.sessWords = 0
-
         colNone  = QColor(*self.theTheme.statNone)
         colTrue  = QColor(*self.theTheme.statUnsaved)
         colFalse = QColor(*self.theTheme.statSaved)
@@ -182,25 +179,18 @@ class GuiMainStatus(QStatusBar):
     def setStats(self, pWC, sWC):
         """Set the current project statistics.
         """
-        self.projWords = pWC
-        self.sessWords = sWC
-        self._updateStats()
+        self.statsText.setToolTip(
+            "Project word count (session change)"
+        )
+        self.statsText.setText(
+            f"Words: {pWC:n} ({sWC:+n})"
+        )
+
         return
 
     ##
     #  Internal Functions
     ##
-
-    def _updateStats(self):
-        """Update statistics.
-        """
-        self.statsText.setToolTip(
-            "Project word count (session change)"
-        )
-        self.statsText.setText(
-            f"Words: {self.projWords:n} ({self.sessWords:+n})"
-        )
-        return
 
     def _updateTime(self):
         """Update the session clock.

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -428,6 +428,7 @@ class GuiMain(QMainWindow):
         self.docEditor.setSpellCheck(self.theProject.spellCheck)
         self.mainMenu.setAutoOutline(self.theProject.autoOutline)
         self.statusBar.setRefTime(self.theProject.projOpened)
+        self.statusBar.setStats(self.theProject.currWCount, 0)
 
         # Restore previously open documents, if any
         if self.theProject.lastEdited is not None:

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -467,7 +467,7 @@ class GuiMain(QMainWindow):
             return False
 
         self.treeView.saveTreeOrder()
-        self.theProject.saveProject(autoSave)
+        self.theProject.saveProject(autoSave=autoSave)
         self.theIndex.saveIndex()
 
         return True

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -432,12 +432,19 @@ class GuiMain(QMainWindow):
         # Restore previously open documents, if any
         if self.theProject.lastEdited is not None:
             self.openDocument(self.theProject.lastEdited, doScroll=True)
+
         if self.theProject.lastViewed is not None:
             self.viewDocument(self.theProject.lastViewed)
 
         # Check if we need to rebuild the index
         if self.theIndex.indexBroken:
             self.rebuildIndex()
+
+        # Make sure the changed status is set to false on all that was
+        # just opened
+        qApp.processEvents()
+        self.docEditor.setDocumentChanged(False)
+        self.theProject.setProjectChanged(False)
 
         logger.debug("Project load complete")
 


### PR DESCRIPTION
This PR fixes a couple of minor issues:

* Changing the size of the document editor, whether it is by changing the window or one of the splitters, flags the document itself as changed. This is now handled. In addition, opening the last viewed document automatically when opening a project also triggered the document changed flag. This is now reset at the end of the open project function.
* When loading a project, the last project word count is loaded, however the current word count remains 0 until the first timed count is run. This value is now also set when the project is opened, and updated on the status bar. This both prevents the project changed flag from being flipped on first word count, and properly sets the word count on the status bar from the start.