### PR TITLE
Add a warning when opening novelWriter alpha version

### DIFF
--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -289,6 +289,13 @@ class GuiMain(QMainWindow):
 
         logger.debug("GUI initialisation complete")
 
+        if nw.__hexversion__[-2] == "a":
+            self.makeAlert(self.tr(
+                "You are running an untested development version of novelWriter. "
+                "Please be careful when working on a live project "
+                "and make sure you take regular backups."
+            ), nwAlert.WARN)
+
         # If a project path was provided at command line, open it
         if self.mainConf.cmdOpen is not None:
             logger.debug("Opening project from additional command line option")

--- a/tests/test_base/test_base_error.py
+++ b/tests/test_base/test_base_error.py
@@ -22,7 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import nw
 import pytest
 
-from PyQt5.QtWidgets import qApp
+from PyQt5.QtWidgets import QMessageBox, qApp
 
 from mock import causeException
 
@@ -33,6 +33,9 @@ from nw.error import NWErrorMessage, exceptionHandler
 def testBaseError_Dialog(qtbot, monkeypatch, fncDir, tmpDir):
     """Test the error dialog.
     """
+    # Block message box
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a: QMessageBox.Yes)
+
     qApp.closeAllWindows()
     nwGUI = nw.main(["--testmode", "--config=%s" % fncDir, "--data=%s" % tmpDir])
     qtbot.addWidget(nwGUI)
@@ -52,7 +55,7 @@ def testBaseError_Dialog(qtbot, monkeypatch, fncDir, tmpDir):
         mp.setattr("PyQt5.QtCore.QSysInfo.kernelVersion", lambda: "1.2.3")
         nwErr.setMessage(Exception, "Fine Error", None)
         theMessage = nwErr.msgBody.toPlainText()
-        assert theMessage
+        assert theMessage != ""
         assert "Fine Error" in theMessage
         assert "Exception" in theMessage
         assert "(1.2.3)" in theMessage
@@ -62,7 +65,7 @@ def testBaseError_Dialog(qtbot, monkeypatch, fncDir, tmpDir):
         mp.setattr("PyQt5.QtCore.QSysInfo.kernelVersion", causeException)
         nwErr.setMessage(Exception, "Almost Fine Error", None)
         theMessage = nwErr.msgBody.toPlainText()
-        assert theMessage
+        assert theMessage != ""
         assert "(Unknown)" in theMessage
 
     nwErr._doClose()


### PR DESCRIPTION
**Summary:**

Adds a dialog box warning the user to be careful when using novelWriter alpha versions to work on a live project.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
