### PR TITLE
Fix "Open Project" list sorting issue

### DIFF
--- a/nw/gui/projload.py
+++ b/nw/gui/projload.py
@@ -258,40 +258,31 @@ class GuiProjectLoad(QDialog):
     def _populateList(self):
         """Populate the list box with recent project data.
         """
-        listOrder = []
-        listData  = {}
-        for projPath in self.mainConf.recentProj.keys():
+        dataList = []
+        for projPath in self.mainConf.recentProj:
             theEntry = self.mainConf.recentProj[projPath]
-            theTitle = ""
-            theTime  = 0
-            theWords = 0
-            if "title" in theEntry.keys():
-                theTitle = theEntry["title"]
-            if "time" in theEntry.keys():
-                theTime = theEntry["time"]
-            if "words" in theEntry.keys():
-                theWords = theEntry["words"]
-            if theTime > 0:
-                listOrder.append(theTime)
-                listData[theTime] = [theTitle, theWords, projPath]
+            theTitle = theEntry.get("title", "")
+            theTime  = theEntry.get("time", 0)
+            theWords = theEntry.get("words", 0)
+            dataList.append([theTitle, theTime, theWords, projPath])
 
         self.listBox.clear()
-        hasSelection = False
-        for timeStamp in sorted(listOrder, reverse=True):
+        sortList = sorted(dataList, key=lambda x: x[1], reverse=True)
+        for theTitle, theTime, theWords, projPath in sortList:
             newItem = QTreeWidgetItem([""]*4)
             newItem.setIcon(self.C_NAME,  self.theParent.theTheme.getIcon("proj_nwx"))
-            newItem.setText(self.C_NAME,  listData[timeStamp][0])
-            newItem.setData(self.C_NAME,  Qt.UserRole, listData[timeStamp][2])
-            newItem.setText(self.C_COUNT, formatInt(listData[timeStamp][1]))
-            newItem.setText(self.C_TIME,  datetime.fromtimestamp(timeStamp).strftime("%x %X"))
+            newItem.setText(self.C_NAME,  theTitle)
+            newItem.setData(self.C_NAME,  Qt.UserRole, projPath)
+            newItem.setText(self.C_COUNT, formatInt(theWords))
+            newItem.setText(self.C_TIME,  datetime.fromtimestamp(theTime).strftime("%x %X"))
             newItem.setTextAlignment(self.C_NAME,  Qt.AlignLeft  | Qt.AlignVCenter)
             newItem.setTextAlignment(self.C_COUNT, Qt.AlignRight | Qt.AlignVCenter)
             newItem.setTextAlignment(self.C_TIME,  Qt.AlignRight | Qt.AlignVCenter)
             newItem.setFont(self.C_TIME, self.theTheme.guiFontFixed)
             self.listBox.addTopLevelItem(newItem)
-            if not hasSelection:
-                newItem.setSelected(True)
-                hasSelection = True
+
+        if self.listBox.topLevelItemCount() > 0:
+            self.listBox.topLevelItem(0).setSelected(True)
 
         projColWidth = self.mainConf.getProjColWidths()
         if len(projColWidth) == 3:


### PR DESCRIPTION
This PR fixes an old issue that I've seen before, but never quite managed to catch and track down.

Essentially, if you have one project open, and then open another project from the "Open Project" dialog, and then open that dialog again, the last opened project will replace the entry for the one before. The underlying data is correct, but the record of recent projects is updated both when you open and close a project. The sorting algorithm uses the timestamp of these events to sort the list. The resolution of these timestamps is 1 second, so the closing of one, and opening of the next, will have the same timestamp as they happen within milliseconds of each other -- provided the "ask before backup" option isn't on. The last one in the recent list would then occupy both slots, as the lookup is done by timestamp *after* the sorting.

The sorting algorithm was just clunky and badly written. The new one added here does not have this issue.