### PR TITLE
Improve Project Details

### DIFF
--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -627,7 +627,7 @@ class NWIndex():
                     pKey = tKey
                     tOrder.append(tKey)
                     tData[tKey] = {
-                        "level": theData["level"],
+                        "level": iLevel,
                         "title": theData["title"],
                         "words": theData["wCount"],
                     }
@@ -635,7 +635,10 @@ class NWIndex():
         theToC = []
         for tKey in tOrder:
             theToC.append((
-                tKey, tData[tKey]["level"], tData[tKey]["title"], tData[tKey]["words"]
+                tKey,
+                tData[tKey]["level"],
+                tData[tKey]["title"],
+                tData[tKey]["words"],
             ))
 
         return theToC

--- a/nw/core/options.py
+++ b/nw/core/options.py
@@ -96,6 +96,7 @@ class OptionState():
                 "widthCol3",
                 "widthCol4",
                 "wordsPerPage",
+                "countFrom",
                 "clearDouble",
             },
         }

--- a/nw/gui/projdetails.py
+++ b/nw/gui/projdetails.py
@@ -358,6 +358,7 @@ class GuiProjectDetailsContents(QWidget):
         # ========
 
         self.outerBox = QVBoxLayout()
+        self.outerBox.addWidget(QLabel("<b>Table of Contents</b>"))
         self.outerBox.addWidget(self.tocTree)
         self.outerBox.addLayout(self.optionsBox)
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -965,6 +965,8 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return
 
+        self.treeView.flushTreeOrder()
+
         dlgDetails = GuiProjectDetails(self, self.theProject)
         dlgDetails.setModal(False)
         dlgDetails.show()

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -659,18 +659,18 @@ def testCoreIndex_ExtractData(nwMinimal, dummyGUI):
     assert theIndex.getTableOfContents(0, True) == []
     assert theIndex.getTableOfContents(1, True) == []
     assert theIndex.getTableOfContents(2, True) == [
-        ("%s:T000001" % hHandle, "H2", "Chapter One", 6),
+        ("%s:T000001" % hHandle, 2, "Chapter One", 6),
     ]
     assert theIndex.getTableOfContents(3, True) == [
-        ("%s:T000001" % hHandle, "H2", "Chapter One", 2),
-        ("%s:T000001" % sHandle, "H3", "Scene One", 2),
-        ("%s:T000001" % tHandle, "H3", "Scene Two", 2),
+        ("%s:T000001" % hHandle, 2, "Chapter One", 2),
+        ("%s:T000001" % sHandle, 3, "Scene One", 2),
+        ("%s:T000001" % tHandle, 3, "Scene Two", 2),
     ]
 
     assert theIndex.getTableOfContents(0, False) == []
     assert theIndex.getTableOfContents(1, False) == [
-        ("%s:T000001" % nHandle, "H1", "Hello World!", 12),
-        ("%s:T000011" % nHandle, "H1", "Hello World!", 18),
+        ("%s:T000001" % nHandle, 1, "Hello World!", 12),
+        ("%s:T000011" % nHandle, 1, "Hello World!", 18),
     ]
 
     assert theProject.closeProject()

--- a/tests/test_gui/test_gui_projdetails.py
+++ b/tests/test_gui/test_gui_projdetails.py
@@ -27,7 +27,6 @@ from tools import getGuiItem
 from PyQt5.QtWidgets import QAction, QMessageBox
 
 from nw.gui import GuiProjectDetails
-from nw.constants import nwUnicode
 
 keyDelay = 2
 typeDelay = 1

--- a/tests/test_gui/test_gui_projdetails.py
+++ b/tests/test_gui/test_gui_projdetails.py
@@ -78,31 +78,33 @@ def testGuiProjDetails_Dialog(qtbot, monkeypatch, nwGUI, nwLipsum):
     tocTree = tocTab.tocTree
     assert tocTree.topLevelItemCount() == 7
     assert tocTree.topLevelItem(0).text(tocTab.C_TITLE) == "Lorem Ipsum"
-    assert tocTree.topLevelItem(2).text(tocTab.C_TITLE) == nwUnicode.U_ENSP+"Prologue"
+    assert tocTree.topLevelItem(2).text(tocTab.C_TITLE) == "Prologue"
     assert tocTree.topLevelItem(3).text(tocTab.C_TITLE) == "Act One"
-    assert tocTree.topLevelItem(4).text(tocTab.C_TITLE) == nwUnicode.U_ENSP+"Chapter One"
-    assert tocTree.topLevelItem(5).text(tocTab.C_TITLE) == nwUnicode.U_ENSP+"Chapter Two"
+    assert tocTree.topLevelItem(4).text(tocTab.C_TITLE) == "Chapter One"
+    assert tocTree.topLevelItem(5).text(tocTab.C_TITLE) == "Chapter Two"
     assert tocTree.topLevelItem(6).text(tocTab.C_TITLE) == "END"
 
     # Count Pages
     tocTab.wpValue.setValue(100)
+    tocTab.poValue.setValue(4)
     tocTab.dblValue.setChecked(False)
     tocTab._populateTree()
 
-    thePages = [1, 2, 1, 1, 11, 17, 0]
-    thePage = [1, 2, 4, 5, 6, 17, 34]
+    thePages = ["1", "2", "1", "1", "11", "17", "0"]
+    thePage = ["i", "ii", "1", "2", "3", "14", "31"]
     for i in range(7):
-        assert tocTree.topLevelItem(i).text(tocTab.C_PAGES) == f"{thePages[i]:n}"
-        assert tocTree.topLevelItem(i).text(tocTab.C_PAGE) == f"{thePage[i]:n}"
+        assert tocTree.topLevelItem(i).text(tocTab.C_PAGES) == thePages[i]
+        assert tocTree.topLevelItem(i).text(tocTab.C_PAGE) == thePage[i]
 
+    tocTab.poValue.setValue(5)
     tocTab.dblValue.setChecked(True)
     tocTab._populateTree()
 
-    thePages = [2, 2, 2, 2, 12, 18, 0]
-    thePage = [1, 3, 5, 7, 9, 21, 39]
+    thePages = ["2", "2", "2", "2", "12", "18", "0"]
+    thePage = ["i", "iii", "1", "3", "5", "17", "35"]
     for i in range(7):
-        assert tocTree.topLevelItem(i).text(tocTab.C_PAGES) == f"{thePages[i]:n}"
-        assert tocTree.topLevelItem(i).text(tocTab.C_PAGE) == f"{thePage[i]:n}"
+        assert tocTree.topLevelItem(i).text(tocTab.C_PAGES) == thePages[i]
+        assert tocTree.topLevelItem(i).text(tocTab.C_PAGE) == thePage[i]
 
     # qtbot.stopForInteraction()
 


### PR DESCRIPTION
This PR makes a few improvements to the Contents tab on the Project Details dialog:
* Remove indentation of chapter titles, and instead make non-chapter titles stand out by using bold, italic and underline.
* Allow the user to select which page is the first page to start counting from. The preceding pages are then counted with roman numbers as is customary in front matter, and the story progress column ignores these pages.

![image](https://user-images.githubusercontent.com/1619840/105644764-9bafe280-5e97-11eb-81fd-de9974189ae3.png)
