### PR TITLE
Fix greater/lesser symbol bug

### DIFF
--- a/novelwriter/core/tohtml.py
+++ b/novelwriter/core/tohtml.py
@@ -150,15 +150,19 @@ class ToHtml(Tokenizer):
 
             # Replace < and > and recompute formatting positions
             cText = []
-            for i, c in enumerate(tDirty):
+            i = 0
+            for c in tDirty:
                 if c == "<":
                     cText.append("&lt;")
                     tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
+                    i += 4
                 elif c == ">":
                     cText.append("&gt;")
                     tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
+                    i += 4
                 else:
                     cText.append(c)
+                    i += 1
 
             tText = "".join(cText)
 

--- a/novelwriter/core/tohtml.py
+++ b/novelwriter/core/tohtml.py
@@ -146,10 +146,21 @@ class ToHtml(Tokenizer):
         parStyle = None
         tmpResult = []
 
-        for tType, tLine, tText, tFormat, tStyle in self.theTokens:
+        for tType, tLine, tDirty, tFormat, tStyle in self.theTokens:
 
-            # Replace < and > before adding html tags
-            tText = tText.replace("<", "&lt;").replace(">", "&gt;")
+            # Replace < and > and recompute formatting positions
+            cText = []
+            for i, c in enumerate(tDirty):
+                if c == "<":
+                    cText.append("&lt;")
+                    tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
+                elif c == ">":
+                    cText.append("&gt;")
+                    tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
+                else:
+                    cText.append(c)
+
+            tText = "".join(cText)
 
             # Styles
             aStyle = []

--- a/tests/test_core/test_core_tohtml.py
+++ b/tests/test_core/test_core_tohtml.py
@@ -379,6 +379,48 @@ def testCoreToHtml_ConvertDirect(mockGUI):
 
 
 @pytest.mark.core
+def testCoreToHtml_SpecialCases(mockGUI):
+    """Test some special cases that has caused errors in the past.
+    """
+    theProject = NWProject(mockGUI)
+    theHtml = ToHtml(theProject)
+    theHtml.isNovel = True
+
+    # Greater/Lesser than symbols
+    # ===========================
+
+    theHtml.theText = "Text with > and < with some **bold text** in it.\n"
+    theHtml.tokenizeText()
+    theHtml.doConvert()
+    assert theHtml.theResult == (
+        "<p>Text with &gt; and &lt; with some <strong>bold text</strong> in it.</p>\n"
+    )
+
+    theHtml.theText = "Text with some <**bold text**> in it.\n"
+    theHtml.tokenizeText()
+    theHtml.doConvert()
+    assert theHtml.theResult == (
+        "<p>Text with some &lt;<strong>bold text</strong>&gt; in it.</p>\n"
+    )
+
+    theHtml.theText = "Let's > be > _difficult **shall** > we_?\n"
+    theHtml.tokenizeText()
+    theHtml.doConvert()
+    assert theHtml.theResult == (
+        "<p>Let's &gt; be &gt; <em>difficult <strong>shall</strong> &gt; we</em>?</p>\n"
+    )
+
+    theHtml.theText = "Test > text _<**bold**>_ and more.\n"
+    theHtml.tokenizeText()
+    theHtml.doConvert()
+    assert theHtml.theResult == (
+        "<p>Test &gt; text <em>&lt;<strong>bold</strong>&gt;</em> and more.</p>\n"
+    )
+
+# END Test testCoreToHtml_SpecialCases
+
+
+@pytest.mark.core
 def testCoreToHtml_Complex(mockGUI, fncDir):
     """Test the save method of the ToHtml class.
     """


### PR DESCRIPTION
**Summary:**

When the greater than or lesser than symbols are used before a formatted piece of text, the html converter places the html tags in the wrong location due to the expansion of `<` to `&lt;` and `>` to `&gt;`, which shifts the rest of the string three characters.

The previous plain replace function is here replaced by a for loop that also shifts the formatting positions calculated by the Tokenizer class. Unfortunately, this is likely to be a bit slower, but it can't really be helped.

Test coverage has been added for these special cases.

**Related Issue(s):**

Resolves #929 

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
