### PR TITLE
Hash check on documents

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -432,9 +432,15 @@ def sha256sum(filePath):
     hDigest = hashlib.sha256()
     bData = bytearray(65536)
     mData = memoryview(bData)
-    with open(filePath, mode="rb", buffering=0) as inFile:
-        for n in iter(lambda: inFile.readinto(mData), 0):
-            hDigest.update(mData[:n])
+    try:
+        with open(filePath, mode="rb", buffering=0) as inFile:
+            for n in iter(lambda: inFile.readinto(mData), 0):
+                hDigest.update(mData[:n])
+    except Exception:
+        logger.error("Could not read sha256sum of: %s", filePath)
+        logException()
+        return None
+
     return hDigest.hexdigest()
 
 

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -24,6 +24,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import json
+import hashlib
 import logging
 
 from datetime import datetime
@@ -411,7 +412,7 @@ def jsonEncode(data, n=0, nmax=0):
 
 
 # =============================================================================================== #
-#  Other Functions
+#  File and File System Functions
 # =============================================================================================== #
 
 def makeFileNameSafe(theText):
@@ -423,6 +424,23 @@ def makeFileNameSafe(theText):
             cleanName += c
     return cleanName
 
+
+def sha256sum(filePath):
+    """Make a shasum of a file using a buffer.
+    Based on: https://stackoverflow.com/a/44873382/5825851
+    """
+    hDigest = hashlib.sha256()
+    bData = bytearray(65536)
+    mData = memoryview(bData)
+    with open(filePath, mode="rb", buffering=0) as inFile:
+        for n in iter(lambda: inFile.readinto(mData), 0):
+            hDigest.update(mData[:n])
+    return hDigest.hexdigest()
+
+
+# =============================================================================================== #
+#  Other Functions
+# =============================================================================================== #
 
 def getGuiItem(theName):
     """Returns a QtWidget based on its objectName.

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -82,13 +82,9 @@ class NWDoc():
 
         theText = ""
         self._docMeta = {}
-        if os.path.isfile(docPath):
-            try:
-                self._prevHash = sha256sum(docPath)
-            except Exception as e:
-                logger.error("Could not read sha256sum of: %s", docPath)
-                self._docError = str(e)
+        self._prevHash = sha256sum(docPath)
 
+        if os.path.isfile(docPath):
             try:
                 with open(docPath, mode="r", encoding="utf-8") as inFile:
 
@@ -134,12 +130,8 @@ class NWDoc():
         docTemp = os.path.join(self.theProject.projContent, docFile+"~")
 
         if self._prevHash is not None and not forceWrite:
-            try:
-                self._currHash = sha256sum(docPath)
-            except Exception as e:
-                logger.error("Could not read sha256sum of: %s", docPath)
-                self._docError = str(e)
-            if self._currHash != self._prevHash:
+            self._currHash = sha256sum(docPath)
+            if self._currHash is not None and self._currHash != self._prevHash:
                 logger.error("File has been altered on disk since opened")
                 return False
 
@@ -167,12 +159,8 @@ class NWDoc():
             os.unlink(docPath)
         os.rename(docTemp, docPath)
 
-        try:
-            self._prevHash = sha256sum(docPath)
-            self._currHash = self._prevHash
-        except Exception as e:
-            logger.error("Could not read sha256sum of: %s", docPath)
-            self._docError = str(e)
+        self._prevHash = sha256sum(docPath)
+        self._currHash = self._prevHash
 
         return True
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -456,7 +456,7 @@ class GuiDocEditor(QTextEdit):
             saveOk = False
             if self._nwDocument._currHash != self._nwDocument._prevHash:
                 msgYes = self.theParent.askQuestion(
-                    self.tr("File Changed"),
+                    self.tr("File Changed on Disk"),
                     self.tr(
                         "This document has been changed outside of novelWriter "
                         "while it was open. Overvrite the file on disk?"

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -453,9 +453,23 @@ class GuiDocEditor(QTextEdit):
 
         self.saveCursorPosition()
         if not self._nwDocument.writeDocument(docText):
-            self.theParent.makeAlert([
-                self.tr("Could not save document."), self._nwDocument.getError()
-            ], nwAlert.ERROR)
+            saveOk = False
+            if self._nwDocument._currHash != self._nwDocument._prevHash:
+                msgYes = self.theParent.askQuestion(
+                    self.tr("File Changed"),
+                    self.tr(
+                        "This document has been changed outside of novelWriter "
+                        "while it was open. Overvrite the file on disk?"
+                    )
+                )
+                if msgYes:
+                    saveOk = self._nwDocument.writeDocument(docText, forceWrite=True)
+
+            if not saveOk:
+                self.theParent.makeAlert([
+                    self.tr("Could not save document."), self._nwDocument.getError()
+                ], nwAlert.ERROR)
+
             return False
 
         self.setDocumentChanged(False)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1121,6 +1121,7 @@ class GuiMain(QMainWindow):
         can be either a string or an array of strings.
         """
         if isinstance(theMessage, list):
+            theMessage = list(filter(None, theMessage))
             popMsg = "<br>".join(theMessage)
             logMsg = theMessage
         else:

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+import hashlib
 import os
 import time
 import pytest
@@ -32,7 +33,7 @@ from novelwriter.common import (
     isItemClass, isItemType, isItemLayout, hexToInt, formatInt,
     formatTimeStamp, formatTime, parseTimeStamp, splitVersionNumber,
     transferCase, fuzzyTime, numberToRoman, jsonEncode, makeFileNameSafe,
-    NWConfigParser
+    sha256sum, NWConfigParser
 )
 
 
@@ -342,18 +343,6 @@ def testBaseCommon_FuzzyTime():
 # END Test testBaseCommon_FuzzyTime
 
 
-@pytest.mark.base
-def testBaseCommon_MakeFileNameSafe():
-    """Test the fuzzyTime function.
-    """
-    assert makeFileNameSafe(" aaaa ") == "aaaa"
-    assert makeFileNameSafe("aaaa,bbbb") == "aaaabbbb"
-    assert makeFileNameSafe("aaaa\tbbbb") == "aaaabbbb"
-    assert makeFileNameSafe("aaaa bbbb") == "aaaa bbbb"
-
-# END Test testBaseCommon_MakeFileNameSafe
-
-
 @pytest.mark.core
 def testBaseCommon_RomanNumbers():
     """Test conversion of integers to Roman numbers.
@@ -464,6 +453,37 @@ def testBaseCommon_JsonEncode():
     )
 
 # END Test testBaseCommon_JsonEncode
+
+
+@pytest.mark.base
+def testBaseCommon_MakeFileNameSafe():
+    """Test the makeFileNameSafe function.
+    """
+    assert makeFileNameSafe(" aaaa ") == "aaaa"
+    assert makeFileNameSafe("aaaa,bbbb") == "aaaabbbb"
+    assert makeFileNameSafe("aaaa\tbbbb") == "aaaabbbb"
+    assert makeFileNameSafe("aaaa bbbb") == "aaaa bbbb"
+
+# END Test testBaseCommon_MakeFileNameSafe
+
+
+@pytest.mark.base
+def testBaseCommon_Sha256Sum(fncDir, ipsumText):
+    """Test the sha256sum function.
+    """
+    testData = 50*(" ".join(ipsumText) + " ")
+    assert len(testData) == 175650
+
+    testFile = os.path.join(fncDir, "hash_me.txt")
+    writeFile(testFile, testData)
+
+    # Taken with sha256sum tests/temp/f_temp/hash_me.txt
+    realHash = "9b22aee35660da4fae204acbe96aec7f563022746ca2b7a3831f5e44544765eb"
+
+    assert sha256sum(testFile) == realHash
+    assert hashlib.sha256(testData.encode("utf-8")).hexdigest() == realHash
+
+# END Test testBaseCommon_Sha256Sum
 
 
 @pytest.mark.base

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -471,17 +471,32 @@ def testBaseCommon_MakeFileNameSafe():
 def testBaseCommon_Sha256Sum(fncDir, ipsumText):
     """Test the sha256sum function.
     """
-    testData = 50*(" ".join(ipsumText) + " ")
-    assert len(testData) == 175650
+    longText = 50*(" ".join(ipsumText) + " ")
+    shortText = "This is a short file"
+    noneText = ""
 
-    testFile = os.path.join(fncDir, "hash_me.txt")
-    writeFile(testFile, testData)
+    assert len(longText) == 175650
 
-    # Taken with sha256sum tests/temp/f_temp/hash_me.txt
-    realHash = "9b22aee35660da4fae204acbe96aec7f563022746ca2b7a3831f5e44544765eb"
+    longFile = os.path.join(fncDir, "long_file.txt")
+    shortFile = os.path.join(fncDir, "short_file.txt")
+    noneFile = os.path.join(fncDir, "none_file.txt")
 
-    assert sha256sum(testFile) == realHash
-    assert hashlib.sha256(testData.encode("utf-8")).hexdigest() == realHash
+    writeFile(longFile, longText)
+    writeFile(shortFile, shortText)
+    writeFile(noneFile, noneText)
+
+    # Taken with sha256sum command on command line
+    longHash = "9b22aee35660da4fae204acbe96aec7f563022746ca2b7a3831f5e44544765eb"
+    shortHash = "6d7c9b2722364c471b8a8666bcb35d18500272d05b23b3427288e2e34c6618f0"
+    noneHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+    assert sha256sum(longFile) == longHash
+    assert sha256sum(shortFile) == shortHash
+    assert sha256sum(noneFile) == noneHash
+
+    assert hashlib.sha256(longText.encode("utf-8")).hexdigest() == longHash
+    assert hashlib.sha256(shortText.encode("utf-8")).hexdigest() == shortHash
+    assert hashlib.sha256(noneText.encode("utf-8")).hexdigest() == noneHash
 
 # END Test testBaseCommon_Sha256Sum
 

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -26,6 +26,7 @@ import pytest
 
 from datetime import datetime
 
+from mock import causeOSError
 from tools import writeFile
 
 from novelwriter.common import (
@@ -468,7 +469,7 @@ def testBaseCommon_MakeFileNameSafe():
 
 
 @pytest.mark.base
-def testBaseCommon_Sha256Sum(fncDir, ipsumText):
+def testBaseCommon_Sha256Sum(monkeypatch, fncDir, ipsumText):
     """Test the sha256sum function.
     """
     longText = 50*(" ".join(ipsumText) + " ")
@@ -497,6 +498,12 @@ def testBaseCommon_Sha256Sum(fncDir, ipsumText):
     assert hashlib.sha256(longText.encode("utf-8")).hexdigest() == longHash
     assert hashlib.sha256(shortText.encode("utf-8")).hexdigest() == shortHash
     assert hashlib.sha256(noneText.encode("utf-8")).hexdigest() == noneHash
+
+    with monkeypatch.context() as mp:
+        mp.setattr("builtins.open", causeOSError)
+        assert sha256sum(longFile) is None
+        assert sha256sum(shortFile) is None
+        assert sha256sum(noneFile) is None
 
 # END Test testBaseCommon_Sha256Sum
 

--- a/tests/test_core/test_core_document.py
+++ b/tests/test_core/test_core_document.py
@@ -23,7 +23,7 @@ import os
 import pytest
 
 from mock import causeOSError
-from tools import readFile
+from tools import readFile, writeFile
 
 from novelwriter.core import NWProject, NWDoc
 from novelwriter.enum import nwItemClass, nwItemLayout
@@ -34,10 +34,13 @@ def testCoreDocument_LoadSave(monkeypatch, mockGUI, nwMinimal):
     """Test loading and saving a document with the NWDoc class.
     """
     theProject = NWProject(mockGUI)
-    assert theProject.openProject(nwMinimal)
+    assert theProject.openProject(nwMinimal) is True
     assert theProject.projPath == nwMinimal
 
     sHandle = "8c659a11cd429"
+
+    # Read Document
+    # =============
 
     # Not a valid handle
     theDoc = NWDoc(theProject, "stuff")
@@ -46,6 +49,7 @@ def testCoreDocument_LoadSave(monkeypatch, mockGUI, nwMinimal):
     # Non-existent handle
     theDoc = NWDoc(theProject, "0000000000000")
     assert theDoc.readDocument() is None
+    assert theDoc._currHash is None
 
     # Cause open() to fail while loading
     with monkeypatch.context() as mp:
@@ -65,11 +69,14 @@ def testCoreDocument_LoadSave(monkeypatch, mockGUI, nwMinimal):
     theDoc = NWDoc(theProject, xHandle)
     assert theDoc.readDocument() == ""
 
+    # Write Document
+    # ==============
+
     # Set handle and save again
     theText = "### Test File\n\nText ...\n\n"
     theDoc = NWDoc(theProject, xHandle)
     assert theDoc.readDocument(xHandle) == ""
-    assert theDoc.writeDocument(theText)
+    assert theDoc.writeDocument(theText) is True
 
     # Save again to ensure temp file and previous file is handled
     assert theDoc.writeDocument(theText)
@@ -84,36 +91,46 @@ def testCoreDocument_LoadSave(monkeypatch, mockGUI, nwMinimal):
         "Text ...\n\n"
     )
 
+    # Alter the document on disk and save again
+    writeFile(docPath, "blablabla")
+    assert theDoc.writeDocument(theText) is False
+
+    # Force the overwrite
+    assert theDoc.writeDocument(theText, forceWrite=True) is True
+
     # Force no meta data
     theDoc._theItem = None
-    assert theDoc.writeDocument(theText)
+    assert theDoc.writeDocument(theText) is True
     assert readFile(docPath) == theText
 
     # Cause open() to fail while saving
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", causeOSError)
-        assert not theDoc.writeDocument(theText)
+        assert theDoc.writeDocument(theText) is False
         assert theDoc.getError() == "OSError"
 
     # Saving with no handle
     theDoc._docHandle = None
-    assert not theDoc.writeDocument(theText)
+    assert theDoc.writeDocument(theText) is False
+
+    # Delete Document
+    # ===============
 
     # Delete the last document
     theDoc = NWDoc(theProject, "stuff")
-    assert not theDoc.deleteDocument()
+    assert theDoc.deleteDocument() is False
     assert os.path.isfile(docPath)
 
     # Cause the delete to fail
     with monkeypatch.context() as mp:
         mp.setattr("os.unlink", causeOSError)
         theDoc = NWDoc(theProject, xHandle)
-        assert not theDoc.deleteDocument()
+        assert theDoc.deleteDocument() is False
         assert theDoc.getError() == "OSError"
 
     # Make the delete pass
     theDoc = NWDoc(theProject, xHandle)
-    assert theDoc.deleteDocument()
+    assert theDoc.deleteDocument() is True
     assert not os.path.isfile(docPath)
 
 # END Test testCoreDocument_Load


### PR DESCRIPTION
**Summary:**

This PR adds a hash check when opening and saving document files. This is used to check that the file has not been altered on disk since it was last saved. If it has, a dialog box pops up to ask if the user wants to overwrite the file.

**Related Issue(s):**

Resolves #878

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
