### PR TITLE
Update linting settings, and drop Ubuntu 18.04 releases

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -27,5 +27,5 @@ jobs:
           flake8 tests --count --select=E9,F63,F7,F82 --show-source --statistics
       - name: Coding Style Violations
         run: | 
-          flake8 novelwriter --count --max-line-length=99 --ignore E221,E226,E228,E241 --show-source --statistics
-          flake8 tests --count --max-line-length=99 --ignore E221,E226,E228,E241 --show-source --statistics
+          flake8 novelwriter --count --max-line-length=99 --ignore E133,E221,E226,E228,E241,W503 --show-source --statistics
+          flake8 tests --count --max-line-length=99 --ignore E133,E221,E226,E228,E241,W503 --show-source --statistics

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,6 @@ gui_scripts =
 universal = 0
 
 [flake8]
-ignore = E221,E226,E228,E241
+ignore = E133,E221,E226,E228,E241,W503
 max-line-length = 99
 exclude = docs/*

--- a/setup.py
+++ b/setup.py
@@ -786,7 +786,6 @@ def makeForLaunchpad(doSign=False, isFirst=False, isSnapshot=False):
             bldNum = "0"
 
     distLoop = [
-        ("18.04", "bionic"),
         ("20.04", "focal"),
         ("21.10", "impish"),
         ("22.04", "jammy"),


### PR DESCRIPTION
**Summary:**

* Updates linting to ignore E133 in favour of the mutually exclusive E123, and W503 in favour of W504.
* Drop making releases for Ubuntu 18.04, which only comes with Python 3.6.

**Related Issue(s):**

Resolves #1005

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
