### PR TITLE
Make Help select correct version of docs

### DIFF
--- a/nw/gui/mainmenu.py
+++ b/nw/gui/mainmenu.py
@@ -1087,10 +1087,15 @@ class GuiMainMenu(QMenuBar):
         self.helpMenu.addSeparator()
 
         # Help > User Manual (Online)
+        if nw.__version__[-2] == "f":
+            docUrl = f"{nw.__docurl__}/en/stable/"
+        else:
+            docUrl = f"{nw.__docurl__}/en/latest/"
+
         self.aHelpDocs = QAction(self.tr("User Manual (Online)"), self)
         self.aHelpDocs.setStatusTip(self.tr("Open documentation in browser"))
         self.aHelpDocs.setShortcut("F1")
-        self.aHelpDocs.triggered.connect(lambda: self._openWebsite(nw.__docurl__))
+        self.aHelpDocs.triggered.connect(lambda: self._openWebsite(docUrl))
         self.helpMenu.addAction(self.aHelpDocs)
 
         # Help > User Manual (PDF)


### PR DESCRIPTION
**Summary:**

The help menu entry for opening documentation should point to "stable" for stable release, and otherwise to "latest".

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
