### PR TITLE
Add PPA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ The application is written in Python 3 (3.6+) using Qt5 and PyQt5 (5.3+). It is 
 but should in principle work fine on other operating systems as well as long as dependencies are
 met. It is regularly tested on Debian and Ubuntu Linux, Windows, and macOS.
 
+## Installation
+
+### Ubuntu and Debian
+
+The Releases page has a `.deb` package (from version 1.5rc1 and on) that should install on both
+Debian and Ubuntu.
+
+You can also use the novelWriter [PPA](https://launchpad.net/~vkbo/+archive/ubuntu/novelwriter).
+For more details, check the [Linux](https://novelwriter.readthedocs.io/en/latest/setup_linux.html)
+setup chapter in the documentation.
+
+### Other Operating Systems
+
+For a regular installation, it is recommended that you download one of the minimal zip files from
+the [Releases](https://github.com/vkbo/novelWriter/releases) page or the
+[novelwriter.io](https://novelwriter.io/) website.
+The [documentation](https://novelwriter.readthedocs.io/) has detailed install instructions for
+[Linux](https://novelwriter.readthedocs.io/en/latest/setup_linux.html),
+[Windows](https://novelwriter.readthedocs.io/en/latest/setup_windows.html), and
+[macOS](https://novelwriter.readthedocs.io/en/latest/setup_mac.html).
+They are pretty straightforward.
+
 ## Project Contributions
 
 Please don't make feature pull requests without first having discussed them with the maintainer.
@@ -48,8 +70,8 @@ New translations are always welcome. Please read the additional
 
 ## Key Features
 
-Some key features of novelWriter are listed below. Consult the
-[documentation](https://novelwriter.readthedocs.io) for more information.
+Some key features of novelWriter are listed below. The
+[documentation](https://novelwriter.readthedocs.io) has a lot more information.
 
 ### Formatting Codes
 
@@ -64,19 +86,17 @@ set of formatting that is useful for the specific task of writing novels.
 | `~~`       | Wrapped  | Strikethrough text. |
 | `%`        | Prefix   | A comment; does not count towards the word count.<sup>1</sup> |
 | `@`        | Prefix   | The following text is parsed as a keyword/value command for meta data. |
-| `>`        | Prefix   | The paragraph is indented one tab width from the left.<sup>2</sup> |
-| `<`        | Suffix   | The paragraph is indented one tab width from the right.<sup>2</sup> |
-| `>>`       | Prefix   | The paragraph is right-aligned.<sup>2</sup> |
-| `<<`       | Suffix   | The paragraph is left-aligned.<sup>2</sup> |
-| `>>`, `<<` | Wrapped  | The paragraph is centred.<sup>2</sup> |
+| `>`        | Prefix   | The paragraph is indented one tab width from the left. |
+| `<`        | Suffix   | The paragraph is indented one tab width from the right. |
+| `>>`       | Prefix   | The paragraph is right-aligned. |
+| `<<`       | Suffix   | The paragraph is left-aligned. |
+| `>>`, `<<` | Wrapped  | The paragraph is centred. |
 
 <sup>1</sup> If the first word of the comment is `synopsis:`, the comment is indexed and treated as the
 synopsis for the section of text where it occurs. These synopsis comments can be used to build an
 outline and exported to external documents.
 
-<sup>2</sup> The indent and alignment codes are available from version 1.4.
-
-In additions:
+In addition:
 
 * A variety of thin and non-breaking spaces are supported. Some of them depend on the system
   running at least Qt 5.9. Earlier versions of Qt will unfortunately strip them out when saving.
@@ -129,83 +149,18 @@ scene connects to the plot, and which characters, etc. occur in them. In additio
 themselves are clickable in the document view pane, and control-clickable in the editor. They make
 it possible to quickly navigate between the documents while writing.
 
-## Install Instructions
-
-### Ubuntu and Debian
-
-The Releases page has a `.deb` package (from version 1.5rc1 and on) that should install on both
-Debian and Ubuntu.
-
-You can also use the novelWriter [PPA](https://launchpad.net/~vkbo/+archive/ubuntu/novelwriter).
-For more details, check the [Linux](https://novelwriter.readthedocs.io/en/latest/setup_linux.html)
-setup chapter in the documentation.
-
-### Other Operating Systems
-
-For a regular installation, it is recommended that you download one of the minimal zip files from
-the [Releases](https://github.com/vkbo/novelWriter/releases) page or the
-[novelwriter.io](https://novelwriter.io/) website.
-The [documentation](https://novelwriter.readthedocs.io/) has detailed install instructions for
-[Linux](https://novelwriter.readthedocs.io/en/latest/setup_linux.html),
-[Windows](https://novelwriter.readthedocs.io/en/latest/setup_windows.html), and
-[macOS](https://novelwriter.readthedocs.io/en/latest/setup_mac.html).
-They are pretty straightforward.
-
-## Running from Source
+## Installing or Running from Source
 
 If you want to run novelWriter directly from the source code, you must run the `novelWriter.py`
 file from command line.
-
-**Note:** You may need to replace `python` with `python3` and `pip` with `pip3` in the instructions
-below on some systems. You may also want to add the `--user` flag for `pip` to install in your user
-space only.
-
-### Dependencies
 
 Dependencies can generally be installed from PyPi with:
 ```bash
 pip install -r requirements.txt
 ```
 
-### Additional Steps for Linux
-
-On Linux, you can most likely find the dependencies in your distribution's repository. On Ubuntu
-and Debian, run:
-```bash
-sudo apt install python3-pyqt5 python3-lxml python3-enchant
-```
-
-If you want to set up a launcher and icons on Linux, you can run:
-```bash
-python setup.py xdg-install
-```
-
-### Additional Steps for macOS
-
-First, make sure you have properly set up Python3 with Homebrew. If not, check their
-[documentation](https://docs.brew.sh/Homebrew-and-Python).
-In addition, the following steps are necessary to install all dependencies:
-```bash
-brew install enchant
-pip3 install --user -r requirements.txt
-pip3 install --user pyobjc
-```
-
-### Additional Steps for Windows
-
-Windows does not by default come with Python installed. If you haven't installed it already, get it
-from [python.org/downloads](https://www.python.org/downloads/). Remember to select "Add Python to
-PATH" during the installation.
-
-The script `windows_install.bat` in the `setup` folder can be used to create desktop and start menu
-icons for novelWriter. The script will also install dependencies for you from PyPi.
-
-### Internationalisation
-
-If you install from source, you must build the translation files yourself if you want to switch to
-a different GUI language than British English. This requires that you have the Qt translation
-framework installed. Check the specific instruction in the README in the `i18n` source folder for
-how to build the translation files.
+For more details on running or installing from source, see
+[Other Setup Methods](https://novelwriter.readthedocs.io/en/latest/setup_other.html).
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,18 @@ scene connects to the plot, and which characters, etc. occur in them. In additio
 themselves are clickable in the document view pane, and control-clickable in the editor. They make
 it possible to quickly navigate between the documents while writing.
 
-## Standard Installation
+## Install Instructions
+
+### Ubuntu and Debian
+
+The Releases page has a `.deb` package (from version 1.5rc1 and on) that should install on both
+Debian and Ubuntu.
+
+You can also use the novelWriter [PPA](https://launchpad.net/~vkbo/+archive/ubuntu/novelwriter).
+For more details, check the [Linux](https://novelwriter.readthedocs.io/en/latest/setup_linux.html)
+setup chapter in the documentation.
+
+### Other Operating Systems
 
 For a regular installation, it is recommended that you download one of the minimal zip files from
 the [Releases](https://github.com/vkbo/novelWriter/releases) page or the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,17 +4,13 @@ novelWriter |release|
 
 .. only:: html
 
-   .. image:: https://github.com/vkbo/novelWriter/workflows/python%203.8/badge.svg?branch=main
+   .. image:: https://github.com/vkbo/novelWriter/actions/workflows/test_linux.yml/badge.svg?branch=main
       :target: https://github.com/vkbo/novelWriter/actions
       :alt: Python Tests
 
    .. image:: https://codecov.io/gh/vkbo/novelWriter/branch/main/graph/badge.svg
       :target: https://codecov.io/gh/vkbo/novelWriter
       :alt: Code Coverage
-
-   .. image:: https://readthedocs.org/projects/novelwriter/badge/?version=latest
-      :target: https://novelwriter.readthedocs.io/en/latest/?badge=latest
-      :alt: Documentation
 
    .. image:: https://img.shields.io/github/v/release/vkbo/novelwriter
       :target: https://github.com/vkbo/novelWriter/releases
@@ -47,8 +43,8 @@ too. novelWriter can be run directly from the Python source, installed from the 
 
 You can also download a minimal archive package of novelWriter tailored for your operating system.
 This package can be extracted anywhere on your computer, and a setup script can be run to create
-the necessary icons and file associations. See :ref:`a_started`, or one or the setup instructions
-for your operating system for further details.
+the necessary icons and file associations. See the setup instructions for your operating system for
+further details.
 
 .. note::
    Version 1.5 introduces a few changes that will require you to make a few minor modifications to
@@ -71,10 +67,10 @@ for your operating system for further details.
    :caption: Introduction
 
    int_introduction
-   int_started
    setup_linux
    setup_mac
    setup_windows
+   setup_other
 
 
 .. toctree::

--- a/docs/source/setup_linux.rst
+++ b/docs/source/setup_linux.rst
@@ -23,7 +23,6 @@ A general Debian package can be downloaded from the `main website`_. This packag
 both Debian and Ubuntu.
 
 If you prefer, you can also add the novelWriter repository on Launchpad to your package manager.
-See below for instructions.
 
 
 Ubuntu
@@ -41,22 +40,23 @@ You can add the Ubuntu PPA_ and install novelWriter with the following commands.
 Debian
 ------
 
-If you're on Debian, the above command may not manage to find a suiteable Ubuntu version to add.
-You can then instead add the PPA manually, and pick an Ubuntu version yourself. Below is an example
-using ``focal`` (Ubuntu 20.04).
+Since this is a pure Python package, the Launchpad PPA can in principle also be used on Debian.
+However, the above command will fail to add the signing key.
 
-Add the following two lines to your ``/etc/apt/sources.list`` file.
-
-.. code-block:: console
-
-   deb http://ppa.launchpad.net/vkbo/novelwriter-pre/ubuntu focal main 
-   deb-src http://ppa.launchpad.net/vkbo/novelwriter-pre/ubuntu focal main 
-
-You then need to import the sign key by running
+Instead, run the following commands to add the repository and key:
 
 .. code-block:: console
 
-   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F19F1FCE50043114
+   sudo mkdir -p /usr/local/share/keyrings/
+   sudo gpg --no-default-keyring --keyring /usr/local/share/novelwriter-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F19F1FCE50043114
+   echo "deb [signed-by=/usr/local/share/keyrings/novelwriter-keyring.gpg] http://ppa.launchpad.net/vkbo/novelwriter/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/novelwriter.list
+
+Then run the update and install command:
+
+.. code-block:: console
+
+   sudo apt update
+   sudo apt install novelwriter
 
 
 Pre-Releases
@@ -71,12 +71,12 @@ There is also a `Pre-Release PPA`_ available beta releases and release candidate
    sudo apt install novelwriter
 
 
-Running from Source
-===================
+Minimal Zip File
+================
 
-To run novelWriter from source, download the latest source package from the release page on
-GitHub_ or the `main website`_, or if you have git running on your computer, you can also clone the
-repository.
+A minimal zip file is provided for Linux. You can download the latest zip file from the release
+page on GitHub_, or from the `main website`_. This zip file contains only the main files needed to
+run novelWriter. You can extract the file to wherever you want, and run the steps below.
 
 
 Step 1: Installing Dependencies
@@ -97,72 +97,35 @@ can install them with:
    pip3 install --user -r requirements.txt
 
 
-Step 2: Install Package (Optional)
-----------------------------------
-
-You can install novelWriter to the default location for Python packages using ``setuptools``. This
-step is optional as you can also just put the novelWriter program folder wherever you like
-yourself. For instance in ``/opt/novelWriter``, and then run Step 3 to set up icons and launcher.
-
-To install novelWriter to the default location requires that you have ``setuptools`` installed on
-your system. If you don't have it installed, it can usually be installed from your distro's
-repository. For Debian and Ubuntu this is achieved with:
-
-.. code-block:: console
-
-   sudo apt install python3-setuptools
-
-The package is also available from PyPi:
-
-.. code-block:: console
-
-   pip3 install --user setuptools
-
-With ``setuptools`` in place, novelWriter can be installed to the user space with:
-
-.. code-block:: console
-
-   ./setup.py install --user
-
-This should install novelWriter as ``~/.local/bin/novelWriter``. If you instead want to install for
-all users, i.e. as ``/usr/local/bin/novelWriter``, run:
-
-.. code-block:: console
-
-   sudo ./setup.py install
-
-This is equivalent to what the ``pip`` installer does. It puts novelWriter in the location on your
-system where Python packages are usually kept. This is not really the best suited location for a
-GUI application like novelWriter, so you may instead copy the entire source to a suiteable location
-yourself.
-
-
-Step 3: Create Launcher Icons
+Step 2: Create Launcher Icons
 -----------------------------
 
-Regardless of where you extract or install the source files, you can set up a standard icon and a
-launcher. To set up this desktop launcher, the needed icons, and the project file association,
-run the following from inside the novelWriter folder at the installed or final location:
+A standard desktop launcher can be installed via the main setup script. It will create the needed
+desktop file and add it to the Applications menu. The necessary icons will also be installed, and a
+file association with ``.nwx`` files added.
+
+To set this up, run the following from inside the novelWriter folder at the final location:
 
 .. code-block:: console
 
-   ./setup.py xdg-install
+   python3 setup.py xdg-install
 
-By default, this command installs the launcher and icons for the current user only. To install for
-all users, run the script with the ``sudo`` command.
+This will only install the launcher and icons for the current user. To set up novelWriter for all
+users, run:
 
-.. tip::
-   All options of the setup script can be listed with: ``./setup.py help``.
+.. code-block:: console
+
+   sudo python3 setup.py xdg-install
 
 
 Uninstalling Icons
-==================
+------------------
 
 The steps taken by the ``xdg-install`` step can be reversed by running:
 
 .. code-block:: console
 
-   ./setup.py xdg-uninstall
+   python3 setup.py xdg-uninstall
 
 This will remove the desktop launcher and icons from the system. As above, whether this is done on
 the current user, or system wide, depends on whether this command is called with ``sudo`` or not.

--- a/docs/source/setup_linux.rst
+++ b/docs/source/setup_linux.rst
@@ -6,11 +6,69 @@ Setup on Linux
 
 .. _GitHub: https://github.com/vkbo/novelWriter/releases
 .. _main website: https://novelwriter.io
+.. _PPA: https://launchpad.net/~vkbo/+archive/ubuntu/novelwriter
+.. _Pre-Release PPA: https://launchpad.net/~vkbo/+archive/ubuntu/novelwriter-pre
 
-This is a brief guide to how you can get novelWriter running on a Linux computer. There are
-currently no install package of novelWriter for Linux, so it is recommended that you download
-either the full source or minimal package and extract it to a practical location on your system and
-run the ``setup.py`` script.
+This is a brief guide to how you can get novelWriter running on a Linux computer.
+
+There are currently install packages available for Ubuntu and Debian. For other distros it is
+recommended that you download either the full source or minimal package and extract it to a
+practical location on your system and run the ``setup.py`` script.
+
+
+Debian or Ubuntu
+================
+
+A general Debian package can be downloaded from the `main website`_. This package should work on
+both Debian and Ubuntu.
+
+If you prefer, you can also add the novelWriter repository on Launchpad to your package manager.
+See below for instructions.
+
+
+Ubuntu
+------
+
+You can add the Ubuntu PPA_ and install novelWriter with the following commands.
+
+.. code-block:: console
+
+   sudo add-apt-repository ppa:vkbo/novelwriter
+   sudo apt update
+   sudo apt install novelwriter
+
+
+Debian
+------
+
+If you're on Debian, the above command may not manage to find a suiteable Ubuntu version to add.
+You can then instead add the PPA manually, and pick an Ubuntu version yourself. Below is an example
+using ``focal`` (Ubuntu 20.04).
+
+Add the following two lines to your ``/etc/apt/sources.list`` file.
+
+.. code-block:: console
+
+   deb http://ppa.launchpad.net/vkbo/novelwriter-pre/ubuntu focal main 
+   deb-src http://ppa.launchpad.net/vkbo/novelwriter-pre/ubuntu focal main 
+
+You then need to import the sign key by running
+
+.. code-block:: console
+
+   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F19F1FCE50043114
+
+
+Pre-Releases
+------------
+
+There is also a `Pre-Release PPA`_ available beta releases and release candidates.
+
+.. code-block:: console
+
+   sudo add-apt-repository ppa:vkbo/novelwriter-pre
+   sudo apt update
+   sudo apt install novelwriter
 
 
 Running from Source

--- a/docs/source/setup_other.rst
+++ b/docs/source/setup_other.rst
@@ -1,25 +1,16 @@
-.. _a_started:
+.. _a_other:
 
-***************
-Getting Started
-***************
+*******************
+Other Setup Methods
+*******************
 
 .. _main website: https://novelwriter.io
 .. _GitHub: https://github.com/vkbo/novelWriter/releases
 .. _PyPi: https://pypi.org/project/novelWriter/
+.. _Sphinx Docs: https://www.sphinx-doc.org/
 
-This section contains brief guides to how you can get novelWriter running on your computer. These
-are the methods currently supported by the developer. Packages may also be available in other
-package managers, but those are not managed by the developer. No installers are provided at this
-time, but it is fairly straightforward to set up novelWriter with the provided install scripts.
-
-As novelWriter matures, more options for how to install it and get it running will be added. For
-non-Windows users the install process is at the present time best suited for people used to working
-with the command line. But even if you're not, the install process is fairly straightforward.
-
-The next pages have specific install instructions for the various operating systems novelWriter can
-run on. The instructions below are supplementary information, instructions for alterbative methods,
-and additional build options.
+This section describes various other setup methods, and instructions for building needed files
+when running novelWriter from the source code directly.
 
 .. note::
    The text below assumes the command ``python`` corresponds to a Python 3 executable. Python 2 is
@@ -28,7 +19,7 @@ and additional build options.
    without the ``python`` command. Likewise, ``pip`` may need to be replaced with ``pip3``.
 
 
-.. _a_started_depend:
+.. _a_other_depend:
 
 Dependencies
 ============
@@ -41,7 +32,7 @@ The following Python packages are needed to run novelWriter:
 
 * ``PyQt5`` – needed for connecting with the Qt5 libraries.
 * ``lxml`` – needed for full XML support.
-* ``PyEnchant`` – needed for efficient spell checking (optional).
+* ``PyEnchant`` – needed for spell checking (optional).
 
 PyQt/Qt should be at least 5.3, but ideally 5.10 or higher for nearly all features to work. For
 instance, searching using regular expressions with full Unicode support requires 5.13. There is no
@@ -59,23 +50,17 @@ source, dependencies can still be installed from PyPi with:
    pip install -r requirements.txt
 
 
-.. _a_started_install:
+.. _a_other_pip:
 
-Installing from Source or PyPi
-==============================
+Installing from PyPi
+====================
 
-You can download the latest version of novelWriter from the source repository on GitHub_. You can
-also install novelWriter from PyPi_.
-
-If you're running novelWriter from source, the main setup script has a number of options that may
-be useful to you. You can list them by running:
-
-.. code-block:: console
-
-   python setup.py --help
+novelWriter is available on the Python Package Index, or PyPi_.
 
 To install from PyPi you must first have the ``python`` and ``pip`` commands available on your
-system. If you don't, see specific instructions for your operating system in this documentation.
+system. If you don't, see specific instructions for your operating system in this documentation on
+how to get the Python environment set up.
+
 To install novelWriter from PyPi, use the following command:
 
 .. code-block:: console
@@ -98,7 +83,42 @@ Make sure the install location for pip is in your PATH variable. This is not alw
 default.
 
 
-.. _a_started_i18n:
+.. _a_other_source:
+
+Installing from Source
+======================
+
+You can download the latest version of novelWriter from the source repository on GitHub_ and run
+the setup manually. It is equivalent to what the ``pip install`` command does, and it installs
+novelWriter to the default location for Python packages.
+
+This step requires that you have ``setuptools`` installed on your system. If you don't have it
+installed, it can usually be installed from your distro's repository. For Debian and Ubuntu this is
+achieved with:
+
+.. code-block:: console
+
+   sudo apt install python3-setuptools
+
+The package is also available from PyPi:
+
+.. code-block:: console
+
+   pip install --user setuptools
+
+With ``setuptools`` in place, novelWriter can be installed to the user space with:
+
+.. code-block:: console
+
+   python setup.py install --user
+
+.. tip::
+
+   The main setup script has a number of options that may be useful to you. You can list them by
+   running ``python setup.py --help``.
+
+
+.. _a_other_i18n:
 
 Building the Translation Files
 ==============================
@@ -112,7 +132,7 @@ You can build the ``.qm`` files with:
 
 .. code-block:: console
 
-   python3 setup.py qtlrelease
+   python setup.py qtlrelease
 
 This requires that the Qt Linguist tool is installed on your system. On Ubuntu and Debian, the
 needed package is called `qttools5-dev-tools`.
@@ -123,14 +143,13 @@ needed package is called `qttools5-dev-tools`.
    the ``i18n`` folder of the source code.
 
 
-.. _a_started_docs:
+.. _a_other_docs:
 
 Building the Documentation
 ==========================
 
-If you installed novelWriter from a package, the documentation should be pre-built and included. If
-you're running novelWriter from the source code, a local copy of this documentation can be
-generated. It requires the following Python packages on Debian and Ubuntu.
+A local copy of this documentation can be generated as HTML. This requires the following Python
+packages on Debian and Ubuntu.
 
 * ``python3-sphinx``
 * ``python3-sphinx-rtd-theme``
@@ -150,15 +169,13 @@ The documentation can then be built from the ``docs`` folder in the source code 
 If successful, the documentation should be available in the ``docs/build/html`` folder and you can
 open the ``index.html`` file in your browser.
 
-You can also build the PDF documentation locally using the setup script:
+You can also build a PDF manual from the documentation using the setup script:
 
 .. code-block:: console
 
-   python setup.py pdfdocs
+   python setup.py manual
 
 This will build the documentation as a PDF using LaTeX. The file will then be copied into the
 assets folder and made available in the :guilabel:`Help` menu in novelWriter. The Sphinx build
-system has a few extra dependencies when building the PDF. Please check the `Sphinx Docs`_ if you
-have any issues.
-
-.. _Sphinx Docs: https://www.sphinx-doc.org/
+system has a few extra dependencies when building the PDF. Please check the `Sphinx Docs`_ for more
+details.

--- a/setup/debian/control
+++ b/setup/debian/control
@@ -2,7 +2,7 @@ Source: novelwriter
 Maintainer: Veronica Berglyd Olsen <code@vkbo.net>
 Section: text
 Priority: optional
-Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9)
+Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.6), python3-pyqt5 (>= 5.3), python3-lxml (>= 4.0), python3-enchant (>= 2.0)
 Standards-Version: 4.5.1
 Homepage: https://novelwriter.io
 X-Python3-Version: >= 3.6

--- a/setup/debian/copyright
+++ b/setup/debian/copyright
@@ -3,14 +3,54 @@ Upstream-Name: novelWriter
 Upstream-Contact: Veronica Berglyd Olsen <code@vkbo.net>
 Source: https://github.com/vkbo/novelWriter
 
+Files: *
+Copyright: 2018-2021, Veronica Berglyd Olsen
+License: GPL-3.0-or-later
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 Files: novelwriter/assets/fonts/Cantarell/*
 Copyright: 2009-2010, Understanding Limited
 License: OFL-1.1
+ This Font Software is licensed under the SIL Open Font License, Version 1.1.
+ This license is available with a FAQ at: http://scripts.sil.org/OFL
 
 Files: novelwriter/assets/icons/typicons_*.svg
 Copyright: 2019, Stephen Hutchings
 License: CC-BY-SA-4.0
-
-Files: novelwriter/*
-Copyright: 2018-2021, Veronica Berglyd Olsen
-License: GPL-3.0-or-later
+ This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
+ International License. To view a copy of this license, visit
+ http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative
+ Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ .
+ Share — copy and redistribute the material in any medium or format
+ .
+ Adapt — remix, transform, and build upon the material for any purpose, even
+ commercially. This license is acceptable for Free Cultural Works. The licensor
+ cannot revoke these freedoms as long as you follow the license terms.
+ .
+ Attribution — You must give appropriate credit, provide a link to the license,
+ and indicate if changes were made. You may do so in any reasonable manner, but
+ not in any way that suggests the licensor endorses you or your use.
+ .
+ ShareAlike — If you remix, transform, or build upon the material, you must
+ distribute your contributions under the same license as the original.
+ No additional restrictions — You may not apply legal terms or technological
+ measures that legally restrict others from doing anything the license permits.
+ .
+ Notices: You do not have to comply with the license for elements of the
+ material in the public domain or where your use is permitted by an applicable
+ exception or limitation. No warranties are given. The license may not give you
+ all of the permissions necessary for your intended use. For example, other
+ rights such as publicity, privacy, or moral rights may limit how you use the
+ material.

--- a/setup/make_pip.sh
+++ b/setup/make_pip.sh
@@ -11,6 +11,8 @@ echo " Building Packages"
 echo "================================================================================"
 echo ""
 python3 setup.py sdist bdist_wheel
+mkdir -pv dist_upload
+cp -v dist/novelWriter-*.whl dist_upload/
 
 echo ""
 echo " Checking Packages"

--- a/setup/make_release.sh
+++ b/setup/make_release.sh
@@ -19,3 +19,4 @@ echo " Building Linux Packages"
 echo "================================================================================"
 echo ""
 python3 setup.py build-deb
+python3 setup.py build-ubuntu

--- a/setup/make_release.sh
+++ b/setup/make_release.sh
@@ -18,5 +18,5 @@ echo ""
 echo " Building Linux Packages"
 echo "================================================================================"
 echo ""
-python3 setup.py build-deb
-python3 setup.py build-ubuntu
+python3 setup.py build-deb --sign
+python3 setup.py build-ubuntu --sign --first


### PR DESCRIPTION
**Summary:**

This PR primarily adds support for making `.deb` packages for [launchpad.net](https://launchpad.net/). This makes installing and updating novelWriter on Ubuntu and Debian significantly easier.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
