### PR TITLE
Remove Ubuntu 21.04 release and add 22.04

### DIFF
--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.6-beta1" hexVersion="0x010600b1" fileVersion="1.3" timeStamp="2022-01-18 20:59:58">
+<novelWriterXML appVersion="1.6-rc1" hexVersion="0x010600c1" fileVersion="1.3" timeStamp="2022-02-06 23:05:58">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>1296</saveCount>
+    <saveCount>1297</saveCount>
     <autoCount>199</autoCount>
-    <editTime>64417</editTime>
+    <editTime>64424</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>

--- a/setup.py
+++ b/setup.py
@@ -788,8 +788,8 @@ def makeForLaunchpad(doSign=False, isFirst=False, isSnapshot=False):
     distLoop = [
         ("18.04", "bionic"),
         ("20.04", "focal"),
-        ("21.04", "hirsute"),
         ("21.10", "impish"),
+        ("22.04", "jammy"),
     ]
 
     tStamp = datetime.datetime.now().strftime("%Y%m%d~%H%M%S")


### PR DESCRIPTION
**Summary:**

Launchpad no longer accepts Ubuntu 21.04 packages,

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
