### PR TITLE
Only compute shasum of file if it exists

### DIFF
--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -89,9 +89,10 @@ class NWDoc():
 
         theText = ""
         self._docMeta = {}
-        self._prevHash = sha256sum(docPath)
+        self._prevHash = None
 
         if os.path.isfile(docPath):
+            self._prevHash = sha256sum(docPath)
             try:
                 with open(docPath, mode="r", encoding="utf-8") as inFile:
                     # Check the first <= 10 lines for metadata


### PR DESCRIPTION
**Summary:**

When a new file is created the shasum function reports an error as it tries to compute the shasum of a file that not yet exists. This PR moves the call into the if-check for file existence to avoid the error message,

**Related Issue(s):**

Resolves #1021

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
