### PR TITLE
Fix idle Time in Writing Stats

### DIFF
--- a/nw/gui/writingstats.py
+++ b/nw/gui/writingstats.py
@@ -511,7 +511,7 @@ class GuiWritingStats(QDialog):
             tempData = []
             sessDate = None
             sessTime = 0
-            sIdle = 0
+            sessIdle = 0
             lstNovel = 0
             lstNotes = 0
 
@@ -519,20 +519,20 @@ class GuiWritingStats(QDialog):
                 if n == 0:
                     sessDate = dStart.date()
                 if sessDate != dStart.date():
-                    tempData.append((sessDate, sessTime, lstNovel, lstNotes, sIdle))
+                    tempData.append((sessDate, sessTime, lstNovel, lstNotes, sessIdle))
                     sessDate = dStart.date()
                     sessTime = sDiff
-                    sIdle = sIdle
+                    sessIdle = sIdle
                     lstNovel = wcNovel
                     lstNotes = wcNotes
                 else:
                     sessTime += sDiff
-                    sIdle += sIdle
+                    sessIdle += sIdle
                     lstNovel = wcNovel
                     lstNotes = wcNotes
 
             if sessDate is not None:
-                tempData.append((sessDate, sessTime, lstNovel, lstNotes, sIdle))
+                tempData.append((sessDate, sessTime, lstNovel, lstNotes, sessIdle))
 
         else:
             tempData = self.logData

--- a/tests/test_gui/test_gui_writingstats.py
+++ b/tests/test_gui/test_gui_writingstats.py
@@ -391,25 +391,25 @@ def testGuiWritingStats_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert jsonData == [
         {
             "date": "2021-01-31", "length": 1800.0,
-            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 10
+            "newWords": 1, "novelWords": 700, "noteWords": 375, "idleTime": 0
         }, {
             "date": "2021-02-01", "length": 3600.0,
             "newWords": -200, "novelWords": 600, "noteWords": 275, "idleTime": 30
         }, {
             "date": "2021-02-02", "length": 3600.0,
-            "newWords": 180, "novelWords": 690, "noteWords": 365, "idleTime": 50
+            "newWords": 180, "novelWords": 690, "noteWords": 365, "idleTime": 70
         }, {
             "date": "2021-02-03", "length": 1800.0,
-            "newWords": -20, "novelWords": 680, "noteWords": 355, "idleTime": 60
+            "newWords": -20, "novelWords": 680, "noteWords": 355, "idleTime": 50
         }, {
             "date": "2021-02-04", "length": 1800.0,
-            "newWords": 40, "novelWords": 700, "noteWords": 375, "idleTime": 70
+            "newWords": 40, "novelWords": 700, "noteWords": 375, "idleTime": 60
         }, {
             "date": "2021-02-05", "length": 1800.0,
-            "newWords": -400, "novelWords": 500, "noteWords": 175, "idleTime": 80
+            "newWords": -400, "novelWords": 500, "noteWords": 175, "idleTime": 70
         }, {
             "date": "2021-02-06", "length": 1800.0,
-            "newWords": 200, "novelWords": 600, "noteWords": 275, "idleTime": 90
+            "newWords": 200, "novelWords": 600, "noteWords": 275, "idleTime": 80
         }, {
             "date": "2021-02-07", "length": 1800.0,
             "newWords": 0, "novelWords": 600, "noteWords": 275, "idleTime": 90


### PR DESCRIPTION
The total idle time when grouping writing statistics by day was summed up wrong. This fixes the calculation and updates the test to check these values correctly.