### PR TITLE
Issue #769: Generating handles on Windows

### DIFF
--- a/nw/core/tree.py
+++ b/nw/core/tree.py
@@ -77,6 +77,7 @@ class NWTree():
         self._treeChanged = False # True if tree structure has changed
 
         self._handleSeed  = None  # Used for generating handles for testing
+        self._handleCount = 0     # A counter that is added to the handle generator
 
         return
 
@@ -515,7 +516,8 @@ class NWTree():
         handle requests come faster than the clock resolution.
         """
         if self._handleSeed is None:
-            newSeed = str(time()) + addSeed
+            newSeed = "%s_%d_%s" % (str(time()), self._handleCount, addSeed)
+            self._handleCount += 1
         else:
             # This is used for debugging
             newSeed = str(self._handleSeed)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -371,9 +371,9 @@ class GuiMain(QMainWindow):
 
         logger.info("Creating new project")
         if self.theProject.newProject(projData):
+            self.hasProject = True
             self.rebuildTrees()
             self.saveProject()
-            self.hasProject = True
             self.docEditor.setDictionaries()
             self.rebuildIndex(beQuiet=True)
             self.statusBar.setRefTime(self.theProject.projOpened)


### PR DESCRIPTION
This PR fixes a minor issue with the new prorject generator asking for new file handles so fast that the clock resolution becomes a problem when on Windows. Collisions of handles is handled, but it causes a warning. This is solved by adding a counter to the time stamp used for generating handles.

This PR also removes an error message printed when generating a new project.

This resolves #769.