### PR TITLE
Class Cleanup

### DIFF
--- a/i18n/nw_en_US.ts
+++ b/i18n/nw_en_US.ts
@@ -798,22 +798,22 @@
 <context>
     <name>GuiDocEditFooter</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2464"/>
+        <location filename="../nw/gui/doceditor.py" line="2475"/>
         <source>Status</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2605"/>
+        <location filename="../nw/gui/doceditor.py" line="2616"/>
         <source>Line: {0} ({1})</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2621"/>
+        <location filename="../nw/gui/doceditor.py" line="2632"/>
         <source>Words: {0} ({1})</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2626"/>
+        <location filename="../nw/gui/doceditor.py" line="2637"/>
         <source>Document size is {0} bytes</source>
         <translation></translation>
     </message>
@@ -821,22 +821,22 @@
 <context>
     <name>GuiDocEditHeader</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2256"/>
+        <location filename="../nw/gui/doceditor.py" line="2267"/>
         <source>Edit document meta</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2267"/>
+        <location filename="../nw/gui/doceditor.py" line="2278"/>
         <source>Search document</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2278"/>
+        <location filename="../nw/gui/doceditor.py" line="2289"/>
         <source>Toggle Focus Mode</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2289"/>
+        <location filename="../nw/gui/doceditor.py" line="2300"/>
         <source>Close the document</source>
         <translation></translation>
     </message>
@@ -844,97 +844,97 @@
 <context>
     <name>GuiDocEditSearch</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1884"/>
+        <location filename="../nw/gui/doceditor.py" line="1895"/>
         <source>Search</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1875"/>
+        <location filename="../nw/gui/doceditor.py" line="1886"/>
         <source>Replace</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1888"/>
+        <location filename="../nw/gui/doceditor.py" line="1899"/>
         <source>Case Sensitive</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1889"/>
+        <location filename="../nw/gui/doceditor.py" line="1900"/>
         <source>Match case</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1896"/>
+        <location filename="../nw/gui/doceditor.py" line="1907"/>
         <source>Whole Words Only</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1897"/>
+        <location filename="../nw/gui/doceditor.py" line="1908"/>
         <source>Match whole words</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1904"/>
+        <location filename="../nw/gui/doceditor.py" line="1915"/>
         <source>RegEx Mode</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1905"/>
+        <location filename="../nw/gui/doceditor.py" line="1916"/>
         <source>Search using regular expressions</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1912"/>
+        <location filename="../nw/gui/doceditor.py" line="1923"/>
         <source>Loop Search</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1913"/>
+        <location filename="../nw/gui/doceditor.py" line="1924"/>
         <source>Loop the search when reaching the end</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1920"/>
+        <location filename="../nw/gui/doceditor.py" line="1931"/>
         <source>Search Next File</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1921"/>
+        <location filename="../nw/gui/doceditor.py" line="1932"/>
         <source>Continue searching in the next file</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1930"/>
+        <location filename="../nw/gui/doceditor.py" line="1941"/>
         <source>Preserve Case</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1931"/>
+        <location filename="../nw/gui/doceditor.py" line="1942"/>
         <source>Preserve case on replace</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1940"/>
+        <location filename="../nw/gui/doceditor.py" line="1951"/>
         <source>Close Search</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1941"/>
+        <location filename="../nw/gui/doceditor.py" line="1952"/>
         <source>Close the search box [{0}]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1953"/>
+        <location filename="../nw/gui/doceditor.py" line="1964"/>
         <source>Show/hide the replace text box</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1959"/>
+        <location filename="../nw/gui/doceditor.py" line="1970"/>
         <source>Find in current document</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1964"/>
+        <location filename="../nw/gui/doceditor.py" line="1975"/>
         <source>Find and replace in current document</source>
         <translation></translation>
     </message>
@@ -947,84 +947,94 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="401"/>
+        <location filename="../nw/gui/doceditor.py" line="407"/>
         <source>The text you are trying to add is too big. The text size is {0} MB. The maximum size allowed is {1} MB.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="669"/>
+        <location filename="../nw/gui/doceditor.py" line="680"/>
         <source>Spell check complete</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>File Location</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>The currently open file is saved in:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="953"/>
+        <location filename="../nw/gui/doceditor.py" line="964"/>
         <source>The document has grown too big and you cannot add more text to it. The maximum size of a single novelWriter document is {0} MB.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="991"/>
+        <location filename="../nw/gui/doceditor.py" line="1002"/>
         <source>Follow Tag</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="997"/>
+        <location filename="../nw/gui/doceditor.py" line="1008"/>
         <source>Cut</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1001"/>
+        <location filename="../nw/gui/doceditor.py" line="1012"/>
         <source>Copy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1005"/>
+        <location filename="../nw/gui/doceditor.py" line="1016"/>
         <source>Paste</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1014"/>
+        <location filename="../nw/gui/doceditor.py" line="1025"/>
         <source>Select All</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1018"/>
+        <location filename="../nw/gui/doceditor.py" line="1029"/>
         <source>Select Word</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1024"/>
+        <location filename="../nw/gui/doceditor.py" line="1035"/>
         <source>Select Paragraph</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1050"/>
+        <location filename="../nw/gui/doceditor.py" line="1061"/>
         <source>Spelling Suggestion(s)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1062"/>
+        <location filename="../nw/gui/doceditor.py" line="1073"/>
         <source>No Suggestions</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1068"/>
+        <location filename="../nw/gui/doceditor.py" line="1079"/>
         <source>Add Word to Dictionary</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1496"/>
+        <location filename="../nw/gui/doceditor.py" line="1507"/>
         <source>Please select some text before calling replace quotes.</source>
         <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="382"/>
+        <source>Opened Document: {0}</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="467"/>
+        <source>Saved Document: {0}</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1050,17 +1060,17 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="117"/>
+        <location filename="../nw/dialogs/docmerge.py" line="118"/>
         <source>No source document selected. Nothing to do.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="124"/>
+        <location filename="../nw/dialogs/docmerge.py" line="125"/>
         <source>Could not parse source document.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="167"/>
+        <location filename="../nw/dialogs/docmerge.py" line="168"/>
         <source>Element selected in the project tree must be a folder.</source>
         <translation></translation>
     </message>
@@ -1068,7 +1078,7 @@
 <context>
     <name>GuiDocSplit</name>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Split Document</source>
         <translation></translation>
     </message>
@@ -1113,27 +1123,27 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="150"/>
+        <location filename="../nw/dialogs/docsplit.py" line="153"/>
         <source>No headers found. Nothing to do.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="158"/>
+        <location filename="../nw/dialogs/docsplit.py" line="161"/>
         <source>Cannot add new folder for the document split. Maximum folder depth has been reached. Please move the file to another level in the project tree.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>The document will be split into {0} file(s) in a new folder. The original document will remain intact.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Continue with the splitting process?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="253"/>
+        <location filename="../nw/dialogs/docsplit.py" line="256"/>
         <source>Element selected in the project tree must be a file.</source>
         <translation></translation>
     </message>
@@ -1379,7 +1389,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Changes are saved automatically.</source>
         <translation></translation>
     </message>
@@ -1464,57 +1474,57 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Indexing: &apos;{0}&apos;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Unknown item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="905"/>
+        <location filename="../nw/guimain.py" line="901"/>
         <source>Indexing completed in {0} ms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="912"/>
+        <location filename="../nw/guimain.py" line="908"/>
         <source>The project index has been successfully rebuilt.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1115"/>
+        <location filename="../nw/guimain.py" line="1111"/>
         <source>Information</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1117"/>
+        <location filename="../nw/guimain.py" line="1113"/>
         <source>Warning</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1119"/>
+        <location filename="../nw/guimain.py" line="1115"/>
         <source>Error</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1121"/>
+        <location filename="../nw/guimain.py" line="1117"/>
         <source>This is a bug!</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1122"/>
+        <location filename="../nw/guimain.py" line="1118"/>
         <source>Internal Error</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Exit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Do you want to exit novelWriter?</source>
         <translation></translation>
     </message>
@@ -3940,57 +3950,57 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="432"/>
+        <location filename="../nw/gui/projtree.py" line="435"/>
         <source>There is currently no Trash folder in this project.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="443"/>
+        <location filename="../nw/gui/projtree.py" line="446"/>
         <source>The Trash folder is already empty.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Empty Trash</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Permanently delete {0} file(s) from Trash?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Delete File</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="508"/>
+        <location filename="../nw/gui/projtree.py" line="511"/>
         <source>Permanently delete file &apos;{0}&apos;?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Move file &apos;{0}&apos; to Trash?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="569"/>
+        <location filename="../nw/gui/projtree.py" line="572"/>
         <source>Cannot delete folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="585"/>
+        <location filename="../nw/gui/projtree.py" line="588"/>
         <source>Cannot delete root folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="872"/>
+        <location filename="../nw/gui/projtree.py" line="875"/>
         <source>The item cannot be moved to that location.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="969"/>
+        <location filename="../nw/gui/projtree.py" line="972"/>
         <source>There is nowhere to add item with name &apos;{0}&apos;.</source>
         <translation></translation>
     </message>
@@ -3998,52 +4008,52 @@
 <context>
     <name>GuiProjectTreeMenu</name>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1091"/>
+        <location filename="../nw/gui/projtree.py" line="1094"/>
         <source>Edit Project Item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1095"/>
+        <location filename="../nw/gui/projtree.py" line="1098"/>
         <source>Open Document</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1099"/>
+        <location filename="../nw/gui/projtree.py" line="1102"/>
         <source>View Document</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1103"/>
+        <location filename="../nw/gui/projtree.py" line="1106"/>
         <source>Toggle Included Flag</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1107"/>
+        <location filename="../nw/gui/projtree.py" line="1110"/>
         <source>New File</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1111"/>
+        <location filename="../nw/gui/projtree.py" line="1114"/>
         <source>New Folder</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1115"/>
+        <location filename="../nw/gui/projtree.py" line="1118"/>
         <source>Delete Item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1119"/>
+        <location filename="../nw/gui/projtree.py" line="1122"/>
         <source>Empty Trash</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1123"/>
+        <location filename="../nw/gui/projtree.py" line="1126"/>
         <source>Move Item Up</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1127"/>
+        <location filename="../nw/gui/projtree.py" line="1130"/>
         <source>Move Item Down</source>
         <translation></translation>
     </message>
@@ -4240,22 +4250,12 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="131"/>
-        <source>Opened Document: {0}</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="167"/>
+        <location filename="../nw/core/document.py" line="162"/>
         <source>Could not save document.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="177"/>
-        <source>Saved Document: {0}</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="202"/>
+        <location filename="../nw/core/document.py" line="192"/>
         <source>Could not delete document file.</source>
         <translation></translation>
     </message>
@@ -4923,12 +4923,12 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="291"/>
+        <location filename="../nw/core/tokenizer.py" line="294"/>
         <source>Document &apos;{0}&apos; is too big ({1} MB). Skipping.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="294"/>
+        <location filename="../nw/core/tokenizer.py" line="297"/>
         <source>ERROR</source>
         <translation></translation>
     </message>

--- a/i18n/nw_fr.ts
+++ b/i18n/nw_fr.ts
@@ -798,22 +798,22 @@
 <context>
     <name>GuiDocEditFooter</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2464"/>
+        <location filename="../nw/gui/doceditor.py" line="2475"/>
         <source>Status</source>
         <translation>État</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2605"/>
+        <location filename="../nw/gui/doceditor.py" line="2616"/>
         <source>Line: {0} ({1})</source>
         <translation>Ligne: {0} ({1})</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2621"/>
+        <location filename="../nw/gui/doceditor.py" line="2632"/>
         <source>Words: {0} ({1})</source>
         <translation>Mots: {0} ({1})</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2626"/>
+        <location filename="../nw/gui/doceditor.py" line="2637"/>
         <source>Document size is {0} bytes</source>
         <translation>La taille du document est de {0} octets</translation>
     </message>
@@ -821,22 +821,22 @@
 <context>
     <name>GuiDocEditHeader</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2256"/>
+        <location filename="../nw/gui/doceditor.py" line="2267"/>
         <source>Edit document meta</source>
         <translation>Modifier les métadonnées du document</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2267"/>
+        <location filename="../nw/gui/doceditor.py" line="2278"/>
         <source>Search document</source>
         <translation>Chercher dans le document</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2278"/>
+        <location filename="../nw/gui/doceditor.py" line="2289"/>
         <source>Toggle Focus Mode</source>
         <translation>Basculer le mode focus</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2289"/>
+        <location filename="../nw/gui/doceditor.py" line="2300"/>
         <source>Close the document</source>
         <translation>Fermer le document</translation>
     </message>
@@ -844,97 +844,97 @@
 <context>
     <name>GuiDocEditSearch</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1884"/>
+        <location filename="../nw/gui/doceditor.py" line="1895"/>
         <source>Search</source>
         <translation>Chercher</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1875"/>
+        <location filename="../nw/gui/doceditor.py" line="1886"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1888"/>
+        <location filename="../nw/gui/doceditor.py" line="1899"/>
         <source>Case Sensitive</source>
         <translation>Sensible à la casse</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1889"/>
+        <location filename="../nw/gui/doceditor.py" line="1900"/>
         <source>Match case</source>
         <translation>Respecter la casse</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1896"/>
+        <location filename="../nw/gui/doceditor.py" line="1907"/>
         <source>Whole Words Only</source>
         <translation>Mots entiers uniquement</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1897"/>
+        <location filename="../nw/gui/doceditor.py" line="1908"/>
         <source>Match whole words</source>
         <translation>Ne vérifier la correspondance que sur des mots entiers</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1904"/>
+        <location filename="../nw/gui/doceditor.py" line="1915"/>
         <source>RegEx Mode</source>
         <translation>Expressions régulières</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1905"/>
+        <location filename="../nw/gui/doceditor.py" line="1916"/>
         <source>Search using regular expressions</source>
         <translation>Chercher en utilisant des expressions régulières</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1912"/>
+        <location filename="../nw/gui/doceditor.py" line="1923"/>
         <source>Loop Search</source>
         <translation>Recherche en boucle</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1913"/>
+        <location filename="../nw/gui/doceditor.py" line="1924"/>
         <source>Loop the search when reaching the end</source>
         <translation>Reprendre la recherche au début du texte lorsque la fin est atteinte</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1920"/>
+        <location filename="../nw/gui/doceditor.py" line="1931"/>
         <source>Search Next File</source>
         <translation>Chercher dans le fichier suivant</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1921"/>
+        <location filename="../nw/gui/doceditor.py" line="1932"/>
         <source>Continue searching in the next file</source>
         <translation>Continuer la recherche dans le fichier suivant</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1930"/>
+        <location filename="../nw/gui/doceditor.py" line="1941"/>
         <source>Preserve Case</source>
         <translation>Conserver la casse</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1931"/>
+        <location filename="../nw/gui/doceditor.py" line="1942"/>
         <source>Preserve case on replace</source>
         <translation>Conserver la casse lors d&apos;un remplacement</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1940"/>
+        <location filename="../nw/gui/doceditor.py" line="1951"/>
         <source>Close Search</source>
         <translation>Terminer la recherche</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1941"/>
+        <location filename="../nw/gui/doceditor.py" line="1952"/>
         <source>Close the search box [{0}]</source>
         <translation>Fermer la boîte de recherche [{0}]</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1953"/>
+        <location filename="../nw/gui/doceditor.py" line="1964"/>
         <source>Show/hide the replace text box</source>
         <translation>Montrer/cacher le texte de remplacement</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1959"/>
+        <location filename="../nw/gui/doceditor.py" line="1970"/>
         <source>Find in current document</source>
         <translation>Chercher dans le document actuel</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1964"/>
+        <location filename="../nw/gui/doceditor.py" line="1975"/>
         <source>Find and replace in current document</source>
         <translation>Chercher et remplacer dans le document actuel</translation>
     </message>
@@ -947,84 +947,94 @@
         <translation>Le document que vous essayez d&apos;ouvrir est trop grand. La taille du document est de {0} MB alors que la taille maximale est de {1} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="401"/>
+        <location filename="../nw/gui/doceditor.py" line="407"/>
         <source>The text you are trying to add is too big. The text size is {0} MB. The maximum size allowed is {1} MB.</source>
         <translation>Le texte que vous voulez ajouter est trop grand. La taille du texte est de {0} MB alors que la taille maximale est de {1} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="669"/>
+        <location filename="../nw/gui/doceditor.py" line="680"/>
         <source>Spell check complete</source>
         <translation>La vérification orthographique est terminée</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>File Location</source>
         <translation>Emplacement du fichier</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>The currently open file is saved in:</source>
         <translation>Le fichier actuellement ouvert est enregistré dans :</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="953"/>
+        <location filename="../nw/gui/doceditor.py" line="964"/>
         <source>The document has grown too big and you cannot add more text to it. The maximum size of a single novelWriter document is {0} MB.</source>
         <translation>Le document est devenu trop grand et vous ne pouvez plus lui ajouter de texte. La taille maximale d&apos;un fichier novelWriter est de {0} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="991"/>
+        <location filename="../nw/gui/doceditor.py" line="1002"/>
         <source>Follow Tag</source>
         <translation>Suivre cette étiquette</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="997"/>
+        <location filename="../nw/gui/doceditor.py" line="1008"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1001"/>
+        <location filename="../nw/gui/doceditor.py" line="1012"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1005"/>
+        <location filename="../nw/gui/doceditor.py" line="1016"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1014"/>
+        <location filename="../nw/gui/doceditor.py" line="1025"/>
         <source>Select All</source>
         <translation>Sélectionner tout</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1018"/>
+        <location filename="../nw/gui/doceditor.py" line="1029"/>
         <source>Select Word</source>
         <translation>Sélectionner le mot</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1024"/>
+        <location filename="../nw/gui/doceditor.py" line="1035"/>
         <source>Select Paragraph</source>
         <translation>Sélectionner le paragraphe</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1050"/>
+        <location filename="../nw/gui/doceditor.py" line="1061"/>
         <source>Spelling Suggestion(s)</source>
         <translation>Orthographe suggérée</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1062"/>
+        <location filename="../nw/gui/doceditor.py" line="1073"/>
         <source>No Suggestions</source>
         <translation>Pas de suggestion</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1068"/>
+        <location filename="../nw/gui/doceditor.py" line="1079"/>
         <source>Add Word to Dictionary</source>
         <translation>Ajouter ce mot au dictionnaire</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1496"/>
+        <location filename="../nw/gui/doceditor.py" line="1507"/>
         <source>Please select some text before calling replace quotes.</source>
         <translation>Veuillez sélectionner du texte avant de demander le remplacement des guillemets.</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="382"/>
+        <source>Opened Document: {0}</source>
+        <translation>Document ouvert : {0}</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="467"/>
+        <source>Saved Document: {0}</source>
+        <translation>Document enregistré : {0}</translation>
     </message>
 </context>
 <context>
@@ -1050,17 +1060,17 @@
         <translation>Pas de document source trouvé. Aucune action.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="117"/>
+        <location filename="../nw/dialogs/docmerge.py" line="118"/>
         <source>No source document selected. Nothing to do.</source>
         <translation>Pas de document source sélectionné. Aucune action.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="124"/>
+        <location filename="../nw/dialogs/docmerge.py" line="125"/>
         <source>Could not parse source document.</source>
         <translation>Impossible d&apos;interpréter le nom du document source.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="167"/>
+        <location filename="../nw/dialogs/docmerge.py" line="168"/>
         <source>Element selected in the project tree must be a folder.</source>
         <translation>L&apos;élement selectionné dans l&apos;arborescence doit être un dossier.</translation>
     </message>
@@ -1068,7 +1078,7 @@
 <context>
     <name>GuiDocSplit</name>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Split Document</source>
         <translation>Découper un document</translation>
     </message>
@@ -1113,27 +1123,27 @@
         <translation>Impossible d&apos;interpréter le nom du document source.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="150"/>
+        <location filename="../nw/dialogs/docsplit.py" line="153"/>
         <source>No headers found. Nothing to do.</source>
         <translation>Pas d&apos;en-tête trouvé. Aucune action.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="158"/>
+        <location filename="../nw/dialogs/docsplit.py" line="161"/>
         <source>Cannot add new folder for the document split. Maximum folder depth has been reached. Please move the file to another level in the project tree.</source>
         <translation>Impossible d&apos;ajouter un nouveau dossier lors du découpage. Le nombre maximum de dossiers a été atteint. Veuillez placer ce fichier à un autre niveau dans l&apos;arborescence.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>The document will be split into {0} file(s) in a new folder. The original document will remain intact.</source>
         <translation>Ce document va être découpé en {0} fichier(s) dans un nouveau dossier. Le document d&apos;origine restera intact.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Continue with the splitting process?</source>
         <translation>Continuer le découpage ?</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="253"/>
+        <location filename="../nw/dialogs/docsplit.py" line="256"/>
         <source>Element selected in the project tree must be a file.</source>
         <translation>L&apos;élément sélectionné dans l&apos;arborescence doit être un fichier.</translation>
     </message>
@@ -1379,7 +1389,7 @@
         <translation>Fermer le projet en cours ?</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Changes are saved automatically.</source>
         <translation>Les changements sont enregistrés automatiquement.</translation>
     </message>
@@ -1464,57 +1474,57 @@
         <translation>Le contenu du fichier importé va remplacer le contenu actuel du document. Faut-il continuer ?</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Indexing: &apos;{0}&apos;</source>
         <translation>Indexation d e: &apos;{0}&apos;</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Unknown item</source>
         <translation>Item inconnu</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="905"/>
+        <location filename="../nw/guimain.py" line="901"/>
         <source>Indexing completed in {0} ms</source>
         <translation>Indexation effectuée en {0} ms</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="912"/>
+        <location filename="../nw/guimain.py" line="908"/>
         <source>The project index has been successfully rebuilt.</source>
         <translation>L&apos;index du projet a été correctement reconstruit.</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1115"/>
+        <location filename="../nw/guimain.py" line="1111"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1117"/>
+        <location filename="../nw/guimain.py" line="1113"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1119"/>
+        <location filename="../nw/guimain.py" line="1115"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1121"/>
+        <location filename="../nw/guimain.py" line="1117"/>
         <source>This is a bug!</source>
         <translation>Ceci est un bug !</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1122"/>
+        <location filename="../nw/guimain.py" line="1118"/>
         <source>Internal Error</source>
         <translation>Erreur interne</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Exit</source>
         <translation>Sortir</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Do you want to exit novelWriter?</source>
         <translation>Voulez-vous sortir de novelWriter ?</translation>
     </message>
@@ -3940,57 +3950,57 @@
         <translation>Nouveau dossier</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="432"/>
+        <location filename="../nw/gui/projtree.py" line="435"/>
         <source>There is currently no Trash folder in this project.</source>
         <translation>Il n&apos;existe pas actuellement de dossier Corbeille pour ce projet.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="443"/>
+        <location filename="../nw/gui/projtree.py" line="446"/>
         <source>The Trash folder is already empty.</source>
         <translation>Le dossier Corbeille est déjà vide.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Empty Trash</source>
         <translation>Vider la Corbeille</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Permanently delete {0} file(s) from Trash?</source>
         <translation>Effacer définitivement {0} fichier(s) dans la Corbeille ?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Delete File</source>
         <translation>Effacer un fichier</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="508"/>
+        <location filename="../nw/gui/projtree.py" line="511"/>
         <source>Permanently delete file &apos;{0}&apos;?</source>
         <translation>Effacer définitivement le fichier &apos;{0}&apos; ?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Move file &apos;{0}&apos; to Trash?</source>
         <translation>Mettre le fichier &apos;{0}&apos; dans la Corbeille ?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="569"/>
+        <location filename="../nw/gui/projtree.py" line="572"/>
         <source>Cannot delete folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation>Impossible d&apos;effacer le dossier car il n&apos;est pas vide. Les effacements récursifs n&apos;étant pas permis vous devez d&apos;abord effacer le contenu.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="585"/>
+        <location filename="../nw/gui/projtree.py" line="588"/>
         <source>Cannot delete root folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation>Impossible d&apos;effacer le dossier racine car il n&apos;est pas vide. Les effacements récursifs n&apos;étant pas permis vous devez d&apos;abord effacer le contenu.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="872"/>
+        <location filename="../nw/gui/projtree.py" line="875"/>
         <source>The item cannot be moved to that location.</source>
         <translation>Impossible de déplacer cet item vers cet emplacement.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="969"/>
+        <location filename="../nw/gui/projtree.py" line="972"/>
         <source>There is nowhere to add item with name &apos;{0}&apos;.</source>
         <translation>Il n&apos;y a pas d&apos;emplacement pour ajouter l&apos;item nommé &apos;{0}&apos;.</translation>
     </message>
@@ -3998,52 +4008,52 @@
 <context>
     <name>GuiProjectTreeMenu</name>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1091"/>
+        <location filename="../nw/gui/projtree.py" line="1094"/>
         <source>Edit Project Item</source>
         <translation>Éditer les caractéristiques</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1095"/>
+        <location filename="../nw/gui/projtree.py" line="1098"/>
         <source>Open Document</source>
         <translation>Ouvrir ce document</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1099"/>
+        <location filename="../nw/gui/projtree.py" line="1102"/>
         <source>View Document</source>
         <translation>Afficher ce document</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1103"/>
+        <location filename="../nw/gui/projtree.py" line="1106"/>
         <source>Toggle Included Flag</source>
         <translation>Basculer le marqueur d&apos;inclusion</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1107"/>
+        <location filename="../nw/gui/projtree.py" line="1110"/>
         <source>New File</source>
         <translation>Nouveau fichier</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1111"/>
+        <location filename="../nw/gui/projtree.py" line="1114"/>
         <source>New Folder</source>
         <translation>Nouveau dossier</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1115"/>
+        <location filename="../nw/gui/projtree.py" line="1118"/>
         <source>Delete Item</source>
         <translation>Supprimer ce composant</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1119"/>
+        <location filename="../nw/gui/projtree.py" line="1122"/>
         <source>Empty Trash</source>
         <translation>Vider la corbeille</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1123"/>
+        <location filename="../nw/gui/projtree.py" line="1126"/>
         <source>Move Item Up</source>
         <translation>Faire monter ce composant</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1127"/>
+        <location filename="../nw/gui/projtree.py" line="1130"/>
         <source>Move Item Down</source>
         <translation>Faire descendre ce composant</translation>
     </message>
@@ -4240,22 +4250,12 @@
         <translation>Impossible d&apos;ouvrir le document.</translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="131"/>
-        <source>Opened Document: {0}</source>
-        <translation>Document ouvert : {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="167"/>
+        <location filename="../nw/core/document.py" line="162"/>
         <source>Could not save document.</source>
         <translation>Impossible d&apos;enregistrer le document.</translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="177"/>
-        <source>Saved Document: {0}</source>
-        <translation>Document enregistré : {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="202"/>
+        <location filename="../nw/core/document.py" line="192"/>
         <source>Could not delete document file.</source>
         <translation>Impossible d&apos;effacer le document.</translation>
     </message>
@@ -4923,12 +4923,12 @@
         <translation>Synopsis</translation>
     </message>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="291"/>
+        <location filename="../nw/core/tokenizer.py" line="294"/>
         <source>Document &apos;{0}&apos; is too big ({1} MB). Skipping.</source>
         <translation>Le document &apos;{0}&apos; est trop grand ({1} Mo). Ignoré.</translation>
     </message>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="294"/>
+        <location filename="../nw/core/tokenizer.py" line="297"/>
         <source>ERROR</source>
         <translation>ERREUR</translation>
     </message>

--- a/i18n/nw_nb_NO.ts
+++ b/i18n/nw_nb_NO.ts
@@ -798,22 +798,22 @@
 <context>
     <name>GuiDocEditFooter</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2464"/>
+        <location filename="../nw/gui/doceditor.py" line="2475"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2605"/>
+        <location filename="../nw/gui/doceditor.py" line="2616"/>
         <source>Line: {0} ({1})</source>
         <translation>Linje: {0} ({1})</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2621"/>
+        <location filename="../nw/gui/doceditor.py" line="2632"/>
         <source>Words: {0} ({1})</source>
         <translation>Ord: {0} ({1})</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2626"/>
+        <location filename="../nw/gui/doceditor.py" line="2637"/>
         <source>Document size is {0} bytes</source>
         <translation>Dokumentet er {0} byte</translation>
     </message>
@@ -821,22 +821,22 @@
 <context>
     <name>GuiDocEditHeader</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2256"/>
+        <location filename="../nw/gui/doceditor.py" line="2267"/>
         <source>Edit document meta</source>
         <translation>Rediger dokumentinstillinger</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2267"/>
+        <location filename="../nw/gui/doceditor.py" line="2278"/>
         <source>Search document</source>
         <translation>Søk i dokumentet</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2278"/>
+        <location filename="../nw/gui/doceditor.py" line="2289"/>
         <source>Toggle Focus Mode</source>
         <translation>Slå av/på &quot;Fokus-modus&quot;</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2289"/>
+        <location filename="../nw/gui/doceditor.py" line="2300"/>
         <source>Close the document</source>
         <translation>Lukk dokumentet</translation>
     </message>
@@ -844,97 +844,97 @@
 <context>
     <name>GuiDocEditSearch</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1884"/>
+        <location filename="../nw/gui/doceditor.py" line="1895"/>
         <source>Search</source>
         <translation>Søk</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1875"/>
+        <location filename="../nw/gui/doceditor.py" line="1886"/>
         <source>Replace</source>
         <translation>Erstatt</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1888"/>
+        <location filename="../nw/gui/doceditor.py" line="1899"/>
         <source>Case Sensitive</source>
         <translation>Skill store/små bokstaver</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1889"/>
+        <location filename="../nw/gui/doceditor.py" line="1900"/>
         <source>Match case</source>
         <translation>Søket skiller mellom store og små bokstaver</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1896"/>
+        <location filename="../nw/gui/doceditor.py" line="1907"/>
         <source>Whole Words Only</source>
         <translation>Kun hele ord</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1897"/>
+        <location filename="../nw/gui/doceditor.py" line="1908"/>
         <source>Match whole words</source>
         <translation>Søk kun etter hele ord</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1904"/>
+        <location filename="../nw/gui/doceditor.py" line="1915"/>
         <source>RegEx Mode</source>
         <translation>RegEx-modus</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1905"/>
+        <location filename="../nw/gui/doceditor.py" line="1916"/>
         <source>Search using regular expressions</source>
         <translation>Søk ved hjelp av &quot;regular expressions&quot;</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1912"/>
+        <location filename="../nw/gui/doceditor.py" line="1923"/>
         <source>Loop Search</source>
         <translation>Søk rundt</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1913"/>
+        <location filename="../nw/gui/doceditor.py" line="1924"/>
         <source>Loop the search when reaching the end</source>
         <translation>Begynn søket på nytt når enden er nådd</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1920"/>
+        <location filename="../nw/gui/doceditor.py" line="1931"/>
         <source>Search Next File</source>
         <translation>Søk i neste file</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1921"/>
+        <location filename="../nw/gui/doceditor.py" line="1932"/>
         <source>Continue searching in the next file</source>
         <translation>Fortsett søket i neste fil</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1930"/>
+        <location filename="../nw/gui/doceditor.py" line="1941"/>
         <source>Preserve Case</source>
         <translation>Behold store/små bokstaver</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1931"/>
+        <location filename="../nw/gui/doceditor.py" line="1942"/>
         <source>Preserve case on replace</source>
         <translation>Behold store og små bokstaver på samme sted ved erstatt</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1940"/>
+        <location filename="../nw/gui/doceditor.py" line="1951"/>
         <source>Close Search</source>
         <translation>Lukk søk</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1941"/>
+        <location filename="../nw/gui/doceditor.py" line="1952"/>
         <source>Close the search box [{0}]</source>
         <translation>Lukk søkeboksen [{0}]</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1953"/>
+        <location filename="../nw/gui/doceditor.py" line="1964"/>
         <source>Show/hide the replace text box</source>
         <translation>Vis/skjul erstatt-boksen</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1959"/>
+        <location filename="../nw/gui/doceditor.py" line="1970"/>
         <source>Find in current document</source>
         <translation>Søk i det åpne dokumentet</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1964"/>
+        <location filename="../nw/gui/doceditor.py" line="1975"/>
         <source>Find and replace in current document</source>
         <translation>Søk og erstatt i det åpne dokumentet</translation>
     </message>
@@ -947,84 +947,94 @@
         <translation>Dokumentet du prøver å åpne er for stort. Dokumenter er på {0} MB. Den maksimale størrelsen tillat er {1} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="401"/>
+        <location filename="../nw/gui/doceditor.py" line="407"/>
         <source>The text you are trying to add is too big. The text size is {0} MB. The maximum size allowed is {1} MB.</source>
         <translation>Teksten du forsøker å legge til er for stor. Teksten er {0} MB. Den maksimale tillatte størrelsen er {1} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="669"/>
+        <location filename="../nw/gui/doceditor.py" line="680"/>
         <source>Spell check complete</source>
         <translation>Stavekontrollen er ferdig</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>File Location</source>
         <translation>Filens plassering</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>The currently open file is saved in:</source>
         <translation>Det åpne dokumentet er lagret på følgende sted:</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="953"/>
+        <location filename="../nw/gui/doceditor.py" line="964"/>
         <source>The document has grown too big and you cannot add more text to it. The maximum size of a single novelWriter document is {0} MB.</source>
         <translation>Dokumentet har blitt for stort og du kan ikke legge til mer tekst. Den maksimale tillatte størrelsen for et novelWriter-dokument er {0} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="991"/>
+        <location filename="../nw/gui/doceditor.py" line="1002"/>
         <source>Follow Tag</source>
         <translation>Følg knagg</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="997"/>
+        <location filename="../nw/gui/doceditor.py" line="1008"/>
         <source>Cut</source>
         <translation>Klipp</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1001"/>
+        <location filename="../nw/gui/doceditor.py" line="1012"/>
         <source>Copy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1005"/>
+        <location filename="../nw/gui/doceditor.py" line="1016"/>
         <source>Paste</source>
         <translation>Lim inn</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1014"/>
+        <location filename="../nw/gui/doceditor.py" line="1025"/>
         <source>Select All</source>
         <translation>Velg hele teksten</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1018"/>
+        <location filename="../nw/gui/doceditor.py" line="1029"/>
         <source>Select Word</source>
         <translation>Velg hele ordet</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1024"/>
+        <location filename="../nw/gui/doceditor.py" line="1035"/>
         <source>Select Paragraph</source>
         <translation>Velg hele avsnittet</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1050"/>
+        <location filename="../nw/gui/doceditor.py" line="1061"/>
         <source>Spelling Suggestion(s)</source>
         <translation>Forslag fra stavekontrollen</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1062"/>
+        <location filename="../nw/gui/doceditor.py" line="1073"/>
         <source>No Suggestions</source>
         <translation>Ingen forslag</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1068"/>
+        <location filename="../nw/gui/doceditor.py" line="1079"/>
         <source>Add Word to Dictionary</source>
         <translation>Legg til ord i ordbok</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1496"/>
+        <location filename="../nw/gui/doceditor.py" line="1507"/>
         <source>Please select some text before calling replace quotes.</source>
         <translation>Venligst velg en del av teksten før du velger å erstatte sitattegn.</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="382"/>
+        <source>Opened Document: {0}</source>
+        <translation>Åpnet dokument: {0}</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="467"/>
+        <source>Saved Document: {0}</source>
+        <translation>Lagret dokument: {0}</translation>
     </message>
 </context>
 <context>
@@ -1050,17 +1060,17 @@
         <translation>Ingen kilde-dokument funnet. Det er ingenting å gjøre.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="117"/>
+        <location filename="../nw/dialogs/docmerge.py" line="118"/>
         <source>No source document selected. Nothing to do.</source>
         <translation>Ingen kilde-dokument er valgt. Det er ingenting å gjøre.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="124"/>
+        <location filename="../nw/dialogs/docmerge.py" line="125"/>
         <source>Could not parse source document.</source>
         <translation>Klarte ikke å lese kilde-dokumentet.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="167"/>
+        <location filename="../nw/dialogs/docmerge.py" line="168"/>
         <source>Element selected in the project tree must be a folder.</source>
         <translation>Elementet som er valgt i prosjekttreet må være en mappe.</translation>
     </message>
@@ -1068,7 +1078,7 @@
 <context>
     <name>GuiDocSplit</name>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Split Document</source>
         <translation>Del opp dokument</translation>
     </message>
@@ -1113,27 +1123,27 @@
         <translation>Klarte ikke å lese kilde-dokumentet.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="150"/>
+        <location filename="../nw/dialogs/docsplit.py" line="153"/>
         <source>No headers found. Nothing to do.</source>
         <translation>Ingen overskrifter ble funnet i dokumentet. Det er ikke noe å gjøre.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="158"/>
+        <location filename="../nw/dialogs/docsplit.py" line="161"/>
         <source>Cannot add new folder for the document split. Maximum folder depth has been reached. Please move the file to another level in the project tree.</source>
         <translation>Kan ikke legge til ny mappe for å dele opp dokumentet. Dokumentet har allerede maksimal dybde i prosjekttreet. Flytt dokumentet til et annet nivå først.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>The document will be split into {0} file(s) in a new folder. The original document will remain intact.</source>
         <translation>Dokumentet vil nå bli delt opp i {0} nye filer i en ny mappe. Det originale dokumentet vil ikke bli endret eller fjernet.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Continue with the splitting process?</source>
         <translation>Fortsette med oppdelingen?</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="253"/>
+        <location filename="../nw/dialogs/docsplit.py" line="256"/>
         <source>Element selected in the project tree must be a file.</source>
         <translation>Elementet som er valgt i prosjekttreet må være et dokument.</translation>
     </message>
@@ -1374,7 +1384,7 @@
         <translation>Ønsker du å lukke dette prosjektet?</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Changes are saved automatically.</source>
         <translation>Endringer lagres automatisk.</translation>
     </message>
@@ -1459,57 +1469,57 @@
         <translation>Å importere filen vil overskrive all eksisterende tekst i dokumentet. Ønsker du å fortsette?</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Indexing: &apos;{0}&apos;</source>
         <translation>Indekserer: &apos;{0}&apos;</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Unknown item</source>
         <translation>Ukjent enhet</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="905"/>
+        <location filename="../nw/guimain.py" line="901"/>
         <source>Indexing completed in {0} ms</source>
         <translation>Indekseringen tok {0} ms</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="912"/>
+        <location filename="../nw/guimain.py" line="908"/>
         <source>The project index has been successfully rebuilt.</source>
         <translation>Prosjektets indeks har blitt bygget på nytt.</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1115"/>
+        <location filename="../nw/guimain.py" line="1111"/>
         <source>Information</source>
         <translation>Informasjon</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1117"/>
+        <location filename="../nw/guimain.py" line="1113"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1119"/>
+        <location filename="../nw/guimain.py" line="1115"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1121"/>
+        <location filename="../nw/guimain.py" line="1117"/>
         <source>This is a bug!</source>
         <translation>Dette er en systemfeil!</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1122"/>
+        <location filename="../nw/guimain.py" line="1118"/>
         <source>Internal Error</source>
         <translation>Intern feil</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Exit</source>
         <translation>Avslutt</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Do you want to exit novelWriter?</source>
         <translation>Ønsker du å avslutte novelWriter?</translation>
     </message>
@@ -3935,52 +3945,52 @@
         <translation>Ny mappe</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="432"/>
+        <location filename="../nw/gui/projtree.py" line="435"/>
         <source>There is currently no Trash folder in this project.</source>
         <translation>Det er for øyeblikket ingen søppel-mappe i dette prosjektet.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="443"/>
+        <location filename="../nw/gui/projtree.py" line="446"/>
         <source>The Trash folder is already empty.</source>
         <translation>Søppel-mappen er allerede tom.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Empty Trash</source>
         <translation>Tøm søppel</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Permanently delete {0} file(s) from Trash?</source>
         <translation>Vil du slette {0} filer i søppel-mappen for godt?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Delete File</source>
         <translation>Slett fil</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="508"/>
+        <location filename="../nw/gui/projtree.py" line="511"/>
         <source>Permanently delete file &apos;{0}&apos;?</source>
         <translation>Slette filen &apos;{0}&apos; for godt?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Move file &apos;{0}&apos; to Trash?</source>
         <translation>Vil du flytte filen &apos;{0}&apos; til søpla?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="569"/>
+        <location filename="../nw/gui/projtree.py" line="572"/>
         <source>Cannot delete folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation>Kan ikke slette mappen da den ikke er tom. Rekursiv sletting er ikke støttet. Du må slette innholdet først.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="585"/>
+        <location filename="../nw/gui/projtree.py" line="588"/>
         <source>Cannot delete root folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation>Kan ikke slette hovedmappen da den ikke er tom. Rekursiv sletting er ikke støttet. Du må slette innholdet først.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="872"/>
+        <location filename="../nw/gui/projtree.py" line="875"/>
         <source>The item cannot be moved to that location.</source>
         <translation>Denne enheten kan ikke flyttes til denne lokasjonen.</translation>
     </message>
@@ -3990,7 +4000,7 @@
         <translation>Kan ikke legge til nye filer eller mapper til søppel-mappen.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="969"/>
+        <location filename="../nw/gui/projtree.py" line="972"/>
         <source>There is nowhere to add item with name &apos;{0}&apos;.</source>
         <translation>Fant ikke noe sted å legge til enheten med navn &apos;{0}&apos;.</translation>
     </message>
@@ -3998,52 +4008,52 @@
 <context>
     <name>GuiProjectTreeMenu</name>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1091"/>
+        <location filename="../nw/gui/projtree.py" line="1094"/>
         <source>Edit Project Item</source>
         <translation>Endre enhet</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1095"/>
+        <location filename="../nw/gui/projtree.py" line="1098"/>
         <source>Open Document</source>
         <translation>Åpne dokument</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1099"/>
+        <location filename="../nw/gui/projtree.py" line="1102"/>
         <source>View Document</source>
         <translation>Vis dokument</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1103"/>
+        <location filename="../nw/gui/projtree.py" line="1106"/>
         <source>Toggle Included Flag</source>
         <translation>Slå av/på inkludering</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1107"/>
+        <location filename="../nw/gui/projtree.py" line="1110"/>
         <source>New File</source>
         <translation>Ny fil</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1111"/>
+        <location filename="../nw/gui/projtree.py" line="1114"/>
         <source>New Folder</source>
         <translation>Ny mappe</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1115"/>
+        <location filename="../nw/gui/projtree.py" line="1118"/>
         <source>Delete Item</source>
         <translation>Slett enhet</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1119"/>
+        <location filename="../nw/gui/projtree.py" line="1122"/>
         <source>Empty Trash</source>
         <translation>Tøm søppel</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1123"/>
+        <location filename="../nw/gui/projtree.py" line="1126"/>
         <source>Move Item Up</source>
         <translation>Flytt enhet opp</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1127"/>
+        <location filename="../nw/gui/projtree.py" line="1130"/>
         <source>Move Item Down</source>
         <translation>Flytt enhet ned</translation>
     </message>
@@ -4240,22 +4250,12 @@
         <translation>Kunne ikke åpne dokumentets fil.</translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="131"/>
-        <source>Opened Document: {0}</source>
-        <translation>Åpnet dokument: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="167"/>
+        <location filename="../nw/core/document.py" line="162"/>
         <source>Could not save document.</source>
         <translation>Kunne ikke lagre dokumentet.</translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="177"/>
-        <source>Saved Document: {0}</source>
-        <translation>Lagret dokumentet: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="202"/>
+        <location filename="../nw/core/document.py" line="192"/>
         <source>Could not delete document file.</source>
         <translation>Kunne ikke slette dokumentets fil.</translation>
     </message>
@@ -4918,12 +4918,12 @@
 <context>
     <name>Tokenizer</name>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="291"/>
+        <location filename="../nw/core/tokenizer.py" line="294"/>
         <source>Document &apos;{0}&apos; is too big ({1} MB). Skipping.</source>
         <translation>Dokumentet &apos;{0}&apos; er for stort ({1} MB). Hopper over.</translation>
     </message>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="294"/>
+        <location filename="../nw/core/tokenizer.py" line="297"/>
         <source>ERROR</source>
         <translation></translation>
     </message>

--- a/i18n/nw_pt.ts
+++ b/i18n/nw_pt.ts
@@ -798,22 +798,22 @@
 <context>
     <name>GuiDocEditFooter</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2605"/>
+        <location filename="../nw/gui/doceditor.py" line="2616"/>
         <source>Line: {0} ({1})</source>
         <translation>Linha: {0} ({1})</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2621"/>
+        <location filename="../nw/gui/doceditor.py" line="2632"/>
         <source>Words: {0} ({1})</source>
         <translation>Palavras: {0} ({1})</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2464"/>
+        <location filename="../nw/gui/doceditor.py" line="2475"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2626"/>
+        <location filename="../nw/gui/doceditor.py" line="2637"/>
         <source>Document size is {0} bytes</source>
         <translation>O tamanho do documento é {0} bytes</translation>
     </message>
@@ -821,22 +821,22 @@
 <context>
     <name>GuiDocEditHeader</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2256"/>
+        <location filename="../nw/gui/doceditor.py" line="2267"/>
         <source>Edit document meta</source>
         <translation>Editar os meta-dados do documento</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2267"/>
+        <location filename="../nw/gui/doceditor.py" line="2278"/>
         <source>Search document</source>
         <translation>Procurar no documento</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2278"/>
+        <location filename="../nw/gui/doceditor.py" line="2289"/>
         <source>Toggle Focus Mode</source>
         <translation>Alternar o &quot;Modo Foco&quot;</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="2289"/>
+        <location filename="../nw/gui/doceditor.py" line="2300"/>
         <source>Close the document</source>
         <translation>Fechar o documento</translation>
     </message>
@@ -844,97 +844,97 @@
 <context>
     <name>GuiDocEditSearch</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1884"/>
+        <location filename="../nw/gui/doceditor.py" line="1895"/>
         <source>Search</source>
         <translation>Pesquisa</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1875"/>
+        <location filename="../nw/gui/doceditor.py" line="1886"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1888"/>
+        <location filename="../nw/gui/doceditor.py" line="1899"/>
         <source>Case Sensitive</source>
         <translation>Diferenciar Maiúsculas e Minúsculas</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1889"/>
+        <location filename="../nw/gui/doceditor.py" line="1900"/>
         <source>Match case</source>
         <translation>Diferencia Maiúsculas e Minúsculas</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1896"/>
+        <location filename="../nw/gui/doceditor.py" line="1907"/>
         <source>Whole Words Only</source>
         <translation>Apenas Palavras Inteiras</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1897"/>
+        <location filename="../nw/gui/doceditor.py" line="1908"/>
         <source>Match whole words</source>
         <translation>Encontra apenas palavras inteiras</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1904"/>
+        <location filename="../nw/gui/doceditor.py" line="1915"/>
         <source>RegEx Mode</source>
         <translation>Expressão Regular</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1912"/>
+        <location filename="../nw/gui/doceditor.py" line="1923"/>
         <source>Loop Search</source>
         <translation>Pesquisa do Início</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1913"/>
+        <location filename="../nw/gui/doceditor.py" line="1924"/>
         <source>Loop the search when reaching the end</source>
         <translation>Pesquisa do início quando chega no final do documento</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1920"/>
+        <location filename="../nw/gui/doceditor.py" line="1931"/>
         <source>Search Next File</source>
         <translation>Busca no Próximo Arquivo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1921"/>
+        <location filename="../nw/gui/doceditor.py" line="1932"/>
         <source>Continue searching in the next file</source>
         <translation>Continua a busca no próximo arquivo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1930"/>
+        <location filename="../nw/gui/doceditor.py" line="1941"/>
         <source>Preserve Case</source>
         <translation>Preserva Maiúsculas e Minúsculas</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1931"/>
+        <location filename="../nw/gui/doceditor.py" line="1942"/>
         <source>Preserve case on replace</source>
         <translation>Preserva maiúsculas e minúsculas ao substituir</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1940"/>
+        <location filename="../nw/gui/doceditor.py" line="1951"/>
         <source>Close Search</source>
         <translation>Fechar a Busca</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1953"/>
+        <location filename="../nw/gui/doceditor.py" line="1964"/>
         <source>Show/hide the replace text box</source>
         <translation>Mostrar/Ocultar a caixa substituição</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1959"/>
+        <location filename="../nw/gui/doceditor.py" line="1970"/>
         <source>Find in current document</source>
         <translation>Encontrar no documento atual</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1964"/>
+        <location filename="../nw/gui/doceditor.py" line="1975"/>
         <source>Find and replace in current document</source>
         <translation>Encontrar e substituir no documento atual</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1941"/>
+        <location filename="../nw/gui/doceditor.py" line="1952"/>
         <source>Close the search box [{0}]</source>
         <translation>Fechar a caixa de busca [{0}]</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1905"/>
+        <location filename="../nw/gui/doceditor.py" line="1916"/>
         <source>Search using regular expressions</source>
         <translation>Busca usando expressões regulares</translation>
     </message>
@@ -942,12 +942,12 @@
 <context>
     <name>GuiDocEditor</name>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="669"/>
+        <location filename="../nw/gui/doceditor.py" line="680"/>
         <source>Spell check complete</source>
         <translation>Verificação ortográfica completa</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1062"/>
+        <location filename="../nw/gui/doceditor.py" line="1073"/>
         <source>No Suggestions</source>
         <translation>Sem Sugestões</translation>
     </message>
@@ -957,74 +957,84 @@
         <translation>O documento que você está tentando abrir é muito grande. O tamanho do documento é {0} MB. O tamanho máximo permitido é {1} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="401"/>
+        <location filename="../nw/gui/doceditor.py" line="407"/>
         <source>The text you are trying to add is too big. The text size is {0} MB. The maximum size allowed is {1} MB.</source>
         <translation>O texto que você está tentando adicionar é muito grande. O tamanho do texto é {0} MB. O tamanho máximo permitido é {1} MB.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>File Location</source>
         <translation>Localização do Arquivo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="991"/>
+        <location filename="../nw/gui/doceditor.py" line="1002"/>
         <source>Follow Tag</source>
         <translation>Seguir Etiqueta</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="997"/>
+        <location filename="../nw/gui/doceditor.py" line="1008"/>
         <source>Cut</source>
         <translation>Recortar</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1001"/>
+        <location filename="../nw/gui/doceditor.py" line="1012"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1005"/>
+        <location filename="../nw/gui/doceditor.py" line="1016"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1014"/>
+        <location filename="../nw/gui/doceditor.py" line="1025"/>
         <source>Select All</source>
         <translation>Selecionar Tudo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1018"/>
+        <location filename="../nw/gui/doceditor.py" line="1029"/>
         <source>Select Word</source>
         <translation>Selecionar Palavra</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1024"/>
+        <location filename="../nw/gui/doceditor.py" line="1035"/>
         <source>Select Paragraph</source>
         <translation>Selecionar Parágrafo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1050"/>
+        <location filename="../nw/gui/doceditor.py" line="1061"/>
         <source>Spelling Suggestion(s)</source>
         <translation>Sugestão de Ortografia</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1068"/>
+        <location filename="../nw/gui/doceditor.py" line="1079"/>
         <source>Add Word to Dictionary</source>
         <translation>Adicionar Palavra ao Dicionário</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="1496"/>
+        <location filename="../nw/gui/doceditor.py" line="1507"/>
         <source>Please select some text before calling replace quotes.</source>
         <translation>Por favor, selecione algum texto antes de invocar a substituição de aspas.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="763"/>
+        <location filename="../nw/gui/doceditor.py" line="774"/>
         <source>The currently open file is saved in:</source>
         <translation>O arquivo aberto atualmente está salvo em:</translation>
     </message>
     <message>
-        <location filename="../nw/gui/doceditor.py" line="953"/>
+        <location filename="../nw/gui/doceditor.py" line="964"/>
         <source>The document has grown too big and you cannot add more text to it. The maximum size of a single novelWriter document is {0} MB.</source>
         <translation>O tamanho do documento aumentou muito e você não pode adicionar mais texto nele. O tamanho máximo de um único documento do novelWriter é {0} MB.</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="382"/>
+        <source>Opened Document: {0}</source>
+        <translation>Documento Aberto: {0}</translation>
+    </message>
+    <message>
+        <location filename="../nw/gui/doceditor.py" line="467"/>
+        <source>Saved Document: {0}</source>
+        <translation>Documento Salvo: {0}</translation>
     </message>
 </context>
 <context>
@@ -1050,17 +1060,17 @@
         <translation>Nenhum documento-fonte foi encontrado. Nada para fazer.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="117"/>
+        <location filename="../nw/dialogs/docmerge.py" line="118"/>
         <source>No source document selected. Nothing to do.</source>
         <translation>Nenhum documento de origem selecionado. Nada a ser feito.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="124"/>
+        <location filename="../nw/dialogs/docmerge.py" line="125"/>
         <source>Could not parse source document.</source>
         <translation>Não foi possível interpretar o documento.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docmerge.py" line="167"/>
+        <location filename="../nw/dialogs/docmerge.py" line="168"/>
         <source>Element selected in the project tree must be a folder.</source>
         <translation>O elemento selecionado na árvore do projeto deve ser um diretório.</translation>
     </message>
@@ -1098,7 +1108,7 @@
         <translation>Dividir até os cabeçalhos de nível 4 (Seção)</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Split Document</source>
         <translation>Divisão de Documento</translation>
     </message>
@@ -1113,27 +1123,27 @@
         <translation>Não foi possível interpretar o documento.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="150"/>
+        <location filename="../nw/dialogs/docsplit.py" line="153"/>
         <source>No headers found. Nothing to do.</source>
         <translation>Nenhum cabeçalho foi encontrado. Nada para fazer.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="158"/>
+        <location filename="../nw/dialogs/docsplit.py" line="161"/>
         <source>Cannot add new folder for the document split. Maximum folder depth has been reached. Please move the file to another level in the project tree.</source>
         <translation>Não é possível adicionar um novo diretório para a divisão do documento. A profundidade máxima dos diretórios foi alcançada. Por favor mova o arquivo para outro nível na árvore do projeto.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>Continue with the splitting process?</source>
         <translation>Continuar com o processo de divisão?</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="253"/>
+        <location filename="../nw/dialogs/docsplit.py" line="256"/>
         <source>Element selected in the project tree must be a file.</source>
         <translation>O elemento selecionado na árvore do projeto deve ser um arquivo.</translation>
     </message>
     <message>
-        <location filename="../nw/dialogs/docsplit.py" line="167"/>
+        <location filename="../nw/dialogs/docsplit.py" line="170"/>
         <source>The document will be split into {0} file(s) in a new folder. The original document will remain intact.</source>
         <translation>O documento será dividio em {0} arquivo(s) em um novo diretório. O documento original será mantido intacto.</translation>
     </message>
@@ -1329,32 +1339,32 @@
         <translation>Nota: Se o programa ou o computador sofreu uma falha anteriormente, o bloqueio pode ser sobrescrito com segurança. Se, no entanto, outra instância do novelWriter esteja com o projeto aberto, sobrescrever o bloqueio pode corromper o projeto e não é recomendado.</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Unknown item</source>
         <translation>Item desconhecido</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1115"/>
+        <location filename="../nw/guimain.py" line="1111"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1117"/>
+        <location filename="../nw/guimain.py" line="1113"/>
         <source>Warning</source>
         <translation>Alerta</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1119"/>
+        <location filename="../nw/guimain.py" line="1115"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1121"/>
+        <location filename="../nw/guimain.py" line="1117"/>
         <source>This is a bug!</source>
         <translation>Isto é um bug!</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1122"/>
+        <location filename="../nw/guimain.py" line="1118"/>
         <source>Internal Error</source>
         <translation>Erro Interno</translation>
     </message>
@@ -1389,7 +1399,7 @@
         <translation>Fechar o projeto atual?</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Changes are saved automatically.</source>
         <translation>As alterações serão salvas automaticamente.</translation>
     </message>
@@ -1434,22 +1444,22 @@
         <translation>Importar o arquivo vai sobrescrever o conteúdo atual do documento. Você deseja continuar?</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="912"/>
+        <location filename="../nw/guimain.py" line="908"/>
         <source>The project index has been successfully rebuilt.</source>
         <translation>O índice do projeto foi reconstruído com sucesso.</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Exit</source>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="1151"/>
+        <location filename="../nw/guimain.py" line="1147"/>
         <source>Do you want to exit novelWriter?</source>
         <translation>Você deseja realmente sair do novelWriter?</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="905"/>
+        <location filename="../nw/guimain.py" line="901"/>
         <source>Indexing completed in {0} ms</source>
         <translation>Indexação completa em {0} ms</translation>
     </message>
@@ -1489,7 +1499,7 @@
         <translation>O projeto foi bloqueado pelo computador &apos;{0}&apos; ({1} {2}), ativo pela última vez em {3}.</translation>
     </message>
     <message>
-        <location filename="../nw/guimain.py" line="887"/>
+        <location filename="../nw/guimain.py" line="886"/>
         <source>Indexing: &apos;{0}&apos;</source>
         <translation>Indexando: &apos;{0}&apos;</translation>
     </message>
@@ -3885,27 +3895,27 @@
         <translation>A profundidade máxima de diretórios foi alcançada.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="432"/>
+        <location filename="../nw/gui/projtree.py" line="435"/>
         <source>There is currently no Trash folder in this project.</source>
         <translation>Não exite um diretório de Lixeira neste projeto.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="443"/>
+        <location filename="../nw/gui/projtree.py" line="446"/>
         <source>The Trash folder is already empty.</source>
         <translation>O diretório de Lixeira já está vazio.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Empty Trash</source>
         <translation>Esvaziar a Lixeira</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Delete File</source>
         <translation>Remover Arquivo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="872"/>
+        <location filename="../nw/gui/projtree.py" line="875"/>
         <source>The item cannot be moved to that location.</source>
         <translation>O item não pode ser movido para este local.</translation>
     </message>
@@ -3960,27 +3970,27 @@
         <translation>Novo Diretório</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="446"/>
+        <location filename="../nw/gui/projtree.py" line="449"/>
         <source>Permanently delete {0} file(s) from Trash?</source>
         <translation>Permanentemente remover {0} arquivo(s) da Lixeira?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="508"/>
+        <location filename="../nw/gui/projtree.py" line="511"/>
         <source>Permanently delete file &apos;{0}&apos;?</source>
         <translation>Permanentemente remover o arquivo &apos;{0}&apos;?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="536"/>
+        <location filename="../nw/gui/projtree.py" line="539"/>
         <source>Move file &apos;{0}&apos; to Trash?</source>
         <translation>Mover o arquivo &apos;{0}&apos; para a Lixeira?</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="569"/>
+        <location filename="../nw/gui/projtree.py" line="572"/>
         <source>Cannot delete folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation>Não foi possível remover o diretório. O diretório não está vazio. Exclusão recursiva não é suportada. Por favor remova todo o conteúdo primeiro.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="585"/>
+        <location filename="../nw/gui/projtree.py" line="588"/>
         <source>Cannot delete root folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
         <translation>Não foi possível remover o diretório-raiz. O diretório não está vazio. Exclusão recursiva não é suportada. Por favor remova todo o conteúdo primeiro.</translation>
     </message>
@@ -3990,7 +4000,7 @@
         <translation>Não foi possível adicionar novos arquivos ou diretórios à Lixeira.</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="969"/>
+        <location filename="../nw/gui/projtree.py" line="972"/>
         <source>There is nowhere to add item with name &apos;{0}&apos;.</source>
         <translation>Não há lugar para adicionar o item com o nome &apos;{0}&apos;.</translation>
     </message>
@@ -3998,52 +4008,52 @@
 <context>
     <name>GuiProjectTreeMenu</name>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1091"/>
+        <location filename="../nw/gui/projtree.py" line="1094"/>
         <source>Edit Project Item</source>
         <translation>Editar Item do Projeto</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1095"/>
+        <location filename="../nw/gui/projtree.py" line="1098"/>
         <source>Open Document</source>
         <translation>Abrir Documento</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1099"/>
+        <location filename="../nw/gui/projtree.py" line="1102"/>
         <source>View Document</source>
         <translation>Ver Documento</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1103"/>
+        <location filename="../nw/gui/projtree.py" line="1106"/>
         <source>Toggle Included Flag</source>
         <translation>Alternar Opção de Inclusão</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1107"/>
+        <location filename="../nw/gui/projtree.py" line="1110"/>
         <source>New File</source>
         <translation>Novo Arquivo</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1111"/>
+        <location filename="../nw/gui/projtree.py" line="1114"/>
         <source>New Folder</source>
         <translation>Novo Diretório</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1115"/>
+        <location filename="../nw/gui/projtree.py" line="1118"/>
         <source>Delete Item</source>
         <translation>Remover Item</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1119"/>
+        <location filename="../nw/gui/projtree.py" line="1122"/>
         <source>Empty Trash</source>
         <translation>Esvaziar a Lixeira</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1123"/>
+        <location filename="../nw/gui/projtree.py" line="1126"/>
         <source>Move Item Up</source>
         <translation>Mover Item Acima</translation>
     </message>
     <message>
-        <location filename="../nw/gui/projtree.py" line="1127"/>
+        <location filename="../nw/gui/projtree.py" line="1130"/>
         <source>Move Item Down</source>
         <translation>Mover Item Abaixo</translation>
     </message>
@@ -4240,22 +4250,12 @@
         <translation>Houve uma falha ao abrir o arquivo do documento.</translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="131"/>
-        <source>Opened Document: {0}</source>
-        <translation>Documento Aberto: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="167"/>
+        <location filename="../nw/core/document.py" line="162"/>
         <source>Could not save document.</source>
         <translation>Não foi possível salvar o documento.</translation>
     </message>
     <message>
-        <location filename="../nw/core/document.py" line="177"/>
-        <source>Saved Document: {0}</source>
-        <translation>Documento Salvo: {0}</translation>
-    </message>
-    <message>
-        <location filename="../nw/core/document.py" line="202"/>
+        <location filename="../nw/core/document.py" line="192"/>
         <source>Could not delete document file.</source>
         <translation>Não foi possível remover o arquivo do documento.</translation>
     </message>
@@ -4918,12 +4918,12 @@
 <context>
     <name>Tokenizer</name>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="294"/>
+        <location filename="../nw/core/tokenizer.py" line="297"/>
         <source>ERROR</source>
         <translation>ERRO</translation>
     </message>
     <message>
-        <location filename="../nw/core/tokenizer.py" line="291"/>
+        <location filename="../nw/core/tokenizer.py" line="294"/>
         <source>Document &apos;{0}&apos; is too big ({1} MB). Skipping.</source>
         <translation>O documento &apos;{0}&apos; é muito grande ({1} MB). Ignorando.</translation>
     </message>

--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -38,10 +38,10 @@ logger = logging.getLogger(__name__)
 
 class NWDoc():
 
-    def __init__(self, theProject, theParent):
+    def __init__(self, theProject):
 
         self.theProject = theProject
-        self.theParent  = theParent
+        self.theParent  = theProject.theParent
 
         # Internal Variables
         self._theItem   = None # The currently open item

--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -68,7 +68,7 @@ class NWDoc():
         self._docMeta   = {}
         return
 
-    def readDocument(self, tHandle, showStatus=True, isOrphan=False):
+    def readDocument(self, tHandle, isOrphan=False):
         """Read a document from handle, capturing potential file system
         errors and parse meta data. If the document doesn't exist on
         disk, return an empty string. If something went wrong, return
@@ -127,11 +127,6 @@ class NWDoc():
             logger.debug("The requested document does not exist.")
             return ""
 
-        if showStatus and not isOrphan:
-            self.theParent.setStatus(
-                self.tr("Opened Document: {0}").format(self._theItem.itemName)
-            )
-
         return theText
 
     def writeDocument(self, docText):
@@ -172,11 +167,6 @@ class NWDoc():
         if os.path.isfile(docPath):
             os.unlink(docPath)
         os.rename(docTemp, docPath)
-
-        if self._theItem is not None:
-            self.theParent.setStatus(
-                self.tr("Saved Document: {0}").format(self._theItem.itemName)
-            )
 
         return True
 

--- a/nw/core/document.py
+++ b/nw/core/document.py
@@ -68,8 +68,8 @@ class NWDoc():
         self._docMeta   = {}
         return
 
-    def openDocument(self, tHandle, showStatus=True, isOrphan=False):
-        """Open a document from handle, capturing potential file system
+    def readDocument(self, tHandle, showStatus=True, isOrphan=False):
+        """Read a document from handle, capturing potential file system
         errors and parse meta data. If the document doesn't exist on
         disk, return an empty string. If something went wrong, return
         None.
@@ -134,8 +134,8 @@ class NWDoc():
 
         return theText
 
-    def saveDocument(self, docText):
-        """Save the document. The file is saved via a temp file in case
+    def writeDocument(self, docText):
+        """Write the document. The file is saved via a temp file in case
         of save failure. Returns True if successful, False if not.
         """
         if self._docHandle is None:

--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -117,7 +117,7 @@ class NWIndex():
             return False
 
         theDoc = NWDoc(self.theProject, self.theParent)
-        theText = theDoc.openDocument(tHandle, showStatus=False)
+        theText = theDoc.readDocument(tHandle, showStatus=False)
         if theText:
             self.scanText(tHandle, theText)
 

--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -32,7 +32,7 @@ import os
 
 from time import time
 
-from nw.enum import nwItemType, nwItemClass, nwItemLayout, nwAlert
+from nw.enum import nwItemType, nwItemClass, nwItemLayout
 from nw.common import isHandle, isTitleTag, isItemClass, isItemLayout
 from nw.constants import nwFiles, nwKeyWords, nwUnicode
 from nw.core.document import NWDoc
@@ -44,12 +44,11 @@ class NWIndex():
     H_VALID = ("H0", "H1", "H2", "H3", "H4")
     H_LEVEL = {"H0": 0, "H1": 1, "H2": 2, "H3": 3, "H4": 4}
 
-    def __init__(self, theProject, theParent):
+    def __init__(self, theProject):
 
         # Internal
         self.mainConf    = nw.CONFIG
         self.theProject  = theProject
-        self.theParent   = theParent
         self.indexBroken = False
 
         # Indices
@@ -116,7 +115,7 @@ class NWIndex():
         if tItem.itemType != nwItemType.FILE:
             return False
 
-        theDoc = NWDoc(self.theProject, self.theParent)
+        theDoc = NWDoc(self.theProject)
         theText = theDoc.readDocument(tHandle)
         if theText:
             self.scanText(tHandle, theText)
@@ -157,10 +156,6 @@ class NWIndex():
                 logger.error("Failed to load index file")
                 nw.logException()
                 self.indexBroken = True
-                self.theParent.makeAlert(
-                    "Could not load cached index file. Rebuilding index.",
-                    nwAlert.WARN
-                )
                 return False
 
             self._tagIndex   = theData.get("tagIndex", {})

--- a/nw/core/index.py
+++ b/nw/core/index.py
@@ -117,7 +117,7 @@ class NWIndex():
             return False
 
         theDoc = NWDoc(self.theProject, self.theParent)
-        theText = theDoc.readDocument(tHandle, showStatus=False)
+        theText = theDoc.readDocument(tHandle)
         if theText:
             self.scanText(tHandle, theText)
 

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -266,7 +266,7 @@ class NWProject():
             titlePage = "%s%s %s\n" % (titlePage, self.tr("By"), self.getAuthors())
 
         # Document object for writing files
-        aDoc = NWDoc(self, self.theParent)
+        aDoc = NWDoc(self)
 
         if popMinimal:
             # Creating a minimal project with a few root folders and a
@@ -1393,7 +1393,7 @@ class NWProject():
             return
 
         # Handle orphans
-        aDoc = NWDoc(self, self.theParent)
+        aDoc = NWDoc(self)
         nOrph = 0
         noWhere = False
         oPrefix = self.tr("Recovered")

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -284,15 +284,15 @@ class NWProject():
             self.projTree.setFileItemLayout(xHandle[5], nwItemLayout.TITLE)
             self.projTree.setFileItemLayout(xHandle[7], nwItemLayout.CHAPTER)
 
-            aDoc.readDocument(xHandle[5], showStatus=False)
+            aDoc.readDocument(xHandle[5])
             aDoc.writeDocument(titlePage)
             aDoc.clearDocument()
 
-            aDoc.readDocument(xHandle[7], showStatus=False)
+            aDoc.readDocument(xHandle[7])
             aDoc.writeDocument("## %s\n\n" % self.tr("New Chapter"))
             aDoc.clearDocument()
 
-            aDoc.readDocument(xHandle[8], showStatus=False)
+            aDoc.readDocument(xHandle[8])
             aDoc.writeDocument("### %s\n\n" % self.tr("New Scene"))
             aDoc.clearDocument()
 
@@ -311,7 +311,7 @@ class NWProject():
             tHandle = self.newFile(self.tr("Title Page"), nwItemClass.NOVEL, nHandle)
             self.projTree.setFileItemLayout(tHandle, nwItemLayout.TITLE)
 
-            aDoc.readDocument(tHandle, showStatus=False)
+            aDoc.readDocument(tHandle)
             aDoc.writeDocument(titlePage)
             aDoc.clearDocument()
 
@@ -331,7 +331,7 @@ class NWProject():
                     cHandle = self.newFile(chTitle, nwItemClass.NOVEL, pHandle)
                     self.projTree.setFileItemLayout(cHandle, nwItemLayout.CHAPTER)
 
-                    aDoc.readDocument(cHandle, showStatus=False)
+                    aDoc.readDocument(cHandle)
                     aDoc.writeDocument("## %s\n\n" % chTitle)
                     aDoc.clearDocument()
 
@@ -341,7 +341,7 @@ class NWProject():
                             scTitle = self.tr("Scene {0}").format(f"{ch+1:d}.{sc+1:d}")
                             sHandle = self.newFile(scTitle, nwItemClass.NOVEL, pHandle)
 
-                            aDoc.readDocument(sHandle, showStatus=False)
+                            aDoc.readDocument(sHandle)
                             aDoc.writeDocument("### %s\n\n" % scTitle)
                             aDoc.clearDocument()
 
@@ -351,7 +351,7 @@ class NWProject():
                     scTitle = self.tr("Scene {0}").format(f"{sc+1:d}")
                     sHandle = self.newFile(scTitle, nwItemClass.NOVEL, nHandle)
 
-                    aDoc.readDocument(sHandle, showStatus=False)
+                    aDoc.readDocument(sHandle)
                     aDoc.writeDocument("### %s\n\n" % scTitle)
                     aDoc.clearDocument()
 
@@ -1404,7 +1404,7 @@ class NWProject():
             oParent = None
             oClass = None
             oLayout = None
-            if aDoc.readDocument(oHandle, showStatus=False, isOrphan=True) is not None:
+            if aDoc.readDocument(oHandle, isOrphan=True) is not None:
                 oName, oParent, oClass, oLayout = aDoc.getMeta()
 
             if oName:

--- a/nw/core/project.py
+++ b/nw/core/project.py
@@ -284,16 +284,16 @@ class NWProject():
             self.projTree.setFileItemLayout(xHandle[5], nwItemLayout.TITLE)
             self.projTree.setFileItemLayout(xHandle[7], nwItemLayout.CHAPTER)
 
-            aDoc.openDocument(xHandle[5], showStatus=False)
-            aDoc.saveDocument(titlePage)
+            aDoc.readDocument(xHandle[5], showStatus=False)
+            aDoc.writeDocument(titlePage)
             aDoc.clearDocument()
 
-            aDoc.openDocument(xHandle[7], showStatus=False)
-            aDoc.saveDocument("## %s\n\n" % self.tr("New Chapter"))
+            aDoc.readDocument(xHandle[7], showStatus=False)
+            aDoc.writeDocument("## %s\n\n" % self.tr("New Chapter"))
             aDoc.clearDocument()
 
-            aDoc.openDocument(xHandle[8], showStatus=False)
-            aDoc.saveDocument("### %s\n\n" % self.tr("New Scene"))
+            aDoc.readDocument(xHandle[8], showStatus=False)
+            aDoc.writeDocument("### %s\n\n" % self.tr("New Scene"))
             aDoc.clearDocument()
 
         elif popCustom:
@@ -311,8 +311,8 @@ class NWProject():
             tHandle = self.newFile(self.tr("Title Page"), nwItemClass.NOVEL, nHandle)
             self.projTree.setFileItemLayout(tHandle, nwItemLayout.TITLE)
 
-            aDoc.openDocument(tHandle, showStatus=False)
-            aDoc.saveDocument(titlePage)
+            aDoc.readDocument(tHandle, showStatus=False)
+            aDoc.writeDocument(titlePage)
             aDoc.clearDocument()
 
             # Create chapters and scenes
@@ -331,8 +331,8 @@ class NWProject():
                     cHandle = self.newFile(chTitle, nwItemClass.NOVEL, pHandle)
                     self.projTree.setFileItemLayout(cHandle, nwItemLayout.CHAPTER)
 
-                    aDoc.openDocument(cHandle, showStatus=False)
-                    aDoc.saveDocument("## %s\n\n" % chTitle)
+                    aDoc.readDocument(cHandle, showStatus=False)
+                    aDoc.writeDocument("## %s\n\n" % chTitle)
                     aDoc.clearDocument()
 
                     # Create chapter scenes
@@ -341,8 +341,8 @@ class NWProject():
                             scTitle = self.tr("Scene {0}").format(f"{ch+1:d}.{sc+1:d}")
                             sHandle = self.newFile(scTitle, nwItemClass.NOVEL, pHandle)
 
-                            aDoc.openDocument(sHandle, showStatus=False)
-                            aDoc.saveDocument("### %s\n\n" % scTitle)
+                            aDoc.readDocument(sHandle, showStatus=False)
+                            aDoc.writeDocument("### %s\n\n" % scTitle)
                             aDoc.clearDocument()
 
             # Create scenes (no chapters)
@@ -351,8 +351,8 @@ class NWProject():
                     scTitle = self.tr("Scene {0}").format(f"{sc+1:d}")
                     sHandle = self.newFile(scTitle, nwItemClass.NOVEL, nHandle)
 
-                    aDoc.openDocument(sHandle, showStatus=False)
-                    aDoc.saveDocument("### %s\n\n" % scTitle)
+                    aDoc.readDocument(sHandle, showStatus=False)
+                    aDoc.writeDocument("### %s\n\n" % scTitle)
                     aDoc.clearDocument()
 
         # Finalise
@@ -1404,7 +1404,7 @@ class NWProject():
             oParent = None
             oClass = None
             oLayout = None
-            if aDoc.openDocument(oHandle, showStatus=False, isOrphan=True) is not None:
+            if aDoc.readDocument(oHandle, showStatus=False, isOrphan=True) is not None:
                 oName, oParent, oClass, oLayout = aDoc.getMeta()
 
             if oName:

--- a/nw/core/tohtml.py
+++ b/nw/core/tohtml.py
@@ -37,8 +37,8 @@ class ToHtml(Tokenizer):
     M_EXPORT  = 1 # Tweak output for saving to HTML or printing
     M_EBOOK   = 2 # Tweak output for converting to epub
 
-    def __init__(self, theProject, theParent):
-        Tokenizer.__init__(self, theProject, theParent)
+    def __init__(self, theProject):
+        Tokenizer.__init__(self, theProject)
 
         self.genMode   = self.M_EXPORT
         self.cssStyles = True

--- a/nw/core/tokenizer.py
+++ b/nw/core/tokenizer.py
@@ -278,13 +278,16 @@ class Tokenizer():
         if self.theItem is None:
             return False
 
+        self.theText = ""
         if theText is not None:
             # If the text is set, just use that
             self.theText = theText
         else:
             # Otherwise, load it from file
-            theDocument  = NWDoc(self.theProject, self.theParent)
-            self.theText = theDocument.openDocument(theHandle)
+            theDoc  = NWDoc(self.theProject, self.theParent)
+            theText = theDoc.readDocument(theHandle)
+            if theText:
+                self.theText = theText
 
         docSize = len(self.theText)
         if docSize > nwConst.MAX_DOCSIZE:

--- a/nw/core/tokenizer.py
+++ b/nw/core/tokenizer.py
@@ -76,10 +76,10 @@ class Tokenizer():
     A_Z_TOPMRG = 0x0100 # Zero top margin
     A_Z_BTMMRG = 0x0200 # Zero bottom margin
 
-    def __init__(self, theProject, theParent):
+    def __init__(self, theProject):
 
         self.theProject = theProject
-        self.theParent  = theParent
+        self.theParent  = theProject.theParent
 
         # Data Variables
         self.theText     = ""   # The raw text to be tokenized
@@ -284,7 +284,7 @@ class Tokenizer():
             self.theText = theText
         else:
             # Otherwise, load it from file
-            theDoc  = NWDoc(self.theProject, self.theParent)
+            theDoc  = NWDoc(self.theProject)
             theText = theDoc.readDocument(theHandle)
             if theText:
                 self.theText = theText

--- a/nw/core/tomd.py
+++ b/nw/core/tomd.py
@@ -36,8 +36,8 @@ class ToMarkdown(Tokenizer):
     M_STD = 0 # Standard Markdown
     M_GH  = 1 # GitHub Markdown
 
-    def __init__(self, theProject, theParent):
-        Tokenizer.__init__(self, theProject, theParent)
+    def __init__(self, theProject):
+        Tokenizer.__init__(self, theProject)
 
         self.genMode = self.M_STD
         self.fullMD = []

--- a/nw/core/toodt.py
+++ b/nw/core/toodt.py
@@ -65,8 +65,8 @@ class ToOdt(Tokenizer):
     X_BRK = 0x08 # Line break
     X_TAB = 0x10 # Tab
 
-    def __init__(self, theProject, theParent, isFlat):
-        Tokenizer.__init__(self, theProject, theParent)
+    def __init__(self, theProject, isFlat):
+        Tokenizer.__init__(self, theProject)
 
         self.mainConf = nw.CONFIG
 

--- a/nw/dialogs/docmerge.py
+++ b/nw/dialogs/docmerge.py
@@ -110,8 +110,9 @@ class GuiDocMerge(QDialog):
         theDoc = NWDoc(self.theProject, self.theParent)
         theText = ""
         for tHandle in finalOrder:
-            theText += theDoc.openDocument(tHandle, False).rstrip("\n")
-            theText += "\n\n"
+            docText = theDoc.readDocument(tHandle, False).rstrip("\n")
+            if docText:
+                theText += docText+"\n\n"
 
         if self.sourceItem is None:
             self.theParent.makeAlert(
@@ -130,8 +131,8 @@ class GuiDocMerge(QDialog):
         newItem = self.theProject.projTree[nHandle]
         newItem.setStatus(srcItem.itemStatus)
 
-        theDoc.openDocument(nHandle, False)
-        theDoc.saveDocument(theText)
+        theDoc.readDocument(nHandle, False)
+        theDoc.writeDocument(theText)
         self.theParent.treeView.revealNewTreeItem(nHandle)
         self.theParent.openDocument(nHandle, doScroll=True)
 

--- a/nw/dialogs/docmerge.py
+++ b/nw/dialogs/docmerge.py
@@ -110,7 +110,7 @@ class GuiDocMerge(QDialog):
         theDoc = NWDoc(self.theProject, self.theParent)
         theText = ""
         for tHandle in finalOrder:
-            docText = theDoc.readDocument(tHandle, False).rstrip("\n")
+            docText = theDoc.readDocument(tHandle).rstrip("\n")
             if docText:
                 theText += docText+"\n\n"
 
@@ -131,7 +131,7 @@ class GuiDocMerge(QDialog):
         newItem = self.theProject.projTree[nHandle]
         newItem.setStatus(srcItem.itemStatus)
 
-        theDoc.readDocument(nHandle, False)
+        theDoc.readDocument(nHandle)
         theDoc.writeDocument(theText)
         self.theParent.treeView.revealNewTreeItem(nHandle)
         self.theParent.openDocument(nHandle, doScroll=True)

--- a/nw/dialogs/docmerge.py
+++ b/nw/dialogs/docmerge.py
@@ -107,7 +107,7 @@ class GuiDocMerge(QDialog):
             )
             return
 
-        theDoc = NWDoc(self.theProject, self.theParent)
+        theDoc = NWDoc(self.theProject)
         theText = ""
         for tHandle in finalOrder:
             docText = theDoc.readDocument(tHandle).rstrip("\n")

--- a/nw/dialogs/docmerge.py
+++ b/nw/dialogs/docmerge.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 class GuiDocMerge(QDialog):
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         QDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiDocMerge ...")
@@ -49,7 +49,7 @@ class GuiDocMerge(QDialog):
 
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
-        self.theProject = theProject
+        self.theProject = theParent.theProject
         self.sourceItem = None
 
         self.outerBox = QVBoxLayout()

--- a/nw/dialogs/docsplit.py
+++ b/nw/dialogs/docsplit.py
@@ -127,8 +127,11 @@ class GuiDocSplit(QDialog):
             )
             return
 
-        theDoc   = NWDoc(self.theProject, self.theParent)
-        theText  = theDoc.openDocument(self.sourceItem, False)
+        theDoc  = NWDoc(self.theProject, self.theParent)
+        theText = theDoc.readDocument(self.sourceItem, False)
+        if theText is None:
+            theText = ""
+
         theLines = theText.splitlines()
         nLines   = len(theLines)
         theLines.insert(0, "%Split Doc")
@@ -214,8 +217,8 @@ class GuiDocSplit(QDialog):
 
             theText = "\n".join(theLines[iStart:iEnd])
             theText = theText.rstrip("\n") + "\n\n"
-            theDoc.openDocument(nHandle, False)
-            theDoc.saveDocument(theText)
+            theDoc.readDocument(nHandle, False)
+            theDoc.writeDocument(theText)
             theDoc.clearDocument()
             self.theParent.treeView.revealNewTreeItem(nHandle)
 
@@ -257,7 +260,9 @@ class GuiDocSplit(QDialog):
 
         self.listBox.clear()
         theDoc  = NWDoc(self.theProject, self.theParent)
-        theText = theDoc.openDocument(self.sourceItem, False)
+        theText = theDoc.readDocument(self.sourceItem, False)
+        if theText is None:
+            theText = ""
 
         spLevel = self.splitLevel.currentData()
         self.optState.setValue("GuiDocSplit", "spLevel", spLevel)

--- a/nw/dialogs/docsplit.py
+++ b/nw/dialogs/docsplit.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 class GuiDocSplit(QDialog):
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         QDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiDocSplit ...")
@@ -50,8 +50,8 @@ class GuiDocSplit(QDialog):
 
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
-        self.theProject = theProject
-        self.optState   = self.theProject.optState
+        self.theProject = theParent.theProject
+        self.optState   = theParent.theProject.optState
         self.sourceItem = None
 
         self.outerBox = QVBoxLayout()

--- a/nw/dialogs/docsplit.py
+++ b/nw/dialogs/docsplit.py
@@ -128,7 +128,7 @@ class GuiDocSplit(QDialog):
             return
 
         theDoc  = NWDoc(self.theProject, self.theParent)
-        theText = theDoc.readDocument(self.sourceItem, False)
+        theText = theDoc.readDocument(self.sourceItem)
         if theText is None:
             theText = ""
 
@@ -217,7 +217,7 @@ class GuiDocSplit(QDialog):
 
             theText = "\n".join(theLines[iStart:iEnd])
             theText = theText.rstrip("\n") + "\n\n"
-            theDoc.readDocument(nHandle, False)
+            theDoc.readDocument(nHandle)
             theDoc.writeDocument(theText)
             theDoc.clearDocument()
             self.theParent.treeView.revealNewTreeItem(nHandle)
@@ -260,7 +260,7 @@ class GuiDocSplit(QDialog):
 
         self.listBox.clear()
         theDoc  = NWDoc(self.theProject, self.theParent)
-        theText = theDoc.readDocument(self.sourceItem, False)
+        theText = theDoc.readDocument(self.sourceItem)
         if theText is None:
             theText = ""
 

--- a/nw/dialogs/docsplit.py
+++ b/nw/dialogs/docsplit.py
@@ -127,7 +127,7 @@ class GuiDocSplit(QDialog):
             )
             return
 
-        theDoc  = NWDoc(self.theProject, self.theParent)
+        theDoc  = NWDoc(self.theProject)
         theText = theDoc.readDocument(self.sourceItem)
         if theText is None:
             theText = ""
@@ -259,7 +259,7 @@ class GuiDocSplit(QDialog):
             return
 
         self.listBox.clear()
-        theDoc  = NWDoc(self.theProject, self.theParent)
+        theDoc  = NWDoc(self.theProject)
         theText = theDoc.readDocument(self.sourceItem)
         if theText is None:
             theText = ""

--- a/nw/dialogs/itemeditor.py
+++ b/nw/dialogs/itemeditor.py
@@ -41,15 +41,15 @@ logger = logging.getLogger(__name__)
 
 class GuiItemEditor(QDialog):
 
-    def __init__(self, theParent, theProject, tHandle):
+    def __init__(self, theParent, tHandle):
         QDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiItemEditor ...")
         self.setObjectName("GuiItemEditor")
 
         self.mainConf   = nw.CONFIG
-        self.theProject = theProject
         self.theParent  = theParent
+        self.theProject = theParent.theProject
 
         ##
         #  Build GUI

--- a/nw/dialogs/preferences.py
+++ b/nw/dialogs/preferences.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 class GuiPreferences(PagedDialog):
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         PagedDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiPreferences ...")
@@ -53,7 +53,7 @@ class GuiPreferences(PagedDialog):
 
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
-        self.theProject = theProject
+        self.theProject = theParent.theProject
 
         self.setWindowTitle(self.tr("Preferences"))
 

--- a/nw/dialogs/projsettings.py
+++ b/nw/dialogs/projsettings.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 class GuiProjectSettings(PagedDialog):
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         PagedDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiProjectSettings ...")
@@ -50,8 +50,8 @@ class GuiProjectSettings(PagedDialog):
 
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
-        self.theProject = theProject
-        self.optState   = theProject.optState
+        self.theProject = theParent.theProject
+        self.optState   = theParent.theProject.optState
 
         self.theProject.countStatus()
         self.setWindowTitle(self.tr("Project Settings"))

--- a/nw/dialogs/quotes.py
+++ b/nw/dialogs/quotes.py
@@ -42,7 +42,7 @@ class GuiQuoteSelect(QDialog):
 
     selectedQuote = ""
 
-    def __init__(self, theParent=None, currentQuote="\""):
+    def __init__(self, theParent=None, currentQuote='"'):
         QDialog.__init__(self, parent=theParent)
 
         self.mainConf = nw.CONFIG

--- a/nw/dialogs/wordlist.py
+++ b/nw/dialogs/wordlist.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 class GuiWordList(QDialog):
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         QDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiWordList ...")
@@ -50,8 +50,8 @@ class GuiWordList(QDialog):
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
         self.theTheme   = theParent.theTheme
-        self.theProject = theProject
-        self.optState   = theProject.optState
+        self.theProject = theParent.theProject
+        self.optState   = theParent.theProject.optState
 
         self.setWindowTitle(self.tr("Project Word List"))
 

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -75,7 +75,7 @@ class GuiDocEditor(QTextEdit):
         self.theTheme   = theParent.theTheme
         self.theIndex   = theParent.theIndex
         self.theProject = theParent.theProject
-        self.nwDocument = NWDoc(self.theProject, self.theParent)
+        self.nwDocument = NWDoc(self.theProject)
 
         self.docChanged = False # Flag for changed status of document
         self.spellCheck = False # Flag for spell checking enabled

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -297,7 +297,7 @@ class GuiDocEditor(QTextEdit):
         document is new (empty string), we set up the editor for editing
         the file.
         """
-        theDoc = self.nwDocument.openDocument(tHandle, showStatus=showStatus)
+        theDoc = self.nwDocument.readDocument(tHandle, showStatus=showStatus)
         if theDoc is None:
             # There was an io error
             self.clearEditor()
@@ -438,7 +438,7 @@ class GuiDocEditor(QTextEdit):
         theItem.setParaCount(self.paraCount)
 
         self.saveCursorPosition()
-        self.nwDocument.saveDocument(docText)
+        self.nwDocument.writeDocument(docText)
         self.setDocumentChanged(False)
 
         self.theIndex.scanText(tHandle, docText)
@@ -454,7 +454,7 @@ class GuiDocEditor(QTextEdit):
 
         if self.theProject.projTree.updateItemLayout(tHandle, hLevel):
             self.theParent.treeView.setTreeItemValues(tHandle)
-            self.nwDocument.saveDocument(docText)
+            self.nwDocument.writeDocument(docText)
             self.docFooter.updateInfo()
 
         return True

--- a/nw/gui/doceditor.py
+++ b/nw/gui/doceditor.py
@@ -288,7 +288,7 @@ class GuiDocEditor(QTextEdit):
 
         return True
 
-    def loadText(self, tHandle, tLine=None, showStatus=True):
+    def loadText(self, tHandle, tLine=None):
         """Load text from a document into the editor. If we have an io
         error, we must handle this and clear the editor so that we don't
         risk overwriting the file if it exists. This can for instance
@@ -297,7 +297,7 @@ class GuiDocEditor(QTextEdit):
         document is new (empty string), we set up the editor for editing
         the file.
         """
-        theDoc = self.nwDocument.readDocument(tHandle, showStatus=showStatus)
+        theDoc = self.nwDocument.readDocument(tHandle)
         if theDoc is None:
             # There was an io error
             self.clearEditor()
@@ -376,6 +376,12 @@ class GuiDocEditor(QTextEdit):
             self.setPlainText("\n")
             self.setPlainText("")
             self.setCursorPosition(0)
+
+        # Update the status bar
+        if theItem is not None:
+            self.theParent.setStatus(
+                self.tr("Opened Document: {0}").format(theItem.itemName)
+            )
 
         return True
 
@@ -456,6 +462,11 @@ class GuiDocEditor(QTextEdit):
             self.theParent.treeView.setTreeItemValues(tHandle)
             self.nwDocument.writeDocument(docText)
             self.docFooter.updateInfo()
+
+        # Update the status bar
+        self.theParent.setStatus(
+            self.tr("Saved Document: {0}").format(theItem.itemName)
+        )
 
         return True
 

--- a/nw/gui/docviewer.py
+++ b/nw/gui/docviewer.py
@@ -168,7 +168,7 @@ class GuiDocViewer(QTextBrowser):
         qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
 
         sPos = self.verticalScrollBar().value()
-        aDoc = ToHtml(self.theProject, self.theParent)
+        aDoc = ToHtml(self.theProject)
         aDoc.setPreview(self.mainConf.viewComments, self.mainConf.viewSynopsis)
         aDoc.setLinkHeaders(True)
 

--- a/nw/gui/projdetails.py
+++ b/nw/gui/projdetails.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 class GuiProjectDetails(PagedDialog):
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         PagedDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiProjectDetails ...")
@@ -51,8 +51,8 @@ class GuiProjectDetails(PagedDialog):
 
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
-        self.theProject = theProject
-        self.optState   = theProject.optState
+        self.theProject = theParent.theProject
+        self.optState   = theParent.theProject.optState
 
         self.setWindowTitle(self.tr("Project Details"))
 

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -287,7 +287,7 @@ class GuiProjectTree(QTreeWidget):
 
         # This is a new files, so let's add some content
         newDoc = NWDoc(self.theProject, self.theParent)
-        curTxt = newDoc.readDocument(tHandle, showStatus=False)
+        curTxt = newDoc.readDocument(tHandle)
         if curTxt is None:
             curTxt = ""
 

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -287,7 +287,10 @@ class GuiProjectTree(QTreeWidget):
 
         # This is a new files, so let's add some content
         newDoc = NWDoc(self.theProject, self.theParent)
-        curTxt = newDoc.openDocument(tHandle, showStatus=False)
+        curTxt = newDoc.readDocument(tHandle, showStatus=False)
+        if curTxt is None:
+            curTxt = ""
+
         if curTxt == "":
             if nwItem.itemLayout == nwItemLayout.CHAPTER:
                 newText = f"## {nwItem.itemName}\n\n"
@@ -299,7 +302,7 @@ class GuiProjectTree(QTreeWidget):
                 newText = f"# {nwItem.itemName}\n\n"
 
             # Save the text and index it
-            newDoc.saveDocument(newText)
+            newDoc.writeDocument(newText)
             self.theIndex.scanText(tHandle, newText)
 
             # Get Word Counts

--- a/nw/gui/projtree.py
+++ b/nw/gui/projtree.py
@@ -286,7 +286,7 @@ class GuiProjectTree(QTreeWidget):
             return True
 
         # This is a new files, so let's add some content
-        newDoc = NWDoc(self.theProject, self.theParent)
+        newDoc = NWDoc(self.theProject)
         curTxt = newDoc.readDocument(tHandle)
         if curTxt is None:
             curTxt = ""
@@ -527,7 +527,7 @@ class GuiProjectTree(QTreeWidget):
                     if self.theParent.docEditor.theHandle == tHandle:
                         self.theParent.closeDocument()
 
-                    theDoc = NWDoc(self.theProject, self.theParent)
+                    theDoc = NWDoc(self.theProject)
                     theDoc.deleteDocument(tHandle)
                     self.theIndex.deleteHandle(tHandle)
                     self._deleteTreeItem(tHandle)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -48,7 +48,7 @@ from nw.dialogs import (
     GuiProjectLoad, GuiProjectSettings, GuiWordList
 )
 from nw.tools import GuiBuildNovel, GuiProjectWizard, GuiWritingStats
-from nw.core import NWProject, NWDoc, NWIndex
+from nw.core import NWProject, NWIndex
 from nw.enum import nwItemType, nwItemClass, nwAlert, nwWidget
 from nw.common import getGuiItem, hexToInt
 from nw.constants import nwLists
@@ -878,7 +878,6 @@ class GuiMain(QMainWindow):
         self.treeView.saveTreeOrder()
         self.theIndex.clearIndex()
 
-        theDoc = NWDoc(self.theProject, self)
         for nDone, tItem in enumerate(self.theProject.projTree):
 
             if tItem is not None:
@@ -888,10 +887,7 @@ class GuiMain(QMainWindow):
 
             if tItem is not None and tItem.itemType == nwItemType.FILE:
                 logger.verbose("Scanning: %s" % tItem.itemName)
-                theText = theDoc.openDocument(tItem.itemHandle, showStatus=False)
-
-                # Build tag index
-                self.theIndex.scanText(tItem.itemHandle, theText)
+                self.theIndex.reIndexHandle(tItem.itemHandle)
 
                 # Get Word Counts
                 cC, wC, pC = self.theIndex.getCounts(tItem.itemHandle)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -88,7 +88,7 @@ class GuiMain(QMainWindow):
         # Core Classes and Settings
         self.theTheme    = GuiTheme(self)
         self.theProject  = NWProject(self)
-        self.theIndex    = NWIndex(self.theProject, self)
+        self.theIndex    = NWIndex(self.theProject)
         self.hasProject  = False
         self.isFocusMode = False
         self.idleRefTime = time()

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -756,7 +756,7 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return False
 
-        dlgMerge = GuiDocMerge(self, self.theProject)
+        dlgMerge = GuiDocMerge(self)
         dlgMerge.exec_()
 
         return True
@@ -768,7 +768,7 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return False
 
-        dlgSplit = GuiDocSplit(self, self.theProject)
+        dlgSplit = GuiDocSplit(self)
         dlgSplit.exec_()
 
         return True
@@ -837,7 +837,7 @@ class GuiMain(QMainWindow):
             return
 
         logger.verbose("Requesting change to item %s" % tHandle)
-        dlgProj = GuiItemEditor(self, self.theProject, tHandle)
+        dlgProj = GuiItemEditor(self, tHandle)
         dlgProj.exec_()
         if dlgProj.result() == QDialog.Accepted:
             self.treeView.setTreeItemValues(tHandle)
@@ -958,7 +958,7 @@ class GuiMain(QMainWindow):
     def showPreferencesDialog(self):
         """Open the preferences dialog.
         """
-        dlgConf = GuiPreferences(self, self.theProject)
+        dlgConf = GuiPreferences(self)
         dlgConf.exec_()
 
         if dlgConf.result() == QDialog.Accepted:
@@ -982,7 +982,7 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return
 
-        dlgProj = GuiProjectSettings(self, self.theProject)
+        dlgProj = GuiProjectSettings(self)
         dlgProj.exec_()
 
         if dlgProj.result() == QDialog.Accepted:
@@ -1001,7 +1001,7 @@ class GuiMain(QMainWindow):
 
         self.treeView.flushTreeOrder()
 
-        dlgDetails = GuiProjectDetails(self, self.theProject)
+        dlgDetails = GuiProjectDetails(self)
         dlgDetails.setModal(False)
         dlgDetails.show()
 
@@ -1016,7 +1016,7 @@ class GuiMain(QMainWindow):
 
         dlgBuild = getGuiItem("GuiBuildNovel")
         if dlgBuild is None:
-            dlgBuild = GuiBuildNovel(self, self.theProject)
+            dlgBuild = GuiBuildNovel(self)
 
         dlgBuild.setModal(False)
         dlgBuild.show()
@@ -1032,7 +1032,7 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return
 
-        dlgWords = GuiWordList(self, self.theProject)
+        dlgWords = GuiWordList(self)
         dlgWords.exec_()
 
         if dlgWords.result() == QDialog.Accepted:
@@ -1050,7 +1050,7 @@ class GuiMain(QMainWindow):
 
         dlgStats = getGuiItem("GuiWritingStats")
         if dlgStats is None:
-            dlgStats = GuiWritingStats(self, self.theProject)
+            dlgStats = GuiWritingStats(self)
 
         dlgStats.setModal(False)
         dlgStats.show()

--- a/nw/tools/build.py
+++ b/nw/tools/build.py
@@ -66,17 +66,17 @@ class GuiBuildNovel(QDialog):
     FMT_JSON_H = 8 # HTML5 wrapped in JSON
     FMT_JSON_M = 9 # nW Markdown wrapped in JSON
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         QDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiBuildNovel ...")
         self.setObjectName("GuiBuildNovel")
 
         self.mainConf   = nw.CONFIG
-        self.theProject = theProject
         self.theParent  = theParent
         self.theTheme   = theParent.theTheme
-        self.optState   = self.theProject.optState
+        self.theProject = theParent.theProject
+        self.optState   = theParent.theProject.optState
 
         self.htmlText  = [] # List of html documents
         self.htmlStyle = [] # List of html styles

--- a/nw/tools/build.py
+++ b/nw/tools/build.py
@@ -608,7 +608,7 @@ class GuiBuildNovel(QDialog):
         # Build Preview
         # =============
 
-        makeHtml = ToHtml(self.theProject, self.theParent)
+        makeHtml = ToHtml(self.theProject)
         self._doBuild(makeHtml, isPreview=True)
         if replaceTabs:
             makeHtml.replaceTabs()
@@ -875,7 +875,7 @@ class GuiBuildNovel(QDialog):
         wSuccess = False
 
         if theFmt == self.FMT_ODT:
-            makeOdt = ToOdt(self.theProject, self.theParent, isFlat=False)
+            makeOdt = ToOdt(self.theProject, isFlat=False)
             self._doBuild(makeOdt)
             try:
                 makeOdt.saveOpenDocText(savePath)
@@ -884,7 +884,7 @@ class GuiBuildNovel(QDialog):
                 errMsg = str(e)
 
         elif theFmt == self.FMT_FODT:
-            makeOdt = ToOdt(self.theProject, self.theParent, isFlat=True)
+            makeOdt = ToOdt(self.theProject, isFlat=True)
             self._doBuild(makeOdt)
             try:
                 makeOdt.saveFlatXML(savePath)
@@ -893,7 +893,7 @@ class GuiBuildNovel(QDialog):
                 errMsg = str(e)
 
         elif theFmt == self.FMT_HTM:
-            makeHtml = ToHtml(self.theProject, self.theParent)
+            makeHtml = ToHtml(self.theProject)
             self._doBuild(makeHtml)
             if replaceTabs:
                 makeHtml.replaceTabs()
@@ -905,7 +905,7 @@ class GuiBuildNovel(QDialog):
                 errMsg = str(e)
 
         elif theFmt == self.FMT_NWD:
-            makeNwd = ToMarkdown(self.theProject, self.theParent)
+            makeNwd = ToMarkdown(self.theProject)
             makeNwd.setKeepMarkdown(True)
             self._doBuild(makeNwd, doConvert=False)
             if replaceTabs:
@@ -918,7 +918,7 @@ class GuiBuildNovel(QDialog):
                 errMsg = str(e)
 
         elif theFmt in (self.FMT_MD, self.FMT_GH):
-            makeMd = ToMarkdown(self.theProject, self.theParent)
+            makeMd = ToMarkdown(self.theProject)
             if theFmt == self.FMT_GH:
                 makeMd.setGitHubMarkdown()
             else:
@@ -945,7 +945,7 @@ class GuiBuildNovel(QDialog):
             }
 
             if theFmt == self.FMT_JSON_H:
-                makeHtml = ToHtml(self.theProject, self.theParent)
+                makeHtml = ToHtml(self.theProject)
                 self._doBuild(makeHtml)
                 if replaceTabs:
                     makeHtml.replaceTabs()
@@ -959,7 +959,7 @@ class GuiBuildNovel(QDialog):
                 }
 
             elif theFmt == self.FMT_JSON_M:
-                makeMd = ToHtml(self.theProject, self.theParent)
+                makeMd = ToHtml(self.theProject)
                 makeMd.setKeepMarkdown(True)
                 self._doBuild(makeMd, doConvert=False)
                 if replaceTabs:

--- a/nw/tools/writingstats.py
+++ b/nw/tools/writingstats.py
@@ -56,7 +56,7 @@ class GuiWritingStats(QDialog):
     FMT_JSON = 0
     FMT_CSV  = 1
 
-    def __init__(self, theParent, theProject):
+    def __init__(self, theParent):
         QDialog.__init__(self, theParent)
 
         logger.debug("Initialising GuiWritingStats ...")
@@ -64,9 +64,9 @@ class GuiWritingStats(QDialog):
 
         self.mainConf   = nw.CONFIG
         self.theParent  = theParent
-        self.theProject = theProject
         self.theTheme   = theParent.theTheme
-        self.optState   = theProject.optState
+        self.theProject = theParent.theProject
+        self.optState   = theParent.theProject.optState
 
         self.logData    = []
         self.filterData = []

--- a/tests/test_core/test_core_document.py
+++ b/tests/test_core/test_core_document.py
@@ -37,7 +37,7 @@ def testCoreDocument_LoadSave(monkeypatch, dummyGUI, nwMinimal):
     assert theProject.openProject(nwMinimal)
     assert theProject.projPath == nwMinimal
 
-    theDoc = NWDoc(theProject, dummyGUI)
+    theDoc = NWDoc(theProject)
     sHandle = "8c659a11cd429"
 
     # Not a valid handle
@@ -126,7 +126,7 @@ def testCoreDocument_Methods(monkeypatch, dummyGUI, nwMinimal):
     assert theProject.openProject(nwMinimal)
     assert theProject.projPath == nwMinimal
 
-    theDoc = NWDoc(theProject, dummyGUI)
+    theDoc = NWDoc(theProject)
     sHandle = "8c659a11cd429"
     docPath = os.path.join(nwMinimal, "content", sHandle+".nwd")
 

--- a/tests/test_core/test_core_document.py
+++ b/tests/test_core/test_core_document.py
@@ -41,10 +41,10 @@ def testCoreDocument_LoadSave(monkeypatch, dummyGUI, nwMinimal):
     sHandle = "8c659a11cd429"
 
     # Not a valid handle
-    assert theDoc.openDocument("dummy") is None
+    assert theDoc.readDocument("dummy") is None
 
     # Non-existent handle
-    assert theDoc.openDocument("0000000000000") is None
+    assert theDoc.readDocument("0000000000000") is None
 
     # Cause open() to fail while loading
     def dummyOpen(*args, **kwargs):
@@ -52,29 +52,29 @@ def testCoreDocument_LoadSave(monkeypatch, dummyGUI, nwMinimal):
 
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", dummyOpen)
-        assert theDoc.openDocument(sHandle) is None
+        assert theDoc.readDocument(sHandle) is None
 
     # Load the text
-    assert theDoc.openDocument(sHandle) == "### New Scene\n\n"
+    assert theDoc.readDocument(sHandle) == "### New Scene\n\n"
 
     # Try to open a new (non-existent) file
     nHandle = theProject.projTree.findRoot(nwItemClass.NOVEL)
     assert nHandle is not None
     xHandle = theProject.newFile("New File", nwItemClass.NOVEL, nHandle)
-    assert theDoc.openDocument(xHandle) == ""
+    assert theDoc.readDocument(xHandle) == ""
 
     # Check cached item
     assert isinstance(theDoc._theItem, NWItem)
-    assert theDoc.openDocument(xHandle, isOrphan=True) == ""
+    assert theDoc.readDocument(xHandle, isOrphan=True) == ""
     assert theDoc._theItem is None
 
     # Set handle and save again
     theText = "### Test File\n\nText ...\n\n"
-    assert theDoc.openDocument(xHandle) == ""
-    assert theDoc.saveDocument(theText)
+    assert theDoc.readDocument(xHandle) == ""
+    assert theDoc.writeDocument(theText)
 
     # Save again to ensure temp file and previous file is handled
-    assert theDoc.saveDocument(theText)
+    assert theDoc.writeDocument(theText)
 
     # Check file content
     docPath = os.path.join(nwMinimal, "content", xHandle+".nwd")
@@ -89,7 +89,7 @@ def testCoreDocument_LoadSave(monkeypatch, dummyGUI, nwMinimal):
 
     # Force no meta data
     theDoc._theItem = None
-    assert theDoc.saveDocument(theText)
+    assert theDoc.writeDocument(theText)
 
     with open(docPath, mode="r", encoding="utf8") as inFile:
         assert inFile.read() == theText
@@ -97,11 +97,11 @@ def testCoreDocument_LoadSave(monkeypatch, dummyGUI, nwMinimal):
     # Cause open() to fail while saving
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", causeOSError)
-        assert not theDoc.saveDocument(theText)
+        assert not theDoc.writeDocument(theText)
 
     # Saving with no handle
     theDoc.clearDocument()
-    assert not theDoc.saveDocument(theText)
+    assert not theDoc.writeDocument(theText)
 
     # Delete the last document
     assert not theDoc.deleteDocument("dummy")
@@ -130,7 +130,7 @@ def testCoreDocument_Methods(monkeypatch, dummyGUI, nwMinimal):
     sHandle = "8c659a11cd429"
     docPath = os.path.join(nwMinimal, "content", sHandle+".nwd")
 
-    assert theDoc.openDocument(sHandle) == "### New Scene\n\n"
+    assert theDoc.readDocument(sHandle) == "### New Scene\n\n"
 
     # Check location
     assert theDoc.getFileLocation() == docPath
@@ -147,7 +147,7 @@ def testCoreDocument_Methods(monkeypatch, dummyGUI, nwMinimal):
     assert theLayout == nwItemLayout.SCENE
 
     # Add meta data garbage
-    assert theDoc.saveDocument("%%~ stuff\n### Test File\n\nText ...\n\n")
+    assert theDoc.writeDocument("%%~ stuff\n### Test File\n\nText ...\n\n")
     with open(docPath, mode="r", encoding="utf8") as inFile:
         assert inFile.read() == (
             "%%~name: New Scene\n"
@@ -158,6 +158,6 @@ def testCoreDocument_Methods(monkeypatch, dummyGUI, nwMinimal):
             "Text ...\n\n"
         )
 
-    assert theDoc.openDocument(sHandle) == "### Test File\n\nText ...\n\n"
+    assert theDoc.readDocument(sHandle) == "### Test File\n\nText ...\n\n"
 
 # END Test testCoreDocument_Methods

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -48,7 +48,7 @@ def testCoreIndex_LoadSave(monkeypatch, nwLipsum, dummyGUI, outDir, refDir):
 
     monkeypatch.setattr("nw.core.index.time", lambda: 123.4)
 
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
     notIndexable = {
         "b3643d0f92e32": False, # Novel ROOT
         "45e6b01ca35c1": False, # Chapter One FOLDER
@@ -132,7 +132,7 @@ def testCoreIndex_ScanThis(nwMinimal, dummyGUI):
     theProject.projTree.setSeed(42)
     assert theProject.openProject(nwMinimal)
 
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
 
     isValid, theBits, thePos = theIndex.scanThis("tag: this, and this")
     assert not isValid
@@ -183,7 +183,7 @@ def testCoreIndex_CheckThese(nwMinimal, dummyGUI):
     theProject.projTree.setSeed(42)
     assert theProject.openProject(nwMinimal)
 
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
     nHandle = theProject.newFile("Hello", nwItemClass.NOVEL,     "a508bb932959c")
     cHandle = theProject.newFile("Jane",  nwItemClass.CHARACTER, "afb3043c7b2b3")
     nItem = theProject.projTree[nHandle]
@@ -244,7 +244,7 @@ def testCoreIndex_ScanText(nwMinimal, dummyGUI):
     theProject.projTree.setSeed(42)
     assert theProject.openProject(nwMinimal)
 
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
 
     # Some items for fail to scan tests
     dHandle = theProject.newFolder("Folder", nwItemClass.NOVEL, "a508bb932959c")
@@ -449,7 +449,7 @@ def testCoreIndex_ExtractData(nwMinimal, dummyGUI):
     theProject.projTree.setSeed(42)
     assert theProject.openProject(nwMinimal)
 
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
     nHandle = theProject.newFile("Hello", nwItemClass.NOVEL,     "a508bb932959c")
     cHandle = theProject.newFile("Jane",  nwItemClass.CHARACTER, "afb3043c7b2b3")
 
@@ -678,7 +678,7 @@ def testCoreIndex_CheckTagIndex(dummyGUI):
     """Test the tag index checker.
     """
     theProject = NWProject(dummyGUI)
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
 
     # Valid Index
     theIndex._tagIndex = {
@@ -742,7 +742,7 @@ def testCoreIndex_CheckRefIndex(dummyGUI):
     """Test the reference index checker.
     """
     theProject = NWProject(dummyGUI)
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
 
     # Valid Index
     theIndex._refIndex = {
@@ -864,7 +864,7 @@ def testCoreIndex_CheckNovelNoteIndex(dummyGUI):
     """Test the novel and note index checkers.
     """
     theProject = NWProject(dummyGUI)
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
 
     # Valid Index
     theIndex._novelIndex = {
@@ -1122,7 +1122,7 @@ def testCoreIndex_CheckTextCounts(dummyGUI):
     """Test the text counts checker.
     """
     theProject = NWProject(dummyGUI)
-    theIndex = NWIndex(theProject, dummyGUI)
+    theIndex = NWIndex(theProject)
 
     # Valid Index
     theIndex._textCounts = {

--- a/tests/test_core/test_core_tohtml.py
+++ b/tests/test_core/test_core_tohtml.py
@@ -32,8 +32,8 @@ def testCoreToHtml_Format(dummyGUI):
     """Test all the formatters for the ToHtml class.
     """
     theProject = NWProject(dummyGUI)
-    dummyGUI.theIndex = NWIndex(theProject, dummyGUI)
-    theHtml = ToHtml(theProject, dummyGUI)
+    dummyGUI.theIndex = NWIndex(theProject)
+    theHtml = ToHtml(theProject)
 
     # Export Mode
     # ===========
@@ -84,8 +84,8 @@ def testCoreToHtml_Convert(dummyGUI):
     """Test the converter of the ToHtml class.
     """
     theProject = NWProject(dummyGUI)
-    dummyGUI.theIndex = NWIndex(theProject, dummyGUI)
-    theHtml = ToHtml(theProject, dummyGUI)
+    dummyGUI.theIndex = NWIndex(theProject)
+    theHtml = ToHtml(theProject)
 
     # Export Mode
     # ===========
@@ -348,7 +348,7 @@ def testCoreToHtml_Complex(dummyGUI, fncDir):
     """Test the ave method of the ToHtml class.
     """
     theProject = NWProject(dummyGUI)
-    theHtml = ToHtml(theProject, dummyGUI)
+    theHtml = ToHtml(theProject)
 
     # Build Project
     # =============
@@ -421,7 +421,7 @@ def testCoreToHtml_Methods(dummyGUI):
     """Test all the other methods of the ToHtml class.
     """
     theProject = NWProject(dummyGUI)
-    theHtml = ToHtml(theProject, dummyGUI)
+    theHtml = ToHtml(theProject)
     theHtml.setKeepMarkdown(True)
 
     # Auto-Replace, keep Unicode

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -33,7 +33,7 @@ def testCoreToken_Setters(dummyGUI):
     """Test all the setters for the Tokenizer class.
     """
     theProject = NWProject(dummyGUI)
-    theToken = Tokenizer(theProject, dummyGUI)
+    theToken = Tokenizer(theProject)
 
     # Verify defaults
     assert theToken.fmtTitle == "%title%"
@@ -120,7 +120,7 @@ def testCoreToken_TextOps(monkeypatch, nwMinimal, dummyGUI):
     theProject.projLang = "en"
     theProject._loadProjectLocalisation()
 
-    theToken = Tokenizer(theProject, dummyGUI)
+    theToken = Tokenizer(theProject)
     theToken.setKeepMarkdown(True)
 
     assert theProject.openProject(nwMinimal)
@@ -137,7 +137,7 @@ def testCoreToken_TextOps(monkeypatch, nwMinimal, dummyGUI):
     )
     docTextR = docText.replace("<A>", "this").replace("<B>", "that")
 
-    nDoc = NWDoc(theProject, dummyGUI)
+    nDoc = NWDoc(theProject)
     nDoc.readDocument(sHandle)
     nDoc.writeDocument(docText)
     nDoc.clearDocument()
@@ -200,7 +200,7 @@ def testCoreToken_Tokenize(dummyGUI):
     """Test the tokenization of the Tokenizer class.
     """
     theProject = NWProject(dummyGUI)
-    theToken = Tokenizer(theProject, dummyGUI)
+    theToken = Tokenizer(theProject)
     theToken.setKeepMarkdown(True)
 
     # Header 1
@@ -417,7 +417,7 @@ def testCoreToken_Headers(dummyGUI):
     theProject = NWProject(dummyGUI)
     theProject.projLang = "en"
     theProject._loadProjectLocalisation()
-    theToken = Tokenizer(theProject, dummyGUI)
+    theToken = Tokenizer(theProject)
 
     # Nothing
     theToken.theText = "Some text ...\n"

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -138,8 +138,8 @@ def testCoreToken_TextOps(monkeypatch, nwMinimal, dummyGUI):
     docTextR = docText.replace("<A>", "this").replace("<B>", "that")
 
     nDoc = NWDoc(theProject, dummyGUI)
-    nDoc.openDocument(sHandle)
-    nDoc.saveDocument(docText)
+    nDoc.readDocument(sHandle)
+    nDoc.writeDocument(docText)
     nDoc.clearDocument()
 
     theProject.setAutoReplace({"A": "this", "B": "that"})

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -48,8 +48,8 @@ def testCoreToOdt_Convert(dummyGUI):
     """Test the converter of the ToHtml class.
     """
     theProject = NWProject(dummyGUI)
-    dummyGUI.theIndex = NWIndex(theProject, dummyGUI)
-    theDoc = ToOdt(theProject, dummyGUI, isFlat=True)
+    dummyGUI.theIndex = NWIndex(theProject)
+    theDoc = ToOdt(theProject, isFlat=True)
 
     # Export Mode
     # ===========


### PR DESCRIPTION
This PR:

* Makes class initialisation consistent. Since the `GuiMain` and `NWProject` classes have a reference to each other, none of the other classes need a reference to both. Some classes extracted one from the other, but this has now been made consistent such that all data classes only get the `NWProject` reference and all GUI classes only get the `GuiMain` reference.
* The duplicate error message generated in `NWIndex` has been removed. It was also not translated.
* The status bar message written from the `NWDoc` class on document open and save are now generated from the `GuiDocEditor` class instead since the `showStatus` flag that disables it was used on every other call to the open function. The flag has now been removed as well.
* The `NWDoc` functions `openDocument` and `saveDocument` have been renamed to `readDocument` and `writeDocument`. Partially because that is what they actually do, and partially because there are already `openDocument` and `saveDocument` functions in the `GuiMain` class. This makes it easier to look them up.