### PR TITLE
Make sure empty files are indexed

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -221,7 +221,8 @@ class NWIndex():
         cC, wC, pC = countWords(theText)
         self._fileMeta[tHandle] = ["H0", cC, wC, pC]
 
-        # If the file is archived or in trash, we don't index the content
+        # If the file's meta data is missing, or the file is out of the
+        # main project, we don't index the content
         if theItem.itemLayout == nwItemLayout.NO_LAYOUT:
             logger.info("Not indexing no-layout item '%s'", tHandle)
             return False

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -112,8 +112,7 @@ class NWIndex():
 
         theDoc = NWDoc(self.theProject, tHandle)
         theText = theDoc.readDocument()
-        if theText:
-            self.scanText(tHandle, theText)
+        self.scanText(tHandle, theText if theText is not None else "")
 
         return True
 
@@ -217,18 +216,18 @@ class NWIndex():
         if theItem.itemType != nwItemType.FILE:
             logger.info("Not indexing non-file item '%s'", tHandle)
             return False
-        if theItem.itemLayout == nwItemLayout.NO_LAYOUT:
-            logger.info("Not indexing no-layout item '%s'", tHandle)
-            return False
-        if theItem.itemParent is None:
-            logger.info("Not indexing orphaned item '%s'", tHandle)
-            return False
 
         # Run word counter for the whole text
         cC, wC, pC = countWords(theText)
         self._fileMeta[tHandle] = ["H0", cC, wC, pC]
 
         # If the file is archived or in trash, we don't index the content
+        if theItem.itemLayout == nwItemLayout.NO_LAYOUT:
+            logger.info("Not indexing no-layout item '%s'", tHandle)
+            return False
+        if theItem.itemParent is None:
+            logger.info("Not indexing orphaned item '%s'", tHandle)
+            return False
         if self.theProject.projTree.isTrashRoot(theItem.itemParent):
             logger.debug("Not indexing trash item '%s'", tHandle)
             return False


### PR DESCRIPTION
**Summary:**

Empty files were not covered by the rebuild index feature, so they would trigger the auto-rebuild every time the project was opened.

**Related Issue(s):**

Resolves #1020

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
