### PR TITLE
Issue #716: Focus Mode Improvement and Bugfix

### DIFF
--- a/nw/constants/__init__.py
+++ b/nw/constants/__init__.py
@@ -6,7 +6,7 @@ from nw.constants.constants import (
 )
 from nw.constants.enum import (
     nwAlert, nwDocAction, nwItemClass, nwItemLayout, nwItemType, nwOutline,
-    nwDocInsert
+    nwDocInsert, nwWidget
 )
 
 __all__ = [
@@ -28,4 +28,5 @@ __all__ = [
     "nwItemType",
     "nwOutline",
     "nwDocInsert",
+    "nwWidget",
 ]

--- a/nw/constants/enum.py
+++ b/nw/constants/enum.py
@@ -112,6 +112,15 @@ class nwAlert(Enum):
 
 # END Enum nwAlert
 
+class nwWidget(Enum):
+
+    TREE    = 1
+    EDITOR  = 2
+    VIEWER  = 3
+    OUTLINE = 4
+
+# END Enum nwWidget
+
 class nwOutline(Enum):
 
     TITLE  = 0

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -2178,7 +2178,6 @@ class GuiDocEditHeader(QWidget):
 
         fPx = int(0.9*self.theTheme.fontPixelSize)
         hSp = self.mainConf.pxInt(6)
-        self.buttonSize = fPx + hSp
 
         # Main Widget Settings
         self.setAutoFillBackground(True)
@@ -2324,6 +2323,17 @@ class GuiDocEditHeader(QWidget):
 
         return True
 
+    def updateFocusMode(self):
+        """Update the minimise/maximise icon of the Focus Mode button.
+        This function is called by the GuiMain class via the
+        toggleFocusMode function and should not be activated directly.
+        """
+        if self.theParent.isFocusMode:
+            self.minmaxButton.setIcon(self.theTheme.getIcon("minimise"))
+        else:
+            self.minmaxButton.setIcon(self.theTheme.getIcon("maximise"))
+        return
+
     ##
     #  Slots
     ##
@@ -2354,18 +2364,6 @@ class GuiDocEditHeader(QWidget):
         """Switch on or off Focus Mode.
         """
         self.theParent.toggleFocusMode()
-        if self.theParent.isFocusMode:
-            self.minmaxButton.setIcon(self.theTheme.getIcon("minimise"))
-            self.setContentsMargins(self.buttonSize, 0, 0, 0)
-            self.editButton.setVisible(False)
-            self.searchButton.setVisible(False)
-            self.closeButton.setVisible(False)
-        else:
-            self.minmaxButton.setIcon(self.theTheme.getIcon("maximise"))
-            self.setContentsMargins(0, 0, 0, 0)
-            self.editButton.setVisible(True)
-            self.searchButton.setVisible(True)
-            self.closeButton.setVisible(True)
         return
 
     ##

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -33,7 +33,7 @@ from PyQt5.QtWidgets import QMenuBar, QAction
 
 from nw.constants import (
     nwItemType, nwItemClass, nwDocAction, nwDocInsert, nwKeyWords, nwLabels,
-    nwUnicode
+    nwUnicode, nwWidget
 )
 
 logger = logging.getLogger(__name__)
@@ -469,28 +469,28 @@ class GuiMainMenu(QMenuBar):
         self.aFocusTree = QAction("Focus Project Tree", self)
         self.aFocusTree.setStatusTip("Move focus to project tree")
         self.aFocusTree.setShortcut("Alt+1")
-        self.aFocusTree.triggered.connect(lambda: self.theParent.switchFocus(1))
+        self.aFocusTree.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.TREE))
         self.viewMenu.addAction(self.aFocusTree)
 
         # View > Document Pane 1
         self.aFocusEditor = QAction("Focus Document Editor", self)
         self.aFocusEditor.setStatusTip("Move focus to left document pane")
         self.aFocusEditor.setShortcut("Alt+2")
-        self.aFocusEditor.triggered.connect(lambda: self.theParent.switchFocus(2))
+        self.aFocusEditor.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.EDITOR))
         self.viewMenu.addAction(self.aFocusEditor)
 
         # View > Document Pane 2
         self.aFocusView = QAction("Focus Document Viewer", self)
         self.aFocusView.setStatusTip("Move focus to right document pane")
         self.aFocusView.setShortcut("Alt+3")
-        self.aFocusView.triggered.connect(lambda: self.theParent.switchFocus(3))
+        self.aFocusView.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.VIEWER))
         self.viewMenu.addAction(self.aFocusView)
 
         # View > Outline
         self.aFocusOutline = QAction("Focus Outline", self)
         self.aFocusOutline.setStatusTip("Move focus to outline")
         self.aFocusOutline.setShortcut("Alt+4")
-        self.aFocusOutline.triggered.connect(lambda: self.theParent.switchFocus(4))
+        self.aFocusOutline.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.OUTLINE))
         self.viewMenu.addAction(self.aFocusOutline)
 
         # View > Separator

--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -469,28 +469,28 @@ class GuiMainMenu(QMenuBar):
         self.aFocusTree = QAction("Focus Project Tree", self)
         self.aFocusTree.setStatusTip("Move focus to project tree")
         self.aFocusTree.setShortcut("Alt+1")
-        self.aFocusTree.triggered.connect(lambda: self.theParent.setFocus(1))
+        self.aFocusTree.triggered.connect(lambda: self.theParent.switchFocus(1))
         self.viewMenu.addAction(self.aFocusTree)
 
         # View > Document Pane 1
         self.aFocusEditor = QAction("Focus Document Editor", self)
         self.aFocusEditor.setStatusTip("Move focus to left document pane")
         self.aFocusEditor.setShortcut("Alt+2")
-        self.aFocusEditor.triggered.connect(lambda: self.theParent.setFocus(2))
+        self.aFocusEditor.triggered.connect(lambda: self.theParent.switchFocus(2))
         self.viewMenu.addAction(self.aFocusEditor)
 
         # View > Document Pane 2
         self.aFocusView = QAction("Focus Document Viewer", self)
         self.aFocusView.setStatusTip("Move focus to right document pane")
         self.aFocusView.setShortcut("Alt+3")
-        self.aFocusView.triggered.connect(lambda: self.theParent.setFocus(3))
+        self.aFocusView.triggered.connect(lambda: self.theParent.switchFocus(3))
         self.viewMenu.addAction(self.aFocusView)
 
         # View > Outline
         self.aFocusOutline = QAction("Focus Outline", self)
         self.aFocusOutline.setStatusTip("Move focus to outline")
         self.aFocusOutline.setShortcut("Alt+4")
-        self.aFocusOutline.triggered.connect(lambda: self.theParent.setFocus(4))
+        self.aFocusOutline.triggered.connect(lambda: self.theParent.switchFocus(4))
         self.viewMenu.addAction(self.aFocusOutline)
 
         # View > Separator

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -558,6 +558,10 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return False
 
+        # Disable focus mode if it is active
+        if self.isFocusMode:
+            self.toggleFocusMode()
+
         self.docEditor.saveCursorPosition()
         if self.docEditor.docChanged:
             self.saveDocument()
@@ -804,10 +808,10 @@ class GuiMain(QMainWindow):
             return False
 
         if tHandle is None:
-            if self.treeView.hasFocus():
-                tHandle = self.treeView.getSelectedHandle()
-            elif self.docEditor.hasFocus():
+            if self.docEditor.anyFocus() or self.isFocusMode:
                 tHandle = self.docEditor.theHandle
+            elif self.treeView.hasFocus():
+                tHandle = self.treeView.getSelectedHandle()
 
         if tHandle is None:
             logger.warning("No item selected")
@@ -1221,6 +1225,7 @@ class GuiMain(QMainWindow):
         if self.isFocusMode:
             logger.debug("Activating Focus Mode")
             self.mainTabs.setCurrentWidget(self.splitDocs)
+            self.setFocus(2)
         else:
             logger.debug("Deactivating Focus Mode")
 
@@ -1232,6 +1237,7 @@ class GuiMain(QMainWindow):
 
         hideDocFooter = self.isFocusMode and self.mainConf.hideFocusFooter
         self.docEditor.docFooter.setVisible(not hideDocFooter)
+        self.docEditor.docHeader.updateFocusMode()
 
         if self.splitView.isVisible():
             self.splitView.setVisible(False)
@@ -1269,11 +1275,12 @@ class GuiMain(QMainWindow):
         """
         # Project
         self.addAction(self.mainMenu.aSaveProject)
+        self.addAction(self.mainMenu.aEditItem)
         self.addAction(self.mainMenu.aExitNW)
 
         # Document
         self.addAction(self.mainMenu.aSaveDoc)
-        self.addAction(self.mainMenu.aFileDetails)
+        self.addAction(self.mainMenu.aCloseDoc)
 
         # Edit
         self.addAction(self.mainMenu.aEditUndo)
@@ -1316,6 +1323,13 @@ class GuiMain(QMainWindow):
 
         for mAction, _ in self.mainMenu.mInsKWItems.values():
             self.addAction(mAction)
+
+        # Search
+        self.addAction(self.mainMenu.aFind)
+        self.addAction(self.mainMenu.aReplace)
+        self.addAction(self.mainMenu.aFindNext)
+        self.addAction(self.mainMenu.aFindPrev)
+        self.addAction(self.mainMenu.aReplaceNext)
 
         # Format
         self.addAction(self.mainMenu.aFmtEmph)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1177,7 +1177,7 @@ class GuiMain(QMainWindow):
 
         return True
 
-    def setFocus(self, paneNo):
+    def switchFocus(self, paneNo):
         """Switch focus between main GUI views.
         """
         if paneNo == 1:
@@ -1225,7 +1225,7 @@ class GuiMain(QMainWindow):
         if self.isFocusMode:
             logger.debug("Activating Focus Mode")
             self.mainTabs.setCurrentWidget(self.splitDocs)
-            self.setFocus(2)
+            self.switchFocus(2)
         else:
             logger.debug("Deactivating Focus Mode")
 

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -46,7 +46,7 @@ from nw.gui import (
     GuiProjectTree, GuiProjectWizard, GuiTheme, GuiWordList, GuiWritingStats
 )
 from nw.core import NWProject, NWDoc, NWIndex
-from nw.constants import nwItemType, nwItemClass, nwAlert, nwLists
+from nw.constants import nwItemType, nwItemClass, nwAlert, nwLists, nwWidget
 from nw.common import getGuiItem, hexToInt
 
 logger = logging.getLogger(__name__)
@@ -810,7 +810,7 @@ class GuiMain(QMainWindow):
         if tHandle is None:
             if self.docEditor.anyFocus() or self.isFocusMode:
                 tHandle = self.docEditor.theHandle
-            elif self.treeView.hasFocus():
+            else:
                 tHandle = self.treeView.getSelectedHandle()
 
         if tHandle is None:
@@ -1180,15 +1180,15 @@ class GuiMain(QMainWindow):
     def switchFocus(self, paneNo):
         """Switch focus between main GUI views.
         """
-        if paneNo == 1:
+        if paneNo == nwWidget.TREE:
             self.treeView.setFocus()
-        elif paneNo == 2:
+        elif paneNo == nwWidget.EDITOR:
             self.mainTabs.setCurrentWidget(self.splitDocs)
             self.docEditor.setFocus()
-        elif paneNo == 3:
+        elif paneNo == nwWidget.VIEWER:
             self.mainTabs.setCurrentWidget(self.splitDocs)
             self.docViewer.setFocus()
-        elif paneNo == 4:
+        elif paneNo == nwWidget.OUTLINE:
             self.mainTabs.setCurrentWidget(self.splitOutline)
             self.projView.setFocus()
         return
@@ -1225,7 +1225,7 @@ class GuiMain(QMainWindow):
         if self.isFocusMode:
             logger.debug("Activating Focus Mode")
             self.mainTabs.setCurrentWidget(self.splitDocs)
-            self.switchFocus(2)
+            self.switchFocus(nwWidget.EDITOR)
         else:
             logger.debug("Deactivating Focus Mode")
 

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -117,14 +117,14 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     nwGUI.mainConf.autoScroll = True
 
     # Add a Character File
-    nwGUI.setFocus(1)
+    nwGUI.switchFocus(1)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("71ee45a3c0db9").setSelected(True)
     nwGUI.treeView.newTreeItem(nwItemType.FILE, None)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
-    nwGUI.setFocus(2)
+    nwGUI.switchFocus(2)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Jane Doe":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -139,14 +139,14 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
 
     # Add a Plot File
-    nwGUI.setFocus(1)
+    nwGUI.switchFocus(1)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("44cb730c42048").setSelected(True)
     nwGUI.treeView.newTreeItem(nwItemType.FILE, None)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
-    nwGUI.setFocus(2)
+    nwGUI.switchFocus(2)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Main Plot":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -161,7 +161,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
 
     # Add a World File
-    nwGUI.setFocus(1)
+    nwGUI.switchFocus(1)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("811786ad1ae74").setSelected(True)
     nwGUI.treeView.newTreeItem(nwItemType.FILE, None)
@@ -173,7 +173,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     nwGUI.docEditor.replaceText("")
 
     # Type something into the document
-    nwGUI.setFocus(2)
+    nwGUI.switchFocus(2)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Main Location":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -192,7 +192,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     nwGUI._autoSaveProject()
 
     # Select the 'New Scene' file
-    nwGUI.setFocus(1)
+    nwGUI.switchFocus(1)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("73475cb40a568").setExpanded(True)
     nwGUI.treeView._getTreeItem("31489056e0916").setExpanded(True)
@@ -200,7 +200,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
-    nwGUI.setFocus(2)
+    nwGUI.switchFocus(2)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Novel":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -300,7 +300,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     qtbot.wait(stepDelay)
 
     # Open and view the edited document
-    nwGUI.setFocus(3)
+    nwGUI.switchFocus(3)
     assert nwGUI.openDocument("0e17daca5f3e1")
     assert nwGUI.viewDocument("0e17daca5f3e1")
     qtbot.wait(stepDelay)

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -33,7 +33,7 @@ from PyQt5.QtWidgets import QAction, QMessageBox, QDialog
 from nw.gui.itemeditor import GuiItemEditor
 from nw.gui.doceditor import GuiDocEditor
 from nw.gui.projtree import GuiProjectTree
-from nw.constants import nwItemType, nwDocAction
+from nw.constants import nwItemType, nwDocAction, nwWidget
 
 keyDelay = 2
 typeDelay = 1
@@ -117,14 +117,14 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     nwGUI.mainConf.autoScroll = True
 
     # Add a Character File
-    nwGUI.switchFocus(1)
+    nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("71ee45a3c0db9").setSelected(True)
     nwGUI.treeView.newTreeItem(nwItemType.FILE, None)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
-    nwGUI.switchFocus(2)
+    nwGUI.switchFocus(nwWidget.EDITOR)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Jane Doe":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -139,14 +139,14 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
 
     # Add a Plot File
-    nwGUI.switchFocus(1)
+    nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("44cb730c42048").setSelected(True)
     nwGUI.treeView.newTreeItem(nwItemType.FILE, None)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
-    nwGUI.switchFocus(2)
+    nwGUI.switchFocus(nwWidget.EDITOR)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Main Plot":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -161,7 +161,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
 
     # Add a World File
-    nwGUI.switchFocus(1)
+    nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("811786ad1ae74").setSelected(True)
     nwGUI.treeView.newTreeItem(nwItemType.FILE, None)
@@ -173,7 +173,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     nwGUI.docEditor.replaceText("")
 
     # Type something into the document
-    nwGUI.switchFocus(2)
+    nwGUI.switchFocus(nwWidget.EDITOR)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Main Location":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -192,7 +192,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     nwGUI._autoSaveProject()
 
     # Select the 'New Scene' file
-    nwGUI.switchFocus(1)
+    nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("73475cb40a568").setExpanded(True)
     nwGUI.treeView._getTreeItem("31489056e0916").setExpanded(True)
@@ -200,7 +200,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
-    nwGUI.switchFocus(2)
+    nwGUI.switchFocus(nwWidget.EDITOR)
     qtbot.keyClick(nwGUI.docEditor, "a", modifier=Qt.ControlModifier, delay=keyDelay)
     for c in "# Novel":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -300,7 +300,7 @@ def testGuiEditor_Main(qtbot, monkeypatch, nwGUI, fncDir, fncProj, refDir, outDi
     qtbot.wait(stepDelay)
 
     # Open and view the edited document
-    nwGUI.switchFocus(3)
+    nwGUI.switchFocus(nwWidget.VIEWER)
     assert nwGUI.openDocument("0e17daca5f3e1")
     assert nwGUI.viewDocument("0e17daca5f3e1")
     qtbot.wait(stepDelay)

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -366,7 +366,7 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
 
     assert nwGUI.treeView._getTreeItem("0e17daca5f3e1") is not None
 
-    nwGUI.setFocus(1)
+    nwGUI.switchFocus(1)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("0e17daca5f3e1").setSelected(True)
     assert nwGUI.openSelectedItem()

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -28,7 +28,9 @@ from PyQt5.QtGui import QTextCursor, QTextBlock
 from PyQt5.QtWidgets import QAction, QFileDialog, QMessageBox
 
 from nw.gui.doceditor import GuiDocEditor
-from nw.constants import nwUnicode, nwDocAction, nwDocInsert, nwKeyWords
+from nw.constants import (
+    nwUnicode, nwDocAction, nwDocInsert, nwKeyWords, nwWidget
+)
 
 keyDelay = 2
 typeDelay = 1
@@ -366,7 +368,7 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
 
     assert nwGUI.treeView._getTreeItem("0e17daca5f3e1") is not None
 
-    nwGUI.switchFocus(1)
+    nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.treeView.clearSelection()
     nwGUI.treeView._getTreeItem("0e17daca5f3e1").setSelected(True)
     assert nwGUI.openSelectedItem()


### PR DESCRIPTION
This PR resolves #716, both in terms of the original request for the Search menu shortcuts to work in Focus Mode and in the mentioned bug discovered when closing a document while in Focus Mode.

The PR changes the following:
* All menu actions with shortcuts in the Search menu now also work in Focus Mode,
* The `setFocus` function in the main GUI class has been renamed to `switchFocus` as it overloads another function otherwise.
* The Edit/Search/Close buttons in the document header are no longer hidden when entering Focus Mode from the header button. They were not hidden when Focus Mode was activated from the main menu. The behaviour was thus inconsitent.
* Closing the document while in Focus Mode now automatically disables Focus Mode.
* The document header Focus Mode button now switches icon correctly when Focus Mode is activated from the main menu as it otherwise also does when the button is clicked.
* The Edit Item shortcut now also works in Focus Mode and opens the Item Editor for the open document.