### PR TITLE
About dialog updates

### DIFF
--- a/i18n/nw_en_US.ts
+++ b/i18n/nw_en_US.ts
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="en_US" sourcelanguage="en_GB">
+<!DOCTYPE TS><TS version="2.0" language="en_US" sourcelanguage="en_GB">
 <context>
     <name>Common</name>
     <message>
@@ -335,7 +334,7 @@
 <context>
     <name>GuiAbout</name>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>About novelWriter</source>
         <translation></translation>
     </message>
@@ -350,69 +349,84 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Website: {0}</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Credits</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is a markdown-like text editor designed for organising and writing novels. It is written in Python 3 with a Qt5 GUI, using PyQt5.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="178"/>
+        <location filename="../nw/gui/about.py" line="191"/>
         <source>Theme: {0}</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Author: {0}</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Credit: {0}</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="188"/>
+        <location filename="../nw/gui/about.py" line="202"/>
         <source>Icons: {0}</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Syntax: {0}</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="95"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Licence</source>
         <translation>License</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>See the Licence tab for the full licence text, or visit the GNU website at {0} for more details.</source>
         <translation>See the License tab for the full license text, or visit the GNU website at {0} for more details.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Licence: {0}</source>
-        <translation>License: {0}</translation>
+        <location filename="../nw/gui/about.py" line="177"/>
+        <source>Translations</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Author</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Credit</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Concept</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>i18n</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Developer</source>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3596,37 +3610,37 @@
 <context>
     <name>GuiProjectEditReplace</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="508"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Keyword</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="508"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Replace With</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="547"/>
+        <location filename="../nw/gui/projsettings.py" line="553"/>
         <source>Save entry</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="527"/>
+        <location filename="../nw/gui/projsettings.py" line="533"/>
         <source>Add new entry</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="531"/>
+        <location filename="../nw/gui/projsettings.py" line="537"/>
         <source>Delete selected entry</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="502"/>
+        <location filename="../nw/gui/projsettings.py" line="508"/>
         <source>Text Replace List for Preview and Export</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="538"/>
+        <location filename="../nw/gui/projsettings.py" line="544"/>
         <source>Select item to edit</source>
         <translation></translation>
     </message>
@@ -3634,77 +3648,77 @@
 <context>
     <name>GuiProjectEditStatus</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="313"/>
+        <location filename="../nw/gui/projsettings.py" line="316"/>
         <source>Save</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="309"/>
+        <location filename="../nw/gui/projsettings.py" line="312"/>
         <source>Colour</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="255"/>
+        <location filename="../nw/gui/projsettings.py" line="258"/>
         <source>Novel File Status Levels</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="259"/>
+        <location filename="../nw/gui/projsettings.py" line="262"/>
         <source>Note File Importance Levels</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="366"/>
+        <location filename="../nw/gui/projsettings.py" line="369"/>
         <source>Select Colour</source>
         <translation>Select Color</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="380"/>
+        <location filename="../nw/gui/projsettings.py" line="383"/>
         <source>New Item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="277"/>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
         <source>Label</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="277"/>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
         <source>Usage</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="292"/>
+        <location filename="../nw/gui/projsettings.py" line="295"/>
         <source>Add new entry</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="296"/>
+        <location filename="../nw/gui/projsettings.py" line="299"/>
         <source>Delete selected entry</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="305"/>
+        <location filename="../nw/gui/projsettings.py" line="308"/>
         <source>Select item to edit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="397"/>
+        <location filename="../nw/gui/projsettings.py" line="400"/>
         <source>Cannot delete a status item that is in use.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="479"/>
+        <location filename="../nw/gui/projsettings.py" line="482"/>
         <source>Not in use</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="481"/>
+        <location filename="../nw/gui/projsettings.py" line="484"/>
         <source>Used once</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="483"/>
+        <location filename="../nw/gui/projsettings.py" line="486"/>
         <source>Used by {0} items</source>
         <translation></translation>
     </message>

--- a/i18n/nw_fr.ts
+++ b/i18n/nw_fr.ts
@@ -3,72 +3,72 @@
 <context>
     <name>Common</name>
     <message>
-        <location filename="../nw/common.py" line="270"/>
+        <location filename="../nw/common.py" line="240"/>
         <source>in the future</source>
         <translation>dans le futur</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="274"/>
+        <location filename="../nw/common.py" line="244"/>
         <source>just now</source>
         <translation>maintenant</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="278"/>
+        <location filename="../nw/common.py" line="248"/>
         <source>a minute ago</source>
         <translation>il y a une minute</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="282"/>
+        <location filename="../nw/common.py" line="252"/>
         <source>{0} minutes ago</source>
         <translation>il y a {0} minutes</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="286"/>
+        <location filename="../nw/common.py" line="256"/>
         <source>an hour ago</source>
         <translation>il y a une heure</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="290"/>
+        <location filename="../nw/common.py" line="260"/>
         <source>{0} hours ago</source>
         <translation>il y a {0} heures</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="294"/>
+        <location filename="../nw/common.py" line="264"/>
         <source>a day ago</source>
         <translation>hier</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="298"/>
+        <location filename="../nw/common.py" line="268"/>
         <source>{0} days ago</source>
         <translation>il y a {0} jours</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="302"/>
+        <location filename="../nw/common.py" line="272"/>
         <source>a week ago</source>
         <translation>il y a une semaine</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="306"/>
+        <location filename="../nw/common.py" line="276"/>
         <source>{0} weeks ago</source>
         <translation>il y a {0} semaines</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="310"/>
+        <location filename="../nw/common.py" line="280"/>
         <source>a month ago</source>
         <translation>il y a un mois</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="314"/>
+        <location filename="../nw/common.py" line="284"/>
         <source>{0} months ago</source>
         <translation>il y a {0} mois</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="318"/>
+        <location filename="../nw/common.py" line="288"/>
         <source>a year ago</source>
         <translation>il y a un an</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="322"/>
+        <location filename="../nw/common.py" line="292"/>
         <source>{0} years ago</source>
         <translation>il y a {0} ans</translation>
     </message>
@@ -334,7 +334,7 @@
 <context>
     <name>GuiAbout</name>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>About novelWriter</source>
         <translation>À propos de novelWriter</translation>
     </message>
@@ -349,69 +349,84 @@
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="95"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Licence</source>
         <translation>Licence</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Website: {0}</source>
         <translation>Site Web: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Credits</source>
         <translation>Crédits</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is a markdown-like text editor designed for organising and writing novels. It is written in Python 3 with a Qt5 GUI, using PyQt5.</source>
         <translation>novelWriter est un éditeur markdown pour organiser et écrire des romans. Il est écrit en Python 3 avec un interface utilisateur Qt5, basé sur PyQt5.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</source>
         <translation>novelWriter est un logiciel libre: vous pouvez le redistribuer et/ou le modifier selon les termes de la licence publique générale GNU telle que publiée par la Free Software Foundation, dans la version 3 de cette licence ou (à votre choix) dans une version plus récente.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>novelWriter est diffusé dans l&apos;espoir qu&apos;il sera utile, mais SANS GARANTIE D&apos;AUCUNE SORTE, en particulier cconcernant sa QUALITÉ MARCHANDE ou son APTITUDE À UN USAGE SPÉCIFIQUE.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>See the Licence tab for the full licence text, or visit the GNU website at {0} for more details.</source>
         <translation>Ouvrez l&apos;onglet Licence pour voir le texte complet de la licence (en anglais), ou visitez le site de GNU à l&apos;adresse {0} pour en lire une traduction ou pour obtenir plus de détails.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="178"/>
+        <location filename="../nw/gui/about.py" line="191"/>
         <source>Theme: {0}</source>
         <translation>Thème: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Author: {0}</source>
-        <translation>Auteur: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Credit: {0}</source>
-        <translation>Crédits: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Licence: {0}</source>
-        <translation>Licence: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="188"/>
+        <location filename="../nw/gui/about.py" line="202"/>
         <source>Icons: {0}</source>
         <translation>Icônes: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Syntax: {0}</source>
         <translation>Syntaxe: {0}</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="177"/>
+        <source>Translations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Author</source>
+        <translation>Auteur</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Credit</source>
+        <translation>Crédits</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Concept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>i18n</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3537,57 +3552,57 @@
 <context>
     <name>GuiProjectEditMain</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="169"/>
+        <location filename="../nw/gui/projsettings.py" line="173"/>
         <source>Project Settings</source>
         <translation>Paramètres du projet</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="178"/>
+        <location filename="../nw/gui/projsettings.py" line="182"/>
         <source>Working title</source>
         <translation>Titre de travail</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="178"/>
+        <location filename="../nw/gui/projsettings.py" line="182"/>
         <source>Should be set only once.</source>
         <translation>Evitez de le changer ensuite.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="188"/>
+        <location filename="../nw/gui/projsettings.py" line="192"/>
         <source>Novel title</source>
         <translation>Titre du roman</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="188"/>
+        <location filename="../nw/gui/projsettings.py" line="192"/>
         <source>Change whenever you want!</source>
         <translation>Modifiez le à volonté !</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="198"/>
+        <location filename="../nw/gui/projsettings.py" line="202"/>
         <source>Author(s)</source>
         <translation>Auteur(s)</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="198"/>
+        <location filename="../nw/gui/projsettings.py" line="202"/>
         <source>One name per line.</source>
         <translation>Un nom par ligne.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="207"/>
+        <location filename="../nw/gui/projsettings.py" line="211"/>
         <source>Default</source>
         <translation>Défauts</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="214"/>
+        <location filename="../nw/gui/projsettings.py" line="218"/>
         <source>Spell check language</source>
         <translation>Langue du texte</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="228"/>
+        <location filename="../nw/gui/projsettings.py" line="232"/>
         <source>Overrides main preferences.</source>
         <translation>Prioritaire sur les réglages de nW.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="228"/>
+        <location filename="../nw/gui/projsettings.py" line="232"/>
         <source>No backup on close</source>
         <translation>Ne pas sauvegarder en fermant</translation>
     </message>
@@ -3595,92 +3610,117 @@
 <context>
     <name>GuiProjectEditReplace</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="455"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Keyword</source>
         <translation>Mot-clé</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="455"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Replace With</source>
         <translation>Remplacer par</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="475"/>
+        <location filename="../nw/gui/projsettings.py" line="553"/>
         <source>Save entry</source>
         <translation>Enregistrer cette entrée</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="476"/>
+        <location filename="../nw/gui/projsettings.py" line="533"/>
         <source>Add new entry</source>
         <translation>Ajouter une nouvelle entrée</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="477"/>
+        <location filename="../nw/gui/projsettings.py" line="537"/>
         <source>Delete selected entry</source>
         <translation>Supprimer l&apos;entrée sélectionnée</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="494"/>
+        <location filename="../nw/gui/projsettings.py" line="508"/>
         <source>Text Replace List for Preview and Export</source>
         <translation>Remplacements dans le texte pour les aperçus et exportations</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="544"/>
+        <source>Select item to edit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GuiProjectEditStatus</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="274"/>
-        <source>New</source>
-        <translation>Nouveau</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/projsettings.py" line="275"/>
-        <source>Delete</source>
-        <translation>Effacer</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/projsettings.py" line="276"/>
+        <location filename="../nw/gui/projsettings.py" line="316"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="279"/>
+        <location filename="../nw/gui/projsettings.py" line="312"/>
         <source>Colour</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="290"/>
-        <source>Name</source>
-        <translation>Nom</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/projsettings.py" line="300"/>
+        <location filename="../nw/gui/projsettings.py" line="258"/>
         <source>Novel File Status Levels</source>
         <translation>États des fichiers du roman</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="302"/>
+        <location filename="../nw/gui/projsettings.py" line="262"/>
         <source>Note File Importance Levels</source>
         <translation>Importance des fichiers de notes</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="327"/>
+        <location filename="../nw/gui/projsettings.py" line="369"/>
         <source>Select Colour</source>
         <translation>Choisir la couleur</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="341"/>
+        <location filename="../nw/gui/projsettings.py" line="383"/>
         <source>New Item</source>
         <translation>Nouvel item</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="357"/>
-        <source>Cannot delete status item that is in use.</source>
-        <translation>On ne peut pas retirer un élément d&apos;état tant qu&apos;il est utilisé.</translation>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
+        <source>Label</source>
+        <translation>Label</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="389"/>
-        <source>{0} [{1}]</source>
-        <translation>{0} [{1}]</translation>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
+        <source>Usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="295"/>
+        <source>Add new entry</source>
+        <translation>Ajouter une nouvelle entrée</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="299"/>
+        <source>Delete selected entry</source>
+        <translation>Supprimer l&apos;entrée sélectionnée</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="308"/>
+        <source>Select item to edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="400"/>
+        <source>Cannot delete a status item that is in use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="482"/>
+        <source>Not in use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="484"/>
+        <source>Used once</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="486"/>
+        <source>Used by {0} items</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/nw_nb_NO.ts
+++ b/i18n/nw_nb_NO.ts
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="nb_NO" sourcelanguage="en_GB">
+<!DOCTYPE TS><TS version="2.0" language="nb_NO" sourcelanguage="en_GB">
 <context>
     <name>Common</name>
     <message>
@@ -335,7 +334,7 @@
 <context>
     <name>GuiAbout</name>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>About novelWriter</source>
         <translation>Om novelWriter</translation>
     </message>
@@ -350,69 +349,84 @@
         <translation>Utgivelse</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="95"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Licence</source>
         <translation>Lisens</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Website: {0}</source>
         <translation>Nettside: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Credits</source>
         <translation>Krediteringer</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is a markdown-like text editor designed for organising and writing novels. It is written in Python 3 with a Qt5 GUI, using PyQt5.</source>
         <translation>novelWriter er en markdown-liknende teksteditor laget for å kunne organisere og skrive romaner og noveller. Programmet er skrevet i Python 3 med et brukergrensesnitt i Qt 5 via PyQt5.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</source>
         <translation>novelWriter er gratis programvare: du kan videredistribuere det og/eller modifisere det under vilkårene i GNU General Public License som utgitt av Free Software Foundation, enten versjon 3 av Lisensen, eller (etter eget valg) enhver senere versjon.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>novelWriter er distribuert i håp om at det vil være nyttig, men UTEN NOEN GARANTI; uten selv en underforstått garanti vedrørende SALGBARHET eller EGNETHET TIL ET BESTEMT FORMÅL. Se GNU General Public Licence for flere detaljer.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>See the Licence tab for the full licence text, or visit the GNU website at {0} for more details.</source>
         <translation>Se lisens-fanen for fulltekst-versjonen av lisensen (på engelsk), eller besøk GNU sin nettside på {0} for mer informasjon.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="178"/>
+        <location filename="../nw/gui/about.py" line="191"/>
         <source>Theme: {0}</source>
         <translation>Tema: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Author: {0}</source>
-        <translation>Ansvarlig: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Credit: {0}</source>
-        <translation>Kreditert: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Licence: {0}</source>
-        <translation>Lisens: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/about.py" line="188"/>
+        <location filename="../nw/gui/about.py" line="202"/>
         <source>Icons: {0}</source>
         <translation>Ikoner: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Syntax: {0}</source>
         <translation>Syntaks: {0}</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="177"/>
+        <source>Translations</source>
+        <translation>Oversettelser</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Author</source>
+        <translation>Ansvarlig</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Credit</source>
+        <translation>Kreditert</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Concept</source>
+        <translation>Konsept</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>i18n</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Developer</source>
+        <translation>Utvikler</translation>
     </message>
 </context>
 <context>
@@ -3596,37 +3610,37 @@
 <context>
     <name>GuiProjectEditReplace</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="508"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Keyword</source>
         <translation>Kodeord</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="508"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Replace With</source>
         <translation>Erstatt med</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="547"/>
+        <location filename="../nw/gui/projsettings.py" line="553"/>
         <source>Save entry</source>
         <translation>Lagre tekst</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="527"/>
+        <location filename="../nw/gui/projsettings.py" line="533"/>
         <source>Add new entry</source>
         <translation>Legg til ny</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="531"/>
+        <location filename="../nw/gui/projsettings.py" line="537"/>
         <source>Delete selected entry</source>
         <translation>Slett valgte element</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="502"/>
+        <location filename="../nw/gui/projsettings.py" line="508"/>
         <source>Text Replace List for Preview and Export</source>
         <translation>Erstatningsliste for forhåndsvisning og eksport</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="538"/>
+        <location filename="../nw/gui/projsettings.py" line="544"/>
         <source>Select item to edit</source>
         <translation>Velg enhet å redigere</translation>
     </message>
@@ -3634,77 +3648,77 @@
 <context>
     <name>GuiProjectEditStatus</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="313"/>
+        <location filename="../nw/gui/projsettings.py" line="316"/>
         <source>Save</source>
         <translation>Lagre</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="309"/>
+        <location filename="../nw/gui/projsettings.py" line="312"/>
         <source>Colour</source>
         <translation>Farge</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="255"/>
+        <location filename="../nw/gui/projsettings.py" line="258"/>
         <source>Novel File Status Levels</source>
         <translation>Statusnivåer i roman-filer</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="259"/>
+        <location filename="../nw/gui/projsettings.py" line="262"/>
         <source>Note File Importance Levels</source>
         <translation>Viktighetsnivåer i notatfiler</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="366"/>
+        <location filename="../nw/gui/projsettings.py" line="369"/>
         <source>Select Colour</source>
         <translation>Velg farge</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="380"/>
+        <location filename="../nw/gui/projsettings.py" line="383"/>
         <source>New Item</source>
         <translation>Legg til</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="277"/>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
         <source>Label</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="277"/>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
         <source>Usage</source>
         <translation>Bruk</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="292"/>
+        <location filename="../nw/gui/projsettings.py" line="295"/>
         <source>Add new entry</source>
         <translation>Legg til ny</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="296"/>
+        <location filename="../nw/gui/projsettings.py" line="299"/>
         <source>Delete selected entry</source>
         <translation>Slett valgte element</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="305"/>
+        <location filename="../nw/gui/projsettings.py" line="308"/>
         <source>Select item to edit</source>
         <translation>Velg enhet å redigere</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="397"/>
+        <location filename="../nw/gui/projsettings.py" line="400"/>
         <source>Cannot delete a status item that is in use.</source>
         <translation>Kan ikke slette status som er i bruk.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="479"/>
+        <location filename="../nw/gui/projsettings.py" line="482"/>
         <source>Not in use</source>
         <translation>Ikke i bruk</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="481"/>
+        <location filename="../nw/gui/projsettings.py" line="484"/>
         <source>Used once</source>
         <translation>Brukt ett sted</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="483"/>
+        <location filename="../nw/gui/projsettings.py" line="486"/>
         <source>Used by {0} items</source>
         <translation>Brukt {0} steder</translation>
     </message>

--- a/i18n/nw_pt.ts
+++ b/i18n/nw_pt.ts
@@ -3,72 +3,72 @@
 <context>
     <name>Common</name>
     <message>
-        <location filename="../nw/common.py" line="270"/>
+        <location filename="../nw/common.py" line="240"/>
         <source>in the future</source>
         <translation>no futuro</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="274"/>
+        <location filename="../nw/common.py" line="244"/>
         <source>just now</source>
         <translation>agora</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="278"/>
+        <location filename="../nw/common.py" line="248"/>
         <source>a minute ago</source>
         <translation>um minuto atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="282"/>
+        <location filename="../nw/common.py" line="252"/>
         <source>{0} minutes ago</source>
         <translation>{0} minutos atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="286"/>
+        <location filename="../nw/common.py" line="256"/>
         <source>an hour ago</source>
         <translation>uma hora atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="290"/>
+        <location filename="../nw/common.py" line="260"/>
         <source>{0} hours ago</source>
         <translation>{0} horas atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="294"/>
+        <location filename="../nw/common.py" line="264"/>
         <source>a day ago</source>
         <translation>um dia atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="298"/>
+        <location filename="../nw/common.py" line="268"/>
         <source>{0} days ago</source>
         <translation>{0} dias atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="302"/>
+        <location filename="../nw/common.py" line="272"/>
         <source>a week ago</source>
         <translation>uma semana atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="306"/>
+        <location filename="../nw/common.py" line="276"/>
         <source>{0} weeks ago</source>
         <translation>{0} semanas atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="310"/>
+        <location filename="../nw/common.py" line="280"/>
         <source>a month ago</source>
         <translation>um mês atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="314"/>
+        <location filename="../nw/common.py" line="284"/>
         <source>{0} months ago</source>
         <translation>{0} meses atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="318"/>
+        <location filename="../nw/common.py" line="288"/>
         <source>a year ago</source>
         <translation>um ano atrás</translation>
     </message>
     <message>
-        <location filename="../nw/common.py" line="322"/>
+        <location filename="../nw/common.py" line="292"/>
         <source>{0} years ago</source>
         <translation>{0} anos atrás</translation>
     </message>
@@ -334,47 +334,47 @@
 <context>
     <name>GuiAbout</name>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>About novelWriter</source>
         <translation>Sobre o novelWriter</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is a markdown-like text editor designed for organising and writing novels. It is written in Python 3 with a Qt5 GUI, using PyQt5.</source>
         <translation>novelWriter é um editor de texto som sintaxe semelhante ao markdown, projetado para a escrita e organização de livros. É escrito em Python 3 com interface de usuário em Qr5, usando PyQt5.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>novelWriter é distribuído na especativa de que seja útil, mas SEM NENHUMA GARANTIA, nem mesmo a garantia implícita de COMERCIALIZAÇÃO ou ADEQUAÇÃO PARA UM PROPÓSITO ESPECÍFICO.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Credits</source>
         <translation>Créditos</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>novelWriter is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</source>
         <translation>novelWriter é um software livre: você pode redistribuí-lo e/ou modificá-lo sob os termos da GNU Licença Pública Geral, assim como publicada pela Free Software Foundation, tanto na versão 3 da licença, ou (à sua escolha) qualquer versão subsequente.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="178"/>
+        <location filename="../nw/gui/about.py" line="191"/>
         <source>Theme: {0}</source>
         <translation>Tema: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="188"/>
+        <location filename="../nw/gui/about.py" line="202"/>
         <source>Icons: {0}</source>
         <translation>Ícones: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Syntax: {0}</source>
         <translation>Sintaxe: {0}</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>Website: {0}</source>
         <translation>Website: {0}</translation>
     </message>
@@ -389,29 +389,44 @@
         <translation>Lançamento</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="146"/>
+        <location filename="../nw/gui/about.py" line="144"/>
         <source>See the Licence tab for the full licence text, or visit the GNU website at {0} for more details.</source>
         <translation>Veja a aba de Licença para o texto completo de licença, ou visite o website da GNU em {0} para mais detalhes.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="95"/>
+        <location filename="../nw/gui/about.py" line="213"/>
         <source>Licence</source>
         <translation>Licença</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Author: {0}</source>
-        <translation>Autor: {0}</translation>
+        <location filename="../nw/gui/about.py" line="177"/>
+        <source>Translations</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Credit: {0}</source>
-        <translation>Créditos: {0}</translation>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Author</source>
+        <translation>Autor</translation>
     </message>
     <message>
-        <location filename="../nw/gui/about.py" line="198"/>
-        <source>Licence: {0}</source>
-        <translation>Licença: {0}</translation>
+        <location filename="../nw/gui/about.py" line="213"/>
+        <source>Credit</source>
+        <translation>Créditos</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Concept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>i18n</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/about.py" line="144"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3537,57 +3552,57 @@
 <context>
     <name>GuiProjectEditMain</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="178"/>
+        <location filename="../nw/gui/projsettings.py" line="182"/>
         <source>Should be set only once.</source>
         <translation>Deve ser definido apenas uma vez.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="188"/>
+        <location filename="../nw/gui/projsettings.py" line="192"/>
         <source>Change whenever you want!</source>
         <translation>Mude quando quiser!</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="198"/>
+        <location filename="../nw/gui/projsettings.py" line="202"/>
         <source>One name per line.</source>
         <translation>Um nome por linha.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="207"/>
+        <location filename="../nw/gui/projsettings.py" line="211"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="228"/>
+        <location filename="../nw/gui/projsettings.py" line="232"/>
         <source>Overrides main preferences.</source>
         <translation>Sobrescreve as preferências globais.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="169"/>
+        <location filename="../nw/gui/projsettings.py" line="173"/>
         <source>Project Settings</source>
         <translation>Configurações do Projeto</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="178"/>
+        <location filename="../nw/gui/projsettings.py" line="182"/>
         <source>Working title</source>
         <translation>Nome do projeto</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="188"/>
+        <location filename="../nw/gui/projsettings.py" line="192"/>
         <source>Novel title</source>
         <translation>Título do tivro</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="198"/>
+        <location filename="../nw/gui/projsettings.py" line="202"/>
         <source>Author(s)</source>
         <translation>Autor(es)</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="214"/>
+        <location filename="../nw/gui/projsettings.py" line="218"/>
         <source>Spell check language</source>
         <translation>Idioma do corretor ortográfico</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="228"/>
+        <location filename="../nw/gui/projsettings.py" line="232"/>
         <source>No backup on close</source>
         <translation>Não salvar cópia de segurança ao fechar</translation>
     </message>
@@ -3595,92 +3610,117 @@
 <context>
     <name>GuiProjectEditReplace</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="455"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Keyword</source>
         <translation>Palavra-chave</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="455"/>
+        <location filename="../nw/gui/projsettings.py" line="514"/>
         <source>Replace With</source>
         <translation>Substituir Com</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="475"/>
+        <location filename="../nw/gui/projsettings.py" line="553"/>
         <source>Save entry</source>
         <translation>Salvar entrada</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="476"/>
+        <location filename="../nw/gui/projsettings.py" line="533"/>
         <source>Add new entry</source>
         <translation>Adiciona uma nova entrada</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="477"/>
+        <location filename="../nw/gui/projsettings.py" line="537"/>
         <source>Delete selected entry</source>
         <translation>Remove a entrada selecionada</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="494"/>
+        <location filename="../nw/gui/projsettings.py" line="508"/>
         <source>Text Replace List for Preview and Export</source>
         <translation>Lista de Substituição de Texto para o Preview ou Exportação</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="544"/>
+        <source>Select item to edit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GuiProjectEditStatus</name>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="290"/>
-        <source>Name</source>
-        <translation>Nome</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/projsettings.py" line="300"/>
+        <location filename="../nw/gui/projsettings.py" line="258"/>
         <source>Novel File Status Levels</source>
         <translation>Níves de Estado do Arquivo do Livro</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="302"/>
+        <location filename="../nw/gui/projsettings.py" line="262"/>
         <source>Note File Importance Levels</source>
         <translation>Níves de Importância do Arquivo do Livro</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="341"/>
+        <location filename="../nw/gui/projsettings.py" line="383"/>
         <source>New Item</source>
         <translation>Novo Item</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="274"/>
-        <source>New</source>
-        <translation>Novo</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/projsettings.py" line="275"/>
-        <source>Delete</source>
-        <translation>Remover</translation>
-    </message>
-    <message>
-        <location filename="../nw/gui/projsettings.py" line="276"/>
+        <location filename="../nw/gui/projsettings.py" line="316"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="279"/>
+        <location filename="../nw/gui/projsettings.py" line="312"/>
         <source>Colour</source>
         <translation>Cor</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="327"/>
+        <location filename="../nw/gui/projsettings.py" line="369"/>
         <source>Select Colour</source>
         <translation>Selecione a Cor</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="357"/>
-        <source>Cannot delete status item that is in use.</source>
-        <translation>Não é possível remover um item de status que estja em uso.</translation>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
+        <source>Label</source>
+        <translation type="unfinished">Rótulo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projsettings.py" line="389"/>
-        <source>{0} [{1}]</source>
-        <translation></translation>
+        <location filename="../nw/gui/projsettings.py" line="280"/>
+        <source>Usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="295"/>
+        <source>Add new entry</source>
+        <translation type="unfinished">Adiciona uma nova entrada</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="299"/>
+        <source>Delete selected entry</source>
+        <translation type="unfinished">Remove a entrada selecionada</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="308"/>
+        <source>Select item to edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="400"/>
+        <source>Cannot delete a status item that is in use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="482"/>
+        <source>Not in use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="484"/>
+        <source>Used once</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/projsettings.py" line="486"/>
+        <source>Used by {0} items</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/nw_pt.ts
+++ b/i18n/nw_pt.ts
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt" sourcelanguage="en_GB">
+<!DOCTYPE TS><TS version="2.0" language="pt" sourcelanguage="en_GB">
 <context>
     <name>Common</name>
     <message>
@@ -3643,7 +3642,7 @@
     <message>
         <location filename="../nw/gui/projsettings.py" line="544"/>
         <source>Select item to edit</source>
-        <translation>Selecione o item para editar</translation>
+        <translation>Selecione um item para editar</translation>
     </message>
 </context>
 <context>

--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -73,10 +73,6 @@ __issuesurl__  = "https://github.com/vkbo/novelWriter/issues"
 __helpurl__    = "https://github.com/vkbo/novelWriter/discussions"
 __releaseurl__ = "https://github.com/vkbo/novelWriter/releases/latest"
 __docurl__     = "https://novelwriter.readthedocs.io"
-__credits__    = [
-    "Veronica Berglyd Olsen (author, maintainer)",
-    "Marian Lückhof (concept, testing)"
-]
 
 ##
 #  Logging

--- a/nw/__init__.py
+++ b/nw/__init__.py
@@ -74,8 +74,8 @@ __helpurl__    = "https://github.com/vkbo/novelWriter/discussions"
 __releaseurl__ = "https://github.com/vkbo/novelWriter/releases/latest"
 __docurl__     = "https://novelwriter.readthedocs.io"
 __credits__    = [
-    "Veronica Berglyd Olsen (developer)",
-    "Marian Lückhof (contributor, tester)"
+    "Veronica Berglyd Olsen (author, maintainer)",
+    "Marian Lückhof (concept, testing)"
 ]
 
 ##

--- a/nw/gui/about.py
+++ b/nw/gui/about.py
@@ -135,8 +135,8 @@ class GuiAbout(QDialog):
         webLink = f"<a href='{nw.__url__:s}'>{nw.__domain__:s}</a>"
         aboutMsg = (
             "<h2>{title1}</h2>"
-            "<p>{copyright}.</p>"
-            "<p>{website}</p>"
+            "<p>{copy}</p>"
+            "<p>{link}</p>"
             "<p>{intro}</p>"
             "<p>{license1}</p>"
             "<p>{license2}</p>"
@@ -144,27 +144,27 @@ class GuiAbout(QDialog):
             "<h3>{title2}</h3>"
             "<p>{credits}</p>"
         ).format(
-            title1    = self.tr("About novelWriter"),
-            copyright = nw.__copyright__,
-            website   = self.tr("Website: {0}").format(webLink),
-            title2    = self.tr("Credits"),
-            credits   = "<br/>".join(["%s%s" % (listPrefix, x) for x in nw.__credits__]),
-            intro     = self.tr(
+            title1 = self.tr("About novelWriter"),
+            copy = nw.__copyright__,
+            link = self.tr("Website: {0}").format(webLink),
+            title2 = self.tr("Credits"),
+            credits = "<br/>".join(["%s%s" % (listPrefix, x) for x in nw.__credits__]),
+            intro = self.tr(
                 "novelWriter is a markdown-like text editor designed for organising and "
                 "writing novels. It is written in Python 3 with a Qt5 GUI, using PyQt5."
             ),
-            license1  = self.tr(
+            license1 = self.tr(
                 "novelWriter is free software: you can redistribute it and/or modify it "
                 "under the terms of the GNU General Public License as published by the "
                 "Free Software Foundation, either version 3 of the License, or (at your "
                 "option) any later version."
             ),
-            license2  = self.tr(
+            license2 = self.tr(
                 "novelWriter is distributed in the hope that it will be useful, but "
                 "WITHOUT ANY WARRANTY; without even the implied warranty of "
                 "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
             ),
-            license3  = self.tr(
+            license3 = self.tr(
                 "See the Licence tab for the full licence text, or visit the "
                 "GNU website at {0} for more details."
             ).format(
@@ -172,34 +172,47 @@ class GuiAbout(QDialog):
             ),
         )
 
+        trOrder = self.tr("{0}{1}: {2}")
+        i18n = [
+            ("American English", "Veronica Berglyd Olsen"),
+            ("British English", "Veronica Berglyd Olsen"),
+            ("Français", "Jan Lüdke (jyhelle)"),
+            ("Norsk Bokmål", "Veronica Berglyd Olsen"),
+            ("Português", "Bruno Meneguello"),
+        ]
+        aboutMsg += "<h4>%s</h4><p>%s</p>" % (
+            self.tr("Translations"),
+            "<br/>".join([trOrder.format(listPrefix, n, c) for n, c in i18n]),
+        )
+
         theTheme = self.theParent.theTheme
         theIcons = self.theParent.theTheme.theIcons
-        if theTheme.themeName:
+        if theTheme.themeName and theTheme.themeAuthor != "N/A":
             aboutMsg += "<h4>%s</h4><p>%s<br/>%s<br/>%s</p>" % (
-                self.tr("Theme: {0}").format(theTheme.themeName),
-                self.tr("Author: {0}").format(theTheme.themeAuthor),
-                self.tr("Credit: {0}").format(theTheme.themeCredit),
-                self.tr("Licence: {0}").format(
+                self.tr("<b>Theme:</b> {0}").format(theTheme.themeName),
+                self.tr("<b>Author:</b> {0}").format(theTheme.themeAuthor),
+                self.tr("<b>Credit:</b> {0}").format(theTheme.themeCredit),
+                self.tr("<b>Licence:</b> {0}").format(
                     f"<a href='{theTheme.themeLicenseUrl}'>{theTheme.themeLicense}</a>"
                 )
             )
 
         if theIcons.themeName:
             aboutMsg += "<h4>%s</h4><p>%s<br/>%s<br/>%s</p>" % (
-                self.tr("Icons: {0}").format(theIcons.themeName),
-                self.tr("Author: {0}").format(theIcons.themeAuthor),
-                self.tr("Credit: {0}").format(theIcons.themeCredit),
-                self.tr("Licence: {0}").format(
+                self.tr("<b>Icons:</b> {0}").format(theIcons.themeName),
+                self.tr("<b>Author:</b> {0}").format(theIcons.themeAuthor),
+                self.tr("<b>Credit:</b> {0}").format(theIcons.themeCredit),
+                self.tr("<b>Licence:</b> {0}").format(
                     f"<a href='{theIcons.themeLicenseUrl}'>{theIcons.themeLicense}</a>"
                 )
             )
 
         if theTheme.syntaxName:
             aboutMsg += "<h4>%s</h4><p>%s<br/>%s<br/>%s</p>" % (
-                self.tr("Syntax: {0}").format(theTheme.syntaxName),
-                self.tr("Author: {0}").format(theTheme.syntaxAuthor),
-                self.tr("Credit: {0}").format(theTheme.syntaxCredit),
-                self.tr("Licence: {0}").format(
+                self.tr("<b>Syntax:</b> {0}").format(theTheme.syntaxName),
+                self.tr("<b>Author:</b> {0}").format(theTheme.syntaxAuthor),
+                self.tr("<b>Credit:</b> {0}").format(theTheme.syntaxCredit),
+                self.tr("<b>Licence:</b> {0}").format(
                     f"<a href='{theTheme.syntaxLicenseUrl}'>{theTheme.syntaxLicense}</a>"
                 )
             )

--- a/nw/gui/about.py
+++ b/nw/gui/about.py
@@ -131,8 +131,6 @@ class GuiAbout(QDialog):
     def _fillAboutPage(self):
         """Generate the content for the About page.
         """
-        listPrefix = "&nbsp;&nbsp;&bull;&nbsp;&nbsp;"
-        webLink = f"<a href='{nw.__url__:s}'>{nw.__domain__:s}</a>"
         aboutMsg = (
             "<h2>{title1}</h2>"
             "<p>{copy}</p>"
@@ -146,9 +144,13 @@ class GuiAbout(QDialog):
         ).format(
             title1 = self.tr("About novelWriter"),
             copy = nw.__copyright__,
-            link = self.tr("Website: {0}").format(webLink),
+            link = self.tr("Website: {0}").format(f"<a href='{nw.__url__}'>{nw.__domain__}</a>"),
             title2 = self.tr("Credits"),
-            credits = "<br/>".join(["%s%s" % (listPrefix, x) for x in nw.__credits__]),
+            credits = self._wrapTable([
+                (self.tr("Developer"), "Veronica Berglyd Olsen"),
+                (self.tr("Concept"), "Veronica Berglyd Olsen, Marian Lückhof"),
+                (self.tr("i18n"), "Bruno Meneguello"),
+            ]),
             intro = self.tr(
                 "novelWriter is a markdown-like text editor designed for organising and "
                 "writing novels. It is written in Python 3 with a Qt5 GUI, using PyQt5."
@@ -172,49 +174,49 @@ class GuiAbout(QDialog):
             ),
         )
 
-        trOrder = self.tr("{0}{1}: {2}")
-        i18n = [
-            ("American English", "Veronica Berglyd Olsen"),
-            ("British English", "Veronica Berglyd Olsen"),
-            ("Français", "Jan Lüdke (jyhelle)"),
-            ("Norsk Bokmål", "Veronica Berglyd Olsen"),
-            ("Português", "Bruno Meneguello"),
-        ]
         aboutMsg += "<h4>%s</h4><p>%s</p>" % (
             self.tr("Translations"),
-            "<br/>".join([trOrder.format(listPrefix, n, c) for n, c in i18n]),
+            self._wrapTable([
+                ("English", "Veronica Berglyd Olsen"),
+                ("Français", "Jan Lüdke (jyhelle)"),
+                ("Norsk Bokmål", "Veronica Berglyd Olsen"),
+                ("Português", "Bruno Meneguello"),
+            ])
         )
 
         theTheme = self.theParent.theTheme
         theIcons = self.theParent.theTheme.theIcons
         if theTheme.themeName and theTheme.themeAuthor != "N/A":
-            aboutMsg += "<h4>%s</h4><p>%s<br/>%s<br/>%s</p>" % (
-                self.tr("<b>Theme:</b> {0}").format(theTheme.themeName),
-                self.tr("<b>Author:</b> {0}").format(theTheme.themeAuthor),
-                self.tr("<b>Credit:</b> {0}").format(theTheme.themeCredit),
-                self.tr("<b>Licence:</b> {0}").format(
-                    f"<a href='{theTheme.themeLicenseUrl}'>{theTheme.themeLicense}</a>"
-                )
+            licURL = f"<a href='{theTheme.themeLicenseUrl}'>{theTheme.themeLicense}</a>"
+            aboutMsg += "<h4>%s</h4><p>%s</p>" % (
+                self.tr("Theme: {0}").format(theTheme.themeName),
+                self._wrapTable([
+                    (self.tr("Author"), theTheme.themeAuthor),
+                    (self.tr("Credit"), theTheme.themeCredit),
+                    (self.tr("Licence"), licURL),
+                ])
             )
 
         if theIcons.themeName:
-            aboutMsg += "<h4>%s</h4><p>%s<br/>%s<br/>%s</p>" % (
-                self.tr("<b>Icons:</b> {0}").format(theIcons.themeName),
-                self.tr("<b>Author:</b> {0}").format(theIcons.themeAuthor),
-                self.tr("<b>Credit:</b> {0}").format(theIcons.themeCredit),
-                self.tr("<b>Licence:</b> {0}").format(
-                    f"<a href='{theIcons.themeLicenseUrl}'>{theIcons.themeLicense}</a>"
-                )
+            licURL = f"<a href='{theIcons.themeLicenseUrl}'>{theIcons.themeLicense}</a>"
+            aboutMsg += "<h4>%s</h4><p>%s</p>" % (
+                self.tr("Icons: {0}").format(theIcons.themeName),
+                self._wrapTable([
+                    (self.tr("Author"), theIcons.themeAuthor),
+                    (self.tr("Credit"), theIcons.themeCredit),
+                    (self.tr("Licence"), licURL),
+                ])
             )
 
         if theTheme.syntaxName:
-            aboutMsg += "<h4>%s</h4><p>%s<br/>%s<br/>%s</p>" % (
-                self.tr("<b>Syntax:</b> {0}").format(theTheme.syntaxName),
-                self.tr("<b>Author:</b> {0}").format(theTheme.syntaxAuthor),
-                self.tr("<b>Credit:</b> {0}").format(theTheme.syntaxCredit),
-                self.tr("<b>Licence:</b> {0}").format(
-                    f"<a href='{theTheme.syntaxLicenseUrl}'>{theTheme.syntaxLicense}</a>"
-                )
+            licURL = f"<a href='{theTheme.syntaxLicenseUrl}'>{theTheme.syntaxLicense}</a>"
+            aboutMsg += "<h4>%s</h4><p>%s</p>" % (
+                self.tr("Syntax: {0}").format(theTheme.syntaxName),
+                self._wrapTable([
+                    (self.tr("Author"), theTheme.syntaxAuthor),
+                    (self.tr("Credit"), theTheme.syntaxCredit),
+                    (self.tr("Licence"), licURL),
+                ])
             )
 
         self.pageAbout.setHtml(aboutMsg)
@@ -245,6 +247,16 @@ class GuiAbout(QDialog):
             self.pageLicense.setHtml("Error loading licence text ...")
         return
 
+    def _wrapTable(self, theData):
+        """Wrap a list of label/value tuples in a html table.
+        """
+        theTable = []
+        for aLabel, aValue in theData:
+            theTable.append(
+                f"<tr><td><b>{aLabel}:</b></td><td>{aValue}</td></tr>"
+            )
+        return "<table>%s</table>" % "".join(theTable)
+
     def _setStyleSheet(self):
         """Set stylesheet for all browser tabs
         """
@@ -254,6 +266,9 @@ class GuiAbout(QDialog):
             "}}\n"
             "a {{"
             "  color: rgb({hColR},{hColG},{hColB});"
+            "}}\n"
+            "td {{"
+            "  padding-right: 0.8em;"
             "}}\n"
         ).format(
             hColR = self.theParent.theTheme.colHead[0],


### PR DESCRIPTION
The main point of this PR is to add translation credit to the About novelWriter dialog, but at the same time it reformats the entire Credits section and wraps the entries in html tables. The column order of the tables are fixed, but generated by a single function, so if this needs to be modified for localisation, it can be handled there.