### PR TITLE
Clean up GUI text

### DIFF
--- a/docs/source/project_overview.rst
+++ b/docs/source/project_overview.rst
@@ -104,11 +104,11 @@ supported. A document or a folder can be deleted from the :guilabel:`Project` me
 
 .. _a_proj_roots_out:
 
-Archived Documents (Outtakes)
------------------------------
+Archived Documents
+------------------
 
 If you don't want to delete a document, or put it in the :guilabel:`Trash` folder where it may be
-deleted, but still want it out of your main project tree, you can create an :guilabel:`Outtakes`
+deleted, but still want it out of your main project tree, you can create an :guilabel:`Archive`
 root folder from the :guilabel:`Project` menu. You are not allowed to move entire folders to this
 root folder, only documents. If you need folders in it to organise your documents, you can of
 course create new ones there.

--- a/docs/source/project_structure.rst
+++ b/docs/source/project_structure.rst
@@ -182,7 +182,7 @@ available to change how the documents where formatted on export. These have now 
 just two layouts: :guilabel:`Novel Document` and :guilabel:`Project Note`.
 
 Novel documents can only live in the :guilabel:`Novel` root folder. You can also move them to
-:guilabel:`Outtakes` and :guilabel:`Trash` of course. Project notes can be added anywhere in the
+:guilabel:`Archive` and :guilabel:`Trash` of course. Project notes can be added anywhere in the
 project.
 
 Depending on which icon theme you're using, the project tree can distinguish between the different

--- a/docs/source/usage_interface.rst
+++ b/docs/source/usage_interface.rst
@@ -78,7 +78,7 @@ major or minor character.
 
 Whether a document uses a "Status" or "Importance" flag depends on which root folder it lives in.
 If it's in the :guilabel:`Novel` folder, it uses the "Status" flag, otherwise it uses an
-"Importance" flag. Some folders, like :guilabel:`Trash` and :guilabel:`Outtakes` allow both.
+"Importance" flag. Some folders, like :guilabel:`Trash` and :guilabel:`Archive` allow both.
 
 
 .. _a_ui_tree_dnd:
@@ -96,7 +96,7 @@ the last move action can be undone by pressing :kbd:`Ctrl`:kbd:`Shift`:kbd:`Z`.
 
 Documents and their folders can be rearranged freely within their root folders. Novel documents
 cannot be moved out of the :guilabel:`Novel` folder, except to :guilabel:`Trash` and the
-:guilabel:`Outtakes` folders. Notes can be moved freely between all root folders, but keep in mind
+:guilabel:`Archive` folders. Notes can be moved freely between all root folders, but keep in mind
 that if you move a note into a :guilabel:`Novel`, its "Importance" setting will be reset to the
 default "Status" setting. See :ref:`a_ui_tree_status`.
 

--- a/i18n/nw_base.ts
+++ b/i18n/nw_base.ts
@@ -77,45 +77,46 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="163" />
-      <location filename="../novelwriter/constants.py" line="158" />
+      <location filename="../novelwriter/constants.py" line="176" />
+      <location filename="../novelwriter/constants.py" line="171" />
+      <location filename="../novelwriter/constants.py" line="145" />
       <location filename="../novelwriter/constants.py" line="132" />
       <source>None</source>
       <translation type="unfinished" />
     </message>
     <message>
+      <location filename="../novelwriter/constants.py" line="146" />
       <location filename="../novelwriter/constants.py" line="133" />
       <source>Novel</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="177" />
+      <location filename="../novelwriter/constants.py" line="190" />
+      <location filename="../novelwriter/constants.py" line="147" />
       <location filename="../novelwriter/constants.py" line="134" />
       <source>Plot</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="176" />
       <location filename="../novelwriter/constants.py" line="135" />
-      <source>Characters</source>
+      <source>Character</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="179" />
       <location filename="../novelwriter/constants.py" line="136" />
-      <source>Locations</source>
+      <source>Location</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="178" />
+      <location filename="../novelwriter/constants.py" line="191" />
+      <location filename="../novelwriter/constants.py" line="150" />
       <location filename="../novelwriter/constants.py" line="137" />
       <source>Timeline</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="180" />
       <location filename="../novelwriter/constants.py" line="138" />
-      <source>Objects</source>
+      <source>Object</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -124,216 +125,238 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="182" />
+      <location filename="../novelwriter/constants.py" line="195" />
+      <location filename="../novelwriter/constants.py" line="153" />
       <location filename="../novelwriter/constants.py" line="140" />
       <source>Custom</source>
       <translation type="unfinished" />
     </message>
     <message>
+      <location filename="../novelwriter/constants.py" line="154" />
       <location filename="../novelwriter/constants.py" line="141" />
-      <source>Outtakes</source>
+      <source>Archive</source>
       <translation type="unfinished" />
     </message>
     <message>
+      <location filename="../novelwriter/constants.py" line="155" />
       <location filename="../novelwriter/constants.py" line="142" />
       <source>Trash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="166" />
-      <location filename="../novelwriter/constants.py" line="159" />
-      <source>Novel Document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="170" />
-      <location filename="../novelwriter/constants.py" line="160" />
-      <source>Project Note</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="164" />
-      <source>Root Folder</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="165" />
-      <source>Folder</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="167" />
-      <source>Novel Title Page</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="168" />
-      <source>Novel Chapter</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="169" />
-      <source>Novel Scene</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="173" />
-      <source>Tag</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="174" />
-      <source>Point of View</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="193" />
-      <location filename="../novelwriter/constants.py" line="175" />
-      <source>Focus</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="181" />
-      <source>Entities</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="185" />
-      <source>Title</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="186" />
-      <source>Level</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="187" />
-      <source>Document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="188" />
-      <source>Line</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../novelwriter/constants.py" line="189" />
-      <source>Chars</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="190" />
-      <source>Words</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="191" />
-      <source>Pars</source>
+      <location filename="../novelwriter/constants.py" line="148" />
+      <source>Characters</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="192" />
-      <source>POV</source>
+      <location filename="../novelwriter/constants.py" line="149" />
+      <source>Locations</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="193" />
+      <location filename="../novelwriter/constants.py" line="151" />
+      <source>Objects</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="194" />
+      <location filename="../novelwriter/constants.py" line="152" />
+      <source>Entities</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="179" />
+      <location filename="../novelwriter/constants.py" line="172" />
+      <source>Novel Document</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="183" />
+      <location filename="../novelwriter/constants.py" line="173" />
+      <source>Project Note</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="177" />
+      <source>Root Folder</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="178" />
+      <source>Folder</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="180" />
+      <source>Novel Title Page</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="181" />
+      <source>Novel Chapter</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="182" />
+      <source>Novel Scene</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="186" />
+      <source>Tag</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="187" />
+      <source>Point of View</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="206" />
+      <location filename="../novelwriter/constants.py" line="188" />
+      <source>Focus</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="198" />
+      <source>Title</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="199" />
+      <source>Level</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="200" />
+      <source>Document</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="201" />
+      <source>Line</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="202" />
+      <source>Chars</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="203" />
+      <source>Words</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="204" />
+      <source>Pars</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="205" />
+      <source>POV</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="214" />
       <source>Synopsis</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="212" />
+      <location filename="../novelwriter/constants.py" line="225" />
       <source>Straight single quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="213" />
+      <location filename="../novelwriter/constants.py" line="226" />
       <source>Straight double quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="215" />
+      <location filename="../novelwriter/constants.py" line="228" />
       <source>Left single quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="216" />
+      <location filename="../novelwriter/constants.py" line="229" />
       <source>Right single quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="217" />
+      <location filename="../novelwriter/constants.py" line="230" />
       <source>Single low-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="218" />
+      <location filename="../novelwriter/constants.py" line="231" />
       <source>Single high-reversed-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="219" />
+      <location filename="../novelwriter/constants.py" line="232" />
       <source>Left double quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="220" />
+      <location filename="../novelwriter/constants.py" line="233" />
       <source>Right double quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="221" />
+      <location filename="../novelwriter/constants.py" line="234" />
       <source>Double low-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="222" />
+      <location filename="../novelwriter/constants.py" line="235" />
       <source>Double high-reversed-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="223" />
+      <location filename="../novelwriter/constants.py" line="236" />
       <source>Double low-reversed-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="225" />
+      <location filename="../novelwriter/constants.py" line="238" />
       <source>Single left-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="226" />
+      <location filename="../novelwriter/constants.py" line="239" />
       <source>Single right-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="227" />
+      <location filename="../novelwriter/constants.py" line="240" />
       <source>Double left-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="228" />
+      <location filename="../novelwriter/constants.py" line="241" />
       <source>Double right-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="230" />
+      <location filename="../novelwriter/constants.py" line="243" />
       <source>Left corner bracket</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="231" />
+      <location filename="../novelwriter/constants.py" line="244" />
       <source>Right corner bracket</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="232" />
+      <location filename="../novelwriter/constants.py" line="245" />
       <source>Left white corner bracket</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="233" />
+      <location filename="../novelwriter/constants.py" line="246" />
       <source>Right white corner bracket</source>
       <translation type="unfinished" />
     </message>
@@ -602,187 +625,172 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="346" />
-      <source>Include files with layouts other than 'Note'.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/tools/build.py" line="352" />
-      <source>Include files with layout 'Note'.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/tools/build.py" line="358" />
-      <source>Ignore the 'Include when building project' setting and include all files in the output.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/tools/build.py" line="366" />
+      <location filename="../novelwriter/tools/build.py" line="360" />
       <source>Include novel files</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="367" />
+      <location filename="../novelwriter/tools/build.py" line="361" />
       <source>Include note files</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="368" />
+      <location filename="../novelwriter/tools/build.py" line="362" />
       <source>Ignore export flag</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="383" />
+      <location filename="../novelwriter/tools/build.py" line="377" />
       <source>Export Options</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="397" />
+      <location filename="../novelwriter/tools/build.py" line="391" />
       <source>Replace tabs with spaces</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="398" />
+      <location filename="../novelwriter/tools/build.py" line="392" />
       <source>Replace Unicode in HTML</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="413" />
+      <location filename="../novelwriter/tools/build.py" line="407" />
       <source>Build Preview</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="424" />
+      <location filename="../novelwriter/tools/build.py" line="418" />
       <source>Print</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="427" />
+      <location filename="../novelwriter/tools/build.py" line="421" />
       <source>Print Preview</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="431" />
+      <location filename="../novelwriter/tools/build.py" line="425" />
       <source>Print to PDF</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="438" />
+      <location filename="../novelwriter/tools/build.py" line="432" />
       <source>Save As</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="441" />
+      <location filename="../novelwriter/tools/build.py" line="435" />
       <source>Open Document (.odt)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="445" />
+      <location filename="../novelwriter/tools/build.py" line="439" />
       <source>Flat Open Document (.fodt)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="449" />
+      <location filename="../novelwriter/tools/build.py" line="443" />
       <source>novelWriter HTML (.htm)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="453" />
+      <location filename="../novelwriter/tools/build.py" line="447" />
       <source>novelWriter Markdown (.nwd)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="457" />
+      <location filename="../novelwriter/tools/build.py" line="451" />
       <source>Standard Markdown (.md)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="461" />
+      <location filename="../novelwriter/tools/build.py" line="455" />
       <source>GitHub Markdown (.md)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="465" />
+      <location filename="../novelwriter/tools/build.py" line="459" />
       <source>JSON + novelWriter HTML (.json)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="469" />
+      <location filename="../novelwriter/tools/build.py" line="463" />
       <source>JSON + novelWriter Markdown (.json)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="473" />
+      <location filename="../novelwriter/tools/build.py" line="467" />
       <source>Close</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="578" />
+      <location filename="../novelwriter/tools/build.py" line="572" />
       <source>Failed to generate preview. The result is too big.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="751" />
+      <location filename="../novelwriter/tools/build.py" line="745" />
       <source>There were problems when building the project:</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="809" />
+      <location filename="../novelwriter/tools/build.py" line="803" />
       <source>Open Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="813" />
+      <location filename="../novelwriter/tools/build.py" line="807" />
       <source>Flat Open Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="817" />
+      <location filename="../novelwriter/tools/build.py" line="811" />
       <source>Plain HTML</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="821" />
+      <location filename="../novelwriter/tools/build.py" line="815" />
       <source>novelWriter Markdown</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="825" />
+      <location filename="../novelwriter/tools/build.py" line="819" />
       <source>Standard Markdown</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="829" />
+      <location filename="../novelwriter/tools/build.py" line="823" />
       <source>GitHub Markdown</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="833" />
+      <location filename="../novelwriter/tools/build.py" line="827" />
       <source>JSON + novelWriter HTML</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="837" />
+      <location filename="../novelwriter/tools/build.py" line="831" />
       <source>JSON + novelWriter Markdown</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="841" />
+      <location filename="../novelwriter/tools/build.py" line="835" />
       <source>PDF</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="857" />
+      <location filename="../novelwriter/tools/build.py" line="851" />
       <source>Save Document As</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="1000" />
+      <location filename="../novelwriter/tools/build.py" line="994" />
       <source>{0} file successfully written to:</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="1003" />
+      <location filename="../novelwriter/tools/build.py" line="997" />
       <source>Failed to write {0} file. {1}</source>
       <translation type="unfinished" />
     </message>
@@ -790,17 +798,17 @@
   <context>
     <name>GuiBuildNovelDocView</name>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="1200" />
+      <location filename="../novelwriter/tools/build.py" line="1194" />
       <source>This area will show the content of the document to be exported or printed. Press the "Build Preview" button to generate content.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="1352" />
+      <location filename="../novelwriter/tools/build.py" line="1346" />
       <source>Unknown</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/build.py" line="1354" />
+      <location filename="../novelwriter/tools/build.py" line="1348" />
       <source>Build Time:</source>
       <translation type="unfinished" />
     </message>
@@ -808,32 +816,32 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2814" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2806" />
       <source>Status</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2963" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2955" />
       <source>Line: {0} ({1})</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2984" />
       <source>Words: {0} ({1})</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2997" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2989" />
       <source>Document size is {0} bytes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3009" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3001" />
       <source>Words: {0} selected</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3012" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3004" />
       <source>Character count: {0}</source>
       <translation type="unfinished" />
     </message>
@@ -841,22 +849,22 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2602" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2594" />
       <source>Edit document meta</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2613" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2605" />
       <source>Search document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2624" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2616" />
       <source>Toggle Focus Mode</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2635" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2627" />
       <source>Close the document</source>
       <translation type="unfinished" />
     </message>
@@ -880,82 +888,42 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2218" />
-      <source>Match case</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2225" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2224" />
       <source>Whole Words Only</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2226" />
-      <source>Match whole words</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2233" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2231" />
       <source>RegEx Mode</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2234" />
-      <source>Search using regular expressions</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2241" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2238" />
       <source>Loop Search</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2242" />
-      <source>Loop the search when reaching the end</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2249" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2245" />
       <source>Search Next File</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2250" />
-      <source>Continue searching in the next file</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2259" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2254" />
       <source>Preserve Case</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2260" />
-      <source>Preserve case on replace</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2269" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2263" />
       <source>Close Search</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2270" />
-      <source>Close the search box [{0}]</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2283" />
-      <source>Show/hide the replace text box</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2289" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2281" />
       <source>Find in current document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2294" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2286" />
       <source>Find and replace in current document</source>
       <translation type="unfinished" />
     </message>
@@ -1424,7 +1392,7 @@
     </message>
     <message>
       <location filename="../novelwriter/guimain.py" line="361" />
-      <source>Cannot create new project when another project is open.</source>
+      <source>Cannot create a new project when another project is open.</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -1603,1201 +1571,668 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="158" />
-      <source>Create new project</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="163" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="162" />
       <source>Open Project</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="164" />
-      <source>Open project</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="170" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="168" />
       <source>Save Project</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="171" />
-      <source>Save project</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="177" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
       <source>Close Project</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="178" />
-      <source>Close project</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="187" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="183" />
       <source>Project Settings</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="188" />
-      <source>Project settings</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="194" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="189" />
       <source>Project Details</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
-      <source>Project details</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="204" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
       <source>Create Root Folder</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="206" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="200" />
       <source>Novel Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="207" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="201" />
       <source>Plot Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="208" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="202" />
       <source>Character Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
       <source>Location Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="210" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="204" />
       <source>Timeline Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="211" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="205" />
       <source>Object Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="212" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="206" />
       <source>Entity Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="213" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="207" />
       <source>Custom Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="214" />
-      <source>Outtakes Root</source>
+      <location filename="../novelwriter/gui/mainmenu.py" line="208" />
+      <source>Archive Root</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="222" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="216" />
       <source>Create Folder</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
-      <source>Create folder</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="232" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="225" />
       <source>Edit Item</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="233" />
-      <source>Change project item settings</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="239" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
       <source>Delete Item</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="240" />
-      <source>Delete selected project item</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="237" />
       <source>Move Item Up</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="247" />
-      <source>Move project item up</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="253" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
       <source>Move Item Down</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
-      <source>Move project item down</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="260" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="249" />
       <source>Undo Last Move</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="261" />
-      <source>Undo last item move</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="267" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="255" />
       <source>Empty Trash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="268" />
-      <source>Permanently delete all files in the Trash folder</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="276" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="263" />
       <source>Exit</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="277" />
-      <source>Exit novelWriter</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="289" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="275" />
       <source>&amp;Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="278" />
       <source>New Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="293" />
-      <source>Create new document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="299" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="284" />
       <source>Open Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
-      <source>Open selected document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="306" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="290" />
       <source>Save Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="307" />
-      <source>Save current document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="313" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="296" />
       <source>Close Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="314" />
-      <source>Close current document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="323" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="305" />
       <source>View Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="324" />
-      <source>View document as HTML</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="330" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="311" />
       <source>Close Document View</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="331" />
-      <source>Close document view pane</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="340" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="320" />
       <source>Show File Details</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="342" />
-      <source>Shows a message box with the document location in the project folder</source>
+      <location filename="../novelwriter/gui/mainmenu.py" line="325" />
+      <source>Import Text from File</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="348" />
-      <source>Import from File</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="349" />
-      <source>Import document from a text or markdown file</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="355" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="331" />
       <source>Merge Folder to Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
-      <source>Merge a folder of documents to a single document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="361" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="336" />
       <source>Split Document to Folder</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="363" />
-      <source>Split a document into a folder of multiple documents</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="374" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
       <source>&amp;Edit</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="377" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="349" />
       <source>Undo</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
-      <source>Undo last change</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="384" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="355" />
       <source>Redo</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="385" />
-      <source>Redo last change</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="364" />
       <source>Cut</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="395" />
-      <source>Cut selected text</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="401" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="370" />
       <source>Copy</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
-      <source>Copy selected text</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="408" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="376" />
       <source>Paste</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="409" />
-      <source>Paste text from clipboard</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="418" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="385" />
       <source>Select All</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="419" />
-      <source>Select all text in document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="425" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="391" />
       <source>Select Paragraph</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="426" />
-      <source>Select all text in paragraph</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
       <source>&amp;View</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="440" />
-      <source>Focus Project Tree</source>
+      <location filename="../novelwriter/gui/mainmenu.py" line="405" />
+      <source>Go to Project Tree</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="441" />
-      <source>Move focus to project tree</source>
+      <location filename="../novelwriter/gui/mainmenu.py" line="414" />
+      <source>Go to Document Editor</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/gui/mainmenu.py" line="423" />
+      <source>Go to Document Viewer</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/gui/mainmenu.py" line="432" />
+      <source>Go to Outline</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/gui/mainmenu.py" line="444" />
+      <source>Navigate Backward</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/gui/mainmenu.py" line="450" />
-      <source>Focus Document Editor</source>
+      <source>Navigate Forward</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="451" />
-      <source>Move focus to left document pane</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="460" />
-      <source>Focus Document Viewer</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="461" />
-      <source>Move focus to right document pane</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="470" />
-      <source>Focus Outline</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="471" />
-      <source>Move focus to outline</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
-      <source>Go Backward</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="484" />
-      <source>Move backward in the view history of the right pane</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="490" />
-      <source>Go Forward</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
-      <source>Move forward in the view history of the right pane</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="500" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="459" />
       <source>Focus Mode</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="502" />
-      <source>Toggles a distraction free mode, only showing text editor</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="511" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="467" />
       <source>Full Screen Mode</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="512" />
-      <source>Maximises the main window</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="523" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="478" />
       <source>&amp;Insert</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="481" />
       <source>Dashes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="529" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="484" />
       <source>Short Dash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="530" />
-      <source>Insert short dash (en dash)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="536" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="490" />
       <source>Long Dash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="537" />
-      <source>Insert long dash (em dash)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="543" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="496" />
       <source>Horizontal Bar</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="544" />
-      <source>Insert a horizontal bar (quotation dash)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="502" />
       <source>Figure Dash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="552" />
-      <source>Insert figure dash (same width as a number character)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="559" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="508" />
       <source>Quote Marks</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="562" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="511" />
       <source>Left Single Quote</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="563" />
-      <source>Insert left single quote</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="569" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="517" />
       <source>Right Single Quote</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="570" />
-      <source>Insert right single quote</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="576" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="523" />
       <source>Left Double Quote</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="577" />
-      <source>Insert left double quote</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="583" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="529" />
       <source>Right Double Quote</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="584" />
-      <source>Insert right double quote</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="590" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="535" />
       <source>Alternative Apostrophe</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="591" />
-      <source>Insert modifier letter single apostrophe</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="597" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="541" />
       <source>General Punctuation</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="600" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="544" />
       <source>Ellipsis</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
-      <source>Insert ellipsis</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="607" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
       <source>Prime</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
-      <source>Insert a prime symbol</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="614" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="556" />
       <source>Double Prime</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="615" />
-      <source>Insert a double prime symbol</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="621" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="562" />
       <source>White Spaces</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="624" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="565" />
       <source>Non-Breaking Space</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="625" />
-      <source>Insert a non-breaking space</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="631" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="571" />
       <source>Thin Space</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="632" />
-      <source>Insert a thin space</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="638" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="577" />
       <source>Thin Non-Breaking Space</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="639" />
-      <source>Insert a thin non-breaking space</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="645" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="583" />
       <source>Other Symbols</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="648" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="586" />
       <source>List Bullet</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="649" />
-      <source>Insert a list bullet</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="655" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="592" />
       <source>Hyphen Bullet</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="656" />
-      <source>Insert a hyphen bullet (alternative bullet)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="598" />
       <source>Flower Mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="663" />
-      <source>Insert a flower mark (alternative bullet)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="669" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="604" />
       <source>Per Mille</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
-      <source>Insert a per mille symbol</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="676" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="610" />
       <source>Degree Symbol</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="677" />
-      <source>Insert a degree symbol</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="683" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="616" />
       <source>Minus Sign</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="684" />
-      <source>Insert a minus sign (not a hypen or dash)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="690" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="622" />
       <source>Times Sign</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="691" />
-      <source>Insert a times sign (multiplication cross)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="697" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="628" />
       <source>Division Sign</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="698" />
-      <source>Insert a division sign</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="704" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="634" />
       <source>Tags and References</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="725" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="655" />
       <source>Page Break and Space</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="728" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="658" />
       <source>Page Break</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="729" />
-      <source>Insert a page break command</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="734" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="663" />
       <source>Vertical Space (Single)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="735" />
-      <source>Insert a vertical space equal to one paragraph</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="740" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="668" />
       <source>Vertical Space (Multi)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="741" />
-      <source>Insert a vertical space equal to n paragraphs</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="751" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="678" />
       <source>&amp;Format</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="754" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
       <source>Emphasis</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="755" />
-      <source>Add emphasis to selected text (italic)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="761" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="687" />
       <source>Strong Emphasis</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="762" />
-      <source>Add strong emphasis to selected text (bold)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="768" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="693" />
       <source>Strikethrough</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="769" />
-      <source>Add strikethrough to selected text</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="778" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="702" />
       <source>Wrap Double Quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="779" />
-      <source>Wrap selected text in double quotes</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="785" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="708" />
       <source>Wrap Single Quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="786" />
-      <source>Wrap selected text in single quotes</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="717" />
       <source>Header 1 (Partition)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="796" />
-      <source>Set the text block format to Header 1 (Partition)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="802" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="723" />
       <source>Header 2 (Chapter)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="803" />
-      <source>Set the text block format to Header 2 (Chapter)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="809" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="729" />
       <source>Header 3 (Scene)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="810" />
-      <source>Set the text block format to Header 3 (Scene)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="816" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="735" />
       <source>Header 4 (Section)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="817" />
-      <source>Set the text block format to Header 4 (Section)</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="826" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="744" />
       <source>Novel Title</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="827" />
-      <source>Set the text block format to Novel Title</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="832" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="749" />
       <source>Unnumbered Chapter</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="833" />
-      <source>Set the text block format to Unnumbered Chapter</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="841" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="757" />
       <source>Align Left</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="842" />
-      <source>Left-align the text block</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="848" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="763" />
       <source>Align Centre</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="849" />
-      <source>Centre the text block</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="855" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="769" />
       <source>Align Right</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="856" />
-      <source>Right-align the text block</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="778" />
       <source>Indent Left</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="866" />
-      <source>Increase the text block's left margin</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="872" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="784" />
       <source>Indent Right</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="873" />
-      <source>Increase the text block's right margin</source>
+      <location filename="../novelwriter/gui/mainmenu.py" line="793" />
+      <source>Toggle Comment</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
-      <source>Comment</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="883" />
-      <source>Change the text block format to comment</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="889" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="799" />
       <source>Remove Block Format</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="890" />
-      <source>Strip text block format</source>
+      <location filename="../novelwriter/gui/mainmenu.py" line="808" />
+      <source>Convert Single Quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="899" />
-      <source>Replace Single Quotes</source>
+      <location filename="../novelwriter/gui/mainmenu.py" line="813" />
+      <source>Convert Double Quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
-      <source>Replace all straight single quotes in the selected text</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
-      <source>Replace Double Quotes</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="909" />
-      <source>Replace all straight double quotes in the selected text</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="915" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="818" />
       <source>Remove In-Paragraph Breaks</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="917" />
-      <source>Remove all line breaks within paragraphs in the selected text</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="928" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="828" />
       <source>&amp;Search</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="931" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
       <source>Find</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="932" />
-      <source>Find text in document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="938" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="837" />
       <source>Replace</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="939" />
-      <source>Replace text in document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="846" />
       <source>Find Next</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="949" />
-      <source>Find next occurrence of text in document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="958" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="855" />
       <source>Find Previous</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="959" />
-      <source>Find previous occurrence of text in document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="968" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="864" />
       <source>Replace Next</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="970" />
-      <source>Find and replace next occurrence of text in document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="982" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="875" />
       <source>&amp;Tools</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="985" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="878" />
       <source>Check Spelling</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="986" />
-      <source>Toggle check spelling</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="994" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="886" />
       <source>Re-Run Spell Check</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
-      <source>Run the spell checker on current document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1001" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="892" />
       <source>Project Word List</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1002" />
-      <source>Edit the project's word list</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1010" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="900" />
       <source>Rebuild Index</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1011" />
-      <source>Rebuild the tag indices and word counts</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1017" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="906" />
       <source>Rebuild Outline</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1018" />
-      <source>Rebuild the novel outline tree</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="912" />
       <source>Auto-Update Outline</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1026" />
-      <source>Update project outline when a novel file is changed</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1037" />
-      <source>Backup Project Folder</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1038" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="922" />
       <source>Backup Project</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1043" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
       <source>Build Novel Project</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1044" />
-      <source>Launch the Build novel project tool</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1050" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="933" />
       <source>Writing Statistics</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1051" />
-      <source>Show the writing statistics dialogue</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1058" />
-      <location filename="../novelwriter/gui/mainmenu.py" line="1057" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="939" />
       <source>Preferences</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1070" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="951" />
       <source>&amp;Help</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1074" />
-      <location filename="../novelwriter/gui/mainmenu.py" line="1073" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="954" />
       <source>About novelWriter</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1081" />
-      <location filename="../novelwriter/gui/mainmenu.py" line="1080" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="960" />
       <source>About Qt5</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1095" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="974" />
       <source>User Manual (Online)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1096" />
-      <source>Open documentation in browser</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1103" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="981" />
       <source>User Manual (PDF)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1104" />
-      <source>Open PDF documentation</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1113" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="990" />
       <source>Report an Issue (GitHub)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1115" />
-      <source>Report a bug or issue on GitHub at {0}</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1121" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
       <source>Ask a Question (GitHub)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1123" />
-      <source>Ask a question on GitHub at {0}</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1129" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
       <source>The novelWriter Website</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1131" />
-      <source>Open the novelWriter website at {0}</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1140" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1008" />
       <source>Check for New Release</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1141" />
-      <source>Check for latest release of novelWriter</source>
       <translation type="unfinished" />
     </message>
   </context>
@@ -2998,107 +2433,103 @@
   <context>
     <name>GuiPreferencesAutomation</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="968" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="964" />
       <source>Automatic Features</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="974" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="970" />
       <source>Auto-select word under cursor</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="976" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="972" />
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="984" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="980" />
       <source>Auto-replace text as you type</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="986" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="982" />
       <source>Allow the editor to replace symbols as you type.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="991" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="987" />
       <source>Replace as You Type</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="998" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="994" />
       <source>Auto-replace single quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1000" />
-      <source>Try to guess which is an opening or a closing single quote.</source>
+      <location filename="../novelwriter/dialogs/preferences.py" line="1006" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="996" />
+      <source>Try to guess which is an opening or a closing quote.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1008" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1004" />
       <source>Auto-replace double quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1010" />
-      <source>Try to guess which is an opening or a closing double quote.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1018" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1014" />
       <source>Auto-replace dashes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1020" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1016" />
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1028" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1024" />
       <source>Auto-replace dots</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1030" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1026" />
       <source>Three consecutive dots become ellipsis.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1035" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1031" />
       <source>Automatic Padding</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1042" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1038" />
       <source>Insert non-breaking space before</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1044" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1040" />
       <source>Automatically add space before any of these symbols.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1052" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1048" />
       <source>Insert non-breaking space after</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1054" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1050" />
       <source>Automatically add space after any of these symbols.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1062" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1058" />
       <source>Use thin space instead</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1064" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1060" />
       <source>Inserts a thin space instead of a regular space.</source>
       <translation type="unfinished" />
     </message>
@@ -3116,18 +2547,16 @@
       <translation type="unfinished" />
     </message>
     <message>
+      <location filename="../novelwriter/dialogs/preferences.py" line="591" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="579" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="530" />
       <location filename="../novelwriter/dialogs/preferences.py" line="517" />
-      <source>Font for the document editor and viewer.</source>
+      <source>Applies to both document editor and viewer.</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="528" />
       <source>Font size</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="530" />
-      <source>Font size for the document editor and viewer.</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -3175,27 +2604,17 @@
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="570" />
-      <source>Hide the information bar at the bottom of the document.</source>
+      <source>Hide the information bar in the document editor.</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="577" />
-      <source>Justify the text margins in editor and viewer</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="579" />
-      <source>Lay out text with straight edges in the editor and viewer.</source>
+      <source>Justify the text margins</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="589" />
-      <source>Text margin</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="591" />
-      <source>The minimum margin around the text in the editor and viewer.</source>
+      <source>Minimum text margin</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -3228,7 +2647,7 @@
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="692" />
-      <source>Spell check language ({0})</source>
+      <source>Spell check language</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -3263,86 +2682,66 @@
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="724" />
-      <source>How often the word count is updated.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
       <source>seconds</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="732" />
-      <source>Include project notes in total word count</source>
+      <location filename="../novelwriter/dialogs/preferences.py" line="731" />
+      <source>Include project notes in status bar word count</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="734" />
-      <source>Affects the word count shown on the status bar.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="737" />
       <source>Writing Guides</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="745" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="743" />
       <source>Show tabs and spaces</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="747" />
-      <source>Add symbols to indicate tabs and spaces in the editor.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="751" />
       <source>Show line endings</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="756" />
-      <source>Add a symbol to indicate line endings in the editor.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="761" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="757" />
       <source>Scroll Behaviour</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="770" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="766" />
       <source>Scroll past end of the document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="772" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
       <source>Set to 0 to disable this feature.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="773" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="769" />
       <source>lines</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="780" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="776" />
       <source>Typewriter style scrolling when you type</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="782" />
-      <source>Try to keep the cursor at a fixed vertical position.</source>
+      <location filename="../novelwriter/dialogs/preferences.py" line="778" />
+      <source>Keeps the cursor at a fixed vertical position.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="792" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="788" />
       <source>Minimum position for Typewriter scrolling</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="794" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="790" />
       <source>Percentage of the editor height from the top.</source>
       <translation type="unfinished" />
     </message>
@@ -3365,7 +2764,7 @@
       <location filename="../novelwriter/dialogs/preferences.py" line="203" />
       <location filename="../novelwriter/dialogs/preferences.py" line="187" />
       <location filename="../novelwriter/dialogs/preferences.py" line="171" />
-      <source>Changing this requires restarting novelWriter.</source>
+      <source>Requires restart.</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -3405,7 +2804,7 @@
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="243" />
-      <source>The novel document labels will be bold and underlined.</source>
+      <source>Makes them stand out in the project tree.</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -3449,7 +2848,7 @@
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="354" />
-      <source>How often the open document is automatically saved.</source>
+      <source>How often the document is automatically saved.</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -3465,7 +2864,7 @@
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="367" />
-      <source>How often the open project is automatically saved.</source>
+      <source>How often the project is automatically saved.</source>
       <translation type="unfinished" />
     </message>
     <message>
@@ -3548,47 +2947,47 @@
   <context>
     <name>GuiPreferencesQuotes</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1125" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1121" />
       <source>Quotation Style</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1142" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1138" />
       <source>Single quote open style</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1144" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1140" />
       <source>The symbol to use for a leading single quote.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1158" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1154" />
       <source>Single quote close style</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1160" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1156" />
       <source>The symbol to use for a trailing single quote.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1171" />
       <source>Double quote open style</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1177" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1173" />
       <source>The symbol to use for a leading double quote.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1191" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1187" />
       <source>Double quote close style</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="1193" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="1189" />
       <source>The symbol to use for a trailing double quote.</source>
       <translation type="unfinished" />
     </message>
@@ -3596,83 +2995,75 @@
   <context>
     <name>GuiPreferencesSyntax</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
       <source>Highlighting Theme</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="855" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="851" />
       <source>Highlighting theme</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="857" />
-      <source>Colour theme to apply to the editor and viewer.</source>
+      <location filename="../novelwriter/dialogs/preferences.py" line="853" />
+      <source>Colour theme for the editor and viewer.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="862" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="858" />
       <source>Quotes &amp; Dialogue</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="868" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="864" />
       <source>Highlight text wrapped in quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="870" />
-      <source>Applies to single, double and straight quotes.</source>
+      <location filename="../novelwriter/dialogs/preferences.py" line="907" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="894" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="866" />
+      <source>Applies to the document editor only.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="876" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="872" />
       <source>Allow open-ended single quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="878" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="874" />
       <source>Highlight single-quoted line with no closing quote.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="884" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="880" />
       <source>Allow open-ended double quotes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="886" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="882" />
       <source>Highlight double-quoted line with no closing quote.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="891" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="887" />
       <source>Text Emphasis</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="896" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="892" />
       <source>Add highlight colour to emphasised text</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="898" />
-      <source>Applies to emphasis (italic) and strong (bold).</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="904" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="900" />
       <source>Text Errors</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="909" />
-      <source>Mark redundant spaces</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="911" />
-      <source>Trailing spaces or multiple spaces between words.</source>
+      <location filename="../novelwriter/dialogs/preferences.py" line="905" />
+      <source>Hihglight multiple spaces</source>
       <translation type="unfinished" />
     </message>
   </context>
@@ -3691,11 +3082,6 @@
     <message>
       <location filename="../novelwriter/dialogs/projdetails.py" line="73" />
       <source>Contents</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="76" />
-      <source>Close</source>
       <translation type="unfinished" />
     </message>
   </context>
@@ -3877,43 +3263,28 @@
   <context>
     <name>GuiProjectEditReplace</name>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="509" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="507" />
       <source>Text Replace List for Preview and Export</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="516" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="514" />
       <source>Keyword</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="517" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="515" />
       <source>Replace With</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="534" />
-      <source>Add new entry</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="538" />
-      <source>Delete selected entry</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="545" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="541" />
       <source>Select item to edit</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="553" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="549" />
       <source>Save</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="554" />
-      <source>Save entry</source>
       <translation type="unfinished" />
     </message>
   </context>
@@ -3940,57 +3311,47 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="295" />
-      <source>Add new entry</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="299" />
-      <source>Delete selected entry</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="308" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="306" />
       <source>Select item to edit</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="312" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="310" />
       <source>Colour</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="314" />
       <source>Save</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="370" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="368" />
       <source>Select Colour</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="381" />
       <source>New Item</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="400" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="398" />
       <source>Cannot delete a status item that is in use.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="482" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="480" />
       <source>Not in use</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="484" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="482" />
       <source>Used once</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projsettings.py" line="486" />
+      <location filename="../novelwriter/dialogs/projsettings.py" line="484" />
       <source>Used by {0} items</source>
       <translation type="unfinished" />
     </message>
@@ -4130,90 +3491,90 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="236" />
-      <location filename="../novelwriter/gui/projtree.py" line="222" />
+      <location filename="../novelwriter/gui/projtree.py" line="238" />
+      <location filename="../novelwriter/gui/projtree.py" line="224" />
       <source>Did not find anywhere to add the file or folder!</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="242" />
+      <location filename="../novelwriter/gui/projtree.py" line="244" />
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="251" />
+      <location filename="../novelwriter/gui/projtree.py" line="253" />
       <source>New File</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="257" />
+      <location filename="../novelwriter/gui/projtree.py" line="259" />
       <source>Cannot add new folder to this item. Maximum folder depth has been reached.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="262" />
+      <location filename="../novelwriter/gui/projtree.py" line="264" />
       <source>New Folder</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="424" />
+      <location filename="../novelwriter/gui/projtree.py" line="426" />
       <source>There is currently no Trash folder in this project.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="435" />
+      <location filename="../novelwriter/gui/projtree.py" line="437" />
       <source>The Trash folder is already empty.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="441" />
+      <location filename="../novelwriter/gui/projtree.py" line="443" />
       <source>Empty Trash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="442" />
+      <location filename="../novelwriter/gui/projtree.py" line="444" />
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="537" />
-      <location filename="../novelwriter/gui/projtree.py" line="503" />
+      <location filename="../novelwriter/gui/projtree.py" line="539" />
+      <location filename="../novelwriter/gui/projtree.py" line="505" />
       <source>Delete File</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="504" />
+      <location filename="../novelwriter/gui/projtree.py" line="506" />
       <source>Permanently delete file '{0}'?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="524" />
+      <location filename="../novelwriter/gui/projtree.py" line="526" />
       <source>Could not delete document file.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="538" />
+      <location filename="../novelwriter/gui/projtree.py" line="540" />
       <source>Move file '{0}' to Trash?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="569" />
+      <location filename="../novelwriter/gui/projtree.py" line="571" />
       <source>Cannot delete folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="585" />
+      <location filename="../novelwriter/gui/projtree.py" line="587" />
       <source>Cannot delete root folder. It is not empty. Recursive deletion is not supported. Please delete the content first.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="879" />
-      <location filename="../novelwriter/gui/projtree.py" line="846" />
+      <location filename="../novelwriter/gui/projtree.py" line="881" />
+      <location filename="../novelwriter/gui/projtree.py" line="848" />
       <source>The item cannot be moved to that location.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="978" />
+      <location filename="../novelwriter/gui/projtree.py" line="980" />
       <source>There is nowhere to add item with name '{0}'.</source>
       <translation type="unfinished" />
     </message>
@@ -4221,52 +3582,52 @@
   <context>
     <name>GuiProjectTreeMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1086" />
+      <location filename="../novelwriter/gui/projtree.py" line="1088" />
       <source>Edit Project Item</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1090" />
+      <location filename="../novelwriter/gui/projtree.py" line="1092" />
       <source>Open Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1094" />
+      <location filename="../novelwriter/gui/projtree.py" line="1096" />
       <source>View Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1098" />
+      <location filename="../novelwriter/gui/projtree.py" line="1100" />
       <source>Toggle Included Flag</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1102" />
+      <location filename="../novelwriter/gui/projtree.py" line="1104" />
       <source>New File</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1106" />
+      <location filename="../novelwriter/gui/projtree.py" line="1108" />
       <source>New Folder</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1110" />
+      <location filename="../novelwriter/gui/projtree.py" line="1112" />
       <source>Delete Item</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1114" />
+      <location filename="../novelwriter/gui/projtree.py" line="1116" />
       <source>Empty Trash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1118" />
+      <location filename="../novelwriter/gui/projtree.py" line="1120" />
       <source>Move Item Up</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1122" />
+      <location filename="../novelwriter/gui/projtree.py" line="1124" />
       <source>Move Item Down</source>
       <translation type="unfinished" />
     </message>
@@ -4314,22 +3675,12 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="82" />
-      <source>Add new entry</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="86" />
-      <source>Delete selected entry</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="126" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="124" />
       <source>Cannot add a blank word.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="132" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="130" />
       <source>The word '{0}' is already in the word list.</source>
       <translation type="unfinished" />
     </message>
@@ -4495,11 +3846,6 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="171" />
-      <source>Trash</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../novelwriter/core/project.py" line="225" />
       <location filename="../novelwriter/core/project.py" line="220" />
       <source>New</source>
@@ -4639,180 +3985,170 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="504" />
-      <source>The format of your project will now be updated. You may also have to make a few minor changes to your title page and unnumbered chapters. Please check the 'Project Format Changes &gt; File Format 1.3' section of the documentation for more information. It is available from the Help menu.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/core/project.py" line="518" />
+      <location filename="../novelwriter/core/project.py" line="508" />
       <source>Version Conflict</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="519" />
+      <location filename="../novelwriter/core/project.py" line="509" />
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="618" />
+      <location filename="../novelwriter/core/project.py" line="608" />
       <source>Opened Project: {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="639" />
+      <location filename="../novelwriter/core/project.py" line="629" />
       <source>Project path not set, cannot save project.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="729" />
-      <location filename="../novelwriter/core/project.py" line="717" />
+      <location filename="../novelwriter/core/project.py" line="719" />
+      <location filename="../novelwriter/core/project.py" line="707" />
       <source>Failed to save project.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="742" />
+      <location filename="../novelwriter/core/project.py" line="732" />
       <source>Saved Project: {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="795" />
+      <location filename="../novelwriter/core/project.py" line="785" />
       <source>Backing up project ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="798" />
-      <source>Cannot backup project because no backup path is set. Please set a valid backup location in Preferences.</source>
+      <location filename="../novelwriter/core/project.py" line="788" />
+      <source>Cannot backup project because no valid backup path is set. Please set a valid backup location in Preferences.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="805" />
+      <location filename="../novelwriter/core/project.py" line="795" />
       <source>Cannot backup project because no project name is set. Please set a Working Title in Project Settings.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="812" />
-      <source>Cannot backup project because the backup path does not exist. Please set a valid backup location in Preferences.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/core/project.py" line="825" />
+      <location filename="../novelwriter/core/project.py" line="808" />
       <source>Could not create backup folder.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="831" />
+      <location filename="../novelwriter/core/project.py" line="814" />
       <source>Cannot backup project because the backup path is within the project folder to be backed up. Please choose a different backup path in Preferences.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="838" />
+      <location filename="../novelwriter/core/project.py" line="821" />
       <source>Backup from {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="847" />
+      <location filename="../novelwriter/core/project.py" line="830" />
       <source>Backup archive file written to: {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="852" />
+      <location filename="../novelwriter/core/project.py" line="835" />
       <source>Could not write backup archive.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="857" />
+      <location filename="../novelwriter/core/project.py" line="840" />
       <source>Project backed up to '{0}'</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="907" />
-      <location filename="../novelwriter/core/project.py" line="885" />
+      <location filename="../novelwriter/core/project.py" line="890" />
+      <location filename="../novelwriter/core/project.py" line="868" />
       <source>Failed to create a new example project.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="912" />
+      <location filename="../novelwriter/core/project.py" line="895" />
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="946" />
+      <location filename="../novelwriter/core/project.py" line="929" />
       <source>Could not create new project folder.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="953" />
+      <location filename="../novelwriter/core/project.py" line="936" />
       <source>New project folder is not empty. Each project requires a dedicated project folder.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1003" />
+      <location filename="../novelwriter/core/project.py" line="986" />
       <source>You must set a valid backup path in Preferences to use the automatic project backup feature.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1010" />
+      <location filename="../novelwriter/core/project.py" line="993" />
       <source>You must set a valid project name in Project Settings to use the automatic project backup feature.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1144" />
+      <location filename="../novelwriter/core/project.py" line="1127" />
       <source>and</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1338" />
+      <location filename="../novelwriter/core/project.py" line="1315" />
       <source>Could not create folder.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1397" />
+      <location filename="../novelwriter/core/project.py" line="1374" />
       <source>Found {0} orphaned file(s) in project folder.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1407" />
+      <location filename="../novelwriter/core/project.py" line="1384" />
       <source>Recovered</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1421" />
+      <location filename="../novelwriter/core/project.py" line="1398" />
       <source>[{0}] {1}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1426" />
+      <location filename="../novelwriter/core/project.py" line="1403" />
       <source>Recovered File {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1453" />
+      <location filename="../novelwriter/core/project.py" line="1430" />
       <source>One or more orphaned files could not be added back into the project. Make sure at least a Novel root folder exists.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1512" />
+      <location filename="../novelwriter/core/project.py" line="1489" />
       <source>Not a folder: {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1534" />
+      <location filename="../novelwriter/core/project.py" line="1511" />
       <source>Could not move: {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1557" />
-      <location filename="../novelwriter/core/project.py" line="1543" />
+      <location filename="../novelwriter/core/project.py" line="1534" />
+      <location filename="../novelwriter/core/project.py" line="1520" />
       <source>Could not delete: {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1569" />
+      <location filename="../novelwriter/core/project.py" line="1546" />
       <source>Could not make folder: {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="1580" />
+      <location filename="../novelwriter/core/project.py" line="1557" />
       <source>Could not move item {0} to {1}.</source>
       <translation type="unfinished" />
     </message>

--- a/i18n/nw_base.ts
+++ b/i18n/nw_base.ts
@@ -3063,7 +3063,7 @@
     </message>
     <message>
       <location filename="../novelwriter/dialogs/preferences.py" line="905" />
-      <source>Hihglight multiple spaces</source>
+      <source>Highlight multiple spaces</source>
       <translation type="unfinished" />
     </message>
   </context>

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -132,13 +132,26 @@ class nwLabels():
         nwItemClass.NO_CLASS:  QT_TRANSLATE_NOOP("Constant", "None"),
         nwItemClass.NOVEL:     QT_TRANSLATE_NOOP("Constant", "Novel"),
         nwItemClass.PLOT:      QT_TRANSLATE_NOOP("Constant", "Plot"),
+        nwItemClass.CHARACTER: QT_TRANSLATE_NOOP("Constant", "Character"),
+        nwItemClass.WORLD:     QT_TRANSLATE_NOOP("Constant", "Location"),
+        nwItemClass.TIMELINE:  QT_TRANSLATE_NOOP("Constant", "Timeline"),
+        nwItemClass.OBJECT:    QT_TRANSLATE_NOOP("Constant", "Object"),
+        nwItemClass.ENTITY:    QT_TRANSLATE_NOOP("Constant", "Entity"),
+        nwItemClass.CUSTOM:    QT_TRANSLATE_NOOP("Constant", "Custom"),
+        nwItemClass.ARCHIVE:   QT_TRANSLATE_NOOP("Constant", "Archive"),
+        nwItemClass.TRASH:     QT_TRANSLATE_NOOP("Constant", "Trash"),
+    }
+    CLASS_NAME_LBL = {
+        nwItemClass.NO_CLASS:  QT_TRANSLATE_NOOP("Constant", "None"),
+        nwItemClass.NOVEL:     QT_TRANSLATE_NOOP("Constant", "Novel"),
+        nwItemClass.PLOT:      QT_TRANSLATE_NOOP("Constant", "Plot"),
         nwItemClass.CHARACTER: QT_TRANSLATE_NOOP("Constant", "Characters"),
         nwItemClass.WORLD:     QT_TRANSLATE_NOOP("Constant", "Locations"),
         nwItemClass.TIMELINE:  QT_TRANSLATE_NOOP("Constant", "Timeline"),
         nwItemClass.OBJECT:    QT_TRANSLATE_NOOP("Constant", "Objects"),
-        nwItemClass.ENTITY:    QT_TRANSLATE_NOOP("Constant", "Entity"),
+        nwItemClass.ENTITY:    QT_TRANSLATE_NOOP("Constant", "Entities"),
         nwItemClass.CUSTOM:    QT_TRANSLATE_NOOP("Constant", "Custom"),
-        nwItemClass.ARCHIVE:   QT_TRANSLATE_NOOP("Constant", "Outtakes"),
+        nwItemClass.ARCHIVE:   QT_TRANSLATE_NOOP("Constant", "Archive"),
         nwItemClass.TRASH:     QT_TRANSLATE_NOOP("Constant", "Trash"),
     }
     CLASS_ICON = {

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -168,7 +168,7 @@ class NWProject():
         trashHandle = self.projTree.trashRoot()
         if trashHandle is None:
             newItem = NWItem(self)
-            newItem.setName(self.tr("Trash"))
+            newItem.setName(trConst(nwLabels.CLASS_NAME[nwItemClass.TRASH]))
             newItem.setType(nwItemType.TRASH)
             newItem.setClass(nwItemClass.TRASH)
             self.projTree.append(None, None, newItem)
@@ -307,7 +307,7 @@ class NWProject():
             nHandle = self.newRoot(self.tr("Novel"), nwItemClass.NOVEL)
             for newRoot in projData.get("addRoots", []):
                 if newRoot in nwItemClass:
-                    self.newRoot(trConst(nwLabels.CLASS_NAME[newRoot]), newRoot)
+                    self.newRoot(trConst(nwLabels.CLASS_NAME_LBL[newRoot]), newRoot)
 
             # Create a title page
             tHandle = self.newFile(self.tr("Title Page"), nwItemClass.NOVEL, nHandle)

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -500,16 +500,6 @@ class NWProject():
                 self.clearProject()
                 return False
 
-            if fileVersion in ("1.0", "1.1", "1.2"):
-                self.theParent.makeAlert(self.tr(
-                    "The format of your project will now be updated. You may "
-                    "also have to make a few minor changes to your title page "
-                    "and unnumbered chapters. Please check the 'Project "
-                    "Format Changes > File Format 1.3' section of the "
-                    "documentation for more information. It is available from "
-                    "the Help menu."
-                ), nwAlert.INFO)
-
         # Check novelWriter Version
         # =========================
 
@@ -794,24 +784,17 @@ class NWProject():
         logger.info("Backing up project")
         self.theParent.setStatus(self.tr("Backing up project ..."))
 
-        if self.mainConf.backupPath is None or self.mainConf.backupPath == "":
+        if not (self.mainConf.backupPath and os.path.isdir(self.mainConf.backupPath)):
             self.theParent.makeAlert(self.tr(
-                "Cannot backup project because no backup path is set. "
+                "Cannot backup project because no valid backup path is set. "
                 "Please set a valid backup location in Preferences."
             ), nwAlert.ERROR)
             return False
 
-        if self.projName is None or self.projName == "":
+        if not self.projName:
             self.theParent.makeAlert(self.tr(
                 "Cannot backup project because no project name is set. "
                 "Please set a Working Title in Project Settings."
-            ), nwAlert.ERROR)
-            return False
-
-        if not os.path.isdir(self.mainConf.backupPath):
-            self.theParent.makeAlert(self.tr(
-                "Cannot backup project because the backup path does not exist. "
-                "Please set a valid backup location in Preferences."
             ), nwAlert.ERROR)
             return False
 

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -168,7 +168,7 @@ class GuiPreferencesGeneral(QWidget):
         self.mainForm.addRow(
             self.tr("Main GUI language"),
             self.guiLang,
-            self.tr("Changing this requires restarting novelWriter.")
+            self.tr("Requires restart.")
         )
 
         # Select Theme
@@ -184,7 +184,7 @@ class GuiPreferencesGeneral(QWidget):
         self.mainForm.addRow(
             self.tr("Main GUI theme"),
             self.guiTheme,
-            self.tr("Changing this requires restarting novelWriter.")
+            self.tr("Requires restart.")
         )
 
         # Select Icon Theme
@@ -200,7 +200,7 @@ class GuiPreferencesGeneral(QWidget):
         self.mainForm.addRow(
             self.tr("Main icon theme"),
             self.guiIcons,
-            self.tr("Changing this requires restarting novelWriter.")
+            self.tr("Requires restart.")
         )
 
         # Font Family
@@ -214,7 +214,7 @@ class GuiPreferencesGeneral(QWidget):
         self.mainForm.addRow(
             self.tr("Font family"),
             self.guiFont,
-            self.tr("Changing this requires restarting novelWriter."),
+            self.tr("Requires restart."),
             theButton=self.fontButton
         )
 
@@ -227,7 +227,7 @@ class GuiPreferencesGeneral(QWidget):
         self.mainForm.addRow(
             self.tr("Font size"),
             self.guiFontSize,
-            self.tr("Changing this requires restarting novelWriter."),
+            self.tr("Requires restart."),
             theUnit=self.tr("pt")
         )
 
@@ -240,7 +240,7 @@ class GuiPreferencesGeneral(QWidget):
         self.mainForm.addRow(
             self.tr("Emphasise partition and chapter labels"),
             self.emphLabels,
-            self.tr("The novel document labels will be bold and underlined."),
+            self.tr("Makes them stand out in the project tree."),
         )
 
         self.showFullPath = QSwitch()
@@ -351,7 +351,7 @@ class GuiPreferencesProjects(QWidget):
         self.mainForm.addRow(
             self.tr("Save document interval"),
             self.autoSaveDoc,
-            self.tr("How often the open document is automatically saved."),
+            self.tr("How often the document is automatically saved."),
             theUnit=self.tr("seconds")
         )
 
@@ -364,7 +364,7 @@ class GuiPreferencesProjects(QWidget):
         self.mainForm.addRow(
             self.tr("Save project interval"),
             self.autoSaveProj,
-            self.tr("How often the open project is automatically saved."),
+            self.tr("How often the project is automatically saved."),
             theUnit=self.tr("seconds")
         )
 
@@ -514,7 +514,7 @@ class GuiPreferencesDocuments(QWidget):
         self.mainForm.addRow(
             self.tr("Font family"),
             self.textFont,
-            self.tr("Font for the document editor and viewer."),
+            self.tr("Applies to both document editor and viewer."),
             theButton=self.fontButton
         )
 
@@ -527,7 +527,7 @@ class GuiPreferencesDocuments(QWidget):
         self.mainForm.addRow(
             self.tr("Font size"),
             self.textSize,
-            self.tr("Font size for the document editor and viewer."),
+            self.tr("Applies to both document editor and viewer."),
             theUnit=self.tr("pt")
         )
 
@@ -567,16 +567,16 @@ class GuiPreferencesDocuments(QWidget):
         self.mainForm.addRow(
             self.tr("Hide document footer in \"Focus Mode\""),
             self.hideFocusFooter,
-            self.tr("Hide the information bar at the bottom of the document.")
+            self.tr("Hide the information bar in the document editor.")
         )
 
         # Justify Text
         self.doJustify = QSwitch()
         self.doJustify.setChecked(self.mainConf.doJustify)
         self.mainForm.addRow(
-            self.tr("Justify the text margins in editor and viewer"),
+            self.tr("Justify the text margins"),
             self.doJustify,
-            self.tr("Lay out text with straight edges in the editor and viewer.")
+            self.tr("Applies to both document editor and viewer."),
         )
 
         # Document Margins
@@ -586,9 +586,9 @@ class GuiPreferencesDocuments(QWidget):
         self.textMargin.setSingleStep(1)
         self.textMargin.setValue(self.mainConf.textMargin)
         self.mainForm.addRow(
-            self.tr("Text margin"),
+            self.tr("Minimum text margin"),
             self.textMargin,
-            self.tr("The minimum margin around the text in the editor and viewer."),
+            self.tr("Applies to both document editor and viewer."),
             theUnit=self.tr("px")
         )
 
@@ -689,7 +689,7 @@ class GuiPreferencesEditor(QWidget):
             self.spellLanguage.setCurrentIndex(spellIdx)
 
         self.mainForm.addRow(
-            self.tr("Spell check language ({0})").format("PyEnchant"),
+            self.tr("Spell check language"),
             self.spellLanguage,
             self.tr("Available languages are determined by your system.")
         )
@@ -721,7 +721,6 @@ class GuiPreferencesEditor(QWidget):
         self.mainForm.addRow(
             self.tr("Word count interval"),
             self.wordCountTimer,
-            self.tr("How often the word count is updated."),
             theUnit=self.tr("seconds")
         )
 
@@ -729,9 +728,8 @@ class GuiPreferencesEditor(QWidget):
         self.incNotesWCount = QSwitch()
         self.incNotesWCount.setChecked(self.mainConf.incNotesWCount)
         self.mainForm.addRow(
-            self.tr("Include project notes in total word count"),
-            self.incNotesWCount,
-            self.tr("Affects the word count shown on the status bar.")
+            self.tr("Include project notes in status bar word count"),
+            self.incNotesWCount
         )
 
         # Writing Guides
@@ -743,8 +741,7 @@ class GuiPreferencesEditor(QWidget):
         self.showTabsNSpaces.setChecked(self.mainConf.showTabsNSpaces)
         self.mainForm.addRow(
             self.tr("Show tabs and spaces"),
-            self.showTabsNSpaces,
-            self.tr("Add symbols to indicate tabs and spaces in the editor.")
+            self.showTabsNSpaces
         )
 
         # Show Line Endings
@@ -752,8 +749,7 @@ class GuiPreferencesEditor(QWidget):
         self.showLineEndings.setChecked(self.mainConf.showLineEndings)
         self.mainForm.addRow(
             self.tr("Show line endings"),
-            self.showLineEndings,
-            self.tr("Add a symbol to indicate line endings in the editor.")
+            self.showLineEndings
         )
 
         # Scroll Behaviour
@@ -779,7 +775,7 @@ class GuiPreferencesEditor(QWidget):
         self.mainForm.addRow(
             self.tr("Typewriter style scrolling when you type"),
             self.autoScroll,
-            self.tr("Try to keep the cursor at a fixed vertical position.")
+            self.tr("Keeps the cursor at a fixed vertical position.")
         )
 
         # Typewriter Position
@@ -854,7 +850,7 @@ class GuiPreferencesSyntax(QWidget):
         self.mainForm.addRow(
             self.tr("Highlighting theme"),
             self.guiSyntax,
-            self.tr("Colour theme to apply to the editor and viewer.")
+            self.tr("Colour theme for the editor and viewer.")
         )
 
         # Quotes & Dialogue
@@ -867,7 +863,7 @@ class GuiPreferencesSyntax(QWidget):
         self.mainForm.addRow(
             self.tr("Highlight text wrapped in quotes"),
             self.highlightQuotes,
-            self.tr("Applies to single, double and straight quotes.")
+            self.tr("Applies to the document editor only.")
         )
 
         self.allowOpenSQuote = QSwitch()
@@ -895,7 +891,7 @@ class GuiPreferencesSyntax(QWidget):
         self.mainForm.addRow(
             self.tr("Add highlight colour to emphasised text"),
             self.highlightEmph,
-            self.tr("Applies to emphasis (italic) and strong (bold).")
+            self.tr("Applies to the document editor only.")
         )
 
         # Text Errors
@@ -906,9 +902,9 @@ class GuiPreferencesSyntax(QWidget):
         self.showMultiSpaces = QSwitch()
         self.showMultiSpaces.setChecked(self.mainConf.showMultiSpaces)
         self.mainForm.addRow(
-            self.tr("Mark redundant spaces"),
+            self.tr("Hihglight multiple spaces"),
             self.showMultiSpaces,
-            self.tr("Trailing spaces or multiple spaces between words.")
+            self.tr("Applies to the document editor only.")
         )
 
         return
@@ -997,7 +993,7 @@ class GuiPreferencesAutomation(QWidget):
         self.mainForm.addRow(
             self.tr("Auto-replace single quotes"),
             self.doReplaceSQuote,
-            self.tr("Try to guess which is an opening or a closing single quote.")
+            self.tr("Try to guess which is an opening or a closing quote.")
         )
 
         # Auto-Replace Double Quotes
@@ -1007,7 +1003,7 @@ class GuiPreferencesAutomation(QWidget):
         self.mainForm.addRow(
             self.tr("Auto-replace double quotes"),
             self.doReplaceDQuote,
-            self.tr("Try to guess which is an opening or a closing double quote.")
+            self.tr("Try to guess which is an opening or a closing quote.")
         )
 
         # Auto-Replace Hyphens

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -902,7 +902,7 @@ class GuiPreferencesSyntax(QWidget):
         self.showMultiSpaces = QSwitch()
         self.showMultiSpaces.setChecked(self.mainConf.showMultiSpaces)
         self.mainForm.addRow(
-            self.tr("Hihglight multiple spaces"),
+            self.tr("Highlight multiple spaces"),
             self.showMultiSpaces,
             self.tr("Applies to the document editor only.")
         )

--- a/novelwriter/dialogs/projdetails.py
+++ b/novelwriter/dialogs/projdetails.py
@@ -73,7 +73,7 @@ class GuiProjectDetails(PagedDialog):
         self.addTab(self.tabContents, self.tr("Contents"))
 
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Close)
-        self.buttonBox.button(QDialogButtonBox.Close).setText(self.tr("Close"))
+        self.buttonBox.button(QDialogButtonBox.Close)
         self.buttonBox.rejected.connect(self._doClose)
         self.addControls(self.buttonBox)
 

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -292,11 +292,9 @@ class GuiProjectEditStatus(QWidget):
         # =============
 
         self.addButton = QPushButton(self.theTheme.getIcon("add"), "")
-        self.addButton.setToolTip(self.tr("Add new entry"))
         self.addButton.clicked.connect(self._newItem)
 
         self.delButton = QPushButton(self.theTheme.getIcon("remove"), "")
-        self.delButton.setToolTip(self.tr("Delete selected entry"))
         self.delButton.clicked.connect(self._delItem)
 
         # Edit Form
@@ -531,11 +529,9 @@ class GuiProjectEditReplace(QWidget):
         # =============
 
         self.addButton = QPushButton(self.theTheme.getIcon("add"), "")
-        self.addButton.setToolTip(self.tr("Add new entry"))
         self.addButton.clicked.connect(self._addEntry)
 
         self.delButton = QPushButton(self.theTheme.getIcon("remove"), "")
-        self.delButton.setToolTip(self.tr("Delete selected entry"))
         self.delButton.clicked.connect(self._delEntry)
 
         # Edit Form
@@ -551,7 +547,6 @@ class GuiProjectEditReplace(QWidget):
         self.editValue.setMaxLength(80)
 
         self.saveButton = QPushButton(self.tr("Save"))
-        self.saveButton.setToolTip(self.tr("Save entry"))
         self.saveButton.clicked.connect(self._saveEntry)
 
         # Assemble

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -79,11 +79,9 @@ class GuiWordList(QDialog):
         self.newEntry = QLineEdit()
 
         self.addButton = QPushButton(self.theTheme.getIcon("add"), "")
-        self.addButton.setToolTip(self.tr("Add new entry"))
         self.addButton.clicked.connect(self._doAdd)
 
         self.delButton = QPushButton(self.theTheme.getIcon("remove"), "")
-        self.delButton.setToolTip(self.tr("Delete selected entry"))
         self.delButton.clicked.connect(self._doDelete)
 
         self.editBox = QHBoxLayout()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -2215,7 +2215,6 @@ class GuiDocEditSearch(QFrame):
         self.resultLabel.setMinimumWidth(self.theTheme.getTextWidth("?/?", self.boxFont))
 
         self.toggleCase = QAction(self.tr("Case Sensitive"), self)
-        self.toggleCase.setToolTip(self.tr("Match case"))
         self.toggleCase.setIcon(self.theTheme.getIcon("search_case"))
         self.toggleCase.setCheckable(True)
         self.toggleCase.setChecked(self.isCaseSense)
@@ -2223,7 +2222,6 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addAction(self.toggleCase)
 
         self.toggleWord = QAction(self.tr("Whole Words Only"), self)
-        self.toggleWord.setToolTip(self.tr("Match whole words"))
         self.toggleWord.setIcon(self.theTheme.getIcon("search_word"))
         self.toggleWord.setCheckable(True)
         self.toggleWord.setChecked(self.isWholeWord)
@@ -2231,7 +2229,6 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addAction(self.toggleWord)
 
         self.toggleRegEx = QAction(self.tr("RegEx Mode"), self)
-        self.toggleRegEx.setToolTip(self.tr("Search using regular expressions"))
         self.toggleRegEx.setIcon(self.theTheme.getIcon("search_regex"))
         self.toggleRegEx.setCheckable(True)
         self.toggleRegEx.setChecked(self.isRegEx)
@@ -2239,7 +2236,6 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addAction(self.toggleRegEx)
 
         self.toggleLoop = QAction(self.tr("Loop Search"), self)
-        self.toggleLoop.setToolTip(self.tr("Loop the search when reaching the end"))
         self.toggleLoop.setIcon(self.theTheme.getIcon("search_loop"))
         self.toggleLoop.setCheckable(True)
         self.toggleLoop.setChecked(self.doLoop)
@@ -2247,7 +2243,6 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addAction(self.toggleLoop)
 
         self.toggleProject = QAction(self.tr("Search Next File"), self)
-        self.toggleProject.setToolTip(self.tr("Continue searching in the next file"))
         self.toggleProject.setIcon(self.theTheme.getIcon("search_project"))
         self.toggleProject.setCheckable(True)
         self.toggleProject.setChecked(self.doNextFile)
@@ -2257,7 +2252,6 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addSeparator()
 
         self.toggleMatchCap = QAction(self.tr("Preserve Case"), self)
-        self.toggleMatchCap.setToolTip(self.tr("Preserve case on replace"))
         self.toggleMatchCap.setIcon(self.theTheme.getIcon("search_preserve"))
         self.toggleMatchCap.setCheckable(True)
         self.toggleMatchCap.setChecked(self.doMatchCap)
@@ -2267,7 +2261,6 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addSeparator()
 
         self.cancelSearch = QAction(self.tr("Close Search"), self)
-        self.cancelSearch.setToolTip(self.tr("Close the search box [{0}]").format("Esc"))
         self.cancelSearch.setIcon(self.theTheme.getIcon("search_cancel"))
         self.cancelSearch.triggered.connect(self._doClose)
         self.searchOpt.addAction(self.cancelSearch)
@@ -2280,7 +2273,6 @@ class GuiDocEditSearch(QFrame):
         self.showReplace = QToolButton(self)
         self.showReplace.setArrowType(Qt.RightArrow)
         self.showReplace.setCheckable(True)
-        self.showReplace.setToolTip(self.tr("Show/hide the replace text box"))
         self.showReplace.setStyleSheet("QToolButton {border: none; background: transparent;}")
         self.showReplace.toggled.connect(self._doToggleReplace)
 

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -155,27 +155,23 @@ class GuiMainMenu(QMenuBar):
 
         # Project > New Project
         self.aNewProject = QAction(self.tr("New Project"), self)
-        self.aNewProject.setStatusTip(self.tr("Create new project"))
         self.aNewProject.triggered.connect(lambda: self.theParent.newProject(None))
         self.projMenu.addAction(self.aNewProject)
 
         # Project > Open Project
         self.aOpenProject = QAction(self.tr("Open Project"), self)
-        self.aOpenProject.setStatusTip(self.tr("Open project"))
         self.aOpenProject.setShortcut("Ctrl+Shift+O")
         self.aOpenProject.triggered.connect(lambda: self.theParent.showProjectLoadDialog())
         self.projMenu.addAction(self.aOpenProject)
 
         # Project > Save Project
         self.aSaveProject = QAction(self.tr("Save Project"), self)
-        self.aSaveProject.setStatusTip(self.tr("Save project"))
         self.aSaveProject.setShortcut("Ctrl+Shift+S")
         self.aSaveProject.triggered.connect(lambda: self.theParent.saveProject())
         self.projMenu.addAction(self.aSaveProject)
 
         # Project > Close Project
         self.aCloseProject = QAction(self.tr("Close Project"), self)
-        self.aCloseProject.setStatusTip(self.tr("Close project"))
         self.aCloseProject.setShortcut("Ctrl+Shift+W")
         self.aCloseProject.triggered.connect(lambda: self.theParent.closeProject(False))
         self.projMenu.addAction(self.aCloseProject)
@@ -185,14 +181,12 @@ class GuiMainMenu(QMenuBar):
 
         # Project > Project Settings
         self.aProjectSettings = QAction(self.tr("Project Settings"), self)
-        self.aProjectSettings.setStatusTip(self.tr("Project settings"))
         self.aProjectSettings.setShortcut("Ctrl+Shift+,")
         self.aProjectSettings.triggered.connect(lambda: self.theParent.showProjectSettingsDialog())
         self.projMenu.addAction(self.aProjectSettings)
 
         # Project > Project Details
         self.aProjectDetails = QAction(self.tr("Project Details"), self)
-        self.aProjectDetails.setStatusTip(self.tr("Project details"))
         self.aProjectDetails.setShortcut("Shift+F6")
         self.aProjectDetails.triggered.connect(lambda: self.theParent.showProjectDetailsDialog())
         self.projMenu.addAction(self.aProjectDetails)
@@ -211,7 +205,7 @@ class GuiMainMenu(QMenuBar):
         self.rootItems[nwItemClass.OBJECT]    = QAction(self.tr("Object Root"),    self.rootMenu)
         self.rootItems[nwItemClass.ENTITY]    = QAction(self.tr("Entity Root"),    self.rootMenu)
         self.rootItems[nwItemClass.CUSTOM]    = QAction(self.tr("Custom Root"),    self.rootMenu)
-        self.rootItems[nwItemClass.ARCHIVE]   = QAction(self.tr("Outtakes Root"),  self.rootMenu)
+        self.rootItems[nwItemClass.ARCHIVE]   = QAction(self.tr("Archive Root"),   self.rootMenu)
         for n, itemClass in enumerate(self.rootItems.keys()):
             self.rootItems[itemClass].triggered.connect(
                 lambda n, itemClass=itemClass: self._newTreeItem(nwItemType.ROOT, itemClass)
@@ -220,7 +214,6 @@ class GuiMainMenu(QMenuBar):
 
         # Project > New Folder
         self.aCreateFolder = QAction(self.tr("Create Folder"), self)
-        self.aCreateFolder.setStatusTip(self.tr("Create folder"))
         self.aCreateFolder.setShortcut("Ctrl+Shift+N")
         self.aCreateFolder.triggered.connect(lambda: self._newTreeItem(nwItemType.FOLDER, None))
         self.projMenu.addAction(self.aCreateFolder)
@@ -230,42 +223,36 @@ class GuiMainMenu(QMenuBar):
 
         # Project > Edit
         self.aEditItem = QAction(self.tr("Edit Item"), self)
-        self.aEditItem.setStatusTip(self.tr("Change project item settings"))
         self.aEditItem.setShortcuts(["Ctrl+E", "F2"])
         self.aEditItem.triggered.connect(lambda: self.theParent.editItem(None))
         self.projMenu.addAction(self.aEditItem)
 
         # Project > Delete
         self.aDeleteItem = QAction(self.tr("Delete Item"), self)
-        self.aDeleteItem.setStatusTip(self.tr("Delete selected project item"))
         self.aDeleteItem.setShortcut("Ctrl+Shift+Del")
         self.aDeleteItem.triggered.connect(lambda: self.theParent.treeView.deleteItem(None))
         self.projMenu.addAction(self.aDeleteItem)
 
         # Project > Move Up
         self.aMoveUp = QAction(self.tr("Move Item Up"), self)
-        self.aMoveUp.setStatusTip(self.tr("Move project item up"))
         self.aMoveUp.setShortcut("Ctrl+Up")
         self.aMoveUp.triggered.connect(lambda: self._moveTreeItem(-1))
         self.projMenu.addAction(self.aMoveUp)
 
         # Project > Move Down
         self.aMoveDown = QAction(self.tr("Move Item Down"), self)
-        self.aMoveDown.setStatusTip(self.tr("Move project item down"))
         self.aMoveDown.setShortcut("Ctrl+Down")
         self.aMoveDown.triggered.connect(lambda: self._moveTreeItem(1))
         self.projMenu.addAction(self.aMoveDown)
 
         # Project > Undo Last Action
         self.aMoveUndo = QAction(self.tr("Undo Last Move"), self)
-        self.aMoveUndo.setStatusTip(self.tr("Undo last item move"))
         self.aMoveUndo.setShortcut("Ctrl+Shift+Z")
         self.aMoveUndo.triggered.connect(lambda: self.theParent.treeView.undoLastMove())
         self.projMenu.addAction(self.aMoveUndo)
 
         # Project > Empty Trash
         self.aEmptyTrash = QAction(self.tr("Empty Trash"), self)
-        self.aEmptyTrash.setStatusTip(self.tr("Permanently delete all files in the Trash folder"))
         self.aEmptyTrash.triggered.connect(lambda: self.theParent.treeView.emptyTrash())
         self.projMenu.addAction(self.aEmptyTrash)
 
@@ -274,7 +261,6 @@ class GuiMainMenu(QMenuBar):
 
         # Project > Exit
         self.aExitNW = QAction(self.tr("Exit"), self)
-        self.aExitNW.setStatusTip(self.tr("Exit novelWriter"))
         self.aExitNW.setShortcut("Ctrl+Q")
         self.aExitNW.setMenuRole(QAction.QuitRole)
         self.aExitNW.triggered.connect(lambda: self.theParent.closeMain())
@@ -290,28 +276,24 @@ class GuiMainMenu(QMenuBar):
 
         # Document > New
         self.aNewDoc = QAction(self.tr("New Document"), self)
-        self.aNewDoc.setStatusTip(self.tr("Create new document"))
         self.aNewDoc.setShortcut("Ctrl+N")
         self.aNewDoc.triggered.connect(lambda: self._newTreeItem(nwItemType.FILE, None))
         self.docuMenu.addAction(self.aNewDoc)
 
         # Document > Open
         self.aOpenDoc = QAction(self.tr("Open Document"), self)
-        self.aOpenDoc.setStatusTip(self.tr("Open selected document"))
         self.aOpenDoc.setShortcut("Ctrl+O")
         self.aOpenDoc.triggered.connect(lambda: self.theParent.openSelectedItem())
         self.docuMenu.addAction(self.aOpenDoc)
 
         # Document > Save
         self.aSaveDoc = QAction(self.tr("Save Document"), self)
-        self.aSaveDoc.setStatusTip(self.tr("Save current document"))
         self.aSaveDoc.setShortcut("Ctrl+S")
         self.aSaveDoc.triggered.connect(lambda: self.theParent.saveDocument())
         self.docuMenu.addAction(self.aSaveDoc)
 
         # Document > Close
         self.aCloseDoc = QAction(self.tr("Close Document"), self)
-        self.aCloseDoc.setStatusTip(self.tr("Close current document"))
         self.aCloseDoc.setShortcut("Ctrl+W")
         self.aCloseDoc.triggered.connect(lambda: self.theParent.closeDocEditor())
         self.docuMenu.addAction(self.aCloseDoc)
@@ -321,14 +303,12 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Preview
         self.aViewDoc = QAction(self.tr("View Document"), self)
-        self.aViewDoc.setStatusTip(self.tr("View document as HTML"))
         self.aViewDoc.setShortcut("Ctrl+R")
         self.aViewDoc.triggered.connect(lambda: self.theParent.viewDocument(None))
         self.docuMenu.addAction(self.aViewDoc)
 
         # Document > Close Preview
         self.aCloseView = QAction(self.tr("Close Document View"), self)
-        self.aCloseView.setStatusTip(self.tr("Close document view pane"))
         self.aCloseView.setShortcut("Ctrl+Shift+R")
         self.aCloseView.triggered.connect(lambda: self.theParent.closeDocViewer())
         self.docuMenu.addAction(self.aCloseView)
@@ -338,30 +318,22 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Show File Details
         self.aFileDetails = QAction(self.tr("Show File Details"), self)
-        self.aFileDetails.setStatusTip(
-            self.tr("Shows a message box with the document location in the project folder")
-        )
         self.aFileDetails.triggered.connect(lambda: self.theParent.docEditor.revealLocation())
         self.docuMenu.addAction(self.aFileDetails)
 
         # Document > Import From File
-        self.aImportFile = QAction(self.tr("Import from File"), self)
-        self.aImportFile.setStatusTip(self.tr("Import document from a text or markdown file"))
+        self.aImportFile = QAction(self.tr("Import Text from File"), self)
         self.aImportFile.setShortcut("Ctrl+Shift+I")
         self.aImportFile.triggered.connect(lambda: self.theParent.importDocument())
         self.docuMenu.addAction(self.aImportFile)
 
         # Document > Merge Documents
         self.aMergeDocs = QAction(self.tr("Merge Folder to Document"), self)
-        self.aMergeDocs.setStatusTip(self.tr("Merge a folder of documents to a single document"))
         self.aMergeDocs.triggered.connect(lambda: self.theParent.mergeDocuments())
         self.docuMenu.addAction(self.aMergeDocs)
 
         # Document > Split Document
         self.aSplitDoc = QAction(self.tr("Split Document to Folder"), self)
-        self.aSplitDoc.setStatusTip(
-            self.tr("Split a document into a folder of multiple documents")
-        )
         self.aSplitDoc.triggered.connect(lambda: self.theParent.splitDocument())
         self.docuMenu.addAction(self.aSplitDoc)
 
@@ -375,14 +347,12 @@ class GuiMainMenu(QMenuBar):
 
         # Edit > Undo
         self.aEditUndo = QAction(self.tr("Undo"), self)
-        self.aEditUndo.setStatusTip(self.tr("Undo last change"))
         self.aEditUndo.setShortcut("Ctrl+Z")
         self.aEditUndo.triggered.connect(lambda: self._docAction(nwDocAction.UNDO))
         self.editMenu.addAction(self.aEditUndo)
 
         # Edit > Redo
         self.aEditRedo = QAction(self.tr("Redo"), self)
-        self.aEditRedo.setStatusTip(self.tr("Redo last change"))
         self.aEditRedo.setShortcut("Ctrl+Y")
         self.aEditRedo.triggered.connect(lambda: self._docAction(nwDocAction.REDO))
         self.editMenu.addAction(self.aEditRedo)
@@ -392,21 +362,18 @@ class GuiMainMenu(QMenuBar):
 
         # Edit > Cut
         self.aEditCut = QAction(self.tr("Cut"), self)
-        self.aEditCut.setStatusTip(self.tr("Cut selected text"))
         self.aEditCut.setShortcut("Ctrl+X")
         self.aEditCut.triggered.connect(lambda: self._docAction(nwDocAction.CUT))
         self.editMenu.addAction(self.aEditCut)
 
         # Edit > Copy
         self.aEditCopy = QAction(self.tr("Copy"), self)
-        self.aEditCopy.setStatusTip(self.tr("Copy selected text"))
         self.aEditCopy.setShortcut("Ctrl+C")
         self.aEditCopy.triggered.connect(lambda: self._docAction(nwDocAction.COPY))
         self.editMenu.addAction(self.aEditCopy)
 
         # Edit > Paste
         self.aEditPaste = QAction(self.tr("Paste"), self)
-        self.aEditPaste.setStatusTip(self.tr("Paste text from clipboard"))
         self.aEditPaste.setShortcut("Ctrl+V")
         self.aEditPaste.triggered.connect(lambda: self._docAction(nwDocAction.PASTE))
         self.editMenu.addAction(self.aEditPaste)
@@ -416,14 +383,12 @@ class GuiMainMenu(QMenuBar):
 
         # Edit > Select All
         self.aSelectAll = QAction(self.tr("Select All"), self)
-        self.aSelectAll.setStatusTip(self.tr("Select all text in document"))
         self.aSelectAll.setShortcut("Ctrl+A")
         self.aSelectAll.triggered.connect(lambda: self._docAction(nwDocAction.SEL_ALL))
         self.editMenu.addAction(self.aSelectAll)
 
         # Edit > Select Paragraph
         self.aSelectPar = QAction(self.tr("Select Paragraph"), self)
-        self.aSelectPar.setStatusTip(self.tr("Select all text in paragraph"))
         self.aSelectPar.setShortcut("Ctrl+Shift+A")
         self.aSelectPar.triggered.connect(lambda: self._docAction(nwDocAction.SEL_PARA))
         self.editMenu.addAction(self.aSelectPar)
@@ -437,8 +402,7 @@ class GuiMainMenu(QMenuBar):
         self.viewMenu = self.addMenu(self.tr("&View"))
 
         # View > TreeView
-        self.aFocusTree = QAction(self.tr("Focus Project Tree"), self)
-        self.aFocusTree.setStatusTip(self.tr("Move focus to project tree"))
+        self.aFocusTree = QAction(self.tr("Go to Project Tree"), self)
         if self.mainConf.osWindows:
             self.aFocusTree.setShortcut("Ctrl+Alt+1")
         else:
@@ -447,8 +411,7 @@ class GuiMainMenu(QMenuBar):
         self.viewMenu.addAction(self.aFocusTree)
 
         # View > Document Pane 1
-        self.aFocusEditor = QAction(self.tr("Focus Document Editor"), self)
-        self.aFocusEditor.setStatusTip(self.tr("Move focus to left document pane"))
+        self.aFocusEditor = QAction(self.tr("Go to Document Editor"), self)
         if self.mainConf.osWindows:
             self.aFocusEditor.setShortcut("Ctrl+Alt+2")
         else:
@@ -457,8 +420,7 @@ class GuiMainMenu(QMenuBar):
         self.viewMenu.addAction(self.aFocusEditor)
 
         # View > Document Pane 2
-        self.aFocusView = QAction(self.tr("Focus Document Viewer"), self)
-        self.aFocusView.setStatusTip(self.tr("Move focus to right document pane"))
+        self.aFocusView = QAction(self.tr("Go to Document Viewer"), self)
         if self.mainConf.osWindows:
             self.aFocusView.setShortcut("Ctrl+Alt+3")
         else:
@@ -467,8 +429,7 @@ class GuiMainMenu(QMenuBar):
         self.viewMenu.addAction(self.aFocusView)
 
         # View > Outline
-        self.aFocusOutline = QAction(self.tr("Focus Outline"), self)
-        self.aFocusOutline.setStatusTip(self.tr("Move focus to outline"))
+        self.aFocusOutline = QAction(self.tr("Go to Outline"), self)
         if self.mainConf.osWindows:
             self.aFocusOutline.setShortcut("Ctrl+Alt+4")
         else:
@@ -480,15 +441,13 @@ class GuiMainMenu(QMenuBar):
         self.viewMenu.addSeparator()
 
         # View > Go Backward
-        self.aViewPrev = QAction(self.tr("Go Backward"), self)
-        self.aViewPrev.setStatusTip(self.tr("Move backward in the view history of the right pane"))
+        self.aViewPrev = QAction(self.tr("Navigate Backward"), self)
         self.aViewPrev.setShortcut("Alt+Left")
         self.aViewPrev.triggered.connect(lambda: self.theParent.docViewer.navBackward())
         self.viewMenu.addAction(self.aViewPrev)
 
         # View > Go Forward
-        self.aViewNext = QAction(self.tr("Go Forward"), self)
-        self.aViewNext.setStatusTip(self.tr("Move forward in the view history of the right pane"))
+        self.aViewNext = QAction(self.tr("Navigate Forward"), self)
         self.aViewNext.setShortcut("Alt+Right")
         self.aViewNext.triggered.connect(lambda: self.theParent.docViewer.navForward())
         self.viewMenu.addAction(self.aViewNext)
@@ -498,9 +457,6 @@ class GuiMainMenu(QMenuBar):
 
         # View > Focus Mode
         self.aFocusMode = QAction(self.tr("Focus Mode"), self)
-        self.aFocusMode.setStatusTip(
-            self.tr("Toggles a distraction free mode, only showing text editor")
-        )
         self.aFocusMode.setShortcut("F8")
         self.aFocusMode.setCheckable(True)
         self.aFocusMode.setChecked(self.theParent.isFocusMode)
@@ -509,7 +465,6 @@ class GuiMainMenu(QMenuBar):
 
         # View > Toggle Full Screen
         self.aFullScreen = QAction(self.tr("Full Screen Mode"), self)
-        self.aFullScreen.setStatusTip(self.tr("Maximises the main window"))
         self.aFullScreen.setShortcut("F11")
         self.aFullScreen.triggered.connect(lambda: self.theParent.toggleFullScreenMode())
         self.viewMenu.addAction(self.aFullScreen)
@@ -527,30 +482,24 @@ class GuiMainMenu(QMenuBar):
 
         # Insert > Short Dash
         self.aInsENDash = QAction(self.tr("Short Dash"), self)
-        self.aInsENDash.setStatusTip(self.tr("Insert short dash (en dash)"))
         self.aInsENDash.setShortcut("Ctrl+K, -")
         self.aInsENDash.triggered.connect(lambda: self._docInsert(nwUnicode.U_ENDASH))
         self.mInsDashes.addAction(self.aInsENDash)
 
         # Insert > Long Dash
         self.aInsEMDash = QAction(self.tr("Long Dash"), self)
-        self.aInsEMDash.setStatusTip(self.tr("Insert long dash (em dash)"))
         self.aInsEMDash.setShortcut("Ctrl+K, _")
         self.aInsEMDash.triggered.connect(lambda: self._docInsert(nwUnicode.U_EMDASH))
         self.mInsDashes.addAction(self.aInsEMDash)
 
         # Insert > Long Dash
         self.aInsHorBar = QAction(self.tr("Horizontal Bar"), self)
-        self.aInsHorBar.setStatusTip(self.tr("Insert a horizontal bar (quotation dash)"))
         self.aInsHorBar.setShortcut("Ctrl+K, Ctrl+_")
         self.aInsHorBar.triggered.connect(lambda: self._docInsert(nwUnicode.U_HBAR))
         self.mInsDashes.addAction(self.aInsHorBar)
 
         # Insert > Figure Dash
         self.aInsFigDash = QAction(self.tr("Figure Dash"), self)
-        self.aInsFigDash.setStatusTip(
-            self.tr("Insert figure dash (same width as a number character)")
-        )
         self.aInsFigDash.setShortcut("Ctrl+K, ~")
         self.aInsFigDash.triggered.connect(lambda: self._docInsert(nwUnicode.U_FGDASH))
         self.mInsDashes.addAction(self.aInsFigDash)
@@ -560,35 +509,30 @@ class GuiMainMenu(QMenuBar):
 
         # Insert > Left Single Quote
         self.aInsQuoteLS = QAction(self.tr("Left Single Quote"), self)
-        self.aInsQuoteLS.setStatusTip(self.tr("Insert left single quote"))
         self.aInsQuoteLS.setShortcut("Ctrl+K, 1")
         self.aInsQuoteLS.triggered.connect(lambda: self._docInsert(nwDocInsert.QUOTE_LS))
         self.mInsQuotes.addAction(self.aInsQuoteLS)
 
         # Insert > Right Single Quote
         self.aInsQuoteRS = QAction(self.tr("Right Single Quote"), self)
-        self.aInsQuoteRS.setStatusTip(self.tr("Insert right single quote"))
         self.aInsQuoteRS.setShortcut("Ctrl+K, 2")
         self.aInsQuoteRS.triggered.connect(lambda: self._docInsert(nwDocInsert.QUOTE_RS))
         self.mInsQuotes.addAction(self.aInsQuoteRS)
 
         # Insert > Left Double Quote
         self.aInsQuoteLD = QAction(self.tr("Left Double Quote"), self)
-        self.aInsQuoteLD.setStatusTip(self.tr("Insert left double quote"))
         self.aInsQuoteLD.setShortcut("Ctrl+K, 3")
         self.aInsQuoteLD.triggered.connect(lambda: self._docInsert(nwDocInsert.QUOTE_LD))
         self.mInsQuotes.addAction(self.aInsQuoteLD)
 
         # Insert > Right Double Quote
         self.aInsQuoteRD = QAction(self.tr("Right Double Quote"), self)
-        self.aInsQuoteRD.setStatusTip(self.tr("Insert right double quote"))
         self.aInsQuoteRD.setShortcut("Ctrl+K, 4")
         self.aInsQuoteRD.triggered.connect(lambda: self._docInsert(nwDocInsert.QUOTE_RD))
         self.mInsQuotes.addAction(self.aInsQuoteRD)
 
         # Insert > Alternative Apostrophe
         self.aInsMSApos = QAction(self.tr("Alternative Apostrophe"), self)
-        self.aInsMSApos.setStatusTip(self.tr("Insert modifier letter single apostrophe"))
         self.aInsMSApos.setShortcut("Ctrl+K, '")
         self.aInsMSApos.triggered.connect(lambda: self._docInsert(nwUnicode.U_MAPOSS))
         self.mInsQuotes.addAction(self.aInsMSApos)
@@ -598,21 +542,18 @@ class GuiMainMenu(QMenuBar):
 
         # Insert > Ellipsis
         self.aInsEllipsis = QAction(self.tr("Ellipsis"), self)
-        self.aInsEllipsis.setStatusTip(self.tr("Insert ellipsis"))
         self.aInsEllipsis.setShortcut("Ctrl+K, .")
         self.aInsEllipsis.triggered.connect(lambda: self._docInsert(nwUnicode.U_HELLIP))
         self.mInsPunct.addAction(self.aInsEllipsis)
 
         # Insert > Prime
         self.aInsPrime = QAction(self.tr("Prime"), self)
-        self.aInsPrime.setStatusTip(self.tr("Insert a prime symbol"))
         self.aInsPrime.setShortcut("Ctrl+K, Ctrl+'")
         self.aInsPrime.triggered.connect(lambda: self._docInsert(nwUnicode.U_PRIME))
         self.mInsPunct.addAction(self.aInsPrime)
 
         # Insert > Double Prime
         self.aInsDPrime = QAction(self.tr("Double Prime"), self)
-        self.aInsDPrime.setStatusTip(self.tr("Insert a double prime symbol"))
         self.aInsDPrime.setShortcut("Ctrl+K, Ctrl+\"")
         self.aInsDPrime.triggered.connect(lambda: self._docInsert(nwUnicode.U_DPRIME))
         self.mInsPunct.addAction(self.aInsDPrime)
@@ -622,21 +563,18 @@ class GuiMainMenu(QMenuBar):
 
         # Insert > Non-Breaking Space
         self.aInsNBSpace = QAction(self.tr("Non-Breaking Space"), self)
-        self.aInsNBSpace.setStatusTip(self.tr("Insert a non-breaking space"))
         self.aInsNBSpace.setShortcut("Ctrl+K, Space")
         self.aInsNBSpace.triggered.connect(lambda: self._docInsert(nwUnicode.U_NBSP))
         self.mInsSpace.addAction(self.aInsNBSpace)
 
         # Insert > Thin Space
         self.aInsThinSpace = QAction(self.tr("Thin Space"), self)
-        self.aInsThinSpace.setStatusTip(self.tr("Insert a thin space"))
         self.aInsThinSpace.setShortcut("Ctrl+K, Shift+Space")
         self.aInsThinSpace.triggered.connect(lambda: self._docInsert(nwUnicode.U_THSP))
         self.mInsSpace.addAction(self.aInsThinSpace)
 
         # Insert > Thin Non-Breaking Space
         self.aInsThinNBSpace = QAction(self.tr("Thin Non-Breaking Space"), self)
-        self.aInsThinNBSpace.setStatusTip(self.tr("Insert a thin non-breaking space"))
         self.aInsThinNBSpace.setShortcut("Ctrl+K, Ctrl+Space")
         self.aInsThinNBSpace.triggered.connect(lambda: self._docInsert(nwUnicode.U_THNBSP))
         self.mInsSpace.addAction(self.aInsThinNBSpace)
@@ -646,56 +584,48 @@ class GuiMainMenu(QMenuBar):
 
         # Insert > List Bullet
         self.aInsBullet = QAction(self.tr("List Bullet"), self)
-        self.aInsBullet.setStatusTip(self.tr("Insert a list bullet"))
         self.aInsBullet.setShortcut("Ctrl+K, *")
         self.aInsBullet.triggered.connect(lambda: self._docInsert(nwUnicode.U_BULL))
         self.mInsSymbol.addAction(self.aInsBullet)
 
         # Insert > Hyphen Bullet
         self.aInsHyBull = QAction(self.tr("Hyphen Bullet"), self)
-        self.aInsHyBull.setStatusTip(self.tr("Insert a hyphen bullet (alternative bullet)"))
         self.aInsHyBull.setShortcut("Ctrl+K, Ctrl+-")
         self.aInsHyBull.triggered.connect(lambda: self._docInsert(nwUnicode.U_HYBULL))
         self.mInsSymbol.addAction(self.aInsHyBull)
 
         # Insert > Flower Mark
         self.aInsFlower = QAction(self.tr("Flower Mark"), self)
-        self.aInsFlower.setStatusTip(self.tr("Insert a flower mark (alternative bullet)"))
         self.aInsFlower.setShortcut("Ctrl+K, Ctrl+*")
         self.aInsFlower.triggered.connect(lambda: self._docInsert(nwUnicode.U_FLOWER))
         self.mInsSymbol.addAction(self.aInsFlower)
 
         # Insert > Per Mille
         self.aInsPerMille = QAction(self.tr("Per Mille"), self)
-        self.aInsPerMille.setStatusTip(self.tr("Insert a per mille symbol"))
         self.aInsPerMille.setShortcut("Ctrl+K, %")
         self.aInsPerMille.triggered.connect(lambda: self._docInsert(nwUnicode.U_PERMIL))
         self.mInsSymbol.addAction(self.aInsPerMille)
 
         # Insert > Degree Symbol
         self.aInsDegree = QAction(self.tr("Degree Symbol"), self)
-        self.aInsDegree.setStatusTip(self.tr("Insert a degree symbol"))
         self.aInsDegree.setShortcut("Ctrl+K, Ctrl+O")
         self.aInsDegree.triggered.connect(lambda: self._docInsert(nwUnicode.U_DEGREE))
         self.mInsSymbol.addAction(self.aInsDegree)
 
         # Insert > Minus Sign
         self.aInsMinus = QAction(self.tr("Minus Sign"), self)
-        self.aInsMinus.setStatusTip(self.tr("Insert a minus sign (not a hypen or dash)"))
         self.aInsMinus.setShortcut("Ctrl+K, Ctrl+M")
         self.aInsMinus.triggered.connect(lambda: self._docInsert(nwUnicode.U_MINUS))
         self.mInsSymbol.addAction(self.aInsMinus)
 
         # Insert > Times Sign
         self.aInsTimes = QAction(self.tr("Times Sign"), self)
-        self.aInsTimes.setStatusTip(self.tr("Insert a times sign (multiplication cross)"))
         self.aInsTimes.setShortcut("Ctrl+K, Ctrl+X")
         self.aInsTimes.triggered.connect(lambda: self._docInsert(nwUnicode.U_TIMES))
         self.mInsSymbol.addAction(self.aInsTimes)
 
         # Insert > Division
         self.aInsDivide = QAction(self.tr("Division Sign"), self)
-        self.aInsDivide.setStatusTip(self.tr("Insert a division sign"))
         self.aInsDivide.setShortcut("Ctrl+K, Ctrl+D")
         self.aInsDivide.triggered.connect(lambda: self._docInsert(nwUnicode.U_DIVIDE))
         self.mInsSymbol.addAction(self.aInsDivide)
@@ -726,19 +656,16 @@ class GuiMainMenu(QMenuBar):
 
         # Insert > New Page
         self.aInsNewPage = QAction(self.tr("Page Break"), self)
-        self.aInsNewPage.setStatusTip(self.tr("Insert a page break command"))
         self.aInsNewPage.triggered.connect(lambda: self._docInsert(nwDocInsert.NEW_PAGE))
         self.mInsBreaks.addAction(self.aInsNewPage)
 
         # Insert > Vertical Space (Single)
         self.aInsVSpaceS = QAction(self.tr("Vertical Space (Single)"), self)
-        self.aInsVSpaceS.setStatusTip(self.tr("Insert a vertical space equal to one paragraph"))
         self.aInsVSpaceS.triggered.connect(lambda: self._docInsert(nwDocInsert.VSPACE_S))
         self.mInsBreaks.addAction(self.aInsVSpaceS)
 
         # Insert > Vertical Space (Multi)
         self.aInsVSpaceM = QAction(self.tr("Vertical Space (Multi)"), self)
-        self.aInsVSpaceM.setStatusTip(self.tr("Insert a vertical space equal to n paragraphs"))
         self.aInsVSpaceM.triggered.connect(lambda: self._docInsert(nwDocInsert.VSPACE_M))
         self.mInsBreaks.addAction(self.aInsVSpaceM)
 
@@ -752,21 +679,18 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Emphasis
         self.aFmtEmph = QAction(self.tr("Emphasis"), self)
-        self.aFmtEmph.setStatusTip(self.tr("Add emphasis to selected text (italic)"))
         self.aFmtEmph.setShortcut("Ctrl+I")
         self.aFmtEmph.triggered.connect(lambda: self._docAction(nwDocAction.EMPH))
         self.fmtMenu.addAction(self.aFmtEmph)
 
         # Format > Strong Emphasis
         self.aFmtStrong = QAction(self.tr("Strong Emphasis"), self)
-        self.aFmtStrong.setStatusTip(self.tr("Add strong emphasis to selected text (bold)"))
         self.aFmtStrong.setShortcut("Ctrl+B")
         self.aFmtStrong.triggered.connect(lambda: self._docAction(nwDocAction.STRONG))
         self.fmtMenu.addAction(self.aFmtStrong)
 
         # Format > Strikethrough
         self.aFmtStrike = QAction(self.tr("Strikethrough"), self)
-        self.aFmtStrike.setStatusTip(self.tr("Add strikethrough to selected text"))
         self.aFmtStrike.setShortcut("Ctrl+D")
         self.aFmtStrike.triggered.connect(lambda: self._docAction(nwDocAction.STRIKE))
         self.fmtMenu.addAction(self.aFmtStrike)
@@ -776,14 +700,12 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Double Quotes
         self.aFmtDQuote = QAction(self.tr("Wrap Double Quotes"), self)
-        self.aFmtDQuote.setStatusTip(self.tr("Wrap selected text in double quotes"))
         self.aFmtDQuote.setShortcut("Ctrl+\"")
         self.aFmtDQuote.triggered.connect(lambda: self._docAction(nwDocAction.D_QUOTE))
         self.fmtMenu.addAction(self.aFmtDQuote)
 
         # Format > Single Quotes
         self.aFmtSQuote = QAction(self.tr("Wrap Single Quotes"), self)
-        self.aFmtSQuote.setStatusTip(self.tr("Wrap selected text in single quotes"))
         self.aFmtSQuote.setShortcut("Ctrl+'")
         self.aFmtSQuote.triggered.connect(lambda: self._docAction(nwDocAction.S_QUOTE))
         self.fmtMenu.addAction(self.aFmtSQuote)
@@ -793,28 +715,24 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Header 1 (Partition)
         self.aFmtHead1 = QAction(self.tr("Header 1 (Partition)"), self)
-        self.aFmtHead1.setStatusTip(self.tr("Set the text block format to Header 1 (Partition)"))
         self.aFmtHead1.setShortcut("Ctrl+1")
         self.aFmtHead1.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H1))
         self.fmtMenu.addAction(self.aFmtHead1)
 
         # Format > Header 2 (Chapter)
         self.aFmtHead2 = QAction(self.tr("Header 2 (Chapter)"), self)
-        self.aFmtHead2.setStatusTip(self.tr("Set the text block format to Header 2 (Chapter)"))
         self.aFmtHead2.setShortcut("Ctrl+2")
         self.aFmtHead2.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H2))
         self.fmtMenu.addAction(self.aFmtHead2)
 
         # Format > Header 3 (Scene)
         self.aFmtHead3 = QAction(self.tr("Header 3 (Scene)"), self)
-        self.aFmtHead3.setStatusTip(self.tr("Set the text block format to Header 3 (Scene)"))
         self.aFmtHead3.setShortcut("Ctrl+3")
         self.aFmtHead3.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H3))
         self.fmtMenu.addAction(self.aFmtHead3)
 
         # Format > Header 4 (Section)
         self.aFmtHead4 = QAction(self.tr("Header 4 (Section)"), self)
-        self.aFmtHead4.setStatusTip(self.tr("Set the text block format to Header 4 (Section)"))
         self.aFmtHead4.setShortcut("Ctrl+4")
         self.aFmtHead4.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_H4))
         self.fmtMenu.addAction(self.aFmtHead4)
@@ -824,13 +742,11 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Novel Title
         self.aFmtTitle = QAction(self.tr("Novel Title"), self)
-        self.aFmtTitle.setStatusTip(self.tr("Set the text block format to Novel Title"))
         self.aFmtTitle.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_TTL))
         self.fmtMenu.addAction(self.aFmtTitle)
 
         # Format > Unnumbered Chapter
         self.aFmtUnNum = QAction(self.tr("Unnumbered Chapter"), self)
-        self.aFmtUnNum.setStatusTip(self.tr("Set the text block format to Unnumbered Chapter"))
         self.aFmtUnNum.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_UNN))
         self.fmtMenu.addAction(self.aFmtUnNum)
 
@@ -839,21 +755,18 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Align Left
         self.aFmtAlignLeft = QAction(self.tr("Align Left"), self)
-        self.aFmtAlignLeft.setStatusTip(self.tr("Left-align the text block"))
         self.aFmtAlignLeft.setShortcut("Ctrl+5")
         self.aFmtAlignLeft.triggered.connect(lambda: self._docAction(nwDocAction.ALIGN_L))
         self.fmtMenu.addAction(self.aFmtAlignLeft)
 
         # Format > Align Centre
         self.aFmtAlignCentre = QAction(self.tr("Align Centre"), self)
-        self.aFmtAlignCentre.setStatusTip(self.tr("Centre the text block"))
         self.aFmtAlignCentre.setShortcut("Ctrl+6")
         self.aFmtAlignCentre.triggered.connect(lambda: self._docAction(nwDocAction.ALIGN_C))
         self.fmtMenu.addAction(self.aFmtAlignCentre)
 
         # Format > Align Right
         self.aFmtAlignRight = QAction(self.tr("Align Right"), self)
-        self.aFmtAlignRight.setStatusTip(self.tr("Right-align the text block"))
         self.aFmtAlignRight.setShortcut("Ctrl+7")
         self.aFmtAlignRight.triggered.connect(lambda: self._docAction(nwDocAction.ALIGN_R))
         self.fmtMenu.addAction(self.aFmtAlignRight)
@@ -863,14 +776,12 @@ class GuiMainMenu(QMenuBar):
 
         # Format > Indent Left
         self.aFmtIndentLeft = QAction(self.tr("Indent Left"), self)
-        self.aFmtIndentLeft.setStatusTip(self.tr("Increase the text block's left margin"))
         self.aFmtIndentLeft.setShortcut("Ctrl+8")
         self.aFmtIndentLeft.triggered.connect(lambda: self._docAction(nwDocAction.INDENT_L))
         self.fmtMenu.addAction(self.aFmtIndentLeft)
 
         # Format > Indent Right
         self.aFmtIndentRight = QAction(self.tr("Indent Right"), self)
-        self.aFmtIndentRight.setStatusTip(self.tr("Increase the text block's right margin"))
         self.aFmtIndentRight.setShortcut("Ctrl+9")
         self.aFmtIndentRight.triggered.connect(lambda: self._docAction(nwDocAction.INDENT_R))
         self.fmtMenu.addAction(self.aFmtIndentRight)
@@ -879,15 +790,13 @@ class GuiMainMenu(QMenuBar):
         self.fmtMenu.addSeparator()
 
         # Format > Comment
-        self.aFmtComment = QAction(self.tr("Comment"), self)
-        self.aFmtComment.setStatusTip(self.tr("Change the text block format to comment"))
+        self.aFmtComment = QAction(self.tr("Toggle Comment"), self)
         self.aFmtComment.setShortcut("Ctrl+/")
         self.aFmtComment.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_COM))
         self.fmtMenu.addAction(self.aFmtComment)
 
         # Format > Remove Block Format
         self.aFmtNoFormat = QAction(self.tr("Remove Block Format"), self)
-        self.aFmtNoFormat.setStatusTip(self.tr("Strip text block format"))
         self.aFmtNoFormat.setShortcuts(["Ctrl+0", "Ctrl+Shift+/"])
         self.aFmtNoFormat.triggered.connect(lambda: self._docAction(nwDocAction.BLOCK_TXT))
         self.fmtMenu.addAction(self.aFmtNoFormat)
@@ -896,26 +805,17 @@ class GuiMainMenu(QMenuBar):
         self.fmtMenu.addSeparator()
 
         # Format > Replace Single Quotes
-        self.aFmtReplSng = QAction(self.tr("Replace Single Quotes"), self)
-        self.aFmtReplSng.setStatusTip(
-            self.tr("Replace all straight single quotes in the selected text")
-        )
+        self.aFmtReplSng = QAction(self.tr("Convert Single Quotes"), self)
         self.aFmtReplSng.triggered.connect(lambda: self._docAction(nwDocAction.REPL_SNG))
         self.fmtMenu.addAction(self.aFmtReplSng)
 
         # Format > Replace Double Quotes
-        self.aFmtReplDbl = QAction(self.tr("Replace Double Quotes"), self)
-        self.aFmtReplDbl.setStatusTip(
-            self.tr("Replace all straight double quotes in the selected text")
-        )
+        self.aFmtReplDbl = QAction(self.tr("Convert Double Quotes"), self)
         self.aFmtReplDbl.triggered.connect(lambda: self._docAction(nwDocAction.REPL_DBL))
         self.fmtMenu.addAction(self.aFmtReplDbl)
 
         # Format > Remove In-Paragraph Breaks
         self.aFmtRmBreaks = QAction(self.tr("Remove In-Paragraph Breaks"), self)
-        self.aFmtRmBreaks.setStatusTip(
-            self.tr("Remove all line breaks within paragraphs in the selected text")
-        )
         self.aFmtRmBreaks.triggered.connect(lambda: self._docAction(nwDocAction.RM_BREAKS))
         self.fmtMenu.addAction(self.aFmtRmBreaks)
 
@@ -929,14 +829,12 @@ class GuiMainMenu(QMenuBar):
 
         # Search > Find
         self.aFind = QAction(self.tr("Find"), self)
-        self.aFind.setStatusTip(self.tr("Find text in document"))
         self.aFind.setShortcut("Ctrl+F")
         self.aFind.triggered.connect(lambda: self.theParent.docEditor.beginSearch())
         self.srcMenu.addAction(self.aFind)
 
         # Search > Replace
         self.aReplace = QAction(self.tr("Replace"), self)
-        self.aReplace.setStatusTip(self.tr("Replace text in document"))
         if self.mainConf.osDarwin:
             self.aReplace.setShortcut("Ctrl+=")
         else:
@@ -946,7 +844,6 @@ class GuiMainMenu(QMenuBar):
 
         # Search > Find Next
         self.aFindNext = QAction(self.tr("Find Next"), self)
-        self.aFindNext.setStatusTip(self.tr("Find next occurrence of text in document"))
         if self.mainConf.osDarwin:
             self.aFindNext.setShortcuts(["Ctrl+G", "F3"])
         else:
@@ -956,7 +853,6 @@ class GuiMainMenu(QMenuBar):
 
         # Search > Find Prev
         self.aFindPrev = QAction(self.tr("Find Previous"), self)
-        self.aFindPrev.setStatusTip(self.tr("Find previous occurrence of text in document"))
         if self.mainConf.osDarwin:
             self.aFindPrev.setShortcuts(["Ctrl+Shift+G", "Shift+F3"])
         else:
@@ -966,9 +862,6 @@ class GuiMainMenu(QMenuBar):
 
         # Search > Replace Next
         self.aReplaceNext = QAction(self.tr("Replace Next"), self)
-        self.aReplaceNext.setStatusTip(
-            self.tr("Find and replace next occurrence of text in document")
-        )
         self.aReplaceNext.setShortcut("Ctrl+Shift+1")
         self.aReplaceNext.triggered.connect(lambda: self.theParent.docEditor.replaceNext())
         self.srcMenu.addAction(self.aReplaceNext)
@@ -983,7 +876,6 @@ class GuiMainMenu(QMenuBar):
 
         # Tools > Check Spelling
         self.aSpellCheck = QAction(self.tr("Check Spelling"), self)
-        self.aSpellCheck.setStatusTip(self.tr("Toggle check spelling"))
         self.aSpellCheck.setCheckable(True)
         self.aSpellCheck.setChecked(self.theProject.spellCheck)
         self.aSpellCheck.triggered.connect(self._toggleSpellCheck)  # triggered, not toggled!
@@ -992,14 +884,12 @@ class GuiMainMenu(QMenuBar):
 
         # Tools > Re-Run Spell Check
         self.aReRunSpell = QAction(self.tr("Re-Run Spell Check"), self)
-        self.aReRunSpell.setStatusTip(self.tr("Run the spell checker on current document"))
         self.aReRunSpell.setShortcut("F7")
         self.aReRunSpell.triggered.connect(lambda: self.theParent.docEditor.spellCheckDocument())
         self.toolsMenu.addAction(self.aReRunSpell)
 
         # Tools > Project Word List
         self.aEditWordList = QAction(self.tr("Project Word List"), self)
-        self.aEditWordList.setStatusTip(self.tr("Edit the project's word list"))
         self.aEditWordList.triggered.connect(lambda: self.theParent.showProjectWordListDialog())
         self.toolsMenu.addAction(self.aEditWordList)
 
@@ -1008,23 +898,18 @@ class GuiMainMenu(QMenuBar):
 
         # Tools > Rebuild Indices
         self.aRebuildIndex = QAction(self.tr("Rebuild Index"), self)
-        self.aRebuildIndex.setStatusTip(self.tr("Rebuild the tag indices and word counts"))
         self.aRebuildIndex.setShortcut("F9")
         self.aRebuildIndex.triggered.connect(lambda: self.theParent.rebuildIndex())
         self.toolsMenu.addAction(self.aRebuildIndex)
 
         # Tools > Rebuild Outline
         self.aRebuildOutline = QAction(self.tr("Rebuild Outline"), self)
-        self.aRebuildOutline.setStatusTip(self.tr("Rebuild the novel outline tree"))
         self.aRebuildOutline.setShortcut("F10")
         self.aRebuildOutline.triggered.connect(lambda: self.theParent.rebuildOutline())
         self.toolsMenu.addAction(self.aRebuildOutline)
 
         # Tools > Toggle Auto Build Outline
         self.aAutoOutline = QAction(self.tr("Auto-Update Outline"), self)
-        self.aAutoOutline.setStatusTip(
-            self.tr("Update project outline when a novel file is changed")
-        )
         self.aAutoOutline.setCheckable(True)
         self.aAutoOutline.toggled.connect(self._toggleAutoOutline)
         self.aAutoOutline.setShortcut("Ctrl+F10")
@@ -1034,28 +919,24 @@ class GuiMainMenu(QMenuBar):
         self.toolsMenu.addSeparator()
 
         # Tools > Backup
-        self.aBackupProject = QAction(self.tr("Backup Project Folder"), self)
-        self.aBackupProject.setStatusTip(self.tr("Backup Project"))
+        self.aBackupProject = QAction(self.tr("Backup Project"), self)
         self.aBackupProject.triggered.connect(lambda: self.theProject.zipIt(True))
         self.toolsMenu.addAction(self.aBackupProject)
 
         # Tools > Export Project
         self.aBuildProject = QAction(self.tr("Build Novel Project"), self)
-        self.aBuildProject.setStatusTip(self.tr("Launch the Build novel project tool"))
         self.aBuildProject.setShortcut("F5")
         self.aBuildProject.triggered.connect(lambda: self.theParent.showBuildProjectDialog())
         self.toolsMenu.addAction(self.aBuildProject)
 
         # Tools > Writing Stats
         self.aWritingStats = QAction(self.tr("Writing Statistics"), self)
-        self.aWritingStats.setStatusTip(self.tr("Show the writing statistics dialogue"))
         self.aWritingStats.setShortcut("F6")
         self.aWritingStats.triggered.connect(lambda: self.theParent.showWritingStatsDialog())
         self.toolsMenu.addAction(self.aWritingStats)
 
         # Tools > Settings
         self.aPreferences = QAction(self.tr("Preferences"), self)
-        self.aPreferences.setStatusTip(self.tr("Preferences"))
         self.aPreferences.setShortcut("Ctrl+,")
         self.aPreferences.setMenuRole(QAction.PreferencesRole)
         self.aPreferences.triggered.connect(lambda: self.theParent.showPreferencesDialog())
@@ -1071,14 +952,12 @@ class GuiMainMenu(QMenuBar):
 
         # Help > About
         self.aAboutNW = QAction(self.tr("About novelWriter"), self)
-        self.aAboutNW.setStatusTip(self.tr("About novelWriter"))
         self.aAboutNW.setMenuRole(QAction.AboutRole)
         self.aAboutNW.triggered.connect(lambda: self.theParent.showAboutNWDialog())
         self.helpMenu.addAction(self.aAboutNW)
 
         # Help > About Qt5
         self.aAboutQt = QAction(self.tr("About Qt5"), self)
-        self.aAboutQt.setStatusTip(self.tr("About Qt5"))
         self.aAboutQt.setMenuRole(QAction.AboutQtRole)
         self.aAboutQt.triggered.connect(lambda: self.theParent.showAboutQtDialog())
         self.helpMenu.addAction(self.aAboutQt)
@@ -1093,7 +972,6 @@ class GuiMainMenu(QMenuBar):
             docUrl = f"{novelwriter.__docurl__}/en/latest/"
 
         self.aHelpDocs = QAction(self.tr("User Manual (Online)"), self)
-        self.aHelpDocs.setStatusTip(self.tr("Open documentation in browser"))
         self.aHelpDocs.setShortcut("F1")
         self.aHelpDocs.triggered.connect(lambda: self._openWebsite(docUrl))
         self.helpMenu.addAction(self.aHelpDocs)
@@ -1101,7 +979,6 @@ class GuiMainMenu(QMenuBar):
         # Help > User Manual (PDF)
         if self.mainConf.pdfDocs is not None:
             self.aPdfDocs = QAction(self.tr("User Manual (PDF)"), self)
-            self.aPdfDocs.setStatusTip(self.tr("Open PDF documentation"))
             self.aPdfDocs.setShortcut("Shift+F1")
             self.aPdfDocs.triggered.connect(self._openUserManualFile)
             self.helpMenu.addAction(self.aPdfDocs)
@@ -1111,25 +988,16 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Report an Issue
         self.aIssue = QAction(self.tr("Report an Issue (GitHub)"), self)
-        self.aIssue.setStatusTip(
-            self.tr("Report a bug or issue on GitHub at {0}").format(novelwriter.__issuesurl__)
-        )
         self.aIssue.triggered.connect(lambda: self._openWebsite(novelwriter.__issuesurl__))
         self.helpMenu.addAction(self.aIssue)
 
         # Document > Ask a Question
         self.aQuestion = QAction(self.tr("Ask a Question (GitHub)"), self)
-        self.aQuestion.setStatusTip(
-            self.tr("Ask a question on GitHub at {0}").format(novelwriter.__helpurl__)
-        )
         self.aQuestion.triggered.connect(lambda: self._openWebsite(novelwriter.__helpurl__))
         self.helpMenu.addAction(self.aQuestion)
 
         # Document > Main Website
         self.aWebsite = QAction(self.tr("The novelWriter Website"), self)
-        self.aWebsite.setStatusTip(
-            self.tr("Open the novelWriter website at {0}").format(novelwriter.__url__)
-        )
         self.aWebsite.triggered.connect(lambda: self._openWebsite(novelwriter.__url__))
         self.helpMenu.addAction(self.aWebsite)
 
@@ -1138,7 +1006,6 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Check for Updates
         self.aUpdates = QAction(self.tr("Check for New Release"), self)
-        self.aUpdates.setStatusTip(self.tr("Check for latest release of novelWriter"))
         self.aUpdates.triggered.connect(lambda: self.theParent.showUpdatesDialog())
         self.helpMenu.addAction(self.aUpdates)
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -206,7 +206,9 @@ class GuiProjectTree(QTreeWidget):
         )
 
         if itemType == nwItemType.ROOT:
-            tHandle = self.theProject.newRoot(trConst(nwLabels.CLASS_NAME[itemClass]), itemClass)
+            tHandle = self.theProject.newRoot(
+                trConst(nwLabels.CLASS_NAME_LBL[itemClass]), itemClass
+            )
             if tHandle is None:
                 logger.error("No root item added")
                 return False

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -359,7 +359,7 @@ class GuiMain(QMainWindow):
         if self.hasProject:
             if not self.closeProject():
                 self.makeAlert(self.tr(
-                    "Cannot create new project when another project is open."
+                    "Cannot create a new project when another project is open."
                 ), nwAlert.ERROR)
                 return False
 

--- a/novelwriter/tools/build.py
+++ b/novelwriter/tools/build.py
@@ -343,22 +343,16 @@ class GuiBuildNovel(QDialog):
         self.fileGroup.setLayout(self.fileForm)
 
         self.novelFiles = QSwitch(width=wS, height=hS)
-        self.novelFiles.setToolTip(self.tr("Include files with layouts other than 'Note'."))
         self.novelFiles.setChecked(
             self.optState.getBool("GuiBuildNovel", "addNovel", True)
         )
 
         self.noteFiles = QSwitch(width=wS, height=hS)
-        self.noteFiles.setToolTip(self.tr("Include files with layout 'Note'."))
         self.noteFiles.setChecked(
             self.optState.getBool("GuiBuildNovel", "addNotes", False)
         )
 
         self.ignoreFlag = QSwitch(width=wS, height=hS)
-        self.ignoreFlag.setToolTip(self.tr(
-            "Ignore the 'Include when building project' setting and include "
-            "all files in the output."
-        ))
         self.ignoreFlag.setChecked(
             self.optState.getBool("GuiBuildNovel", "ignoreFlag", False)
         )

--- a/novelwriter/tools/projwizard.py
+++ b/novelwriter/tools/projwizard.py
@@ -310,22 +310,22 @@ class ProjWizardCustomPage(QWizardPage):
         self.rootGroup.setLayout(self.rootForm)
 
         self.lblPlot = QLabel(self.tr("{0} folder").format(
-            trConst(nwLabels.CLASS_NAME[nwItemClass.PLOT]))
+            trConst(nwLabels.CLASS_NAME_LBL[nwItemClass.PLOT]))
         )
         self.lblChar = QLabel(self.tr("{0} folder").format(
-            trConst(nwLabels.CLASS_NAME[nwItemClass.CHARACTER]))
+            trConst(nwLabels.CLASS_NAME_LBL[nwItemClass.CHARACTER]))
         )
         self.lblWorld = QLabel(self.tr("{0} folder").format(
-            trConst(nwLabels.CLASS_NAME[nwItemClass.WORLD]))
+            trConst(nwLabels.CLASS_NAME_LBL[nwItemClass.WORLD]))
         )
         self.lblTime = QLabel(self.tr("{0} folder").format(
-            trConst(nwLabels.CLASS_NAME[nwItemClass.TIMELINE]))
+            trConst(nwLabels.CLASS_NAME_LBL[nwItemClass.TIMELINE]))
         )
         self.lblObject = QLabel(self.tr("{0} folder").format(
-            trConst(nwLabels.CLASS_NAME[nwItemClass.OBJECT]))
+            trConst(nwLabels.CLASS_NAME_LBL[nwItemClass.OBJECT]))
         )
         self.lblEntity = QLabel(self.tr("{0} folder").format(
-            trConst(nwLabels.CLASS_NAME[nwItemClass.ENTITY]))
+            trConst(nwLabels.CLASS_NAME_LBL[nwItemClass.ENTITY]))
         )
 
         self.addPlot   = QSwitch()

--- a/sample/content/8a5deb88c0e97.nwd
+++ b/sample/content/8a5deb88c0e97.nwd
@@ -3,4 +3,4 @@
 %%~kind: NOVEL/DOCUMENT
 ### Discarded Scene
 
-If you have files you no longer want in your main project, you can move them to the “Outtakes” folder. This is equivalent to turning off the “Include when building project” switch, just that you also put the file away, although the switch can be ignored when building the project, this folder cannot.
+If you have files you no longer want in your main project, you can move them to the “Archive” folder. This is equivalent to turning off the “Include when building project” switch, just that you also put the file away, although the switch can be ignored when building the project, this folder cannot.

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.6-beta1" hexVersion="0x010600b1" fileVersion="1.3" timeStamp="2022-01-18 18:48:36">
+<novelWriterXML appVersion="1.6-beta1" hexVersion="0x010600b1" fileVersion="1.3" timeStamp="2022-01-18 20:59:58">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>1283</saveCount>
+    <saveCount>1296</saveCount>
     <autoCount>199</autoCount>
-    <editTime>63909</editTime>
+    <editTime>64417</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>
@@ -121,7 +121,7 @@
       <charCount>2429</charCount>
       <wordCount>432</wordCount>
       <paraCount>14</paraCount>
-      <cursorPos>2</cursorPos>
+      <cursorPos>219</cursorPos>
     </item>
     <item handle="bc0cbd2a407f3" order="2" parent="e7ded148d6e4a">
       <name>Another Scene</name>
@@ -265,7 +265,7 @@
       <cursorPos>45</cursorPos>
     </item>
     <item handle="6827118336ac1" order="3" parent="None">
-      <name>Outtakes</name>
+      <name>Archive</name>
       <type>ROOT</type>
       <class>ARCHIVE</class>
       <status>New</status>

--- a/tests/reference/coreProject_NewCustomA_nwProject.nwx
+++ b/tests/reference/coreProject_NewCustomA_nwProject.nwx
@@ -85,7 +85,7 @@
       <expanded>False</expanded>
     </item>
     <item handle="98010bd9270f9" order="0" parent="None">
-      <name>Entity</name>
+      <name>Entities</name>
       <type>ROOT</type>
       <class>ENTITY</class>
       <status>New</status>

--- a/tests/reference/coreProject_NewCustomB_nwProject.nwx
+++ b/tests/reference/coreProject_NewCustomB_nwProject.nwx
@@ -85,7 +85,7 @@
       <expanded>False</expanded>
     </item>
     <item handle="98010bd9270f9" order="0" parent="None">
-      <name>Entity</name>
+      <name>Entities</name>
       <type>ROOT</type>
       <class>ENTITY</class>
       <status>New</status>

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -281,7 +281,7 @@ def testCoreIndex_ScanText(nwMinimal, mockGUI):
     assert theIndex.scanText(xHandle, "Hello World!") is False
 
     # Create the archive root
-    aHandle = theProject.newRoot("Outtakes", nwItemClass.ARCHIVE)
+    aHandle = theProject.newRoot("Archive", nwItemClass.ARCHIVE)
     assert theProject.projTree[aHandle] is not None
     xItem.setParent(aHandle)
     assert theIndex.scanText(xHandle, "Hello World!") is False


### PR DESCRIPTION
**Summary:**

This PR removes a lot of GUI text. There were a number of redundant tooltips. That is, tooltips that say exactly the same as the GUI element says. That includes every status bar message from hovering over menu entries. Some dialog boxes have been removed or merged with other boxes. In addition, the class name labels have been split into singular and plurals.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
