### PR TITLE
Drop short sessions from the log file

### DIFF
--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -714,7 +714,8 @@ class NWIndex():
         for refTitle in self._refIndex[tHandle]:
             for aTag in self._refIndex[tHandle][refTitle].get("tags", []):
                 if len(aTag) == 3 and (sTitle is None or sTitle == refTitle):
-                    theRefs[aTag[1]].append(aTag[2])
+                    if aTag[1] in theRefs: # Future-compatible. Check can be removed in 1.2.
+                        theRefs[aTag[1]].append(aTag[2])
 
         return theRefs
 

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -1398,6 +1398,15 @@ class NWProject():
         sessionFile = os.path.join(self.projMeta, nwFiles.SESS_STATS)
         isFile = os.path.isfile(sessionFile)
 
+        nowTime = time()
+        sessDiff = self.getSessionWordCount()
+        sessTime = nowTime - self.projOpened
+
+        logger.info("The session lasted %d sec and added %d words" % (int(sessTime), sessDiff))
+        if sessTime < 300 and sessDiff == 0:
+            logger.info("Session too short, skipping log entry")
+            return False
+
         try:
             with open(sessionFile, mode="a+", encoding="utf8") as outFile:
                 if not isFile:
@@ -1410,7 +1419,7 @@ class NWProject():
 
                 outFile.write("%-19s  %-19s  %8d  %8d\n" % (
                     formatTimeStamp(self.projOpened),
-                    formatTimeStamp(time()),
+                    formatTimeStamp(nowTime),
                     self.novelWCount,
                     self.notesWCount,
                 ))

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -1073,7 +1073,6 @@ def testCoreProject_OldFormat(dummyGUI, nwOldProj):
 
     # Check that new files have been created
     assert os.path.isfile(os.path.join(nwOldProj, "meta", "guiOptions.json"))
-    assert os.path.isfile(os.path.join(nwOldProj, "meta", "sessionStats.log"))
     assert os.path.isfile(os.path.join(nwOldProj, "ToC.txt"))
 
 # END Test testCoreProject_OldFormat


### PR DESCRIPTION
There is no point logging a writing session where the user just opened the project and closed it again without making any changes.

This PR adds a check to the session entry code skip appending a line if the session was shorter than 5 minutes and no word count difference was recorded. Both conditions must be true.