### PR TITLE
Simplify the setup instructions for Windows in docs

### DIFF
--- a/docs/source/setup_windows.rst
+++ b/docs/source/setup_windows.rst
@@ -9,46 +9,18 @@ This is a brief guide to how you can get novelWriter running on a Windows comput
 Unlike other operating systems, Windows does not come prepared with an environment to run Python
 applications, so you must first install Python. After that, running novelWriter is straightforward.
 
-.. tip::
-   If you have any problems, you can always open a question on the project's discussions_ page.
-   This requires a GitHub account.
 
-.. _discussions: https://github.com/vkbo/novelWriter/discussions
+.. _a_setup_win_install:
 
-
-.. _a_setup_win_installer:
-
-Using the Installer
+Install novelWriter
 ===================
 
-The installer for Windows is no longer provided. See the `installer issue`_ for more info on why.
-You can still create the installer yourself if you want to. It can be generated with the provided
-``setup.py`` script. use the script's ``help`` command to get further instructions.
+The recommended way to run novelWriter on Windows is to download the "Minimal Package" option from
+the `main website`_, or from the GitHub_ releases page (it's the same download file).
 
-Please use the "Running from Source" option below instead. It has been improved and a script has
-been added that does nearly the same thing.
-
-.. _installer issue: https://github.com/vkbo/novelWriter/issues/640
-
-
-.. _a_setup_win_source:
-
-Running from Source
-===================
-
-To run novelWriter from source, download the latest source zip file from the release page on
-GitHub_, or from the `main website`_. You can download the "Minimal Windows" zip file. It is a
-minimal version of the source that contains only the files needed for running on Windows. You can
-also download the full source if you wish.
-
-In order to make novelWriter run on your system, you must first have Python installed (Step 1).
-Thereafter, a script will do the rest of the job (Step 2). Alternatively, you can run this step
-manually from the command prompt if you wish to.
-
-.. tip::
-   If your system already has all the dependencies installed, you can run novelWriter directly from
-   the extracted folder by double-clicking the ``novelWriter.pyw`` file. However, running the
-   script also adds start icons.
+This is a zip file containing only the files you need to run novelWriter on Windows. In order to
+make it run on your system, you must first have Python installed (Step 1). Thereafter, a script
+will do the rest of the job (Step 2).
 
 .. _GitHub: https://github.com/vkbo/novelWriter/releases
 .. _main website: https://novelwriter.io
@@ -58,7 +30,7 @@ Step 1: Installing Python
 -------------------------
 
 If you already have Python installed, you can skip this step. If you don't have it installed, you
-can download it from the python.org_ website. novelWriter should work with Python 3.6 or higher,
+can download it from the `python.org`_ website. novelWriter should work with Python 3.6 or higher,
 but it is recommended that you install the latest version of Python.
 
 Make sure you select the "Add Python to PATH" option during installation, otherwise the ``python``
@@ -70,80 +42,91 @@ command will not work in the command line window.
 .. _python.org: https://www.python.org/downloads/windows
 
 
-Step 2: Dependencies and Icons
+Step 2: Installing novelWriter
 ------------------------------
 
-**Alternative A: By Script**
+Extract the novelWriter zip file, and move the extracted folder to a suitable location. You should
+probably not keep it on your desktop or in your downloads folder where it may be accidentally
+deleted. Instead, move and rename it to for instance ``C:\novelWriter``.
 
-Open the folder where you extracted novelWriter, and double-click the file named
-``windows_install.bat``. This should open a command line window and run the setup script to install
+After you've got the folder where you want it, open it and double-click the file named
+``windows_install.bat``. This will open a command line window and run the setup script to install
 dependencies, and add desktop and start menu icons.
 
-.. note::
-   If you downloaded the full source package, the file may be in the ``setup`` subfolder.
 
-The script will also check that it can find Python on your system and alert you if it cannot run
-it. If you are sure you have installed it, but the script cannot find it, you probably didn't
-install it with the "Add Python to PATH" option mentioned in Step 1.
+.. _a_setup_win_update:
 
-.. note::
-   If you upgrade Python to a newer version and the path to ``pythonw.exe`` has therefore changed,
-   you may need to run this script again. You can also run it to upgrade dependencies to the latest
-   version.
+Update novelWriter
+==================
 
-**Alternative B: Manual Installation**
+To update novelWriter, simply replace the folder containing the old version with the extracted
+folder of the new version you've downloaded. After this, you may need to run the
+``windows_install.bat`` script again to update icons.
 
-The above alternative can also be run manually.
+.. tip::
+   As long as your system has all the dependencies installed, you can also run novelWriter directly
+   from the extracted folder by double-clicking the ``novelWriter.pyw`` file.
 
-Open the windows command prompt. It can be launched by pressing the :kbd:`Win` key and typing "cmd".
-The "Command Prompt" app should then be in the list of applications.
 
-With the command prompt open, navigate to the folder where you extracted the novelWriter source,
-and run the following commands:
+.. _a_setup_win_uninstall:
+
+Uninstall novelWriter
+=====================
+
+If you installed novelWriter with the method described above, you can uninstall it again by
+double-clicking the file named ``windows_uninstall.bat``. This should open a command line window
+and run the setup script to remove the main dependency packages and remove desktop and start menu
+icons.
+
+After that, you can simply delete the novelWriter folder.
+
+If you want to remove Python, it has its own uninstall tool. Just keep in mind that the Python
+package manager may leave some files on your system.
+
+
+.. _a_setup_win_manual:
+
+Manual Approach
+===============
+
+If you want more control of what's happening during the install process, or want to do the steps
+yourself, you can run the install steps below from a command line window from inside the folder
+containing either the minimal package, or the extracted full source package.
 
 .. code-block:: console
 
-   pip install --user pywin32 -r requirements.txt
+   pip install --user -r requirements.txt
+   pip install --user pywin32
    python setup.py win-install
 
-The first command will install the dependencies on your system from the `Python Package Index`_,
-and the second command will create a desktop icon and a start menu icon. That should be all that
-you need.
+The first command will install the three main dependencies of novelWriter using the
+`Python Package Index`_ install tool. The packages are ``PyQt5`` for the GUI, ``lxml`` for handling
+XML data files, and ``PyEncant`` for spell checking.
 
-.. _Python Package Index: https://pypi.org/
+The second command installs a Python tool for Windows that assists the setup script in installing
+icons and setting a few registry keys.
 
+The third command runs the setup script that creates the icons for your desktop and start menu, and
+adds the necessary registry keys so you can also launch a project by double-clicking a novelWriter
+project file from your file explorer.
 
-Uninstalling
-============
-
-**Alternative A: By Script**
-
-Open the folder where you keep the novelWriter files, and double-click the file named
-``windows_uninstall.bat``. This should open a command line window and run the setup script to
-remove the main dependency packages and remove desktop and start menu icons.
-
-.. note::
-   If you downloaded the full source package, the file may be in the ``setup`` subfolder.
-
-If you plan to also remove Python from your system, you must run the above script first as it needs
-Python in order to run.
-
-.. note::
-   Due to limitations of the ``pip`` installer, dependencies of the dependencies will not be
-   removed, only the ones the setup script directly installed.
-
-**Alternative B: Manual Uninstallation**
-
-Like for the install process, the script just runs two commands. You can of course run them
-yourself if you wish. They are:
+The above steps can be reverted by running:
 
 .. code-block:: console
 
    python setup.py win-uninstall
+   pip uninstall -r pywin32
    pip uninstall -r requirements.txt
 
-There may be other packages on your system installed by ``pip``. To list all packages, run:
+.. _Python Package Index: https://pypi.org/
 
-.. code-block:: console
 
-   pip freeze --user
+Windows Installer
+-----------------
+
+There used to be a Windows installer, but this is no longer provided. See the `installer issue`_
+for more info on why. You can still create the installer yourself if you want to. It can be
+generated with the provided ``setup.py`` script. use the script's ``help`` command to get further
+instructions.
+
+.. _installer issue: https://github.com/vkbo/novelWriter/issues/640


### PR DESCRIPTION
**Summary:**

Rewrite the Setup on Windows section of the documentation. This should be more precise and clearer for regular users. The old page had a bit too much irrelevant or outdated information.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
