### PR TITLE
Change how PPA key is added

### DIFF
--- a/docs/source/setup_linux.rst
+++ b/docs/source/setup_linux.rst
@@ -47,9 +47,8 @@ Instead, run the following commands to add the repository and key:
 
 .. code-block:: console
 
-   sudo mkdir -p /usr/local/share/keyrings/
-   sudo gpg --no-default-keyring --keyring /usr/local/share/keyrings/novelwriter-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F19F1FCE50043114
-   echo "deb [signed-by=/usr/local/share/keyrings/novelwriter-keyring.gpg] http://ppa.launchpad.net/vkbo/novelwriter/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/novelwriter.list
+   sudo gpg --no-default-keyring --keyring /usr/share/keyrings/novelwriter-ppa-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F19F1FCE50043114
+   echo "deb [signed-by=/usr/share/keyrings/novelwriter-ppa-keyring.gpg] http://ppa.launchpad.net/vkbo/novelwriter/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/novelwriter.list
 
 Then run the update and install commands as for Ubuntu:
 


### PR DESCRIPTION
**Summary:**

Docs: Looking at other updated repo setups, this seems to be the correct way to add repo keyrings.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
