### PR TITLE
Empty Trash Fix

### DIFF
--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -451,14 +451,14 @@ class GuiProjectTree(QTreeWidget):
         for tHandle in self.getTreeFromHandle(trashHandle):
             if tHandle == trashHandle:
                 continue
-            self.deleteItem(tHandle, alreadyAsked=True)
+            self.deleteItem(tHandle, alreadyAsked=True, bulkAction=True)
 
         if nTrash > 0:
             self._setTreeChanged(True)
 
         return True
 
-    def deleteItem(self, tHandle=None, alreadyAsked=False, askForTrash=False):
+    def deleteItem(self, tHandle=None, alreadyAsked=False, askForTrash=False, bulkAction=False):
         """Delete an item from the project tree. As a first step, files are
         moved to the Trash folder. Permanent deletion is a second step. This
         second step also deletes the item from the project object as well as
@@ -469,24 +469,27 @@ class GuiProjectTree(QTreeWidget):
             logger.error("No project open")
             return False
 
-        if not self.hasFocus():
+        if not self.hasFocus() and not bulkAction:
+            logger.info("Delete action blocked due to no widget focus")
             return False
 
         if tHandle is None:
             tHandle = self.getSelectedHandle()
 
         if tHandle is None:
+            logger.error("There is no item to delete")
             return False
 
         trItemS = self._getTreeItem(tHandle)
         nwItemS = self.theProject.projTree[tHandle]
 
         if trItemS is None or nwItemS is None:
+            logger.error("Could not find tree item for deletion")
             return False
 
         wCount = int(trItemS.data(self.C_COUNT, Qt.UserRole))
         if nwItemS.itemType == nwItemType.FILE:
-            logger.debug("User requested file %s moved to trash" % tHandle)
+            logger.debug("User requested file %s deleted" % tHandle)
             trItemP = trItemS.parent()
             trItemT = self._addTrashRoot()
             if trItemP is None or trItemT is None:
@@ -539,6 +542,8 @@ class GuiProjectTree(QTreeWidget):
                 if doTrash:
                     if pHandle is None:
                         logger.warning("File has no parent item")
+
+                    logger.debug("Moving file %s to trash" % tHandle)
 
                     self.propagateCount(tHandle, 0)
                     tIndex  = trItemP.indexOfChild(trItemS)

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -458,7 +458,7 @@ class GuiProjectTree(QTreeWidget):
 
         return True
 
-    def deleteItem(self, tHandle=None, alreadyAsked=False, askForTrash=False, bulkAction=False):
+    def deleteItem(self, tHandle=None, alreadyAsked=False, bulkAction=False):
         """Delete an item from the project tree. As a first step, files are
         moved to the Trash folder. Permanent deletion is a second step. This
         second step also deletes the item from the project object as well as
@@ -529,17 +529,10 @@ class GuiProjectTree(QTreeWidget):
             else:
                 # The file is not already in the trash folder, so we
                 # move it there.
-                doTrash = False
-                if askForTrash:
-                    msgYes = self.askQuestion(
-                        "Delete File", "Move file '%s' to Trash?" % nwItemS.itemName
-                    )
-                    if msgYes:
-                        doTrash = True
-                else:
-                    doTrash = True
-
-                if doTrash:
+                msgYes = self.askQuestion(
+                    "Delete File", "Move file '%s' to Trash?" % nwItemS.itemName
+                )
+                if msgYes:
                     if pHandle is None:
                         logger.warning("File has no parent item")
 
@@ -1210,7 +1203,7 @@ class GuiProjectTreeMenu(QMenu):
         """Forward the delete item call to the project tree.
         """
         if self.theItem is not None:
-            self.theTree.deleteItem(askForTrash=True)
+            self.theTree.deleteItem()
         return
 
     def _doEmptyTrash(self):

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -42,7 +42,6 @@ def testGuiProjTree_TreeItems(qtbot, caplog, monkeypatch, nwGUI, nwMinimal):
     monkeypatch.setattr(QMessageBox, "warning", lambda *args: QMessageBox.Yes)
     monkeypatch.setattr(QMessageBox, "information", lambda *args: QMessageBox.Yes)
     monkeypatch.setattr(GuiMain, "editItem", lambda *args: None)
-    monkeypatch.setattr(GuiProjectTree, "hasFocus", lambda *args: True)
 
     nwGUI.theProject.projTree.setSeed(42)
     nwTree = nwGUI.treeView


### PR DESCRIPTION
This PR resolves #701

The Empty Trash function was blocked due to the focus check implemented in #631 (issue #629). Since the Empty Trash action opens a dialog box, the project tree doesn't have focus when the deleted items are being processed and the deleteItem function returns without doing anything.

The PR also adds some debug logging to the checks so it's easier to identify what's going on.