### PR TITLE
Text width

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -117,7 +117,6 @@ class Config:
         # Text Editor
         self.textFont        = None   # Editor font
         self.textSize        = 12     # Editor font size
-        self.textFixedW      = True   # Keep editor text fixed width
         self.textWidth       = 600    # Editor text width
         self.textMargin      = 40     # Editor/viewer text margin
         self.tabWidth        = 40     # Editor tabulator width
@@ -468,7 +467,6 @@ class Config:
         cnfSec = "Editor"
         self.textFont        = theConf.rdStr(cnfSec, "textfont", self.textFont)
         self.textSize        = theConf.rdInt(cnfSec, "textsize", self.textSize)
-        self.textFixedW      = theConf.rdBool(cnfSec, "fixedwidth", self.textFixedW)
         self.textWidth       = theConf.rdInt(cnfSec, "width", self.textWidth)
         self.textMargin      = theConf.rdInt(cnfSec, "margin", self.textMargin)
         self.tabWidth        = theConf.rdInt(cnfSec, "tabwidth", self.tabWidth)
@@ -590,7 +588,6 @@ class Config:
         theConf["Editor"] = {
             "textfont":        str(self.textFont),
             "textsize":        str(self.textSize),
-            "fixedwidth":      str(self.textFixedW),
             "width":           str(self.textWidth),
             "margin":          str(self.textMargin),
             "tabwidth":        str(self.tabWidth),
@@ -923,16 +920,16 @@ class Config:
         return [int(x*self.guiScale) for x in self.outlnPanePos]
 
     def getTextWidth(self):
-        return self.pxInt(self.textWidth)
+        return self.pxInt(max(self.textWidth, 200))
 
     def getTextMargin(self):
-        return self.pxInt(self.textMargin)
+        return self.pxInt(max(self.textMargin, 0))
 
     def getTabWidth(self):
-        return self.pxInt(self.tabWidth)
+        return self.pxInt(max(self.tabWidth, 0))
 
     def getFocusWidth(self):
-        return self.pxInt(self.focusWidth)
+        return self.pxInt(max(self.focusWidth, 200))
 
     def getErrData(self):
         """Compile and return error messages from the initialisation of

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -919,17 +919,17 @@ class Config:
     def getOutlinePanePos(self):
         return [int(x*self.guiScale) for x in self.outlnPanePos]
 
-    def getTextWidth(self):
-        return self.pxInt(max(self.textWidth, 200))
+    def getTextWidth(self, focusMode=False):
+        if focusMode:
+            return self.pxInt(max(self.focusWidth, 200))
+        else:
+            return self.pxInt(max(self.textWidth, 200))
 
     def getTextMargin(self):
         return self.pxInt(max(self.textMargin, 0))
 
     def getTabWidth(self):
         return self.pxInt(max(self.tabWidth, 0))
-
-    def getFocusWidth(self):
-        return self.pxInt(max(self.focusWidth, 200))
 
     def getErrData(self):
         """Compile and return error messages from the initialisation of

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -537,37 +537,28 @@ class GuiPreferencesDocuments(QWidget):
 
         # Max Text Width in Normal Mode
         self.textWidth = QSpinBox(self)
-        self.textWidth.setMinimum(300)
+        self.textWidth.setMinimum(0)
         self.textWidth.setMaximum(10000)
         self.textWidth.setSingleStep(10)
         self.textWidth.setValue(self.mainConf.textWidth)
         self.mainForm.addRow(
             self.tr("Maximum text width in \"Normal Mode\""),
             self.textWidth,
-            self.tr("Horizontal margins are scaled automatically."),
+            self.tr("Set to 0 to disable this feature."),
             theUnit=self.tr("px")
         )
 
         # Max Text Width in Focus Mode
         self.focusWidth = QSpinBox(self)
-        self.focusWidth.setMinimum(300)
+        self.focusWidth.setMinimum(200)
         self.focusWidth.setMaximum(10000)
         self.focusWidth.setSingleStep(10)
         self.focusWidth.setValue(self.mainConf.focusWidth)
         self.mainForm.addRow(
             self.tr("Maximum text width in \"Focus Mode\""),
             self.focusWidth,
-            self.tr("Horizontal margins are scaled automatically."),
+            self.tr("The maximum width cannot be disabled."),
             theUnit=self.tr("px")
-        )
-
-        # Document Fixed Width
-        self.textFixedW = QSwitch()
-        self.textFixedW.setChecked(not self.mainConf.textFixedW)
-        self.mainForm.addRow(
-            self.tr("Disable maximum text width in \"Normal Mode\""),
-            self.textFixedW,
-            self.tr("Text width is defined by the margins only.")
         )
 
         # Focus Mode Footer
@@ -597,7 +588,7 @@ class GuiPreferencesDocuments(QWidget):
         self.mainForm.addRow(
             self.tr("Text margin"),
             self.textMargin,
-            self.tr("If maximum width is set, this becomes the minimum margin."),
+            self.tr("The minimum margin around the text in the editor and viewer."),
             theUnit=self.tr("px")
         )
 
@@ -626,7 +617,6 @@ class GuiPreferencesDocuments(QWidget):
         # Text Flow
         self.mainConf.textWidth       = self.textWidth.value()
         self.mainConf.focusWidth      = self.focusWidth.value()
-        self.mainConf.textFixedW      = not self.textFixedW.isChecked()
         self.mainConf.hideFocusFooter = self.hideFocusFooter.isChecked()
         self.mainConf.doJustify       = self.doJustify.isChecked()
         self.mainConf.textMargin      = self.textMargin.value()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -522,16 +522,10 @@ class GuiDocEditor(QTextEdit):
         hBar = self.horizontalScrollBar()
         sH = hBar.height() if hBar.isVisible() else 0
 
+        tM = cM
         if self.mainConf.textWidth > 0 or self.theParent.isFocusMode:
-            if self.theParent.isFocusMode:
-                tW = self.mainConf.getFocusWidth()
-            else:
-                tW = self.mainConf.getTextWidth()
-            tM = (wW - sW - tW)//2
-            if tM < cM:
-                tM = cM
-        else:
-            tM = cM
+            tW = self.mainConf.getTextWidth(self.theParent.isFocusMode)
+            tM = max((wW - sW - tW)//2, cM)
 
         tB = self.frameWidth()
         tW = wW - 2*tB - sW
@@ -541,13 +535,12 @@ class GuiDocEditor(QTextEdit):
         self.docHeader.setGeometry(tB, tB, tW, tH)
         self.docFooter.setGeometry(tB, fY, tW, fH)
 
+        rH = 0
         if self.docSearch.isVisible():
             rH = self.docSearch.height()
             rW = self.docSearch.width()
             rL = wW - sW - rW - 2*tB
             self.docSearch.move(rL, 2*tB)
-        else:
-            rH = 0
 
         uM = max(cM, tH, rH)
         lM = max(cM, fH)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -509,8 +509,8 @@ class GuiDocEditor(QTextEdit):
 
     def updateDocMargins(self):
         """Automatically adjust the margins so the text is centred if
-        Config.textFixedW is enabled or we're in Focus Mode. Otherwise,
-        just ensure the margins are set correctly.
+        we have a text width set or we're in Focus Mode. Otherwise, just
+        ensure the margins are set correctly.
         """
         wW = self.width()
         wH = self.height()
@@ -522,7 +522,7 @@ class GuiDocEditor(QTextEdit):
         hBar = self.horizontalScrollBar()
         sH = hBar.height() if hBar.isVisible() else 0
 
-        if self.mainConf.textFixedW or self.theParent.isFocusMode:
+        if self.mainConf.textWidth > 0 or self.theParent.isFocusMode:
             if self.theParent.isFocusMode:
                 tW = self.mainConf.getFocusWidth()
             else:

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -313,22 +313,30 @@ class GuiDocViewer(QTextBrowser):
     def updateDocMargins(self):
         """Automatically adjust the margins so the text is centred.
         """
+        wW = self.width()
+        wH = self.height()
+        cM = self.mainConf.getTextMargin()
+
         vBar = self.verticalScrollBar()
         sW = vBar.width() if vBar.isVisible() else 0
 
         hBar = self.horizontalScrollBar()
         sH = hBar.height() if hBar.isVisible() else 0
 
-        cM = self.mainConf.getTextMargin()
+        tM = cM
+        if self.mainConf.textWidth > 0:
+            tW = self.mainConf.getTextWidth()
+            tM = max((wW - sW - tW)//2, cM)
+
         tB = self.frameWidth()
-        tW = self.width() - 2*tB - sW
+        tW = wW - 2*tB - sW
         tH = self.docHeader.height()
         fH = self.docFooter.height()
-        fY = self.height() - fH - tB - sH
+        fY = wH - fH - tB - sH
 
         self.docHeader.setGeometry(tB, tB, tW, tH)
         self.docFooter.setGeometry(tB, fY, tW, fH)
-        self.setViewportMargins(cM, max(cM, tH), cM, max(cM, fH))
+        self.setViewportMargins(tM, max(cM, tH), tM, max(cM, fH))
 
         return
 

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Main]
-timestamp = 2021-09-15 14:39:52
+timestamp = 2021-12-31 16:45:32
 theme = default
 syntax = default_light
 icons = typicons_light
@@ -30,7 +30,6 @@ emphlabels = True
 [Editor]
 textfont = None
 textsize = 12
-fixedwidth = True
 width = 600
 margin = 40
 tabwidth = 40

--- a/tests/reference/guiPreferences_novelwriter.conf
+++ b/tests/reference/guiPreferences_novelwriter.conf
@@ -1,5 +1,5 @@
 [Main]
-timestamp = 2021-09-15 14:29:30
+timestamp = 2021-12-31 16:45:34
 theme = default
 syntax = default_light
 icons = typicons_light
@@ -30,7 +30,6 @@ emphlabels = True
 [Editor]
 textfont = None
 textsize = 13
-fixedwidth = False
 width = 700
 margin = 45
 tabwidth = 45

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -505,16 +505,16 @@ def testBaseConfig_SettersGetters(tmpConf, tmpDir, outDir, refDir):
     # ============
 
     tmpConf.guiScale = 1.0
-    assert tmpConf.getTextWidth() == 600
+    assert tmpConf.getTextWidth(False) == 600
+    assert tmpConf.getTextWidth(True) == 800
     assert tmpConf.getTextMargin() == 40
     assert tmpConf.getTabWidth() == 40
-    assert tmpConf.getFocusWidth() == 800
 
     tmpConf.guiScale = 2.0
-    assert tmpConf.getTextWidth() == 1200
+    assert tmpConf.getTextWidth(False) == 1200
+    assert tmpConf.getTextWidth(True) == 1600
     assert tmpConf.getTextMargin() == 80
     assert tmpConf.getTabWidth() == 80
-    assert tmpConf.getFocusWidth() == 1600
 
     # Flag Setters
     # ============

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -145,11 +145,6 @@ def testDlgPreferences_Main(qtbot, monkeypatch, fncDir, outDir, refDir):
     tabDocs.tabWidth.setValue(45)
 
     qtbot.wait(keyDelay)
-    assert not tabDocs.textFixedW.isChecked()
-    qtbot.mouseClick(tabDocs.textFixedW, Qt.LeftButton)
-    assert tabDocs.textFixedW.isChecked()
-
-    qtbot.wait(keyDelay)
     assert not tabDocs.hideFocusFooter.isChecked()
     qtbot.mouseClick(tabDocs.hideFocusFooter, Qt.LeftButton)
     assert tabDocs.hideFocusFooter.isChecked()


### PR DESCRIPTION
**Summary:**

Remove the switch to enable/disable fixed text width in editor and instead allow the user to set the value to 0 to disable it. Also apply the max width setting to the document viewer.

**Related Issue(s):**

Resolves #924

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
