### PR TITLE
PyQt5 minimum version requirement consistency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyqt5>=5.2.1
+pyqt5>=5.3
 lxml>=4.2.0
 pyenchant>=3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ python_requires = >=3.6
 include_package_data = True
 packages = find:
 install_requires =
-    pyqt5>=5.2.1
+    pyqt5>=5.3
     lxml>=4.2.0
     pyenchant>=3.0.0
 


### PR DESCRIPTION
**Summary:**

The minimum required version for PyQt5 is stated in requirements.txt and setup.cfg to be 5.2.1, but the code itself checks that it's at least 5.3.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
