### PR TITLE
Change the branching model

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,18 +2,19 @@
 Please check the following before you make a pull request:
 
 * The branch you are making the pull request from (in your own fork) has a unique and descriptive
-  name. Do not make a pull request directly from your copy of `main`, `dev` or `testing`.
+  name. Do not make a pull request directly from your copy of `main`.
 * If you are submitting translation files, only submit the files that you have added translations
   to, not the other .ts files that may have been updated in the process.
 * Make sure your contribution follows the style guide and other requirements mentioned in the
   CONTRIBUTING.md file in the repository.
+* Fill in the Summary section below, and if relevant, mention the issue numbers related to the PR.
 -->
 
 **Summary:**
 
 **Related Issue(s):**
 
-**Checklist:**
+**Reviewer's Checklist:**
 
 * [ ] The header of all files contain a reference to the repository license
 * [ ] The overall test coverage is increased or remains the same as before

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -2,9 +2,11 @@ name: flake8
 
 on:
   push:
-    branches: [ main, testing, dev ]
+    branches: 
+      - main
   pull_request:
-    branches: [ main, testing, dev ]
+    branches:
+      - main
 
 jobs:
   checkSyntax:

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -2,9 +2,11 @@ name: Linux
 
 on:
   push:
-    branches: [ main, testing, dev ]
+    branches: 
+      - main
   pull_request:
-    branches: [ main, testing, dev ]
+    branches:
+      - main
 
 jobs:
   testLinux:
@@ -21,17 +23,14 @@ jobs:
       - name: Install Packages (apt)
         run: |
           sudo apt update
-          sudo apt install libenchant-dev qt5-default qttools5-dev-tools
+          sudo apt install libenchant-dev qttools5-dev-tools
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Install Dependencies (pip)
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest-timeout
-          pip install pytest-cov
-          pip install pytest-qt
-          pip install codecov
+          pip install -r requirements-dev.txt
       - name: Run Build Commands
         run: python setup.py qtlrelease sample
       - name: Run Tests

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -2,9 +2,11 @@ name: macOS
 
 on:
   push:
-    branches: [ main, testing, dev ]
+    branches: 
+      - main
   pull_request:
-    branches: [ main, testing, dev ]
+    branches:
+      - main
 
 jobs:
   testMac:
@@ -24,11 +26,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
           pip install pyobjc
-          pip install pytest-timeout
-          pip install pytest-cov
-          pip install pytest-qt
-          pip install codecov
       - name: Run Tests
         run: |
           export QT_QPA_PLATFORM=offscreen

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -2,9 +2,11 @@ name: Windows
 
 on:
   push:
-    branches: [ main, testing, dev ]
+    branches: 
+      - main
   pull_request:
-    branches: [ main, testing, dev ]
+    branches:
+      - main
 
 jobs:
   testWin:
@@ -21,10 +23,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest-timeout
-          pip install pytest-cov
-          pip install pytest-qt
-          pip install codecov
+          pip install -r requirements-dev.txt
       - name: Run Tests
         run: |
           pytest -v --cov=nw --timeout=60

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,35 +7,16 @@ request directly.
 
 ## Branching Structure
 
-There are three protected branches on this repository. They are used in the following way:
-
-* `main` – This is the Stable branch. It is used for releases and subsequent patches. No
-  development code should be merged into this branch starting from version 1.0.
-* `dev` – This is the Unstable (development) branch. It is where new features are merged, and where
-  pre-releases are taken from.
-* `testing` – This is the Testing branch. It is populated from the `dev` branch for pre-releases
-  that need a longer testing phase.
-
-Stable releases and patches will be tagged in the `main` branch, pre-releases may be tagged from
-either `testing` or `dev` branch.
-
-### What Branch to Use for Contributions
-
-* If your contribution is a fix for the latest stable release, branch from the `main` branch.
-* If your contribution is a new feature, branch from the `dev` branch.
-* The `testing` branch is used infrequently. It is only used for pre-releases when new code is
-  being developed that is not a part of the current testing release.
-
-The current status of each branch is described in a pinned issue titled
-"[Development Flow & Status](https://github.com/vkbo/novelWriter/issues/707)".
-
-Please do not make your changes on a branch with the same name as any of the above mentioned
-branches. You should make a unique and descriptive branch name in your fork for your changes.
+This project mainly follows the OneFlow branching structure. The `main` branch is the default
+branch. If your contribution is a bugfix for a specific version, please make a bugfix branch from
+the tag you want the fix to be applied to. For other changes, make a feature branch from the
+current `main` branch.
 
 ## Pull Request Process
 
 1. Make sure your code passes all tests and conforms to the style guide. You can check that the
-   code conforms by running `flake8` from the root of the project folder.
+   code conforms by running `flake8` from the root of the project folder. The same check is also
+   run on pull requests by the maintainer.
 2. Please provide a complete description of the changes in the pull request, and a summary that can
    be copied into the [CHANGELOG](CHANGELOG.md). Remember to reference any issue related by
    providing the issue number.
@@ -70,7 +51,7 @@ lines should wrap at 79 characters, not 99. If wrapping can be avoided by going 
 generally preferrable.
 
 For text files, the text should also be wrapped at 99 character. The exception is markdown image
-tags and urls.
+tags and urls which can run past that limit.
 
 Please do not submit pull requests that re-wrap existing source or text unless this has been
 discussed beforehand.
@@ -84,22 +65,22 @@ The `setup.cfg` file in the root of this project has the following settings for 
 matches the coding standard:
 ```conf
 [flake8]
-ignore = E203,E221,E226,E228,E241,E251
+ignore = E221,E226,E228,E241
 max-line-length = 99
 exclude = docs/*
 ```
 
 The command line equivalent, with reporting, is:
 ```bash
-flake8 . --count --ignore E203,E221,E226,E228,E241,E251 --max-line-length=99 --show-source --statistics
+flake8 . --count --ignore E221,E226,E228,E241 --max-line-length=99 --show-source --statistics
 ```
 
-Passing this check is required before contributions are merged into the `main`, `testing` or `dev`
-branches. This is checked automatically when you make a pull request. You can run the `flake8`
-command locally to check beforehand. The full command will give you a detailed description of the
-code lines that do not conform to the standard.
+Passing this check is required before contributions are merged into the `main` branch. This is
+checked automatically when you make a pull request. You can run the `flake8` command locally to
+check beforehand. The full command will give you a detailed description of the code lines that do
+not conform to the standard.
 
-## Ignored Errors
+### Ignored Errors
 
 Some `flake8` error codes are ignored for this project for various reasons. The source also uses
 camelCase function and variable names. This is the standard for the Qt libraries novelWriter
@@ -108,7 +89,7 @@ integrates with. It also happens to be the author's personal preferences. (Yay!)
 The reason behind the other ignored error codes are listed below. Two of them are due to PEP8 not
 permitting column alignment as opposed to many other coding styles, like for instance for Go. I
 find them useful in regions of bulk value assignments. There's a reason why tables are more
-readable than lists. They should be used sparingly though.
+readable than lists. They should be used sparingly though. If you're unsure, follow PEP8.
 
 The ignored errors are all `pycodestyle` errors, and they are documented
 [here](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes).

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ met. It is regularly tested on Debian and Ubuntu Linux, Windows, and macOS.
 
 ## Project Contributions
 
-The project isn't taking feature contributions at the moment. If you have an idea, please make a
-feature request in the issue tracker. Fixes and patches are welcome. So are new translations.
+Please don't make feature pull requests without first having discussed them with the maintainer.
+You can make a feature request in the issue tracker, or if the idea isn't fully formed, start a
+discussion on the discussion page. Fixes and patches are welcome. So are new translations.
 Contributions related to packaging and installing novelWriter will also be appreciated.
 
 If you want to help translating novelWriter into another language, please see the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,3 @@ pytest>=4.0.0
 pytest-timeout
 pytest-cov
 pytest-qt
-codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest>=4.0.0
+pytest-timeout
+pytest-cov
+pytest-qt
+codecov


### PR DESCRIPTION
**Summary:**

The GitFlow-based branching model used in this repo is a bit clunky, so I've decided to change it to the OneFlow model. Due to this, some minor changes have to be made to the repo and a few of the readmes.

**Related Issue(s):**

**Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
