### PR TITLE
Add automatic index rebuild

### DIFF
--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -84,6 +84,7 @@ class NWProject():
         self.projSpell   = None  # The spell check language, if different than default
         self.projLang    = None  # The project language, used for builds
         self.projFile    = None  # The file name of the project main XML file
+        self.projFiles   = []    # A list of all files in the content folder on load
 
         # Project Meta
         self.projName    = ""  # Project name (working title)
@@ -203,6 +204,7 @@ class NWProject():
         self.projSpell   = None
         self.projLang    = None
         self.projFile    = nwFiles.PROJ_FILE
+        self.projFiles   = []
         self.projName    = ""
         self.bookTitle   = ""
         self.bookAuthors = []
@@ -1352,6 +1354,7 @@ class NWProject():
         # Then check the files in the data folder
         logger.debug("Checking files in project content folder")
         orphanFiles = []
+        self.projFiles = []
         for fileItem in os.listdir(self.projContent):
             if not fileItem.endswith(".nwd"):
                 logger.warning("Skipping file: %s", fileItem)
@@ -1359,11 +1362,14 @@ class NWProject():
             if len(fileItem) != 17:
                 logger.warning("Skipping file: %s", fileItem)
                 continue
+
             fHandle = fileItem[:13]
             if not isHandle(fHandle):
                 logger.warning("Skipping file: %s", fileItem)
                 continue
+
             if fHandle in self.projTree:
+                self.projFiles.append(fHandle)
                 logger.debug("Checking file %s, handle '%s': OK", fileItem, fHandle)
             else:
                 logger.warning("Checking file %s, handle '%s': Orphaned", fileItem, fHandle)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -550,8 +550,7 @@ class GuiMain(QMainWindow):
             ), nwAlert.WARN)
             self.rebuildIndex()
 
-        # Make sure the changed status is set to false on all that was
-        # just opened
+        # Make sure the changed status is set to false on things opened
         qApp.processEvents()
         self.docEditor.setDocumentChanged(False)
         self.theProject.setProjectChanged(False)

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -108,7 +108,7 @@ def testCoreIndex_LoadSave(monkeypatch, nwLipsum, mockGUI, outDir, refDir):
     # Break the index and check that we notice
     assert theIndex.indexBroken is False
     theIndex._tagIndex["Bod"].append("Stuff")
-    theIndex.checkIndex()
+    theIndex._checkIndex()
     assert theIndex.indexBroken is True
 
     # Finalise

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -46,9 +46,7 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, nwLipsum):
     nwGUI.theProject.projTree.setSeed(42)
     assert nwGUI.openProject(nwLipsum)
 
-    # Rebuild the index as it isn't automatically copied
-    assert nwGUI.theIndex._tagIndex == {}
-    assert nwGUI.theIndex._refIndex == {}
+    # Rebuild the index
     nwGUI.mainMenu.aRebuildIndex.activate(QAction.Trigger)
     assert nwGUI.theIndex._tagIndex != {}
     assert nwGUI.theIndex._refIndex != {}

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -61,10 +61,6 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, nwMinimal):
     ##
 
     nwGUI.projTabs.setCurrentIndex(nwGUI.idxNovelView)
-
-    # The tree should be empty as there is no index
-    assert nwTree.topLevelItemCount() == 0
-
     nwGUI.rebuildIndex()
     nwTree._populateTree()
     assert nwTree.topLevelItemCount() == 1


### PR DESCRIPTION
**Summary:**

This PR adds an automatic rebuild of the project index if not all files in the project's content folder are present in the index when the index is opened. The list of files is registered in the project class when the scan is performed.

**Related Issue(s):**

Resolves #957

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
