### PR TITLE
Fix layout margins on paged dialogs

### DIFF
--- a/nw/gui/custom.py
+++ b/nw/gui/custom.py
@@ -393,11 +393,11 @@ class PagedDialog(QDialog):
         self._outerBox.addLayout(self._buttonBox)
 
         # Default Margins
-        qM = self._outerBox.contentsMargins()
-        mL = qM.left()
-        mR = qM.right()
-        mT = qM.top()
-        mB = qM.bottom()
+        thisStyle = self.style()
+        mL = thisStyle.pixelMetric(QStyle.PM_LayoutLeftMargin)
+        mR = thisStyle.pixelMetric(QStyle.PM_LayoutRightMargin)
+        mT = thisStyle.pixelMetric(QStyle.PM_LayoutLeftMargin)
+        mB = thisStyle.pixelMetric(QStyle.PM_LayoutBottomMargin)
 
         # Set Margins
         self.setContentsMargins(0, 0, 0, 0)

--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -1002,9 +1002,13 @@ class GuiMain(QMainWindow):
 
         self.treeView.flushTreeOrder()
 
-        dlgDetails = GuiProjectDetails(self)
+        dlgDetails = getGuiItem("GuiProjectDetails")
+        if dlgDetails is None:
+            dlgDetails = GuiProjectDetails(self)
+
         dlgDetails.setModal(False)
         dlgDetails.show()
+        dlgDetails.raise_()
 
         return
 
@@ -1021,6 +1025,7 @@ class GuiMain(QMainWindow):
 
         dlgBuild.setModal(False)
         dlgBuild.show()
+        dlgBuild.raise_()
         qApp.processEvents()
         dlgBuild.viewCachedDoc()
 
@@ -1055,6 +1060,7 @@ class GuiMain(QMainWindow):
 
         dlgStats.setModal(False)
         dlgStats.show()
+        dlgStats.raise_()
         qApp.processEvents()
         dlgStats.populateGUI()
 
@@ -1063,9 +1069,13 @@ class GuiMain(QMainWindow):
     def showAboutNWDialog(self, showNotes=False):
         """Show the about dialog for novelWriter.
         """
-        dlgAbout = GuiAbout(self)
+        dlgAbout = getGuiItem("GuiAbout")
+        if dlgAbout is None:
+            dlgAbout = GuiAbout(self)
+
         dlgAbout.setModal(True)
         dlgAbout.show()
+        dlgAbout.raise_()
         qApp.processEvents()
         dlgAbout.populateGUI()
 


### PR DESCRIPTION
**Summary:**

At some point it seems there has been a change in when a widget's contents margin values are defined because the PagedDialog class suddenly started setting all margins to 0. These are now forced to use the QLayout default margins.

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
