### PR TITLE
Resolve HTML render bug

### DIFF
--- a/novelwriter/core/tohtml.py
+++ b/novelwriter/core/tohtml.py
@@ -154,25 +154,31 @@ class ToHtml(Tokenizer):
         parStyle = None
         tmpResult = []
 
-        for tType, tLine, tDirty, tFormat, tStyle in self._theTokens:
+        for tType, tLine, tText, tFormat, tStyle in self._theTokens:
 
-            # Replace < and > and recompute formatting positions
-            cText = []
-            i = 0
-            for c in tDirty:
-                if c == "<":
-                    cText.append("&lt;")
-                    tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
-                    i += 4
-                elif c == ">":
-                    cText.append("&gt;")
-                    tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
-                    i += 4
-                else:
-                    cText.append(c)
-                    i += 1
+            # Replace < and > with HTML entities
+            if tFormat:
+                # If we have formatting, we must recompute the locations
+                cText = []
+                i = 0
+                for c in tText:
+                    if c == "<":
+                        cText.append("&lt;")
+                        tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
+                        i += 4
+                    elif c == ">":
+                        cText.append("&gt;")
+                        tFormat = [[a + 3 if a > i else a, b, c] for a, b, c in tFormat]
+                        i += 4
+                    else:
+                        cText.append(c)
+                        i += 1
 
-            tText = "".join(cText)
+                tText = "".join(cText)
+
+            else:
+                # If we don't have formatting, we can do a plain replace
+                tText = tText.replace("<", "&lt;").replace(">", "&gt;")
 
             # Styles
             aStyle = []

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -184,6 +184,7 @@ class GuiDocViewer(QTextBrowser):
             logger.error("Failed to generate preview for document with handle '%s'", tHandle)
             logException()
             self.setText(self.tr("An error occurred while generating the preview."))
+            qApp.restoreOverrideCursor()
             return False
 
         # Refresh the tab stops

--- a/tests/test_core/test_core_tohtml.py
+++ b/tests/test_core/test_core_tohtml.py
@@ -417,6 +417,27 @@ def testCoreToHtml_SpecialCases(mockGUI):
         "<p>Test &gt; text <em>&lt;<strong>bold</strong>&gt;</em> and more.</p>\n"
     )
 
+    # Test for bug #950
+    # =================
+    # See: https://github.com/vkbo/novelWriter/issues/950
+
+    theHtml.setComments(True)
+    theHtml._theText = "% Test > text _<**bold**>_ and more.\n"
+    theHtml.tokenizeText()
+    theHtml.doConvert()
+    assert theHtml.theResult == (
+        "<p class='comment'>"
+        "<strong>Comment:</strong> Test &gt; text _&lt;**bold**&gt;_ and more."
+        "</p>\n"
+    )
+
+    theHtml._theText = "## Heading <1>\n"
+    theHtml.tokenizeText()
+    theHtml.doConvert()
+    assert theHtml.theResult == (
+        "<h1 style='page-break-before: always;'>Heading &lt;1&gt;</h1>\n"
+    )
+
 # END Test testCoreToHtml_SpecialCases
 
 


### PR DESCRIPTION
**Summary:**

The HTML rendering fails if a text line that is not a plain text paragraph contains a < or > symbol. It tries to iterate over a None object instead of a list of formats.

**Related Issue(s):**

Resolves #950

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
