### PR TITLE
Backport from 1.1: clear project tree meta panel on close

### DIFF
--- a/nw/gui/itemdetails.py
+++ b/nw/gui/itemdetails.py
@@ -190,6 +190,22 @@ class GuiItemDetails(QWidget):
     #  Class Methods
     ##
 
+    def clearDetails(self):
+        """Clear all the data values.
+        """
+        self.labelFlag.setPixmap(QPixmap(1, 1))
+        self.labelData.setText("")
+        self.statusFlag.setPixmap(QPixmap(1, 1))
+        self.statusData.setText("")
+        self.classFlag.setText("")
+        self.classData.setText("")
+        self.layoutFlag.setText("")
+        self.layoutData.setText("")
+        self.cCountData.setText("–")
+        self.wCountData.setText("–")
+        self.pCountData.setText("–")
+        return
+
     def updateCounts(self, tHandle, cC, wC, pC):
         """Just update the counts if the handle is the same as the one
         we're already showing.
@@ -207,17 +223,7 @@ class GuiItemDetails(QWidget):
         nwItem = self.theProject.projTree[tHandle]
 
         if nwItem is None:
-            self.labelFlag.setText("")
-            self.labelData.setText("")
-            self.statusFlag.setText("")
-            self.statusData.setText("")
-            self.classFlag.setText("")
-            self.classData.setText("")
-            self.layoutFlag.setText("")
-            self.layoutData.setText("")
-            self.cCountData.setText("–")
-            self.wCountData.setText("–")
-            self.pCountData.setText("–")
+            self.clearDetails()
 
         else:
             theLabel = nwItem.itemName

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -252,10 +252,17 @@ class GuiMain(QMainWindow):
     def clearGUI(self):
         """Wrapper function to clear all sub-elements of the main GUI.
         """
+        # Project Area
         self.treeView.clearTree()
+        self.treeMeta.clearDetails()
+
+        # Work Area
         self.docEditor.clearEditor()
         self.closeDocViewer()
+
+        # General
         self.statusBar.clearStatus()
+
         return True
 
     def initMain(self):


### PR DESCRIPTION
The details panel below the project tree is not cleared when a project is closed. This is just a cosmetic issue, but it is inconsistent with the rest of the GUi were all information is cleared.