### PR TITLE
Fix docs build issues

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,6 +20,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/source/requirements.txt

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,1 +1,2 @@
 sphinx_rtd_theme
+docutils==0.17.1


### PR DESCRIPTION
**Summary:**

Fixes docs build error, but solution is unsatisfactory as it requires pinning the version of `docutils`.

See https://github.com/sphinx-doc/sphinx/issues/9777

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
