### PR TITLE
Apply open document shortcuts to the tree that has focus

### DIFF
--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -135,7 +135,7 @@ class GuiNovelTree(QTreeWidget):
         logger.verbose("Requesting refresh of the novel tree")
         treeChanged = self.theParent.treeView.changedSince(self._lastBuild)
         indexChanged = self.theIndex.novelChangedSince(self._lastBuild)
-        if not (treeChanged or indexChanged):
+        if not (treeChanged or indexChanged or overRide):
             logger.verbose("No changes have been made to the novel index")
             return
 

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -175,10 +175,13 @@ class GuiNovelTree(QTreeWidget):
         selected, return the first.
         """
         selItem = self.selectedItems()
+        tHandle = None
+        tLine = 0
         if selItem:
-            return selItem[0].data(self.C_TITLE, Qt.UserRole)[0]
+            tHandle = selItem[0].data(self.C_TITLE, Qt.UserRole)[0]
+            tLine = checkInt(selItem[0].data(self.C_TITLE, Qt.UserRole)[1], 1) - 1
 
-        return None
+        return tHandle, tLine
 
     ##
     #  Events
@@ -201,7 +204,7 @@ class GuiNovelTree(QTreeWidget):
             if not isinstance(selItem, QTreeWidgetItem):
                 return
 
-            tHandle = self.getSelectedHandle()
+            tHandle, _ = self.getSelectedHandle()
             if tHandle is None:
                 return
 
@@ -218,13 +221,8 @@ class GuiNovelTree(QTreeWidget):
         clicked, and send it to the main gui class for opening in the
         document editor.
         """
-        theData = tItem.data(self.C_TITLE, Qt.UserRole)
-        tHandle = theData[0]
-        tLine = checkInt(theData[1], 1)
-
-        logger.verbose("User selected entry with handle '%s' on line %s", tHandle, tLine)
+        tHandle, tLine = self.getSelectedHandle()
         self.theParent.openDocument(tHandle, tLine=tLine-1, doScroll=True)
-
         return
 
     def _itemSelected(self):

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -34,6 +34,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter.enum import nwItemLayout, nwItemType, nwOutline
+from novelwriter.common import checkInt
 from novelwriter.constants import trConst, nwKeyWords, nwLabels
 
 logger = logging.getLogger(__name__)
@@ -201,12 +202,11 @@ class GuiOutline(QTreeWidget):
         selected, return the first.
         """
         selItem = self.selectedItems()
+        tHandle = None
+        tLine = 0
         if selItem:
             tHandle = selItem[0].data(self._colIdx[nwOutline.TITLE], Qt.UserRole)
-            try:
-                tLine = int(selItem[0].text(self._colIdx[nwOutline.LINE])) - 1
-            except Exception:
-                tLine = 0
+            tLine = checkInt(selItem[0].text(self._colIdx[nwOutline.LINE]), 1) - 1
 
         return tHandle, tLine
 

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -196,6 +196,20 @@ class GuiOutline(QTreeWidget):
         self._firstView = True
         return
 
+    def getSelectedHandle(self):
+        """Get the currently selected handle. If multiple items are
+        selected, return the first.
+        """
+        selItem = self.selectedItems()
+        if selItem:
+            tHandle = selItem[0].data(self._colIdx[nwOutline.TITLE], Qt.UserRole)
+            try:
+                tLine = int(selItem[0].text(self._colIdx[nwOutline.LINE])) - 1
+            except Exception:
+                tLine = 0
+
+        return tHandle, tLine
+
     ##
     #  Slots
     ##
@@ -206,15 +220,8 @@ class GuiOutline(QTreeWidget):
         clicked, and send it to the main gui class for opening in the
         document editor.
         """
-        tHandle = tItem.data(self._colIdx[nwOutline.TITLE], Qt.UserRole)
-        try:
-            tLine = int(tItem.text(self._colIdx[nwOutline.LINE]))
-        except Exception:
-            tLine = 1
-
-        logger.verbose("User selected entry with handle '%s' on line %s", tHandle, tLine)
+        tHandle, tLine = self.getSelectedHandle()
         self.theParent.openDocument(tHandle, tLine=tLine-1, doScroll=True)
-
         return
 
     @pyqtSlot()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1599,9 +1599,8 @@ class GuiMain(QMainWindow):
 
     @pyqtSlot()
     def _keyPressReturn(self):
-        """The user pressed return on the main GUI. If it is a
-        file, we open it. Otherwise, we do nothing. Pressing return does
-        not change focus to the editor as double click does.
+        """Forward the return/enter keypress to the function that opens
+        the currently selected item.
         """
         self.openSelectedItem()
         return

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -29,7 +29,7 @@ from PyQt5.QtWidgets import QAction, QFileDialog, QMessageBox
 from tools import writeFile
 
 from novelwriter.gui.doceditor import GuiDocEditor
-from novelwriter.enum import nwDocAction, nwDocInsert, nwWidget
+from novelwriter.enum import nwDocAction, nwDocInsert
 from novelwriter.constants import nwKeyWords, nwUnicode
 
 keyDelay = 2
@@ -471,11 +471,7 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncDir, fncProj):
     assert nwGUI.newProject({"projPath": fncProj})
 
     assert nwGUI.treeView._getTreeItem("0e17daca5f3e1") is not None
-
-    nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.clearSelection()
-    nwGUI.treeView._getTreeItem("0e17daca5f3e1").setSelected(True)
-    assert nwGUI.openSelectedItem()
+    assert nwGUI.openDocument("0e17daca5f3e1") is True
     nwGUI.docEditor.clear()
 
     # Test Faulty Inserts

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -74,7 +74,7 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, nwMinimal):
     assert not topItem.isSelected()
     topItem.setSelected(True)
     assert nwTree.selectedItems()[0] == topItem
-    assert nwTree.getSelectedHandle() == "a35baf2e93843"
+    assert nwTree.getSelectedHandle() == ("a35baf2e93843", 0)
 
     nwTree.refreshTree()
     assert nwTree.topLevelItem(0).isSelected()

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -77,6 +77,10 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, nwLipsum):
     selItem = chpItem.child(0)
 
     nwGUI.projView.setCurrentItem(selItem)
+    tHandle, tLine = nwGUI.projView.getSelectedHandle()
+    assert tHandle == "88243afbe5ed8"
+    assert tLine == 0
+
     assert nwGUI.projMeta.titleLabel.text() == "<b>Scene</b>"
     assert nwGUI.projMeta.titleValue.text() == "Scene One"
     assert nwGUI.projMeta.fileValue.text() == "Scene One"
@@ -86,6 +90,25 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, nwLipsum):
     assert nwGUI.projMeta.povKeyValue.text() == "<a href='#pov=Bod'>Bod</a>"
     nwGUI.projMeta._tagClicked("#pov=Bod")
     assert nwGUI.docViewer.docHandle() == "4c4f28287af27"
+
+    # Scene One, Section Two
+    actItem = nwGUI.projView.topLevelItem(1)
+    chpItem = actItem.child(0)
+    scnItem = chpItem.child(0)
+    selItem = scnItem.child(0)
+
+    nwGUI.projView.setCurrentItem(selItem)
+    tHandle, tLine = nwGUI.projView.getSelectedHandle()
+    assert tHandle == "88243afbe5ed8"
+    assert tLine == 12
+
+    assert nwGUI.projMeta.titleLabel.text() == "<b>Section</b>"
+    assert nwGUI.projMeta.titleValue.text() == "Scene One, Section Two"
+    assert nwGUI.projMeta.fileValue.text() == "Scene One"
+    assert nwGUI.projMeta.itemValue.text() == "Finished"
+
+    nwGUI.projView._treeDoubleClick(selItem, 0)
+    assert nwGUI.docEditor.docHandle() == "88243afbe5ed8"
 
     # qtbot.stopForInteraction()
 


### PR DESCRIPTION
**Summary:**

This PR alters how the Enter, Return and Ctrl+O shortcuts work. They will now open the selected document in the Project Tree, Novel Tree, or Project Outline, depending on which of these trees have focus.

**Related Issue(s):**

Resolves #913

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
