### PR TITLE
Fix issue with icons not updating when index is rebuilt

### DIFF
--- a/nw/guimain.py
+++ b/nw/guimain.py
@@ -900,6 +900,7 @@ class GuiMain(QMainWindow):
                 tItem.setWordCount(wC)
                 tItem.setParaCount(pC)
                 self.treeView.propagateCount(tItem.itemHandle, wC)
+                self.treeView.setTreeItemValues(tItem.itemHandle)
                 self.treeView.projectWordCount()
 
         tEnd = time()


### PR DESCRIPTION
**Summary:**

Rebuilding the index should also update the document icons.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
