### PR TITLE
Issue #688: Indexing of invalid keywords

### DIFF
--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -477,9 +477,17 @@ class NWIndex():
             return False
 
         sTitle = "T%06d" % nTitle
-        if sTitle in self._refIndex[tHandle] and theBits[0] != nwKeyWords.TAG_KEY:
-            for aVal in theBits[1:]:
-                self._refIndex[tHandle][sTitle]["tags"].append([nLine, theBits[0], aVal])
+        if sTitle not in self._refIndex[tHandle]:
+            return False
+
+        if theBits[0] == nwKeyWords.TAG_KEY:
+            return False
+
+        if theBits[0] not in nwKeyWords.VALID_KEYS:
+            return False
+
+        for aVal in theBits[1:]:
+            self._refIndex[tHandle][sTitle]["tags"].append([nLine, theBits[0], aVal])
 
         return True
 


### PR DESCRIPTION
This PR prevents the note reference parser of the index to save misspelled keywords into the index dictionary. The indexer function was checking a few things, but not that the keyword is allowed. The wrongly indexed keyword would then be written to file.

For the 1.1.1 version, this isn't an issue as the index is not checked that closely on loading, and the wrroneus keyword is filtered out. Although in 1.1 it would cause a crash.

For 1.2 and the current `dev` branch, the extended index validator would pick up this when the index was loaded, and deem the index broken and rebuild it. However, this would happen every time the project was launched.

This resolves #688.