### PR TITLE
Issue #773: Fix QTranslate() filePath issue

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Packages
         run: |
           sudo apt update
-          sudo apt install libenchant-dev qt5-default
+          sudo apt install libenchant-dev qt5-default qttools5-dev-tools
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Install Dependencies
@@ -32,6 +32,8 @@ jobs:
           pip install pytest-cov
           pip install pytest-qt
           pip install codecov
+      - name: Update Translations
+        run: python setup.py qtlrelease
       - name: Run Tests
         run: |
           export QT_QPA_PLATFORM=offscreen

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - name: Install Packages
+      - name: Install Packages (apt)
         run: |
           sudo apt update
           sudo apt install libenchant-dev qt5-default qttools5-dev-tools
       - name: Checkout Source
         uses: actions/checkout@v2
-      - name: Install Dependencies
+      - name: Install Dependencies (pip)
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
@@ -32,8 +32,8 @@ jobs:
           pip install pytest-cov
           pip install pytest-qt
           pip install codecov
-      - name: Update Translations
-        run: python setup.py qtlrelease
+      - name: Run Build Commands
+        run: python setup.py qtlrelease sample
       - name: Run Tests
         run: |
           export QT_QPA_PLATFORM=offscreen

--- a/docs/source/int_started.rst
+++ b/docs/source/int_started.rst
@@ -106,8 +106,8 @@ Building the Translation Files
 
 If you installed novelWriter from a package, the translation files should be pre-built and
 included. If you're running novelWriter from the source code, you will need to generate the files
-yourself. The files you need will be written to the ``i18n`` folder, and will have the ``.qm`` file
-extension.
+yourself. The files you need will be written to the ``nw/assets/i18n`` folder, and will have the
+``.qm`` file extension.
 
 You can build the ``.qm`` files with:
 
@@ -115,7 +115,8 @@ You can build the ``.qm`` files with:
 
    python3 setup.py qtlrelease
 
-This requires that the Python package ``pylupdate5`` to be installed.
+This requires that the Qt Linguist tool is installed on your system. On Ubuntu and Debian, the
+needed package is called `qttools5-dev-tools`.
 
 .. note::
    If you want to improve novelWriter with translation files for another language, or update an

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -36,8 +36,15 @@ test it.
 Please do not submit the `.qm` files to the repository. Only the `.ts` files in the `i18n` folder
 are needed.
 
-**Note:** This requires that you have the tools Qt 5 Linguist and the PyQt5 tool `pylupdate5`
+**Note**
+
+These commands require that you have the tools Qt 5 Linguist and the PyQt5 tool `pylupdate5`
 installed on your system.
+
+For Ubuntu/Debian, run:
+```bash
+sudo apt install qttools5-dev-tools pyqt5-dev-tools
+```
 
 ### Missing QtBase Translations
 

--- a/nw/config.py
+++ b/nw/config.py
@@ -391,7 +391,7 @@ class Config:
                 lngFile = "%s_%s" % (lngBase, lngCode.replace("-", "_"))
                 if lngFile not in self.qtTrans:
                     if qTrans.load(lngFile, lngPath):
-                        logger.debug("Loaded: %s" % qTrans.filePath())
+                        logger.debug("Loaded: %s" % os.path.join(lngPath, lngFile))
                         nwApp.installTranslator(qTrans)
                         self.qtTrans[lngFile] = qTrans
 

--- a/setup.py
+++ b/setup.py
@@ -225,8 +225,9 @@ def buildQtI18n():
     try:
         subprocess.call(["lrelease", "-verbose", "novelWriter.pro"])
     except Exception as e:
-        print("QtI18n Release Error:")
+        print("Qt5 Linguist tools seem to be missing")
         print(str(e))
+        sys.exit(1)
 
     print("")
     print("Moving QM Files to Assets")
@@ -262,8 +263,9 @@ def buildQtI18nTS():
     try:
         subprocess.call(["pylupdate5", "-verbose", "-noobsolete", "novelWriter.pro"])
     except Exception as e:
-        print("QtI18n Release Error:")
+        print("PyQt5 Linguist tools seem to be missing")
         print(str(e))
+        sys.exit(1)
 
     print("")
 


### PR DESCRIPTION
The function called was only added in Qt 5.15: https://doc.qt.io/qt-5/qtranslator.html#filePath

~~Also add a GitHub action to run the tests under minimum package dependencies to try to detect such bugs early.~~
The old package setup doesn't really work because the test environment isn't designed for outdated packages. Need to run a virtualbox locally instead.

Resolves #773