### PR TITLE
Simple Spell Check Speedup

### DIFF
--- a/nw/core/spellcheck.py
+++ b/nw/core/spellcheck.py
@@ -238,7 +238,7 @@ class NWSpellSimple(NWSpellCheck):
     when no other is available. This method is fairly slow compared to
     other implementations.
     """
-    WORDS = []
+    theWords = set()
 
     def __init__(self):
         NWSpellCheck.__init__(self)
@@ -250,17 +250,19 @@ class NWSpellSimple(NWSpellCheck):
         """Load a dictionary as a list from the app assets folder.
         """
         self.theLang = theLang
-        self.WORDS = []
+        self.theWords = set()
         dictFile = os.path.join(self.mainConf.dictPath, theLang+".dict")
         try:
             with open(dictFile, mode="r", encoding="utf-8") as wordsFile:
                 for theLine in wordsFile:
                     if len(theLine) == 0 or theLine.startswith("#"):
                         continue
-                    self.WORDS.append(theLine.strip().lower())
-            logger.debug("Spell check word list for language %s loaded" % theLang)
-            logger.debug("Word list contains %d words" % len(self.WORDS))
+                    self.theWords.add(theLine.strip().lower())
+
+            logger.debug("Spell check dictionary for language %s loaded" % theLang)
+            logger.debug("Dictionary contains %d words" % len(self.theWords))
             self.spellLanguage = theLang
+
         except Exception as e:
             logger.error("Failed to load spell check word list for language %s" % theLang)
             logger.error(str(e))
@@ -268,8 +270,7 @@ class NWSpellSimple(NWSpellCheck):
 
         self._readProjectDictionary(projectDict)
         for pWord in self.projDict:
-            if pWord not in self.WORDS:
-                self.WORDS.append(pWord)
+            self.theWords.add(pWord)
 
         return
 
@@ -279,7 +280,7 @@ class NWSpellSimple(NWSpellCheck):
         word by the syntax highlighter.
         """
         theWord = theWord.replace(self.mainConf.fmtApostrophe, "'").lower()
-        return theWord in self.WORDS
+        return theWord in self.theWords
 
     def suggestWords(self, theWord):
         """Get suggestions for correct word from difflib, and make sure
@@ -292,7 +293,7 @@ class NWSpellSimple(NWSpellCheck):
         if len(theWord) == 0:
             return []
 
-        theMatches = difflib.get_close_matches(theWord.lower(), self.WORDS, n=10, cutoff=0.75)
+        theMatches = difflib.get_close_matches(theWord.lower(), self.theWords, n=10, cutoff=0.75)
         theOptions = []
         for aWord in theMatches:
             if len(aWord) == 0:
@@ -308,8 +309,8 @@ class NWSpellSimple(NWSpellCheck):
         """Wrapper for the internal project dictionary feature.
         """
         newWord = newWord.strip().lower()
-        if newWord not in self.WORDS:
-            self.WORDS.append(newWord)
+        if newWord not in self.theWords:
+            self.theWords.add(newWord)
         NWSpellCheck.addWord(self, newWord)
         return
 

--- a/tests/test_core/test_core_spell.py
+++ b/tests/test_core/test_core_spell.py
@@ -139,13 +139,13 @@ def testCoreSpell_Simple(monkeypatch, tmpDir, tmpConf):
     monkeypatch.setattr("builtins.open", causeOSError)
     spChk.setLanguage("en", wList)
     assert spChk.spellLanguage is None
-    assert spChk.WORDS == spChk.projDict
+    assert spChk.theWords == set(spChk.projDict)
     monkeypatch.undo()
 
     # Load dictionary properly
     spChk.setLanguage("en", wList)
     assert spChk.projDict == ["a_word", "b_word", "c_word"]
-    assert spChk.WORDS == ["e_word", "f_word", "g_word", "a_word", "b_word", "c_word"]
+    assert spChk.theWords == set(["e_word", "f_word", "g_word", "a_word", "b_word", "c_word"])
 
     # Check words
     assert spChk.checkWord("a_word")

--- a/tests/test_core/test_core_spell.py
+++ b/tests/test_core/test_core_spell.py
@@ -145,7 +145,7 @@ def testCoreSpell_Simple(monkeypatch, tmpDir, tmpConf):
     # Load dictionary properly
     spChk.setLanguage("en", wList)
     assert spChk.projDict == ["a_word", "b_word", "c_word"]
-    assert spChk.theWords == set(["e_word", "f_word", "g_word", "a_word", "b_word", "c_word"])
+    assert spChk.theWords == {"e_word", "f_word", "g_word", "a_word", "b_word", "c_word"}
 
     # Check words
     assert spChk.checkWord("a_word")


### PR DESCRIPTION
It turns out the difflib that is used for simple spell checking can accept any hashable, iterable object as the check list. This PR changes the loaded dictionary from a list to a set, which is pre-hashed, making lookups significantly faster. Spell checking a large file with the simple checker is now an order of magnitude faster.