### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -12,7 +12,7 @@ jobs:
   testLinux:
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
           architecture: x64
       - name: Install Packages
         run: |

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
           architecture: x64
       - name: Install Packages
         run: |

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
           architecture: x64
       - name: Checkout Source
         uses: actions/checkout@v2

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
           architecture: x64
       - name: Checkout Source
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The full credits are listed in
 
 ## Implementation
 
-The application is written in Python 3 (3.6+) using Qt5 and PyQt5 (5.3+). It is developed on Linux,
-but should in principle work fine on other operating systems as well as long as dependencies are
-met. It is regularly tested on Debian and Ubuntu Linux, Windows, and macOS.
+The application is written with Python 3 (3.7+) using Qt5 and PyQt5 (5.3+). It is developed on
+Linux, but should in principle work fine on other operating systems as well as long as dependencies
+are met. It is regularly tested on Debian and Ubuntu Linux, Windows, and macOS.
 
 ## Installation
 

--- a/docs/source/int_started.rst
+++ b/docs/source/int_started.rst
@@ -115,7 +115,7 @@ Windows
 -------
 
 First, make sure you have Python installed on your system. If you don't, you can download it from
-`python.org`_. Python 3.6 or higher is required, but it is recommended that you install the latest
+`python.org`_. Python 3.7 or higher is required, but it is recommended that you install the latest
 version.
 
 Make sure you select the "Add Python to PATH" option during installation, otherwise the ``python``

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -209,9 +209,9 @@ def main(sysArgs=None):
     # Check Packages and Versions
     errorData = []
     errorCode = 0
-    if sys.hexversion < 0x030600f0:
+    if sys.hexversion < 0x030700f0:
         errorData.append(
-            "At least Python 3.6 is required, found %s" % CONFIG.verPyString
+            "At least Python 3.7 is required, found %s" % CONFIG.verPyString
         )
         errorCode |= 0x04
     if CONFIG.verQtValue < 50300:

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -241,19 +241,6 @@ def formatTime(tS):
     return "ERROR"
 
 
-def parseTimeStamp(theStamp, default, allowNone=False):
-    """Parses a text representation of a timestamp and converts it into
-    a float. Note that negative timestamps cause an OSError on Windows.
-    See https://bugs.python.org/issue29097
-    """
-    if str(theStamp).lower() == "none" and allowNone:
-        return None
-    try:
-        return datetime.strptime(theStamp, nwConst.FMT_TSTAMP).timestamp()
-    except Exception:
-        return default
-
-
 # =============================================================================================== #
 #  String Functions
 # =============================================================================================== #

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -330,7 +330,7 @@ class ToOdt(Tokenizer):
 
         # Meta Data
         xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "creation-date"))
-        xMeta.text = datetime.now().strftime(r"%Y-%m-%dT%H:%M:%S")
+        xMeta.text = datetime.now().isoformat(sep="T", timespec="seconds")
 
         xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "generator"))
         xMeta.text = f"novelWriter/{novelwriter.__version__}"

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -457,12 +457,8 @@ class GuiWritingStats(QDialog):
                     if len(inData) < 6:
                         continue
 
-                    dStart = datetime.strptime(
-                        "%s %s" % (inData[0], inData[1]), nwConst.FMT_TSTAMP
-                    )
-                    dEnd = datetime.strptime(
-                        "%s %s" % (inData[2], inData[3]), nwConst.FMT_TSTAMP
-                    )
+                    dStart = datetime.fromisoformat(" ".join(inData[0:2]))
+                    dEnd   = datetime.fromisoformat(" ".join(inData[2:4]))
 
                     sIdle = 0
                     if len(inData) > 6:

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ license_file = LICENSE.md
 license = GNU General Public License v3
 classifiers =
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -29,7 +28,7 @@ project_urls =
     Source Code = https://github.com/vkbo/novelWriter
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 packages = find:
 install_requires =

--- a/setup/debian/control
+++ b/setup/debian/control
@@ -2,14 +2,14 @@ Source: novelwriter
 Maintainer: Veronica Berglyd Olsen <code@vkbo.net>
 Section: text
 Priority: optional
-Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.6), python3-pyqt5 (>= 5.3), python3-lxml (>= 4.0), python3-enchant (>= 2.0)
+Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.7), python3-pyqt5 (>= 5.3), python3-lxml (>= 4.0), python3-enchant (>= 2.0)
 Standards-Version: 4.5.1
 Homepage: https://novelwriter.io
-X-Python3-Version: >= 3.6
+X-Python3-Version: >= 3.7
 
 Package: novelwriter
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.6), python3-pyqt5 (>= 5.3), python3-lxml (>= 4.0), python3-enchant (>= 2.0)
+Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.7), python3-pyqt5 (>= 5.3), python3-lxml (>= 4.0), python3-enchant (>= 2.0)
 Description: A markdown-like text editor for planning and writing novels
  novelWriter is a plain text editor designed for writing novels assembled from
  many smaller text documents. It uses a minimal formatting syntax inspired by

--- a/setup/description_pypi.md
+++ b/setup/description_pypi.md
@@ -10,9 +10,9 @@ synchronisation tools. All text is saved as plain text files with a meta data he
 project structure is stored in a single project XML file, and other meta data is primarily saved as
 JSON files.
 
-The application is written in Python 3 (3.6+) using Qt5 and PyQt5 (5.3+). It is developed on Linux,
-but should in principle work fine on other operating systems as well as long as dependencies are
-met. It is regularly tested on Debian and Ubuntu Linux, Windows, and macOS.
+The application is written with Python 3 (3.7+) using Qt5 and PyQt5 (5.3+). It is developed on
+Linux, but should in principle work fine on other operating systems as well as long as dependencies
+are met. It is regularly tested on Debian and Ubuntu Linux, Windows, and macOS.
 
 novelWriter is developed and maintained by [Veronica Berglyd Olsen](https://github.com/vkbo).
 

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -24,8 +24,6 @@ import os
 import time
 import pytest
 
-from datetime import datetime
-
 from mock import causeOSError
 from tools import writeFile
 
@@ -33,9 +31,9 @@ from novelwriter.guimain import GuiMain
 from novelwriter.common import (
     checkString, checkInt, checkFloat, checkBool, checkHandle, isHandle,
     isTitleTag, isItemClass, isItemType, isItemLayout, hexToInt, checkIntRange,
-    checkIntTuple, formatInt, formatTimeStamp, formatTime, parseTimeStamp,
-    splitVersionNumber, transferCase, fuzzyTime, numberToRoman, jsonEncode,
-    readTextFile, makeFileNameSafe, sha256sum, getGuiItem, NWConfigParser
+    checkIntTuple, formatInt, formatTimeStamp, formatTime, splitVersionNumber,
+    transferCase, fuzzyTime, numberToRoman, jsonEncode, readTextFile,
+    makeFileNameSafe, sha256sum, getGuiItem, NWConfigParser
 )
 
 
@@ -270,21 +268,6 @@ def testBaseCommon_FormatTime():
     assert formatTime(360000) == "4-04:00:00"
 
 # END Test testBaseCommon_FormatTime
-
-
-@pytest.mark.base
-def testBaseCommon_ParseTimeStamp():
-    """Test the parseTimeStamp function.
-    """
-    localEpoch = datetime(2000, 1, 1).timestamp()
-    assert parseTimeStamp(None, 0.0, allowNone=True) is None
-    assert parseTimeStamp("None", 0.0, allowNone=True) is None
-    assert parseTimeStamp("None", 0.0) == 0.0
-    assert parseTimeStamp("2000-01-01 00:00:00", 123.0) == localEpoch
-    assert parseTimeStamp("2000-13-01 00:00:00", 123.0) == 123.0
-    assert parseTimeStamp("2000-01-32 00:00:00", 123.0) == 123.0
-
-# END Test testBaseCommon_ParseTimeStamp
 
 
 @pytest.mark.base


### PR DESCRIPTION
**Summary:**

Python 3.6 reached end of life on December 23rd, 2021. This PR removes all mentions of Python 3.6 support and drops testing against a 3.6 environment. Since 3.6 is dropped, the couple of places were custom code was used to avoid using 3.7 features have been updated.

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
