### PR TITLE
Duplicate index entry issue

### DIFF
--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -277,10 +277,12 @@ class NWIndex():
             "updated" : round(time()),
         }
         if itemLayout == nwItemLayout.NOTE:
+            self.novelIndex.pop(tHandle, None)
             self.noteIndex[tHandle] = {}
             isNovel = False
         else:
             self.novelIndex[tHandle] = {}
+            self.noteIndex.pop(tHandle, None)
             isNovel = True
 
         # Also clear references to file in tag index


### PR DESCRIPTION
When a document is indexed by the indexer class, the meta data is either saved to a novel index or a note index based on the layout of the document. However, if a document has its layout changed from one of the novel layouts to a note, or vice versa, the indexer will not clear the old data in the previous internal index.

This PR adds a clearing command to make sure the entry does not exist in the opposite index when the new entry is created in the new index.