### PR TITLE
Code and GUI text cleanup

### DIFF
--- a/i18n/nw_en_US.ts
+++ b/i18n/nw_en_US.ts
@@ -4610,17 +4610,17 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="788"/>
-        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Tools &gt; Preferences.</source>
+        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Preferences.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="795"/>
-        <source>Cannot backup project because no project name is set. Please set a Working Title in Project &gt; Project Settings.</source>
+        <source>Cannot backup project because no project name is set. Please set a Working Title in Project Settings.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="802"/>
-        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Tools &gt; Preferences.</source>
+        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Preferences.</source>
         <translation></translation>
     </message>
     <message>
@@ -4630,7 +4630,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="821"/>
-        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Tools &gt; Preferences.</source>
+        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Preferences.</source>
         <translation></translation>
     </message>
     <message>

--- a/i18n/nw_en_US.ts
+++ b/i18n/nw_en_US.ts
@@ -3253,7 +3253,7 @@
     </message>
     <message>
         <location filename="../novelwriter/dialogs/preferences.py" line="788"/>
-        <source>Also improves trypewriter scrolling for short documents.</source>
+        <source>Also improves typewriter scrolling for short documents.</source>
         <translation></translation>
     </message>
     <message>

--- a/i18n/nw_fr.ts
+++ b/i18n/nw_fr.ts
@@ -3253,7 +3253,7 @@
     </message>
     <message>
         <location filename="../novelwriter/dialogs/preferences.py" line="788"/>
-        <source>Also improves trypewriter scrolling for short documents.</source>
+        <source>Also improves typewriter scrolling for short documents.</source>
         <translation>Améliore également le défilement machine à écrire pour les documents courts.</translation>
     </message>
     <message>

--- a/i18n/nw_fr.ts
+++ b/i18n/nw_fr.ts
@@ -4610,18 +4610,18 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="788"/>
-        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>Il est impossible de sauvegarder le projet car aucun emplacement de sauvegarde n&apos;a été défini. Veuillez en définir un dans Outils &gt; Préférences.</translation>
+        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Preferences.</source>
+        <translation>Il est impossible de sauvegarder le projet car aucun emplacement de sauvegarde n&apos;a été défini. Veuillez en définir un dans Préférences.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="795"/>
-        <source>Cannot backup project because no project name is set. Please set a Working Title in Project &gt; Project Settings.</source>
-        <translation>Il est impossible de sauvegarder le projet car il n&apos;a pas reçu de nom. Veuillez définir un titre de travail dans Projet &gt; Caractéristiques du projet.</translation>
+        <source>Cannot backup project because no project name is set. Please set a Working Title in Project Settings.</source>
+        <translation>Il est impossible de sauvegarder le projet car il n&apos;a pas reçu de nom. Veuillez définir un titre de travail dans Caractéristiques du projet.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="802"/>
-        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>Il est impossible de sauvegarder le projet car l&apos;emplacement de sauvegarde défini n&apos;existe pas. Veuillez définir un emplacement correct dans Outils &gt; Préférences.</translation>
+        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Preferences.</source>
+        <translation>Il est impossible de sauvegarder le projet car l&apos;emplacement de sauvegarde défini n&apos;existe pas. Veuillez définir un emplacement correct dans Préférences.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="815"/>
@@ -4630,8 +4630,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="821"/>
-        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Tools &gt; Preferences.</source>
-        <translation>La sauvegarde du projet est impossible car l&apos;emplacement défini est situé dans le dossier à sauvegarder. Veuillez définir un autre répertoire de sauvegarde dans Outils &gt; Préférences.</translation>
+        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Preferences.</source>
+        <translation>La sauvegarde du projet est impossible car l&apos;emplacement défini est situé dans le dossier à sauvegarder. Veuillez définir un autre répertoire de sauvegarde dans Préférences.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="828"/>

--- a/i18n/nw_nb_NO.ts
+++ b/i18n/nw_nb_NO.ts
@@ -3253,7 +3253,7 @@
     </message>
     <message>
         <location filename="../novelwriter/dialogs/preferences.py" line="788"/>
-        <source>Also improves trypewriter scrolling for short documents.</source>
+        <source>Also improves typewriter scrolling for short documents.</source>
         <translation>Forbedrer funksjonen til skrivemaskin-rulling.</translation>
     </message>
     <message>

--- a/i18n/nw_nb_NO.ts
+++ b/i18n/nw_nb_NO.ts
@@ -4605,18 +4605,18 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="788"/>
-        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>Kan ikke ta sikkerhetskopi av prosjektet da ingen filbane er satt. Du må først sette en filbane i Verktøy &gt; Innstillinger.</translation>
+        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Preferences.</source>
+        <translation>Kan ikke ta sikkerhetskopi av prosjektet da ingen filbane er satt. Du må først sette en filbane i Innstillinger.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="795"/>
-        <source>Cannot backup project because no project name is set. Please set a Working Title in Project &gt; Project Settings.</source>
-        <translation>Kan ikke ta sikkerhetskopi av prosjektet da ingen arbeidstittel er satt. Du må først sette en arbeidstittel i Prosjekt &gt; Prosjektinnstillinger.</translation>
+        <source>Cannot backup project because no project name is set. Please set a Working Title in Project Settings.</source>
+        <translation>Kan ikke ta sikkerhetskopi av prosjektet da ingen arbeidstittel er satt. Du må først sette en arbeidstittel i Prosjektinnstillinger.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="802"/>
-        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>Kan ikke ta sikkerhetskopi av prosjektet da filbane ikke finnes. Du må sette en ny filbane i Verktøy &gt; Innstillinger.</translation>
+        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Preferences.</source>
+        <translation>Kan ikke ta sikkerhetskopi av prosjektet da filbane ikke finnes. Du må sette en ny filbane i Innstillinger.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="815"/>
@@ -4625,8 +4625,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="821"/>
-        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Tools &gt; Preferences.</source>
-        <translation>Kan ikke ta sikkerhetskopi av prosjektet da filbanen er inne i prosjektmappen. Du må sette en ny filbane i Verktøy &gt; Innstillinger.</translation>
+        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Preferences.</source>
+        <translation>Kan ikke ta sikkerhetskopi av prosjektet da filbanen er inne i prosjektmappen. Du må sette en ny filbane i Innstillinger.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="828"/>

--- a/i18n/nw_pt.ts
+++ b/i18n/nw_pt.ts
@@ -4580,18 +4580,18 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="788"/>
-        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>Não foi possível realizar uma cópia de segurança do projeto porquê o caminho das cópias de segurança não foi definido. Por favor, defina um caminho válido para as cópias de segurança em Ferramentas &gt; Preferências.</translation>
+        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Preferences.</source>
+        <translation>Não foi possível realizar uma cópia de segurança do projeto porquê o caminho das cópias de segurança não foi definido. Por favor, defina um caminho válido para as cópias de segurança em Preferências.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="795"/>
-        <source>Cannot backup project because no project name is set. Please set a Working Title in Project &gt; Project Settings.</source>
-        <translation>Não foi possível realizar a cópia de segurança do projeto porque o nome do projeto não está definido. Por favor defina o Nome do Projeto em Projeto &gt; Configurações do Projeto.</translation>
+        <source>Cannot backup project because no project name is set. Please set a Working Title in Project Settings.</source>
+        <translation>Não foi possível realizar a cópia de segurança do projeto porque o nome do projeto não está definido. Por favor defina o Nome do Projeto em Configurações do Projeto.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="802"/>
-        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>Não foi possível realizar a cópia de segurança do projeto porque o caminho das cópias de segurança não exite. Por favor, defina um cainho válido para as cópias de segurança em Ferramentas &gt; Preferências.</translation>
+        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Preferences.</source>
+        <translation>Não foi possível realizar a cópia de segurança do projeto porque o caminho das cópias de segurança não exite. Por favor, defina um cainho válido para as cópias de segurança em Preferências.</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="815"/>
@@ -4600,7 +4600,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="821"/>
-        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Tools &gt; Preferences.</source>
+        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Preferences.</source>
         <translation>Não foi possível realizar a cópia de segurança do projeto porque o caminho das cópias de segurança está em um caminho dentro do diretório do projeto. Por favor, escolha um caminho diferente para as cópias de segurança em Ferramentas&gt; Preferências.</translation>
     </message>
     <message>

--- a/i18n/nw_pt.ts
+++ b/i18n/nw_pt.ts
@@ -3228,7 +3228,7 @@
     </message>
     <message>
         <location filename="../novelwriter/dialogs/preferences.py" line="788"/>
-        <source>Also improves trypewriter scrolling for short documents.</source>
+        <source>Also improves typewriter scrolling for short documents.</source>
         <translation>Também melhora a rolagem de máquina de escrever em documentos curtos.</translation>
     </message>
     <message>

--- a/i18n/nw_zh_CN.ts
+++ b/i18n/nw_zh_CN.ts
@@ -4616,18 +4616,18 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="788"/>
-        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>由于未设置备份路径，无法备份项目。 请在工具 &gt; 首选项中设置一个有效的备份位置。</translation>
+        <source>Cannot backup project because no backup path is set. Please set a valid backup location in Preferences.</source>
+        <translation>由于未设置备份路径，无法备份项目。 首选项中设置一个有效的备份位置。</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="795"/>
-        <source>Cannot backup project because no project name is set. Please set a Working Title in Project &gt; Project Settings.</source>
-        <translation>由于未设置项目名，无法备份项目。 请在项目 &gt; 项目设置中设置一个工作标题。</translation>
+        <source>Cannot backup project because no project name is set. Please set a Working Title in Project Settings.</source>
+        <translation>由于未设置项目名，无法备份项目。 项目设置中设置一个工作标题。</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="802"/>
-        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Tools &gt; Preferences.</source>
-        <translation>无法备份项目，因为备份路径不存在。 请在工具 &gt; 首选项中设置一个有效的备份位置。</translation>
+        <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Preferences.</source>
+        <translation>无法备份项目，因为备份路径不存在。 首选项中设置一个有效的备份位置。</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="815"/>
@@ -4636,8 +4636,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="821"/>
-        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Tools &gt; Preferences.</source>
-        <translation>无法备份项目，因为备份路径在要备份的项目文件夹内。 请在工具 &gt; 首选项中选择不同的备份路径。</translation>
+        <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Preferences.</source>
+        <translation>无法备份项目，因为备份路径在要备份的项目文件夹内。 首选项中选择不同的备份路径。</translation>
     </message>
     <message>
         <location filename="../novelwriter/core/project.py" line="828"/>

--- a/i18n/nw_zh_CN.ts
+++ b/i18n/nw_zh_CN.ts
@@ -3253,7 +3253,7 @@
     </message>
     <message>
         <location filename="../novelwriter/dialogs/preferences.py" line="788"/>
-        <source>Also improves trypewriter scrolling for short documents.</source>
+        <source>Also improves typewriter scrolling for short documents.</source>
         <translation>还为短文档改进了打字机滚动。</translation>
     </message>
     <message>

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -215,25 +215,25 @@ def main(sysArgs=None):
     errorCode = 0
     if sys.hexversion < 0x030600f0:
         errorData.append(
-            "At least Python 3.6.0 is required, found %s" % CONFIG.verPyString
+            "At least Python 3.6 is required, found %s" % CONFIG.verPyString
         )
-        errorCode |= 4
+        errorCode |= 0x04
     if CONFIG.verQtValue < 50300:
         errorData.append(
             "At least Qt5 version 5.3 is required, found %s" % CONFIG.verQtString
         )
-        errorCode |= 8
+        errorCode |= 0x08
     if CONFIG.verPyQtValue < 50300:
         errorData.append(
             "At least PyQt5 version 5.3 is required, found %s" % CONFIG.verPyQtString
         )
-        errorCode |= 16
+        errorCode |= 0x10
 
     try:
         import lxml  # noqa: F401
     except ImportError:
         errorData.append("Python module 'lxml' is missing")
-        errorCode |= 32
+        errorCode |= 0x20
 
     if errorData:
         errApp = QApplication([])

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -174,6 +174,26 @@ def hexToInt(value, default=0):
     return default
 
 
+def checkIntRange(value, first, last, default):
+    """Check that an int is in a given range. If it isn't, return the
+    default value.
+    """
+    if isinstance(value, int):
+        if value >= first and value <= last:
+            return value
+    return default
+
+
+def checkIntTuple(value, valid, default):
+    """Check that an int is an element of a tuple. If it isn't, return
+    the default value.
+    """
+    if isinstance(value, int):
+        if value in valid:
+            return value
+    return default
+
+
 # =============================================================================================== #
 #  Formatting Functions
 # =============================================================================================== #

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -307,12 +307,12 @@ class Config:
         if not os.path.isdir(self.confPath):
             try:
                 os.mkdir(self.confPath)
-            except Exception as e:
+            except Exception as exc:
                 logger.error("Could not create folder: %s", self.confPath)
                 logException()
                 self.hasError = True
                 self.errData.append("Could not create folder: %s" % self.confPath)
-                self.errData.append(str(e))
+                self.errData.append(str(exc))
                 self.confPath = None
 
         # Check if config file exists
@@ -330,12 +330,12 @@ class Config:
             if not os.path.isdir(self.dataPath):
                 try:
                     os.mkdir(self.dataPath)
-                except Exception as e:
+                except Exception as exc:
                     logger.error("Could not create folder: %s", self.dataPath)
                     logException()
                     self.hasError = True
                     self.errData.append("Could not create folder: %s" % self.dataPath)
-                    self.errData.append(str(e))
+                    self.errData.append(str(exc))
                     self.dataPath = None
 
         # Host and Kernel
@@ -425,12 +425,12 @@ class Config:
         try:
             with open(cnfPath, mode="r", encoding="utf-8") as inFile:
                 theConf.read_file(inFile)
-        except Exception as e:
+        except Exception as exc:
             logger.error("Could not load config file")
             logException()
             self.hasError = True
             self.errData.append("Could not load config file")
-            self.errData.append(str(e))
+            self.errData.append(str(exc))
             return False
 
         # Main
@@ -655,12 +655,12 @@ class Config:
             with open(cnfPath, mode="w", encoding="utf-8") as outFile:
                 theConf.write(outFile)
             self.confChanged = False
-        except Exception as e:
+        except Exception as exc:
             logger.error("Could not save config file")
             logException()
             self.hasError = True
             self.errData.append("Could not save config file")
-            self.errData.append(str(e))
+            self.errData.append(str(exc))
             return False
 
         return True
@@ -688,10 +688,10 @@ class Config:
                     "words": theEntry.get("words", 0),
                 }
 
-        except Exception as e:
+        except Exception as exc:
             self.hasError = True
             self.errData.append("Could not load recent project cache")
-            self.errData.append(str(e))
+            self.errData.append(str(exc))
             return False
 
         return True
@@ -708,10 +708,10 @@ class Config:
         try:
             with open(cacheTemp, mode="w+", encoding="utf-8") as outFile:
                 json.dump(self.recentProj, outFile, indent=2)
-        except Exception as e:
+        except Exception as exc:
             self.hasError = True
             self.errData.append("Could not save recent project cache")
-            self.errData.append(str(e))
+            self.errData.append(str(exc))
             return False
 
         if os.path.isfile(cacheFile):

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -100,8 +100,8 @@ class NWDoc():
                     # Load the rest of the file
                     theText += inFile.read()
 
-            except Exception as e:
-                self._docError = str(e)
+            except Exception as exc:
+                self._docError = str(exc)
                 return None
 
         else:
@@ -149,8 +149,8 @@ class NWDoc():
             with open(docTemp, mode="w", encoding="utf-8") as outFile:
                 outFile.write(docMeta)
                 outFile.write(docText)
-        except Exception as e:
-            self._docError = str(e)
+        except Exception as exc:
+            self._docError = str(exc)
             return False
 
         # If we're here, the file was successfully saved, so we can
@@ -184,8 +184,8 @@ class NWDoc():
                 try:
                     os.unlink(chkFile)
                     logger.debug("Deleted: %s", chkFile)
-                except Exception as e:
-                    self._docError = str(e)
+                except Exception as exc:
+                    self._docError = str(exc)
                     return False
 
         return True

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -185,26 +185,4 @@ class OptionState():
                 return checkBool(self._theState[group].get(name, default), default)
         return default
 
-    ##
-    #  Validators
-    ##
-
-    def validIntRange(self, value, first, last, default):
-        """Check that an int is in a given range. If it isn't, return
-        the default value.
-        """
-        if isinstance(value, int):
-            if value >= first and value <= last:
-                return value
-        return default
-
-    def validIntTuple(self, value, valid, default):
-        """Check that an int is an element of a tuple. If it isn't,
-        return the default value.
-        """
-        if isinstance(value, int):
-            if value in valid:
-                return value
-        return default
-
 # END Class OptionState

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -788,21 +788,21 @@ class NWProject():
         if self.mainConf.backupPath is None or self.mainConf.backupPath == "":
             self.theParent.makeAlert(self.tr(
                 "Cannot backup project because no backup path is set. "
-                "Please set a valid backup location in Tools > Preferences."
+                "Please set a valid backup location in Preferences."
             ), nwAlert.ERROR)
             return False
 
         if self.projName is None or self.projName == "":
             self.theParent.makeAlert(self.tr(
                 "Cannot backup project because no project name is set. "
-                "Please set a Working Title in Project > Project Settings."
+                "Please set a Working Title in Project Settings."
             ), nwAlert.ERROR)
             return False
 
         if not os.path.isdir(self.mainConf.backupPath):
             self.theParent.makeAlert(self.tr(
                 "Cannot backup project because the backup path does not exist. "
-                "Please set a valid backup location in Tools > Preferences."
+                "Please set a valid backup location in Preferences."
             ), nwAlert.ERROR)
             return False
 
@@ -822,7 +822,7 @@ class NWProject():
             self.theParent.makeAlert(self.tr(
                 "Cannot backup project because the backup path is within the "
                 "project folder to be backed up. Please choose a different "
-                "backup path in Tools > Preferences."
+                "backup path in Preferences."
             ), nwAlert.ERROR)
             return False
 

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -415,10 +415,10 @@ class NWProject():
 
         try:
             nwXML = etree.parse(fileName)
-        except Exception as e:
-            self.theParent.makeAlert([
-                self.tr("Failed to parse project xml."), str(e)
-            ], nwAlert.ERROR)
+        except Exception as exc:
+            self.theParent.makeAlert(self.tr(
+                "Failed to parse project xml."
+            ), nwAlert.ERROR, exception=exc)
 
             # Trying to open backup file instead
             backFile = fileName[:-3]+"bak"
@@ -428,10 +428,10 @@ class NWProject():
                 ), nwAlert.INFO)
                 try:
                     nwXML = etree.parse(backFile)
-                except Exception as e:
-                    self.theParent.makeAlert([
-                        self.tr("Failed to parse project xml."), str(e)
-                    ], nwAlert.ERROR)
+                except Exception as exc:
+                    self.theParent.makeAlert(self.tr(
+                        "Failed to parse project xml."
+                    ), nwAlert.ERROR, exception=exc)
                     self.clearProject()
                     return False
             else:
@@ -708,10 +708,10 @@ class NWProject():
                     encoding="utf-8",
                     xml_declaration=True
                 ))
-        except Exception as e:
-            self.theParent.makeAlert([
-                self.tr("Failed to save project."), str(e)
-            ], nwAlert.ERROR)
+        except Exception as exc:
+            self.theParent.makeAlert(self.tr(
+                "Failed to save project."
+            ), nwAlert.ERROR, exception=exc)
             return False
 
         # If we're here, the file was successfully saved,
@@ -812,10 +812,10 @@ class NWProject():
             try:
                 os.mkdir(baseDir)
                 logger.debug("Created folder: %s", baseDir)
-            except Exception as e:
-                self.theParent.makeAlert([
-                    self.tr("Could not create backup folder."), str(e)
-                ], nwAlert.ERROR)
+            except Exception as exc:
+                self.theParent.makeAlert(self.tr(
+                    "Could not create backup folder."
+                ), nwAlert.ERROR, exception=exc)
                 return False
 
         if os.path.commonpath([self.projPath, baseDir]) == self.projPath:
@@ -839,10 +839,10 @@ class NWProject():
                     "Backup archive file written to: {0}"
                 ).format(f"{os.path.join(cleanName, archName)}.zip"), nwAlert.INFO)
 
-        except Exception as e:
-            self.theParent.makeAlert([
-                self.tr("Could not write backup archive."), str(e)
-            ], nwAlert.ERROR)
+        except Exception as exc:
+            self.theParent.makeAlert(self.tr(
+                "Could not write backup archive."
+            ), nwAlert.ERROR, exception=exc)
             return False
 
         self.theParent.setStatus(self.tr(
@@ -872,10 +872,10 @@ class NWProject():
             try:
                 shutil.unpack_archive(pkgSample, projPath)
                 isSuccess = True
-            except Exception as e:
-                self.theParent.makeAlert([
-                    self.tr("Failed to create a new example project."), str(e)
-                ], nwAlert.ERROR)
+            except Exception as exc:
+                self.theParent.makeAlert(self.tr(
+                    "Failed to create a new example project."
+                ), nwAlert.ERROR, exception=exc)
 
         elif os.path.isdir(srcSample):
 
@@ -894,10 +894,10 @@ class NWProject():
 
                 isSuccess = True
 
-            except Exception as e:
-                self.theParent.makeAlert([
-                    self.tr("Failed to create a new example project."), str(e)
-                ], nwAlert.ERROR)
+            except Exception as exc:
+                self.theParent.makeAlert(self.tr(
+                    "Failed to create a new example project."
+                ), nwAlert.ERROR, exception=exc)
 
         else:
             self.theParent.makeAlert(self.tr(
@@ -933,10 +933,10 @@ class NWProject():
                 try:
                     os.mkdir(projPath)
                     logger.debug("Created folder: %s", projPath)
-                except Exception as e:
-                    self.theParent.makeAlert([
-                        self.tr("Could not create new project folder."), str(e)
-                    ], nwAlert.ERROR)
+                except Exception as exc:
+                    self.theParent.makeAlert(self.tr(
+                        "Could not create new project folder."
+                    ), nwAlert.ERROR, exception=exc)
                     return False
 
             if os.path.isdir(projPath):
@@ -1327,10 +1327,10 @@ class NWProject():
             try:
                 os.mkdir(thePath)
                 logger.debug("Created folder: %s", thePath)
-            except Exception as e:
-                self.theParent.makeAlert([
-                    self.tr("Could not create folder."), str(e)
-                ], nwAlert.ERROR)
+            except Exception as exc:
+                self.theParent.makeAlert(self.tr(
+                    "Could not create folder."
+                ), nwAlert.ERROR, exception=exc)
                 return False
         return True
 

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -487,8 +487,8 @@ class NWProject():
                 self.tr("File Version"),
                 self.tr(
                     "The file format of your project is about to be updated. "
-                    "If you proceed, this project can no longer be opened by "
-                    "an older version of novelWriter. Continue?"
+                    "If you proceed, older versions of novelWriter will no "
+                    "longer be able to open this project. Continue?"
                 )
             )
             if not msgYes:

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -776,7 +776,7 @@ class GuiPreferencesEditor(QWidget):
         self.mainForm.addRow(
             self.tr("Scroll past end of the document"),
             self.scrollPastEnd,
-            self.tr("Also improves trypewriter scrolling for short documents.")
+            self.tr("Also improves typewriter scrolling for short documents.")
         )
 
         # Typewriter Scrolling

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -183,13 +183,13 @@ def exceptionHandler(exType, exValue, exTrace):
             nwGUI.closeMain()
             logger.info("Emergency shutdown successful")
 
-        except Exception as e:
+        except Exception as exc:
             logger.critical("Could not close the project before exiting")
-            logger.critical(str(e))
+            logger.critical(str(exc))
 
         qApp.exit(1)
 
-    except Exception as e:
-        logger.critical(str(e))
+    except Exception as exc:
+        logger.critical(str(exc))
 
     return

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -793,28 +793,28 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Header 1 (Partition)
         self.aFmtHead1 = QAction(self.tr("Header 1 (Partition)"), self)
-        self.aFmtHead1.setStatusTip(self.tr("Change the block format to Header 1"))
+        self.aFmtHead1.setStatusTip(self.tr("Set the text block format to Header 1 (Partition)"))
         self.aFmtHead1.setShortcut("Ctrl+1")
         self.aFmtHead1.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H1))
         self.fmtMenu.addAction(self.aFmtHead1)
 
         # Format > Header 2 (Chapter)
         self.aFmtHead2 = QAction(self.tr("Header 2 (Chapter)"), self)
-        self.aFmtHead2.setStatusTip(self.tr("Change the block format to Header 2"))
+        self.aFmtHead2.setStatusTip(self.tr("Set the text block format to Header 2 (Chapter)"))
         self.aFmtHead2.setShortcut("Ctrl+2")
         self.aFmtHead2.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H2))
         self.fmtMenu.addAction(self.aFmtHead2)
 
         # Format > Header 3 (Scene)
         self.aFmtHead3 = QAction(self.tr("Header 3 (Scene)"), self)
-        self.aFmtHead3.setStatusTip(self.tr("Change the block format to Header 3"))
+        self.aFmtHead3.setStatusTip(self.tr("Set the text block format to Header 3 (Scene)"))
         self.aFmtHead3.setShortcut("Ctrl+3")
         self.aFmtHead3.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H3))
         self.fmtMenu.addAction(self.aFmtHead3)
 
         # Format > Header 4 (Section)
         self.aFmtHead4 = QAction(self.tr("Header 4 (Section)"), self)
-        self.aFmtHead4.setStatusTip(self.tr("Change the block format to Header 4"))
+        self.aFmtHead4.setStatusTip(self.tr("Set the text block format to Header 4 (Section)"))
         self.aFmtHead4.setShortcut("Ctrl+4")
         self.aFmtHead4.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H4))
         self.fmtMenu.addAction(self.aFmtHead4)
@@ -824,13 +824,13 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Novel Title
         self.aFmtTitle = QAction(self.tr("Novel Title"), self)
-        self.aFmtTitle.setStatusTip(self.tr("Change the block format to Novel Title"))
+        self.aFmtTitle.setStatusTip(self.tr("Set the text block format to Novel Title"))
         self.aFmtTitle.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_TTL))
         self.fmtMenu.addAction(self.aFmtTitle)
 
         # Format > Unnumbered Chapter
         self.aFmtUnNum = QAction(self.tr("Unnumbered Chapter"), self)
-        self.aFmtUnNum.setStatusTip(self.tr("Change the block format to Unnumbered Chapter"))
+        self.aFmtUnNum.setStatusTip(self.tr("Set the text block format to Unnumbered Chapter"))
         self.aFmtUnNum.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_UNN))
         self.fmtMenu.addAction(self.aFmtUnNum)
 
@@ -839,21 +839,21 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Align Left
         self.aFmtAlignLeft = QAction(self.tr("Align Left"), self)
-        self.aFmtAlignLeft.setStatusTip(self.tr("Change the block alignment to left"))
+        self.aFmtAlignLeft.setStatusTip(self.tr("Left-align the text block"))
         self.aFmtAlignLeft.setShortcut("Ctrl+5")
         self.aFmtAlignLeft.triggered.connect(lambda: self._docAction(nwDocAction.ALIGN_L))
         self.fmtMenu.addAction(self.aFmtAlignLeft)
 
         # Format > Align Centre
         self.aFmtAlignCentre = QAction(self.tr("Align Centre"), self)
-        self.aFmtAlignCentre.setStatusTip(self.tr("Change the block alignment to centre"))
+        self.aFmtAlignCentre.setStatusTip(self.tr("Centre the text block"))
         self.aFmtAlignCentre.setShortcut("Ctrl+6")
         self.aFmtAlignCentre.triggered.connect(lambda: self._docAction(nwDocAction.ALIGN_C))
         self.fmtMenu.addAction(self.aFmtAlignCentre)
 
         # Format > Align Right
         self.aFmtAlignRight = QAction(self.tr("Align Right"), self)
-        self.aFmtAlignRight.setStatusTip(self.tr("Change the block alignment to right"))
+        self.aFmtAlignRight.setStatusTip(self.tr("Right-align the text block"))
         self.aFmtAlignRight.setShortcut("Ctrl+7")
         self.aFmtAlignRight.triggered.connect(lambda: self._docAction(nwDocAction.ALIGN_R))
         self.fmtMenu.addAction(self.aFmtAlignRight)
@@ -863,14 +863,14 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Indent Left
         self.aFmtIndentLeft = QAction(self.tr("Indent Left"), self)
-        self.aFmtIndentLeft.setStatusTip(self.tr("Increase the block's left margin"))
+        self.aFmtIndentLeft.setStatusTip(self.tr("Increase the text block's left margin"))
         self.aFmtIndentLeft.setShortcut("Ctrl+8")
         self.aFmtIndentLeft.triggered.connect(lambda: self._docAction(nwDocAction.INDENT_L))
         self.fmtMenu.addAction(self.aFmtIndentLeft)
 
         # Format > Indent Right
         self.aFmtIndentRight = QAction(self.tr("Indent Right"), self)
-        self.aFmtIndentRight.setStatusTip(self.tr("Increase the block's right margin"))
+        self.aFmtIndentRight.setStatusTip(self.tr("Increase the text block's right margin"))
         self.aFmtIndentRight.setShortcut("Ctrl+9")
         self.aFmtIndentRight.triggered.connect(lambda: self._docAction(nwDocAction.INDENT_R))
         self.fmtMenu.addAction(self.aFmtIndentRight)
@@ -880,14 +880,14 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Comment
         self.aFmtComment = QAction(self.tr("Comment"), self)
-        self.aFmtComment.setStatusTip(self.tr("Change the block format to comment"))
+        self.aFmtComment.setStatusTip(self.tr("Change the text block format to comment"))
         self.aFmtComment.setShortcut("Ctrl+/")
         self.aFmtComment.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_COM))
         self.fmtMenu.addAction(self.aFmtComment)
 
         # Format > Remove Block Format
         self.aFmtNoFormat = QAction(self.tr("Remove Block Format"), self)
-        self.aFmtNoFormat.setStatusTip(self.tr("Strips block format"))
+        self.aFmtNoFormat.setStatusTip(self.tr("Strip text block format"))
         self.aFmtNoFormat.setShortcuts(["Ctrl+0", "Ctrl+Shift+/"])
         self.aFmtNoFormat.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_TXT))
         self.fmtMenu.addAction(self.aFmtNoFormat)
@@ -898,7 +898,7 @@ class GuiMainMenu(QMenuBar):
         # Format > Replace Single Quotes
         self.aFmtReplSng = QAction(self.tr("Replace Single Quotes"), self)
         self.aFmtReplSng.setStatusTip(
-            self.tr("Replace all straight single quotes in selected text")
+            self.tr("Replace all straight single quotes in the selected text")
         )
         self.aFmtReplSng.triggered.connect(lambda: self._docAction(nwDocAction.REPL_SNG))
         self.fmtMenu.addAction(self.aFmtReplSng)
@@ -906,7 +906,7 @@ class GuiMainMenu(QMenuBar):
         # Format > Replace Double Quotes
         self.aFmtReplDbl = QAction(self.tr("Replace Double Quotes"), self)
         self.aFmtReplDbl.setStatusTip(
-            self.tr("Replace all straight double quotes in selected text")
+            self.tr("Replace all straight double quotes in the selected text")
         )
         self.aFmtReplDbl.triggered.connect(lambda: self._docAction(nwDocAction.REPL_DBL))
         self.fmtMenu.addAction(self.aFmtReplDbl)
@@ -914,7 +914,7 @@ class GuiMainMenu(QMenuBar):
         # Format > Remove In-Paragraph Breaks
         self.aFmtRmBreaks = QAction(self.tr("Remove In-Paragraph Breaks"), self)
         self.aFmtRmBreaks.setStatusTip(
-            self.tr("Removes all line breaks within paragraphs in the selected text")
+            self.tr("Remove all line breaks within paragraphs in the selected text")
         )
         self.aFmtRmBreaks.triggered.connect(lambda: self._docAction(nwDocAction.RM_BREAKS))
         self.fmtMenu.addAction(self.aFmtRmBreaks)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -500,10 +500,10 @@ class GuiMain(QMainWindow):
                     ),
                     self.tr(
                         "Note: If the program or the computer previously "
-                        "crashed, the lock can safely be overridden. If, "
-                        "however, another instance of novelWriter has the "
-                        "project open, overriding the lock may corrupt the "
-                        "project, and is not recommended."
+                        "crashed, the lock can safely be overridden. However, "
+                        "overriding it is not recommended if the project is "
+                        "open in another instance of novelWriter. Doing so "
+                        "may corrupt the project."
                     ),
                     lockDetails
                 ),

--- a/novelwriter/tools/build.py
+++ b/novelwriter/tools/build.py
@@ -872,8 +872,8 @@ class GuiBuildNovel(QDialog):
             try:
                 makeOdt.saveOpenDocText(savePath)
                 wSuccess = True
-            except Exception as e:
-                errMsg = str(e)
+            except Exception as exc:
+                errMsg = str(exc)
 
         elif theFmt == self.FMT_FODT:
             makeOdt = ToOdt(self.theProject, isFlat=True)
@@ -881,8 +881,8 @@ class GuiBuildNovel(QDialog):
             try:
                 makeOdt.saveFlatXML(savePath)
                 wSuccess = True
-            except Exception as e:
-                errMsg = str(e)
+            except Exception as exc:
+                errMsg = str(exc)
 
         elif theFmt == self.FMT_HTM:
             makeHtml = ToHtml(self.theProject)
@@ -893,8 +893,8 @@ class GuiBuildNovel(QDialog):
             try:
                 makeHtml.saveHTML5(savePath)
                 wSuccess = True
-            except Exception as e:
-                errMsg = str(e)
+            except Exception as exc:
+                errMsg = str(exc)
 
         elif theFmt == self.FMT_NWD:
             makeNwd = ToMarkdown(self.theProject)
@@ -906,8 +906,8 @@ class GuiBuildNovel(QDialog):
             try:
                 makeNwd.saveRawMarkdown(savePath)
                 wSuccess = True
-            except Exception as e:
-                errMsg = str(e)
+            except Exception as exc:
+                errMsg = str(exc)
 
         elif theFmt in (self.FMT_MD, self.FMT_GH):
             makeMd = ToMarkdown(self.theProject)
@@ -923,8 +923,8 @@ class GuiBuildNovel(QDialog):
             try:
                 makeMd.saveMarkdown(savePath)
                 wSuccess = True
-            except Exception as e:
-                errMsg = str(e)
+            except Exception as exc:
+                errMsg = str(exc)
 
         elif theFmt == self.FMT_JSON_H or theFmt == self.FMT_JSON_M:
             jsonData = {
@@ -968,8 +968,8 @@ class GuiBuildNovel(QDialog):
                 with open(savePath, mode="w", encoding="utf-8") as outFile:
                     outFile.write(json.dumps(jsonData, indent=2))
                     wSuccess = True
-            except Exception as e:
-                errMsg = str(e)
+            except Exception as exc:
+                errMsg = str(exc)
 
         elif theFmt == self.FMT_PDF:
             try:
@@ -983,8 +983,8 @@ class GuiBuildNovel(QDialog):
                 self.docView.document().print(thePrinter)
                 wSuccess = True
 
-            except Exception as e:
-                errMsg - str(e)
+            except Exception as exc:
+                errMsg = str(exc)
 
         else:
             # If the if statements above and here match, it should not

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -38,7 +38,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter.enum import nwAlert
-from novelwriter.common import formatTime, checkInt
+from novelwriter.common import formatTime, checkInt, checkIntRange, checkIntTuple
 from novelwriter.constants import nwConst, nwFiles
 from novelwriter.gui.custom import QSwitch
 
@@ -114,13 +114,10 @@ class GuiWritingStats(QDialog):
         hHeader.setTextAlignment(self.C_IDLE, Qt.AlignRight)
         hHeader.setTextAlignment(self.C_COUNT, Qt.AlignRight)
 
-        sortValid = (Qt.AscendingOrder, Qt.DescendingOrder)
-        sortCol = self.optState.validIntRange(
-            self.optState.getInt("GuiWritingStats", "sortCol", 0), 0, 2, 0
-        )
-        sortOrder = self.optState.validIntTuple(
+        sortCol = checkIntRange(self.optState.getInt("GuiWritingStats", "sortCol", 0), 0, 2, 0)
+        sortOrder = checkIntTuple(
             self.optState.getInt("GuiWritingStats", "sortOrder", Qt.DescendingOrder),
-            sortValid, Qt.DescendingOrder
+            (Qt.AscendingOrder, Qt.DescendingOrder), Qt.DescendingOrder
         )
         self.listBox.sortByColumn(sortCol, sortOrder)
         self.listBox.setSortingEnabled(True)
@@ -406,8 +403,8 @@ class GuiWritingStats(QDialog):
                         outFile.write(f'"{sD}",{tT:.0f},{wD},{wA},{wB},{tI}\n')
                     wSuccess = True
 
-        except Exception as e:
-            errMsg = str(e)
+        except Exception as exc:
+            errMsg = str(exc)
             wSuccess = False
 
         # Report to user
@@ -482,9 +479,9 @@ class GuiWritingStats(QDialog):
 
                     self.logData.append((dStart, sDiff, wcNovel, wcNotes, sIdle))
 
-        except Exception as e:
+        except Exception as exc:
             self.theParent.makeAlert([
-                self.tr("Failed to read session log file."), str(e)
+                self.tr("Failed to read session log file."), str(exc)
             ], nwAlert.ERROR)
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ def extractVersion():
                     hexVers = getValue((aLine))
                 if aLine.startswith("__date__"):
                     relDate = getValue((aLine))
-    except Exception as e:
+    except Exception as exc:
         print("Could not read file: %s" % initFile)
-        print(str(e))
+        print(str(exc))
 
     print("novelWriter version: %s (%s) at %s" % (numVers, hexVers, relDate))
 
@@ -127,9 +127,9 @@ def makeCheckSum(sumFile, cwd=None):
         with open(shaFile, mode="w") as fOut:
             subprocess.call(["sha256sum", sumFile], stdout=fOut, cwd=cwd)
         print("SHA256 Sum: %s" % shaFile)
-    except Exception as e:
+    except Exception as exc:
         print("Could not generate sha256 file")
-        print(str(e))
+        print(str(exc))
 
     return shaFile
 
@@ -163,9 +163,9 @@ def installPackages(hostOS):
         pkgCmd = stepCmd.split(" ")
         try:
             subprocess.call(pyCmd + pipCmd + pkgCmd)
-        except Exception as e:
+        except Exception as exc:
             print("Failed with error:")
-            print(str(e))
+            print(str(exc))
             sys.exit(1)
 
     return
@@ -243,10 +243,10 @@ def buildPdfManual():
         print("PDF manual build: OK")
         print("")
 
-    except Exception as e:
+    except Exception as exc:
         print("PDF manual build: FAILED")
         print("")
-        print(str(e))
+        print(str(exc))
         print("")
         print("Dependencies:")
         print(" * pip install sphinx")
@@ -286,10 +286,10 @@ def buildQtI18n():
 
     try:
         subprocess.call(["lrelease", "-verbose", *tsList])
-    except Exception as e:
+    except Exception as exc:
         print("Qt5 Linguist tools seem to be missing")
         print("On Debian/Ubuntu, install: qttools5-dev-tools pyqt5-dev-tools")
-        print(str(e))
+        print(str(exc))
         sys.exit(1)
 
     print("")
@@ -387,10 +387,10 @@ def buildQtI18nTS(sysArgs):
 
     # try:
     #     subprocess.call(["pylupdate5", "-verbose", "-noobsolete", *srcList, "-ts", *tsList])
-    # except Exception as e:
+    # except Exception as exc:
     #     print("PyQt5 Linguist tools seem to be missing")
     #     print("On Debian/Ubuntu, install: qttools5-dev-tools pyqt5-dev-tools")
-    #     print(str(e))
+    #     print(str(exc))
     #     sys.exit(1)
 
     print("")
@@ -922,9 +922,9 @@ def makeSimplePackage(embedPython):
     sysCmd += [libDir]
     try:
         subprocess.call(sysCmd)
-    except Exception as e:
+    except Exception as exc:
         print("Failed with error:")
-        print(str(e))
+        print(str(exc))
         sys.exit(1)
 
     for subDir in os.listdir(libDir):
@@ -1432,9 +1432,9 @@ def innoSetup():
 
     try:
         subprocess.call(["iscc", "setup.iss"])
-    except Exception as e:
+    except Exception as exc:
         print("Inno Setup failed with error:")
-        print(str(e))
+        print(str(exc))
         sys.exit(1)
 
     return

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -43,15 +43,15 @@ class MockGuiMain():
     def releaseNotes(self):
         return
 
-    def makeAlert(self, theMessage, theLevel):
-        assert isinstance(theMessage, str) or isinstance(theMessage, list)
-        print("%s: %s" % (str(theLevel), theMessage))
-        self.lastAlert = str(theMessage)
+    def makeAlert(self, message, level=0, exception=None):
+        assert isinstance(message, str) or isinstance(message, list)
+        print("%s: %s" % (str(level), message))
+        self.lastAlert = str(message)
         return
 
-    def askQuestion(self, theTitle, theQustion):
-        print("Question: %s" % theQustion)
-        self.lastQuestion = (theTitle, theQustion)
+    def askQuestion(self, title, qustion):
+        print("Question: %s" % qustion)
+        self.lastQuestion = (title, qustion)
         return self.askResponse
 
     def setStatus(self, theMessage):

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -32,10 +32,10 @@ from tools import writeFile
 from novelwriter.guimain import GuiMain
 from novelwriter.common import (
     checkString, checkInt, checkFloat, checkBool, checkHandle, isHandle,
-    isTitleTag, isItemClass, isItemType, isItemLayout, hexToInt, formatInt,
-    formatTimeStamp, formatTime, parseTimeStamp, splitVersionNumber,
-    transferCase, fuzzyTime, numberToRoman, jsonEncode, readTextFile,
-    makeFileNameSafe, sha256sum, getGuiItem, NWConfigParser
+    isTitleTag, isItemClass, isItemType, isItemLayout, hexToInt, checkIntRange,
+    checkIntTuple, formatInt, formatTimeStamp, formatTime, parseTimeStamp,
+    splitVersionNumber, transferCase, fuzzyTime, numberToRoman, jsonEncode,
+    readTextFile, makeFileNameSafe, sha256sum, getGuiItem, NWConfigParser
 )
 
 
@@ -214,6 +214,28 @@ def testBaseCommon_HexToInt():
     assert hexToInt("0xffffq", 12) == 12
 
 # END Test testBaseCommon_HexToInt
+
+
+@pytest.mark.base
+def testBaseCommon_CheckIntRange():
+    """Test the checkIntRange function.
+    """
+    assert checkIntRange(5, 0, 9, 3) == 5
+    assert checkIntRange(5, 0, 4, 3) == 3
+    assert checkIntRange(5, 0, 5, 3) == 5
+    assert checkIntRange(0, 0, 5, 3) == 0
+
+# END Test testBaseCommon_CheckIntRange
+
+
+@pytest.mark.base
+def testBaseCommon_CheckIntTuple():
+    """Test the checkIntTuple function.
+    """
+    assert checkIntTuple(0, (0, 1, 2), 3) == 0
+    assert checkIntTuple(5, (0, 1, 2), 3) == 3
+
+# END Test testBaseCommon_CheckIntTuple
 
 
 @pytest.mark.base

--- a/tests/test_core/test_core_options.py
+++ b/tests/test_core/test_core_options.py
@@ -140,13 +140,4 @@ def testCoreOptions_SetGet(mockGUI):
     assert theOpts.getBool("GuiBuildNovel", "addNovel", None) is True
     assert theOpts.getBool("GuiBuildNovel", "mockItem", None) is None
 
-    # Check integer validators
-    assert theOpts.validIntRange(5, 0, 9, 3) == 5
-    assert theOpts.validIntRange(5, 0, 4, 3) == 3
-    assert theOpts.validIntRange(5, 0, 5, 3) == 5
-    assert theOpts.validIntRange(0, 0, 5, 3) == 0
-
-    assert theOpts.validIntTuple(0, (0, 1, 2), 3) == 0
-    assert theOpts.validIntTuple(5, (0, 1, 2), 3) == 3
-
 # END Test testCoreOptions_SetGet

--- a/tests/test_tools/test_tools_projwizard.py
+++ b/tests/test_tools/test_tools_projwizard.py
@@ -40,16 +40,14 @@ stepDelay = 20
 
 
 @pytest.mark.gui
+@pytest.mark.skipif(sys.platform.startswith("darwin"), reason="Not running on Darwin")
 def testToolProjectWizard_Main(qtbot, monkeypatch, nwGUI, nwMinimal):
     """Test the new project wizard.
+    Disabled for macOS because the test segfaults on QWizard.show()
     """
     # Block message box
     monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
     monkeypatch.setattr(QMessageBox, "critical", lambda *a: QMessageBox.Yes)
-
-    if sys.platform.startswith("darwin"):
-        # Disable for macOS because the test segfaults on QWizard.show()
-        return
 
     ##
     #  Test New Project Function

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -33,14 +33,14 @@ def cmpFiles(fileOne, fileTwo, ignoreLines=None, ignoreStart=None):
 
     try:
         foOne = open(fileOne, mode="r", encoding="utf-8")
-    except Exception as e:
-        print(str(e))
+    except Exception as exc:
+        print(str(exc))
         return False
 
     try:
         foTwo = open(fileTwo, mode="r", encoding="utf-8")
-    except Exception as e:
-        print(str(e))
+    except Exception as exc:
+        print(str(exc))
         return False
 
     txtOne = foOne.readlines()


### PR DESCRIPTION
**Summary:**

Various code and GUI cleanups:

* Move some int checking functions to the common module.
* Change how runtime errors are reported and printed.
* Some minor changes to initialisation.
* Add a `skipif` entry for the wizard test on macOS (segfaults in Qt).
* Fix a typo on the Preferences dialog.
* Drop descriptions of menu path in various help texts.
* Improve the help text in the Format menu.
* Minor rewording of a few dialogs.

**Related Issue(s):**

Closes #923

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
