### PR TITLE
Fix failed initial project dictionary

### DIFF
--- a/nw/core/spellcheck.py
+++ b/nw/core/spellcheck.py
@@ -108,26 +108,27 @@ class NWSpellCheck():
         lookup lists.
         """
         self.projDict = []
-        if projectDict is not None:
-            if not os.path.isfile(projectDict):
-                self.projectDict = None
-                return False
-            else:
-                self.projectDict = projectDict
+        self.projectDict = projectDict
 
-            try:
-                logger.debug("Loading project word list")
-                with open(projectDict, mode="r", encoding="utf-8") as wordsFile:
-                    for theLine in wordsFile:
-                        theLine = theLine.strip()
-                        if len(theLine) > 0 and theLine not in self.projDict:
-                            self.projDict.append(theLine)
-                logger.debug("Project word list contains %d words" % len(self.projDict))
+        if projectDict is None:
+            return False
 
-            except Exception:
-                logger.error("Failed to load project word list")
-                nw.logException()
-                return False
+        if not os.path.isfile(projectDict):
+            return False
+
+        try:
+            logger.debug("Loading project word list")
+            with open(projectDict, mode="r", encoding="utf-8") as wordsFile:
+                for theLine in wordsFile:
+                    theLine = theLine.strip()
+                    if len(theLine) > 0 and theLine not in self.projDict:
+                        self.projDict.append(theLine)
+            logger.debug("Project word list contains %d words" % len(self.projDict))
+
+        except Exception:
+            logger.error("Failed to load project word list")
+            nw.logException()
+            return False
 
         return True
 


### PR DESCRIPTION
This PR fixes an issue where the project dictionary variable was not set in the spell checker class when the file didn't already exist. The variable *must* be set, otherwise the words aren't saved, only added to the current session.

This resolves #733.