### PR TITLE
Set a default editor font for Windows and macOS

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -235,8 +235,19 @@ class GuiDocEditor(QTextEdit):
         theFont = QFont()
         qDoc = self.document()
         if self.mainConf.textFont is None:
-            # If none is defined, set the default back to config
-            self.mainConf.textFont = qDoc.defaultFont().family()
+            # If none is defined, set a default font
+            theFont = QFont()
+            if self.mainConf.osWindows and "Arial" in self.guiFontDB.families():
+                theFont.setFamily("Arial")
+                theFont.setPointSize(12)
+            elif self.mainConf.osDarwin and "Courier" in self.guiFontDB.families():
+                theFont.setFamily("Courier")
+                theFont.setPointSize(12)
+            else:
+                theFont = qDoc.defaultFont()
+
+            self.mainConf.textFont = theFont.family()
+            self.mainConf.textSize = theFont.pointSize()
 
         theFont.setFamily(self.mainConf.textFont)
         theFont.setPointSize(self.mainConf.textSize)


### PR DESCRIPTION
**Summary:**

The default font on Windows and macOS are GUI fonts and aren't necessarily suitable for text documents. This PR defaults the font to Arial on Windows and Courier on macOS, if the fonts are available.

**Related Issue(s):**

Resolves #988

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
