### PR TITLE
Issue #608: Missing Cursor

### DIFF
--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -345,8 +345,13 @@ class GuiDocEditor(QTextEdit):
 
         qApp.processEvents()
         self.setDocumentChanged(False)
-
         qApp.restoreOverrideCursor()
+
+        # This is a hack to fix invisble cursor on an empty document
+        if self.qDocument.characterCount() <= 1:
+            self.setPlainText("\n")
+            self.setPlainText("")
+            self.setCursorPosition(0)
 
         return True
 
@@ -513,9 +518,10 @@ class GuiDocEditor(QTextEdit):
         if not isinstance(thePosition, int):
             return False
 
-        if thePosition >= 0:
+        nChars = self.qDocument.characterCount()
+        if nChars > 1:
             theCursor = self.textCursor()
-            theCursor.setPosition(thePosition)
+            theCursor.setPosition(min(max(thePosition, 0), nChars-1))
             self.setTextCursor(theCursor)
             self.docFooter.updateLineCount()
 


### PR DESCRIPTION
This resolves #608 which describes an issue with opening a blank document and no cursor being visible when the editor has focus.

I did not manage to find out why this happens. Presumably, some action by novelWriter causes the cursor to not show. I added a simple hack that will add a line break and remove it again if the opened document is empty. This brings back the cursor. However, it doesn't work if the blank document is opened automatically when the application is launched. The latter is why I expect it is caused by a conflict with some other internal feature. Still, fixing it for when the user manually opens a blank document solves it in 99% of cases, and it's probably good enough.

If I figure out exactly what is causing this, I'll make a better fix.