### PR TITLE
Make settings layouts more responsive

### DIFF
--- a/nw/common.py
+++ b/nw/common.py
@@ -167,7 +167,7 @@ def colRange(rgbStart, rgbEnd, nStep):
         cA = rgbStart[c]
         cB = rgbEnd[c]
         dC[c] = (cB-cA)/(nStep-1)
-    print(dC)
+
     retCol = [rgbStart]
     for n in range(nStep):
         if n > 0 and n < nStep:
@@ -177,7 +177,6 @@ def colRange(rgbStart, rgbEnd, nStep):
                 int(retCol[n-1][2] + dC[2]),
             ])
     retCol[-1] = rgbEnd
-    print(retCol)
 
     return retCol
 

--- a/nw/config.py
+++ b/nw/config.py
@@ -104,6 +104,7 @@ class Config:
 
         ## Sizes
         self.winGeometry   = [1200, 650]
+        self.prefGeometry  = [700, 615]
         self.treeColWidth  = [200, 50, 30]
         self.novelColWidth = [200, 50]
         self.projColWidth  = [200, 60, 140]
@@ -472,6 +473,9 @@ class Config:
         self.winGeometry = self._parseLine(
             cnfParse, cnfSec, "geometry", self.CNF_I_LST, self.winGeometry
         )
+        self.prefGeometry = self._parseLine(
+            cnfParse, cnfSec, "preferences", self.CNF_I_LST, self.prefGeometry
+        )
         self.treeColWidth = self._parseLine(
             cnfParse, cnfSec, "treecols", self.CNF_I_LST, self.treeColWidth
         )
@@ -701,6 +705,7 @@ class Config:
         cnfSec = "Sizes"
         cnfParse.add_section(cnfSec)
         cnfParse.set(cnfSec, "geometry",    self._packList(self.winGeometry))
+        cnfParse.set(cnfSec, "preferences", self._packList(self.prefGeometry))
         cnfParse.set(cnfSec, "treecols",    self._packList(self.treeColWidth))
         cnfParse.set(cnfSec, "novelcols",   self._packList(self.novelColWidth))
         cnfParse.set(cnfSec, "projcols",    self._packList(self.projColWidth))
@@ -921,6 +926,12 @@ class Config:
             self.confChanged = True
         return True
 
+    def setPreferencesSize(self, newWidth, newHeight):
+        self.prefGeometry[0] = int(newWidth/self.guiScale)
+        self.prefGeometry[1] = int(newHeight/self.guiScale)
+        self.confChanged = True
+        return True
+
     def setTreeColWidths(self, colWidths):
         self.treeColWidth = [int(x/self.guiScale) for x in colWidths]
         self.confChanged = True
@@ -983,6 +994,9 @@ class Config:
 
     def getWinSize(self):
         return [int(x*self.guiScale) for x in self.winGeometry]
+
+    def getPreferencesSize(self):
+        return [int(x*self.guiScale) for x in self.prefGeometry]
 
     def getTreeColWidths(self):
         return [int(x*self.guiScale) for x in self.treeColWidth]

--- a/nw/gui/custom.py
+++ b/nw/gui/custom.py
@@ -36,7 +36,8 @@ from PyQt5.QtCore import (
 from PyQt5.QtWidgets import (
     QGridLayout, QLabel, QWidget, QVBoxLayout, QHBoxLayout, QSizePolicy,
     QAbstractButton, QDialog, QTabWidget, QTabBar, QStyle, QDialogButtonBox,
-    QStylePainter, QStyleOptionTab, QListWidget, QListWidgetItem, QFrame
+    QStylePainter, QStyleOptionTab, QListWidget, QListWidgetItem, QFrame,
+    QLineEdit
 )
 
 from nw.constants import trConst, nwUnicode, nwQuotes
@@ -61,6 +62,7 @@ class QConfigLayout(QGridLayout):
         wSp = nw.CONFIG.pxInt(8)
         self.setHorizontalSpacing(wSp)
         self.setVerticalSpacing(wSp)
+        self.setColumnStretch(0, 1)
 
         return
 
@@ -151,6 +153,7 @@ class QConfigLayout(QGridLayout):
             labelBox.addWidget(qLabel)
             labelBox.addWidget(qHelp)
             labelBox.setSpacing(0)
+            labelBox.addStretch(1)
 
             thisEntry["help"] = qHelp
             self.addLayout(labelBox, self._nextRow, 0, 1, 1, Qt.AlignLeft | Qt.AlignTop)
@@ -163,15 +166,22 @@ class QConfigLayout(QGridLayout):
             controlBox.addWidget(qWidget, 0, Qt.AlignVCenter)
             controlBox.addWidget(QLabel(theUnit), 0, Qt.AlignVCenter)
             controlBox.setSpacing(wSp)
-            self.addLayout(controlBox, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignVCenter)
+            self.addLayout(controlBox, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignTop)
+
         elif theButton is not None:
             controlBox = QHBoxLayout()
             controlBox.addWidget(qWidget, 0, Qt.AlignVCenter)
             controlBox.addWidget(theButton, 0, Qt.AlignVCenter)
             controlBox.setSpacing(wSp)
-            self.addLayout(controlBox, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignVCenter)
+            self.addLayout(controlBox, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignTop)
+
         else:
-            self.addWidget(qWidget, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignVCenter)
+            if isinstance(theWidget, QLineEdit):
+                qLayout = QHBoxLayout()
+                qLayout.addWidget(theWidget)
+                self.addLayout(qLayout, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignTop)
+            else:
+                self.addWidget(qWidget, self._nextRow, 1, 1, 1, Qt.AlignRight | Qt.AlignTop)
 
         qLabel.setBuddy(qWidget)
 
@@ -206,6 +216,9 @@ class QHelpLabel(QLabel):
         lblFont = self.font()
         lblFont.setPointSizeF(fontSize*lblFont.pointSizeF())
         self.setFont(lblFont)
+
+        self.setWordWrap(True)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         return
 
@@ -409,6 +422,7 @@ class VerticalTabBar(QTabBar):
 
     def __init__(self, theParent=None):
         QTabBar.__init__(self, parent=theParent)
+        self._mW = nw.CONFIG.pxInt(150)
         return
 
     def tabSizeHint(self, theIndex):
@@ -416,6 +430,7 @@ class VerticalTabBar(QTabBar):
         """
         tSize = QTabBar.tabSizeHint(self, theIndex)
         tSize.transpose()
+        tSize.setWidth(min(tSize.width(), self._mW))
         return tSize
 
     def paintEvent(self, theEvent):

--- a/nw/gui/preferences.py
+++ b/nw/gui/preferences.py
@@ -74,12 +74,14 @@ class GuiPreferences(PagedDialog):
         self.buttonBox.rejected.connect(self._doClose)
         self.addControls(self.buttonBox)
 
+        self.resize(*self.mainConf.getPreferencesSize())
+
         logger.debug("GuiPreferences initialisation complete")
 
         return
 
     ##
-    #  Buttons
+    #  Slots
     ##
 
     def _doSave(self):
@@ -102,6 +104,7 @@ class GuiPreferences(PagedDialog):
                 nwAlert.INFO
             )
 
+        self._saveWindowSize()
         self.accept()
 
         return
@@ -109,7 +112,20 @@ class GuiPreferences(PagedDialog):
     def _doClose(self):
         """Close the preferences without saving the changes.
         """
+        self._saveWindowSize()
         self.reject()
+        return
+
+    ##
+    #  Internal Functions
+    ##
+
+    def _saveWindowSize(self):
+        """Save the dialog window size.
+        """
+        winWidth  = self.mainConf.rpxInt(self.width())
+        winHeight = self.mainConf.rpxInt(self.height())
+        self.mainConf.setPreferencesSize(winWidth, winHeight)
         return
 
 # END Class GuiPreferences

--- a/nw/gui/projsettings.py
+++ b/nw/gui/projsettings.py
@@ -169,11 +169,11 @@ class GuiProjectEditMain(QWidget):
         self.mainForm.addGroupLabel(self.tr("Project Settings"))
 
         xW = self.mainConf.pxInt(250)
-        xH = self.mainConf.pxInt(100)
+        xH = self.mainConf.pxInt(80)
 
         self.editName = QLineEdit()
         self.editName.setMaxLength(200)
-        self.editName.setFixedWidth(xW)
+        self.editName.setMaximumWidth(xW)
         self.editName.setText(self.theProject.projName)
         self.mainForm.addRow(
             self.tr("Working title"),
@@ -183,7 +183,7 @@ class GuiProjectEditMain(QWidget):
 
         self.editTitle = QLineEdit()
         self.editTitle.setMaxLength(200)
-        self.editTitle.setFixedWidth(xW)
+        self.editTitle.setMaximumWidth(xW)
         self.editTitle.setText(self.theProject.bookTitle)
         self.mainForm.addRow(
             self.tr("Novel title"),
@@ -192,12 +192,9 @@ class GuiProjectEditMain(QWidget):
         )
 
         self.editAuthors = QPlainTextEdit()
-        bookAuthors = ""
-        for bookAuthor in self.theProject.bookAuthors:
-            bookAuthors += bookAuthor+"\n"
-        self.editAuthors.setPlainText(bookAuthors)
-        self.editAuthors.setFixedHeight(xH)
-        self.editAuthors.setFixedWidth(xW)
+        self.editAuthors.setMinimumHeight(xH)
+        self.editAuthors.setMaximumWidth(xW)
+        self.editAuthors.setPlainText("\n".join(self.theProject.bookAuthors))
         self.mainForm.addRow(
             self.tr("Author(s)"),
             self.editAuthors,
@@ -205,7 +202,7 @@ class GuiProjectEditMain(QWidget):
         )
 
         self.spellLang = QComboBox(self)
-        self.spellLang.setFixedWidth(xW)
+        self.spellLang.setMaximumWidth(xW)
         theDict = self.theParent.docEditor.theDict
         self.spellLang.addItem(self.tr("Default"), "None")
         if theDict is not None:

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -11,6 +11,7 @@ guilang = en-GB
 
 [Sizes]
 geometry = 1200, 650
+preferences = 700, 615
 treecols = 200, 50, 30
 novelcols = 200, 50
 projcols = 200, 60, 140

--- a/tests/reference/guiPreferences_novelwriter.conf
+++ b/tests/reference/guiPreferences_novelwriter.conf
@@ -11,6 +11,7 @@ guilang = en-GB
 
 [Sizes]
 geometry = 1200, 650
+preferences = 700, 615
 treecols = 200, 50, 30
 novelcols = 200, 50
 projcols = 200, 60, 140

--- a/tests/test_gui/test_gui_projsettings.py
+++ b/tests/test_gui/test_gui_projsettings.py
@@ -79,7 +79,7 @@ def testGuiProjSettings_Dialog(qtbot, monkeypatch, nwGUI, fncDir, fncProj, outDi
 
     assert projEdit.tabMain.editName.text() == "New Project"
     assert projEdit.tabMain.editTitle.text() == ""
-    assert projEdit.tabMain.editAuthors.toPlainText() == "Jane Smith\nJohn Smith\n"
+    assert projEdit.tabMain.editAuthors.toPlainText() == "Jane Smith\nJohn Smith"
     assert projEdit.tabMain.spellLang.currentData() == "en"
     assert projEdit.tabMain.doBackup.isChecked() is False
 


### PR DESCRIPTION
This PR tries to improve the layouts used for preferences dialogs to be more responsive to labels and texts of various lengths due to translations. The help labels on these forms now wrap, and various aspects of the form layout expands and tries to fit the content better. When there is no room, the text is clipped, but the dialogs can generally be resized.