### PR TITLE
Fix error in Debian setup instructions

### DIFF
--- a/docs/source/setup_linux.rst
+++ b/docs/source/setup_linux.rst
@@ -48,7 +48,7 @@ Instead, run the following commands to add the repository and key:
 .. code-block:: console
 
    sudo mkdir -p /usr/local/share/keyrings/
-   sudo gpg --no-default-keyring --keyring /usr/local/share/novelwriter-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F19F1FCE50043114
+   sudo gpg --no-default-keyring --keyring /usr/local/share/keyrings/novelwriter-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F19F1FCE50043114
    echo "deb [signed-by=/usr/local/share/keyrings/novelwriter-keyring.gpg] http://ppa.launchpad.net/vkbo/novelwriter/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/novelwriter.list
 
 Then run the update and install commands as for Ubuntu:


### PR DESCRIPTION
**Summary:**

Fixes an erroneous path in the list of commands to run to set up the Launchpad PPA on Debian.

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
