### PR TITLE
Issue #612: Change Focus

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -2,9 +2,9 @@ name: flake8
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, release ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, release ]
 
 jobs:
   checkSyntax:

--- a/docs/source/int_interface.rst
+++ b/docs/source/int_interface.rst
@@ -344,6 +344,7 @@ Most features are available as keyboard shortcuts. These are as follows:
    ":kbd:`Alt`:kbd:`1`",                 "Switch focus to the project tree."
    ":kbd:`Alt`:kbd:`2`",                 "Switch focus to document editor."
    ":kbd:`Alt`:kbd:`3`",                 "Switch focus to document viewer."
+   ":kbd:`Alt`:kbd:`4`",                 "Switch focus to outline view."
    ":kbd:`Alt`:kbd:`Left`",              "Move backward in the view history of the document viewer."
    ":kbd:`Alt`:kbd:`Right`",             "Move forward in the view history of the document viewer."
    ":kbd:`Ctrl`:kbd:`.`",                "Open menu to correct word under cursor."

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -468,6 +468,13 @@ class GuiMainMenu(QMenuBar):
         self.aFocusView.triggered.connect(lambda: self.theParent.setFocus(3))
         self.viewMenu.addAction(self.aFocusView)
 
+        # View > Outline
+        self.aFocusOutline = QAction("Focus Outline", self)
+        self.aFocusOutline.setStatusTip("Move focus to outline")
+        self.aFocusOutline.setShortcut("Alt+4")
+        self.aFocusOutline.triggered.connect(lambda: self.theParent.setFocus(4))
+        self.viewMenu.addAction(self.aFocusOutline)
+
         # View > Separator
         self.viewMenu.addSeparator()
 

--- a/nw/gui/projdetails.py
+++ b/nw/gui/projdetails.py
@@ -5,7 +5,7 @@ novelWriter – GUI Project Details
 Class holding the project details dialog
 
 File History:
-Created: 2021-01-03 [1.0a0]
+Created: 2021-01-03 [1.1a0]
 
 This file is a part of novelWriter
 Copyright 2018–2021, Veronica Berglyd Olsen

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1128,14 +1128,19 @@ class GuiMain(QMainWindow):
         return True
 
     def setFocus(self, paneNo):
-        """Switch focus to one of the three main GUI panes.
+        """Switch focus between main GUI views.
         """
         if paneNo == 1:
             self.treeView.setFocus()
         elif paneNo == 2:
+            self.mainTabs.setCurrentWidget(self.splitDocs)
             self.docEditor.setFocus()
         elif paneNo == 3:
+            self.mainTabs.setCurrentWidget(self.splitDocs)
             self.docViewer.setFocus()
+        elif paneNo == 4:
+            self.mainTabs.setCurrentWidget(self.splitOutline)
+            self.projView.setFocus()
         return
 
     def closeDocEditor(self):


### PR DESCRIPTION
This adds `Alt+4` as a shortcut to change focus to the Outline view, and also switches the main window tab when required by focus shift.

This resolves issues #609 and #612.