### PR TITLE
Fix Win-Install from Source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.egg-info
 setup.iss
 novelwriter.desktop
+novelWriter.pyw
 i18n/*.qm
 i18n/*.qph
 

--- a/setup.py
+++ b/setup.py
@@ -695,6 +695,9 @@ def winInstall():
     targetPy = os.path.join(targetDir, "novelWriter.pyw")
     targetIcon = os.path.join(targetDir, "nw", "assets", "icons", "novelwriter.ico")
 
+    if not os.path.isfile(targetPy):
+        shutil.copy2(os.path.join(targetDir, "novelWriter.py"), targetPy)
+
     print("Collecting Info ...")
     print("Desktop Folder:    %s" % desktopDir)
     print("Start Menu Folder: %s" % startMenuDir)


### PR DESCRIPTION
Make sure the novelWriter.pyw file exists on win-install from a source package.

Resolves #727