### PR TITLE
Session Idle Time

### DIFF
--- a/nw/assets/icons/fallback/status_idle-dark.svg
+++ b/nw/assets/icons/fallback/status_idle-dark.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.2"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg5582">
+  <metadata
+     id="metadata5588">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5586" />
+  <path
+     d="m 6.7499997,3 c -1.656,0 -3,1.3440001 -3,3.0000001 V 17.999999 c 0,1.656 1.344,3.000001 3,3.000001 1.6560002,0 2.9999998,-1.344001 2.9999998,-3.000001 V 6.0000001 C 9.7499995,4.3440001 8.4059999,3 6.7499997,3 Z M 17.249999,3 c -1.656,0 -3.000001,1.3440001 -3.000001,3.0000001 V 17.999999 c 0,1.656 1.344001,3.000001 3.000001,3.000001 1.656,0 3.000001,-1.344001 3.000001,-3.000001 V 6.0000001 C 20.25,4.3440001 18.905999,3 17.249999,3 Z"
+     id="path5580"
+     style="fill:#aeaeae;fill-opacity:1;stroke-width:1.49999" />
+</svg>

--- a/nw/assets/icons/fallback/status_idle.svg
+++ b/nw/assets/icons/fallback/status_idle.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.2"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg5582">
+  <metadata
+     id="metadata5588">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5586" />
+  <path
+     d="m 6.7499997,3 c -1.656,0 -3,1.3440001 -3,3.0000001 V 17.999999 c 0,1.656 1.344,3.000001 3,3.000001 1.6560002,0 2.9999998,-1.344001 2.9999998,-3.000001 V 6.0000001 C 9.7499995,4.3440001 8.4059999,3 6.7499997,3 Z M 17.249999,3 c -1.656,0 -3.000001,1.3440001 -3.000001,3.0000001 V 17.999999 c 0,1.656 1.344001,3.000001 3.000001,3.000001 1.656,0 3.000001,-1.344001 3.000001,-3.000001 V 6.0000001 C 20.25,4.3440001 18.905999,3 17.249999,3 Z"
+     id="path5580"
+     style="fill:#000000;fill-opacity:0.780392;stroke-width:1.49999" />
+</svg>

--- a/nw/config.py
+++ b/nw/config.py
@@ -144,6 +144,9 @@ class Config:
         self.allowOpenDQuote = True  # Allow open-ended double quotes
         self.highlightEmph   = True  # Add colour to text emphasis
 
+        self.stopWhenIdle    = True  # Stop the status bar clock when the user is idle
+        self.userIdleTime    = 300   # Time of inactivity to consider user idle
+
         ## User-Selected Symbols
         self.fmtApostrophe   = nwUnicode.U_RSQUO
         self.fmtSingleQuotes = [nwUnicode.U_LSQUO, nwUnicode.U_RSQUO]
@@ -532,6 +535,12 @@ class Config:
         self.highlightEmph = self._parseLine(
             cnfParse, cnfSec, "highlightemph", self.CNF_BOOL, self.highlightEmph
         )
+        self.stopWhenIdle = self._parseLine(
+            cnfParse, cnfSec, "stopwhenidle", self.CNF_BOOL, self.stopWhenIdle
+        )
+        self.userIdleTime = self._parseLine(
+            cnfParse, cnfSec, "useridletime", self.CNF_INT, self.userIdleTime
+        )
 
         ## Backup
         cnfSec = "Backup"
@@ -672,6 +681,8 @@ class Config:
         cnfParse.set(cnfSec, "allowopensquote", str(self.allowOpenSQuote))
         cnfParse.set(cnfSec, "allowopendquote", str(self.allowOpenDQuote))
         cnfParse.set(cnfSec, "highlightemph",   str(self.highlightEmph))
+        cnfParse.set(cnfSec, "stopwhenidle",    str(self.stopWhenIdle))
+        cnfParse.set(cnfSec, "useridletime",    str(self.userIdleTime))
 
         ## Backup
         cnfSec = "Backup"

--- a/nw/core/options.py
+++ b/nw/core/options.py
@@ -47,6 +47,7 @@ class OptionState():
                 "widthCol0",
                 "widthCol1",
                 "widthCol2",
+                "widthCol3",
                 "sortCol",
                 "sortOrder",
                 "incNovel",

--- a/nw/core/options.py
+++ b/nw/core/options.py
@@ -55,6 +55,7 @@ class OptionState():
                 "hideZeros",
                 "hideNegative",
                 "groupByDay",
+                "showIdleTime",
                 "histMax",
             },
             "GuiDocSplit": {

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -726,12 +726,12 @@ class NWProject():
 
         return True
 
-    def closeProject(self):
+    def closeProject(self, idleTime=0):
         """Close the current project and clear all meta data.
         """
         self.optState.saveSettings()
         self.projTree.writeToCFile()
-        self._appendSessionStats()
+        self._appendSessionStats(idleTime)
         self._clearLockFile()
         self.clearProject()
         self.lockedBy = None
@@ -1389,7 +1389,7 @@ class NWProject():
 
         return True
 
-    def _appendSessionStats(self):
+    def _appendSessionStats(self, idleTime):
         """Append session statistics to the sessions log file.
         """
         if not self.ensureFolderStructure():
@@ -1404,15 +1404,16 @@ class NWProject():
                     # It's a new file, so add a header
                     if self.lastWCount > 0:
                         outFile.write("# Offset %d\n" % self.lastWCount)
-                    outFile.write("# %-17s  %-19s  %8s  %8s\n" % (
-                        "Start Time", "End Time", "Novel", "Notes"
+                    outFile.write("# %-17s  %-19s  %8s  %8s  %8s\n" % (
+                        "Start Time", "End Time", "Novel", "Notes", "Idle"
                     ))
 
-                outFile.write("%-19s  %-19s  %8d  %8d\n" % (
+                outFile.write("%-19s  %-19s  %8d  %8d  %8d\n" % (
                     formatTimeStamp(self.projOpened),
                     formatTimeStamp(time()),
                     self.novelWCount,
                     self.notesWCount,
+                    int(idleTime),
                 ))
 
         except Exception:

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -91,6 +91,7 @@ class GuiDocEditor(QTextEdit):
         self.wordCount  = 0     # Word count
         self.paraCount  = 0     # Paragraph count
         self.lastEdit   = 0     # Time stamp of last edit
+        self.lastActive = 0     # Time stamp of last activity
         self.lastFind   = None  # Position of the last found search word
         self.bigDoc     = False # Flag for very large document size
         self.doReplace  = False # Switch to temporarily disable auto-replace
@@ -169,15 +170,16 @@ class GuiDocEditor(QTextEdit):
         self.clear()
         self.wcTimer.stop()
 
-        self.theHandle = None
-        self.charCount = 0
-        self.wordCount = 0
-        self.paraCount = 0
-        self.lastEdit  = 0
-        self.lastFind  = None
-        self.bigDoc    = False
-        self.doReplace = False
-        self.queuePos  = None
+        self.theHandle  = None
+        self.charCount  = 0
+        self.wordCount  = 0
+        self.paraCount  = 0
+        self.lastEdit   = 0
+        self.lastActive = 0
+        self.lastFind   = None
+        self.bigDoc     = False
+        self.doReplace  = False
+        self.queuePos   = None
 
         self.setDocumentChanged(False)
         self.docHeader.setTitleFromHandle(self.theHandle)
@@ -319,6 +321,7 @@ class GuiDocEditor(QTextEdit):
         logger.debug("Document highlighted in %.3f ms" % (1000*(afTime-bfTime)))
 
         self.lastEdit = time()
+        self.lastActive = time()
         self._runCounter()
         self.wcTimer.start()
         self.theHandle = tHandle
@@ -722,6 +725,7 @@ class GuiDocEditor(QTextEdit):
             return False
 
         self._allowAutoReplace(True)
+        self.lastActive = time()
 
         return True
 
@@ -839,6 +843,7 @@ class GuiDocEditor(QTextEdit):
           * The undo/redo/select all sequences bypasses the docAction
             pathway from the menu, so we redirect them back from here.
         """
+        self.lastActive = time()
         isReturn  = keyEvent.key() == Qt.Key_Return
         isReturn |= keyEvent.key() == Qt.Key_Enter
         if isReturn and self.docSearch.anyFocus():
@@ -1083,7 +1088,7 @@ class GuiDocEditor(QTextEdit):
             logger.verbose("Word counter is busy")
             return
 
-        if time() - self.lastEdit < 5*self.wcInterval:
+        if time() - self.lastEdit < 5 * self.wcInterval:
             logger.verbose("Running word counter")
             self.theParent.threadPool.start(self.wCounter)
 

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -358,6 +358,33 @@ class GuiPreferencesProjects(QWidget):
             "If off, backups will run in the background."
         )
 
+        # Session Timer
+        # =============
+        self.mainForm.addGroupLabel("Session Timer")
+
+        ## Pause when idle
+        self.stopWhenIdle = QSwitch()
+        self.stopWhenIdle.setChecked(self.mainConf.stopWhenIdle)
+        self.mainForm.addRow(
+            "Pause the session timer when not writing",
+            self.stopWhenIdle,
+            "Also pauses when the application window does not have focus."
+        )
+
+        ## Inactive time for idle
+        self.userIdleTime = QDoubleSpinBox()
+        self.userIdleTime.setMinimum(0.5)
+        self.userIdleTime.setMaximum(600.0)
+        self.userIdleTime.setSingleStep(0.5)
+        self.userIdleTime.setDecimals(1)
+        self.userIdleTime.setValue(self.mainConf.userIdleTime/60.0)
+        self.mainForm.addRow(
+            "Editor inactive time before pausing timer",
+            self.userIdleTime,
+            "User activity includes typing and changing the content.",
+            theUnit="minutes"
+        )
+
         return
 
     def saveValues(self):
@@ -371,6 +398,10 @@ class GuiPreferencesProjects(QWidget):
         self.mainConf.backupPath      = self.backupPath
         self.mainConf.backupOnClose   = self.backupOnClose.isChecked()
         self.mainConf.askBeforeBackup = self.askBeforeBackup.isChecked()
+
+        # Session Timer
+        self.mainConf.stopWhenIdle = self.stopWhenIdle.isChecked()
+        self.mainConf.userIdleTime = round(self.userIdleTime.value() * 60)
 
         self.mainConf.confChanged = True
 

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -182,6 +182,9 @@ class GuiMainStatus(QStatusBar):
     def setUserIdle(self, userIdle):
         """Change the idle status icon.
         """
+        if not self.mainConf.stopWhenIdle:
+            userIdle = False
+
         if self.userIdle != userIdle:
             if userIdle:
                 self.timeIcon.setPixmap(self.idlePixmap)
@@ -198,7 +201,11 @@ class GuiMainStatus(QStatusBar):
         if self.refTime is None:
             self.timeText.setText("00:00:00")
         else:
-            self.timeText.setText(formatTime(round(time() - self.refTime - idleTime)))
+            if self.mainConf.stopWhenIdle:
+                sessTime = round(time() - self.refTime - idleTime)
+            else:
+                sessTime = round(time() - self.refTime)
+            self.timeText.setText(formatTime(sessTime))
         return
 
 # END Class GuiMainStatus

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -29,7 +29,6 @@ import logging
 
 from time import time
 
-from PyQt5.QtCore import QTimer
 from PyQt5.QtGui import QColor, QPainter
 from PyQt5.QtWidgets import qApp, QStatusBar, QLabel, QAbstractButton
 
@@ -110,12 +109,6 @@ class GuiMainStatus(QStatusBar):
         # Other Settings
         self.setSizeGripEnabled(True)
 
-        # Start the Clock
-        self.sessionTimer = QTimer()
-        self.sessionTimer.setInterval(1000)
-        self.sessionTimer.timeout.connect(self._updateTime)
-        self.sessionTimer.start()
-
         logger.debug("GuiMainStatus initialisation complete")
 
         self.clearStatus()
@@ -130,7 +123,7 @@ class GuiMainStatus(QStatusBar):
         self.setStats(0, 0)
         self.setProjectStatus(None)
         self.setDocumentStatus(None)
-        self._updateTime()
+        self.updateTime()
         return True
 
     ##
@@ -182,11 +175,7 @@ class GuiMainStatus(QStatusBar):
         self.statsText.setToolTip("Project word count (session change)")
         return
 
-    ##
-    #  Internal Functions
-    ##
-
-    def _updateTime(self):
+    def updateTime(self):
         """Update the session clock.
         """
         if self.refTime is None:

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -175,13 +175,13 @@ class GuiMainStatus(QStatusBar):
         self.statsText.setToolTip("Project word count (session change)")
         return
 
-    def updateTime(self):
+    def updateTime(self, idleTime=0.0):
         """Update the session clock.
         """
         if self.refTime is None:
             self.timeText.setText("00:00:00")
         else:
-            self.timeText.setText(formatTime(round(time() - self.refTime)))
+            self.timeText.setText(formatTime(round(time() - self.refTime - idleTime)))
         return
 
 # END Class GuiMainStatus

--- a/nw/gui/statusbar.py
+++ b/nw/gui/statusbar.py
@@ -48,6 +48,7 @@ class GuiMainStatus(QStatusBar):
         self.theParent = theParent
         self.theTheme  = theParent.theTheme
         self.refTime   = None
+        self.userIdle  = False
 
         colNone  = QColor(*self.theTheme.statNone)
         colTrue  = QColor(*self.theTheme.statUnsaved)
@@ -96,9 +97,12 @@ class GuiMainStatus(QStatusBar):
 
         ## The Session Clock
         ### Set the mimimum width so the label doesn't rescale every second
+        self.timePixmap = self.theTheme.getPixmap("status_time", (iPx, iPx))
+        self.idlePixmap = self.theTheme.getPixmap("status_idle", (iPx, iPx))
+
         self.timeIcon = QLabel()
         self.timeText = QLabel("")
-        self.timeIcon.setPixmap(self.theTheme.getPixmap("status_time", (iPx, iPx)))
+        self.timeIcon.setPixmap(self.timePixmap)
         self.timeText.setToolTip("Session Time")
         self.timeText.setMinimumWidth(self.theTheme.getTextWidth("00:00:00:"))
         self.timeIcon.setContentsMargins(0, 0, 0, 0)
@@ -173,6 +177,19 @@ class GuiMainStatus(QStatusBar):
         """
         self.statsText.setText(f"Words: {pWC:n} ({sWC:+n})")
         self.statsText.setToolTip("Project word count (session change)")
+        return
+
+    def setUserIdle(self, userIdle):
+        """Change the idle status icon.
+        """
+        if self.userIdle != userIdle:
+            if userIdle:
+                self.timeIcon.setPixmap(self.idlePixmap)
+            else:
+                self.timeIcon.setPixmap(self.timePixmap)
+
+            self.userIdle = userIdle
+
         return
 
     def updateTime(self, idleTime=0.0):

--- a/nw/gui/theme.py
+++ b/nw/gui/theme.py
@@ -539,6 +539,7 @@ class GuiIcons:
         "proj_nwx"        : (None, None),
         "status_lang"     : (None, None),
         "status_time"     : (None, None),
+        "status_idle"     : (None, None),
         "status_stats"    : (None, None),
         "status_lines"    : (None, None),
         "doc_h0"          : (QStyle.SP_FileIcon, "x-office-document"),

--- a/nw/gui/writingstats.py
+++ b/nw/gui/writingstats.py
@@ -204,17 +204,25 @@ class GuiWritingStats(QDialog):
         )
         self.groupByDay.clicked.connect(self._updateListBox)
 
+        self.showIdleTime = QSwitch(width=2*sPx, height=sPx)
+        self.showIdleTime.setChecked(
+            self.optState.getBool("GuiWritingStats", "showIdleTime", False)
+        )
+        self.showIdleTime.clicked.connect(self._idleTimeVisibility)
+
         self.filterForm.addWidget(QLabel("Count novel files"),        0, 0)
         self.filterForm.addWidget(QLabel("Count note files"),         1, 0)
         self.filterForm.addWidget(QLabel("Hide zero word count"),     2, 0)
         self.filterForm.addWidget(QLabel("Hide negative word count"), 3, 0)
         self.filterForm.addWidget(QLabel("Group entries by day"),     4, 0)
+        self.filterForm.addWidget(QLabel("Show idle time column"),    5, 0)
         self.filterForm.addWidget(self.incNovel,     0, 1)
         self.filterForm.addWidget(self.incNotes,     1, 1)
         self.filterForm.addWidget(self.hideZeros,    2, 1)
         self.filterForm.addWidget(self.hideNegative, 3, 1)
         self.filterForm.addWidget(self.groupByDay,   4, 1)
-        self.filterForm.setRowStretch(5, 1)
+        self.filterForm.addWidget(self.showIdleTime, 5, 1)
+        self.filterForm.setRowStretch(6, 1)
 
         # Settings
         self.histMax = QSpinBox(self)
@@ -263,6 +271,9 @@ class GuiWritingStats(QDialog):
 
         self.setLayout(self.outerBox)
 
+        # Finalise
+        self._idleTimeVisibility(None)
+
         logger.debug("GuiWritingStats initialisation complete")
 
         return
@@ -298,7 +309,11 @@ class GuiWritingStats(QDialog):
         hideZeros    = self.hideZeros.isChecked()
         hideNegative = self.hideNegative.isChecked()
         groupByDay   = self.groupByDay.isChecked()
+        showIdleTime = self.showIdleTime.isChecked()
         histMax      = self.histMax.value()
+
+        if not showIdleTime:
+            widthCol2 = 80
 
         self.optState.setValue("GuiWritingStats", "winWidth",     winWidth)
         self.optState.setValue("GuiWritingStats", "winHeight",    winHeight)
@@ -313,6 +328,7 @@ class GuiWritingStats(QDialog):
         self.optState.setValue("GuiWritingStats", "hideZeros",    hideZeros)
         self.optState.setValue("GuiWritingStats", "hideNegative", hideNegative)
         self.optState.setValue("GuiWritingStats", "groupByDay",   groupByDay)
+        self.optState.setValue("GuiWritingStats", "showIdleTime", showIdleTime)
         self.optState.setValue("GuiWritingStats", "histMax",      histMax)
 
         self.optState.saveSettings()
@@ -476,6 +492,16 @@ class GuiWritingStats(QDialog):
         self.totalWords.setText(f"{ttWords:n}")
 
         return True
+
+    ##
+    #  Slots
+    ##
+
+    def _idleTimeVisibility(self, dummyVar=None):
+        """
+        """
+        self.listBox.setColumnHidden(self.C_IDLE, not self.showIdleTime.isChecked())
+        return
 
     def _updateListBox(self, dummyVar=None):
         """Load/reload the content of the list box. The dummyVar

--- a/nw/gui/writingstats.py
+++ b/nw/gui/writingstats.py
@@ -313,7 +313,7 @@ class GuiWritingStats(QDialog):
         histMax      = self.histMax.value()
 
         if not showIdleTime:
-            widthCol2 = 80
+            widthCol2 = self.mainConf.pxInt(80)
 
         self.optState.setValue("GuiWritingStats", "winWidth",     winWidth)
         self.optState.setValue("GuiWritingStats", "winHeight",    winHeight)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -420,7 +420,7 @@ class GuiMain(QMainWindow):
             self.closeDocument()
             self.docViewer.clearNavHistory()
             self.projView.closeOutline()
-            self.theProject.closeProject()
+            self.theProject.closeProject(self.idleTime)
             self.theIndex.clearIndex()
             self.clearGUI()
             self.hasProject = False

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -86,6 +86,8 @@ class GuiMain(QMainWindow):
         self.theIndex    = NWIndex(self.theProject, self)
         self.hasProject  = False
         self.isFocusMode = False
+        self.userActive  = False
+        self.lastActive  = 0
 
         # Prepare Main Window
         self.resize(*self.mainConf.getWinSize())
@@ -240,6 +242,12 @@ class GuiMain(QMainWindow):
         # Set Up Auto-Save Document Timer
         self.asDocTimer = QTimer()
         self.asDocTimer.timeout.connect(self._autoSaveDocument)
+
+        # Main Clock
+        self.mainTimer = QTimer()
+        self.mainTimer.setInterval(1000)
+        self.mainTimer.timeout.connect(self._timeTick)
+        self.mainTimer.start()
 
         # Shortcuts and Actions
         self._connectMenuActions()
@@ -1413,6 +1421,13 @@ class GuiMain(QMainWindow):
     ##
     #  Slots
     ##
+
+    @pyqtSlot()
+    def _timeTick(self):
+        """Triggered on every tick of the timer.
+        """
+        self.statusBar.updateTime()
+        return
 
     @pyqtSlot()
     def _treeSingleClick(self):

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1437,6 +1437,9 @@ class GuiMain(QMainWindow):
 
         if editIdle or userIdle:
             self.idleTime += currTime - self.idleRefTime
+            self.statusBar.setUserIdle(True)
+        else:
+            self.statusBar.setUserIdle(False)
 
         self.idleRefTime = currTime
         self.statusBar.updateTime(idleTime=self.idleTime)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -420,7 +420,11 @@ class GuiMain(QMainWindow):
             self.closeDocument()
             self.docViewer.clearNavHistory()
             self.projView.closeOutline()
+
             self.theProject.closeProject(self.idleTime)
+            self.idleRefTime = time()
+            self.idleTime    = 0.0
+
             self.theIndex.clearIndex()
             self.clearGUI()
             self.hasProject = False
@@ -1432,7 +1436,7 @@ class GuiMain(QMainWindow):
             return
 
         currTime = time()
-        editIdle = currTime - self.docEditor.lastEdit > 30.0
+        editIdle = currTime - self.docEditor.lastActive > self.mainConf.userIdleTime
         userIdle = qApp.applicationState() != Qt.ApplicationActive
 
         if editIdle or userIdle:

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1440,7 +1440,6 @@ class GuiMain(QMainWindow):
 
         self.idleRefTime = currTime
         self.statusBar.updateTime(idleTime=self.idleTime)
-        # print(editIdle, userIdle, self.idleTime)
 
         return
 

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,12 +1,12 @@
 [Main]
-timestamp = 2020-10-11 22:50:45
+timestamp = 2021-02-09 21:07:03
 theme = default
 syntax = default_light
 icons = typicons_colour_light
 guidark = False
 guifont = 
 guifontsize = 11
-lastnotes = 1.0
+lastnotes = 0x0
 
 [Sizes]
 geometry = 1200, 650
@@ -56,6 +56,8 @@ highlightquotes = True
 allowopensquote = False
 allowopendquote = True
 highlightemph = True
+stopwhenidle = True
+useridletime = 300
 
 [Backup]
 backuppath = 

--- a/tests/reference/guiPreferences_novelwriter.conf
+++ b/tests/reference/guiPreferences_novelwriter.conf
@@ -1,18 +1,18 @@
 [Main]
-timestamp = 2020-06-29 17:34:15
+timestamp = 2021-02-09 21:07:17
 theme = default
 syntax = default_light
 icons = typicons_colour_light
 guidark = True
-guifont = Cantarell
+guifont = Sans
 guifontsize = 12
-lastnotes = 1.0
+lastnotes = 0x0
 
 [Sizes]
-geometry = 1100, 650
-treecols = 120, 30, 50
+geometry = 1200, 650
+treecols = 200, 50, 30
 novelcols = 200, 50
-projcols = 140, 55, 140
+projcols = 200, 60, 140
 mainpane = 300, 800
 docpane = 400, 400
 viewpane = 500, 150
@@ -26,7 +26,7 @@ autosaveproject = 40
 autosavedoc = 20
 
 [Editor]
-textfont = Cantarell
+textfont = None
 textsize = 13
 fixedwidth = False
 width = 700
@@ -56,6 +56,8 @@ highlightquotes = False
 allowopensquote = False
 allowopendquote = True
 highlightemph = False
+stopwhenidle = True
+useridletime = 300
 
 [Backup]
 backuppath = some/dir

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -859,12 +859,12 @@ def testCoreProject_Methods(monkeypatch, nwMinimal, dummyGUI, tmpDir):
 
     # Session stats
     monkeypatch.setattr("os.path.isdir", lambda *args, **kwargs: False)
-    assert not theProject._appendSessionStats()
+    assert not theProject._appendSessionStats(idleTime=0)
     monkeypatch.undo()
 
     # Block open
     monkeypatch.setattr("builtins.open", causeOSError)
-    assert not theProject._appendSessionStats()
+    assert not theProject._appendSessionStats(idleTime=0)
     monkeypatch.undo()
 
     # Write entry
@@ -876,13 +876,13 @@ def testCoreProject_Methods(monkeypatch, nwMinimal, dummyGUI, tmpDir):
     theProject.notesWCount = 100
 
     monkeypatch.setattr("nw.core.project.time", lambda: 1600005600)
-    assert theProject._appendSessionStats()
+    assert theProject._appendSessionStats(idleTime=99)
     monkeypatch.undo()
 
     assert readFile(statsFile) == (
         "# Offset 100\n"
-        "# Start Time         End Time                Novel     Notes\n"
-        "%s  %s       200       100\n"
+        "# Start Time         End Time                Novel     Notes      Idle\n"
+        "%s  %s       200       100        99\n"
     ) % (formatTimeStamp(1600002000), formatTimeStamp(1600005600))
 
     # Pack XML Value

--- a/tests/test_gui/test_gui_writingstats.py
+++ b/tests/test_gui/test_gui_writingstats.py
@@ -101,17 +101,17 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
 
     writeFile(sessFile, (
         "# Offset 1075\n"
-        "# Start Time         End Time                Novel     Notes\n"
-        "2021-01-31 19:00:00  2021-01-31 19:30:00       700       375\n"
-        "2021-02-01 19:00:00  2021-02-01 19:30:00       700       375\n"
-        "2021-02-01 20:00:00  2021-02-01 20:30:00       600       275\n"
-        "2021-02-02 19:00:00  2021-02-02 19:30:00       750       425\n"
-        "2021-02-02 20:00:00  2021-02-02 20:30:00       690       365\n"
-        "2021-02-03 19:00:00  2021-02-03 19:30:00       680       355\n"
-        "2021-02-04 19:00:00  2021-02-04 19:30:00       700       375\n"
-        "2021-02-05 19:00:00  2021-02-05 19:30:00       500       175\n"
-        "2021-02-06 19:00:00  2021-02-06 19:30:00       600       275\n"
-        "2021-02-07 19:00:00  2021-02-07 19:30:00       600       275\n"
+        "# Start Time         End Time                Novel     Notes      Idle\n"
+        "2021-01-31 19:00:00  2021-01-31 19:30:00       700       375         0\n"
+        "2021-02-01 19:00:00  2021-02-01 19:30:00       700       375        10\n"
+        "2021-02-01 20:00:00  2021-02-01 20:30:00       600       275        20\n"
+        "2021-02-02 19:00:00  2021-02-02 19:30:00       750       425        30\n"
+        "2021-02-02 20:00:00  2021-02-02 20:30:00       690       365        40\n"
+        "2021-02-03 19:00:00  2021-02-03 19:30:00       680       355        50\n"
+        "2021-02-04 19:00:00  2021-02-04 19:30:00       700       375        60\n"
+        "2021-02-05 19:00:00  2021-02-05 19:30:00       500       175        70\n"
+        "2021-02-06 19:00:00  2021-02-06 19:30:00       600       275        80\n"
+        "2021-02-07 19:00:00  2021-02-07 19:30:00       600       275        90\n"
     ))
     sessLog.populateGUI()
 
@@ -156,28 +156,28 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData == [
         {
             "date": "2021-01-31 19:00:00", "length": 1800.0,
-            "newWords": 1, "novelWords": 700, "noteWords": 375
+            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 0
         }, {
             "date": "2021-02-01 20:00:00", "length": 1800.0,
-            "newWords": -200, "novelWords": 600, "noteWords": 275
+            "newWords": -200, "novelWords": 600, "noteWords": 275, "idleTime": 20
         }, {
             "date": "2021-02-02 19:00:00", "length": 1800.0,
-            "newWords": 300, "novelWords": 750, "noteWords": 425
+            "newWords": 300, "novelWords": 750, "noteWords": 425, "idleTime": 30
         }, {
             "date": "2021-02-02 20:00:00", "length": 1800.0,
-            "newWords": -120, "novelWords": 690, "noteWords": 365
+            "newWords": -120, "novelWords": 690, "noteWords": 365, "idleTime": 40
         }, {
             "date": "2021-02-03 19:00:00", "length": 1800.0,
-            "newWords": -20, "novelWords": 680, "noteWords": 355
+            "newWords": -20, "novelWords": 680, "noteWords": 355, "idleTime": 50
         }, {
             "date": "2021-02-04 19:00:00", "length": 1800.0,
-            "newWords": 40, "novelWords": 700, "noteWords": 375
+            "newWords": 40, "novelWords": 700, "noteWords": 375, "idleTime": 60
         }, {
             "date": "2021-02-05 19:00:00", "length": 1800.0,
-            "newWords": -400, "novelWords": 500, "noteWords": 175
+            "newWords": -400, "novelWords": 500, "noteWords": 175, "idleTime": 70
         }, {
             "date": "2021-02-06 19:00:00", "length": 1800.0,
-            "newWords": 200, "novelWords": 600, "noteWords": 275
+            "newWords": 200, "novelWords": 600, "noteWords": 275, "idleTime": 80
         }
     ]
 
@@ -206,28 +206,28 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData == [
         {
             "date": "2021-01-31 19:00:00", "length": 1800.0,
-            "newWords": 1, "novelWords": 700, "noteWords": 375
+            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 0
         }, {
             "date": "2021-02-01 20:00:00", "length": 1800.0,
-            "newWords": -100, "novelWords": 600, "noteWords": 275
+            "newWords": -100, "novelWords": 600, "noteWords": 275, "idleTime": 20
         }, {
             "date": "2021-02-02 19:00:00", "length": 1800.0,
-            "newWords": 150, "novelWords": 750, "noteWords": 425
+            "newWords": 150, "novelWords": 750, "noteWords": 425, "idleTime": 30
         }, {
             "date": "2021-02-02 20:00:00", "length": 1800.0,
-            "newWords": -60, "novelWords": 690, "noteWords": 365
+            "newWords": -60, "novelWords": 690, "noteWords": 365, "idleTime": 40
         }, {
             "date": "2021-02-03 19:00:00", "length": 1800.0,
-            "newWords": -10, "novelWords": 680, "noteWords": 355
+            "newWords": -10, "novelWords": 680, "noteWords": 355, "idleTime": 50
         }, {
             "date": "2021-02-04 19:00:00", "length": 1800.0,
-            "newWords": 20, "novelWords": 700, "noteWords": 375
+            "newWords": 20, "novelWords": 700, "noteWords": 375, "idleTime": 60
         }, {
             "date": "2021-02-05 19:00:00", "length": 1800.0,
-            "newWords": -200, "novelWords": 500, "noteWords": 175
+            "newWords": -200, "novelWords": 500, "noteWords": 175, "idleTime": 70
         }, {
             "date": "2021-02-06 19:00:00", "length": 1800.0,
-            "newWords": 100, "novelWords": 600, "noteWords": 275
+            "newWords": 100, "novelWords": 600, "noteWords": 275, "idleTime": 80
         }
     ]
 
@@ -254,28 +254,28 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData == [
         {
             "date": "2021-01-31 19:00:00", "length": 1800.0,
-            "newWords": 1, "novelWords": 700, "noteWords": 375
+            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 0
         }, {
             "date": "2021-02-01 20:00:00", "length": 1800.0,
-            "newWords": -100, "novelWords": 600, "noteWords": 275
+            "newWords": -100, "novelWords": 600, "noteWords": 275, "idleTime": 20
         }, {
             "date": "2021-02-02 19:00:00", "length": 1800.0,
-            "newWords": 150, "novelWords": 750, "noteWords": 425
+            "newWords": 150, "novelWords": 750, "noteWords": 425, "idleTime": 30
         }, {
             "date": "2021-02-02 20:00:00", "length": 1800.0,
-            "newWords": -60, "novelWords": 690, "noteWords": 365
+            "newWords": -60, "novelWords": 690, "noteWords": 365, "idleTime": 40
         }, {
             "date": "2021-02-03 19:00:00", "length": 1800.0,
-            "newWords": -10, "novelWords": 680, "noteWords": 355
+            "newWords": -10, "novelWords": 680, "noteWords": 355, "idleTime": 50
         }, {
             "date": "2021-02-04 19:00:00", "length": 1800.0,
-            "newWords": 20, "novelWords": 700, "noteWords": 375
+            "newWords": 20, "novelWords": 700, "noteWords": 375, "idleTime": 60
         }, {
             "date": "2021-02-05 19:00:00", "length": 1800.0,
-            "newWords": -200, "novelWords": 500, "noteWords": 175
+            "newWords": -200, "novelWords": 500, "noteWords": 175, "idleTime": 70
         }, {
             "date": "2021-02-06 19:00:00", "length": 1800.0,
-            "newWords": 100, "novelWords": 600, "noteWords": 275
+            "newWords": 100, "novelWords": 600, "noteWords": 275, "idleTime": 80
         }
     ]
 
@@ -300,16 +300,16 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData == [
         {
             "date": "2021-01-31 19:00:00", "length": 1800.0,
-            "newWords": 1, "novelWords": 700, "noteWords": 375
+            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 0
         }, {
             "date": "2021-02-02 19:00:00", "length": 1800.0,
-            "newWords": 300, "novelWords": 750, "noteWords": 425
+            "newWords": 300, "novelWords": 750, "noteWords": 425, "idleTime": 30
         }, {
             "date": "2021-02-04 19:00:00", "length": 1800.0,
-            "newWords": 40, "novelWords": 700, "noteWords": 375
+            "newWords": 40, "novelWords": 700, "noteWords": 375, "idleTime": 60
         }, {
             "date": "2021-02-06 19:00:00", "length": 1800.0,
-            "newWords": 200, "novelWords": 600, "noteWords": 275
+            "newWords": 200, "novelWords": 600, "noteWords": 275, "idleTime": 80
         }
     ]
 
@@ -338,34 +338,34 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData == [
         {
             "date": "2021-01-31 19:00:00", "length": 1800.0,
-            "newWords": 1, "novelWords": 700, "noteWords": 375
+            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 0
         }, {
             "date": "2021-02-01 19:00:00", "length": 1800.0,
-            "newWords": 0, "novelWords": 700, "noteWords": 375
+            "newWords": 0, "novelWords": 700, "noteWords": 375, "idleTime": 10
         }, {
             "date": "2021-02-01 20:00:00", "length": 1800.0,
-            "newWords": -200, "novelWords": 600, "noteWords": 275
+            "newWords": -200, "novelWords": 600, "noteWords": 275, "idleTime": 20
         }, {
             "date": "2021-02-02 19:00:00", "length": 1800.0,
-            "newWords": 300, "novelWords": 750, "noteWords": 425
+            "newWords": 300, "novelWords": 750, "noteWords": 425, "idleTime": 30
         }, {
             "date": "2021-02-02 20:00:00", "length": 1800.0,
-            "newWords": -120, "novelWords": 690, "noteWords": 365
+            "newWords": -120, "novelWords": 690, "noteWords": 365, "idleTime": 40
         }, {
             "date": "2021-02-03 19:00:00", "length": 1800.0,
-            "newWords": -20, "novelWords": 680, "noteWords": 355
+            "newWords": -20, "novelWords": 680, "noteWords": 355, "idleTime": 50
         }, {
             "date": "2021-02-04 19:00:00", "length": 1800.0,
-            "newWords": 40, "novelWords": 700, "noteWords": 375
+            "newWords": 40, "novelWords": 700, "noteWords": 375, "idleTime": 60
         }, {
             "date": "2021-02-05 19:00:00", "length": 1800.0,
-            "newWords": -400, "novelWords": 500, "noteWords": 175
+            "newWords": -400, "novelWords": 500, "noteWords": 175, "idleTime": 70
         }, {
             "date": "2021-02-06 19:00:00", "length": 1800.0,
-            "newWords": 200, "novelWords": 600, "noteWords": 275
+            "newWords": 200, "novelWords": 600, "noteWords": 275, "idleTime": 80
         }, {
             "date": "2021-02-07 19:00:00", "length": 1800.0,
-            "newWords": 0, "novelWords": 600, "noteWords": 275
+            "newWords": 0, "novelWords": 600, "noteWords": 275, "idleTime": 90
         }
     ]
 
@@ -391,28 +391,28 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData == [
         {
             "date": "2021-01-31", "length": 1800.0,
-            "newWords": 1, "novelWords": 700, "noteWords": 375
+            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 10
         }, {
             "date": "2021-02-01", "length": 3600.0,
-            "newWords": -200, "novelWords": 600, "noteWords": 275
+            "newWords": -200, "novelWords": 600, "noteWords": 275, "idleTime": 30
         }, {
             "date": "2021-02-02", "length": 3600.0,
-            "newWords": 180, "novelWords": 690, "noteWords": 365
+            "newWords": 180, "novelWords": 690, "noteWords": 365, "idleTime": 50
         }, {
             "date": "2021-02-03", "length": 1800.0,
-            "newWords": -20, "novelWords": 680, "noteWords": 355
+            "newWords": -20, "novelWords": 680, "noteWords": 355, "idleTime": 60
         }, {
             "date": "2021-02-04", "length": 1800.0,
-            "newWords": 40, "novelWords": 700, "noteWords": 375
+            "newWords": 40, "novelWords": 700, "noteWords": 375, "idleTime": 70
         }, {
             "date": "2021-02-05", "length": 1800.0,
-            "newWords": -400, "novelWords": 500, "noteWords": 175
+            "newWords": -400, "novelWords": 500, "noteWords": 175, "idleTime": 80
         }, {
             "date": "2021-02-06", "length": 1800.0,
-            "newWords": 200, "novelWords": 600, "noteWords": 275
+            "newWords": 200, "novelWords": 600, "noteWords": 275, "idleTime": 90
         }, {
             "date": "2021-02-07", "length": 1800.0,
-            "newWords": 0, "novelWords": 600, "noteWords": 275
+            "newWords": 0, "novelWords": 600, "noteWords": 275, "idleTime": 90
         }
     ]
 

--- a/tests/test_gui/test_gui_writingstats.py
+++ b/tests/test_gui/test_gui_writingstats.py
@@ -72,7 +72,7 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     # Make a test log file
     writeFile(sessFile, (
         "# Offset 123\n"
-        "# Start Time         End Time                Novel     Notes\n"
+        "# Start Time         End Time                Novel     Notes      Idle\n"
         "2020-01-01 21:00:00  2020-01-01 21:00:05         6         0\n"
         "2020-01-03 21:00:00  2020-01-03 21:00:15       125         0\n"
         "2020-01-03 21:30:00  2020-01-03 21:30:15       125         5\n"
@@ -86,8 +86,8 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     # Make sure a faulty file can still be read
     writeFile(sessFile, (
         "# Offset abc123\n"
-        "# Start Time         End Time                Novel     Notes\n"
-        "2020-01-01 21:00:00  2020-01-01 21:00:05         6         0\n"
+        "# Start Time         End Time                Novel     Notes      Idle\n"
+        "2020-01-01 21:00:00  2020-01-01 21:00:05         6         0        50\n"
         "2020-01-03 21:00:00  2020-01-03 21:00:15       125         0\n"
         "2020-01-03 21:30:00  2020-01-03 21:30:15       125         5\n"
         "2020-01-06 21:00:00  2020-01-06 21:00:10       125\n"
@@ -100,8 +100,8 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     # ==============
 
     writeFile(sessFile, (
-        "# Start Time         End Time                Novel     Notes\n"
-        "2020-01-01 21:00:00  2020-01-01 21:00:05         6         0\n"
+        "# Start Time         End Time                Novel     Notes      Idle\n"
+        "2020-01-01 21:00:00  2020-01-01 21:00:05         6         0        50\n"
         "2020-01-03 21:00:00  2020-01-03 21:00:15       125         0\n"
         "2020-01-03 21:30:00  2020-01-03 21:30:15       125         5\n"
         "2020-01-06 21:00:00  2020-01-06 21:00:10       125         5\n"
@@ -133,10 +133,17 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
         jsonData = json.load(inFile)
 
     assert len(jsonData) == 4
+    assert jsonData[0]["length"] >= 4.0
+    assert jsonData[0]["newWords"] == 6
+    assert jsonData[0]["novelWords"] == 6
+    assert jsonData[0]["noteWords"] == 0
+    assert jsonData[0]["idleTime"] == 50
+
     assert jsonData[1]["length"] >= 14.0
     assert jsonData[1]["newWords"] == 119
     assert jsonData[1]["novelWords"] == 125
     assert jsonData[1]["noteWords"] == 0
+    assert jsonData[1]["idleTime"] == 0
 
     # Test Filters
     # ============
@@ -160,6 +167,7 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData[0]["newWords"] == 5
     assert jsonData[0]["novelWords"] == 125
     assert jsonData[0]["noteWords"] == 5
+    assert jsonData[0]["idleTime"] == 0
 
     # No Note Files
     qtbot.mouseClick(sessLog.incNovel, Qt.LeftButton)
@@ -177,6 +185,7 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData[1]["newWords"] == 119
     assert jsonData[1]["novelWords"] == 125
     assert jsonData[1]["noteWords"] == 0
+    assert jsonData[1]["idleTime"] == 0
 
     # No Negative Entries
     qtbot.mouseClick(sessLog.incNotes, Qt.LeftButton)


### PR DESCRIPTION
This PR adds code to keep track of idle time during a writing session. The idle time is recorded as a seventh column in the session log file and displayed as a new column in the Writing Stats dialog.