### PR TITLE
Simplify text labels in XML

### DIFF
--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -301,142 +301,142 @@ class NWItem():
     #  Set Item Values
     ##
 
-    def setName(self, theName):
+    def setName(self, name):
         """Set the item name.
         """
-        if isinstance(theName, str):
-            self._name = simplified(theName)
+        if isinstance(name, str):
+            self._name = simplified(name)
         else:
             self._name = ""
         return
 
-    def setHandle(self, theHandle):
+    def setHandle(self, tHandle):
         """Set the item handle, and ensure it is valid.
         """
-        if isHandle(theHandle):
-            self._handle = theHandle
+        if isHandle(tHandle):
+            self._handle = tHandle
         else:
             self._handle = None
         return
 
-    def setParent(self, theParent):
+    def setParent(self, pHandle):
         """Set the parent handle, and ensure it is valid.
         """
-        if theParent is None:
+        if pHandle is None:
             self._parent = None
-        elif isHandle(theParent):
-            self._parent = theParent
+        elif isHandle(pHandle):
+            self._parent = pHandle
         else:
             self._parent = None
         return
 
-    def setOrder(self, theOrder):
+    def setOrder(self, order):
         """Set the item order, and ensure that it is valid. This value
         is purely a meta value, and not actually used by novelWriter at
         the moment.
         """
-        self._order = checkInt(theOrder, 0)
+        self._order = checkInt(order, 0)
         return
 
-    def setType(self, theType):
+    def setType(self, itemType):
         """Set the item type from either a proper nwItemType, or set it
         from a string representing an nwItemType.
         """
-        if isinstance(theType, nwItemType):
-            self._type = theType
-        elif isItemType(theType):
-            self._type = nwItemType[theType]
+        if isinstance(itemType, nwItemType):
+            self._type = itemType
+        elif isItemType(itemType):
+            self._type = nwItemType[itemType]
         else:
-            logger.error("Unrecognised item type '%s'", theType)
+            logger.error("Unrecognised item type '%s'", itemType)
             self._type = nwItemType.NO_TYPE
         return
 
-    def setClass(self, theClass):
+    def setClass(self, itemClass):
         """Set the item class from either a proper nwItemClass, or set
         it from a string representing an nwItemClass.
         """
-        if isinstance(theClass, nwItemClass):
-            self._class = theClass
-        elif isItemClass(theClass):
-            self._class = nwItemClass[theClass]
+        if isinstance(itemClass, nwItemClass):
+            self._class = itemClass
+        elif isItemClass(itemClass):
+            self._class = nwItemClass[itemClass]
         else:
-            logger.error("Unrecognised item class '%s'", theClass)
+            logger.error("Unrecognised item class '%s'", itemClass)
             self._class = nwItemClass.NO_CLASS
         return
 
-    def setLayout(self, theLayout):
+    def setLayout(self, itemLayout):
         """Set the item layout from either a proper nwItemLayout, or set
         it from a string representing an nwItemLayout.
         """
-        if isinstance(theLayout, nwItemLayout):
-            self._layout = theLayout
-        elif isItemLayout(theLayout):
-            self._layout = nwItemLayout[theLayout]
-        elif theLayout in nwLists.DEP_LAYOUT:
+        if isinstance(itemLayout, nwItemLayout):
+            self._layout = itemLayout
+        elif isItemLayout(itemLayout):
+            self._layout = nwItemLayout[itemLayout]
+        elif itemLayout in nwLists.DEP_LAYOUT:
             self._layout = nwItemLayout.DOCUMENT
         else:
-            logger.error("Unrecognised item layout '%s'", theLayout)
+            logger.error("Unrecognised item layout '%s'", itemLayout)
             self._layout = nwItemLayout.NO_LAYOUT
         return
 
-    def setStatus(self, theStatus):
+    def setStatus(self, itemStatus):
         """Set the item status by looking it up in the valid status
         items of the current project.
         """
-        self._status = self.theProject.statusItems.check(theStatus)
+        self._status = self.theProject.statusItems.check(itemStatus)
         return
 
-    def setImport(self, theImport):
+    def setImport(self, itemImport):
         """Set the item importance by looking it up in the valid import
         items of the current project.
         """
-        self._import = self.theProject.importItems.check(theImport)
+        self._import = self.theProject.importItems.check(itemImport)
         return
 
-    def setExpanded(self, expState):
+    def setExpanded(self, state):
         """Set the expanded status of an item in the project tree.
         """
-        if isinstance(expState, str):
-            self._expanded = (expState == str(True))
+        if isinstance(state, str):
+            self._expanded = (state == str(True))
         else:
-            self._expanded = (expState is True)
+            self._expanded = (state is True)
         return
 
-    def setExported(self, expState):
+    def setExported(self, state):
         """Set the export flag.
         """
-        if isinstance(expState, str):
-            self._exported = (expState == str(True))
+        if isinstance(state, str):
+            self._exported = (state == str(True))
         else:
-            self._exported = (expState is True)
+            self._exported = (state is True)
         return
 
     ##
     #  Set Document Meta Data
     ##
 
-    def setCharCount(self, theCount):
+    def setCharCount(self, count):
         """Set the character count, and ensure that it is an integer.
         """
-        self._charCount = max(0, checkInt(theCount, 0))
+        self._charCount = max(0, checkInt(count, 0))
         return
 
-    def setWordCount(self, theCount):
+    def setWordCount(self, count):
         """Set the word count, and ensure that it is an integer.
         """
-        self._wordCount = max(0, checkInt(theCount, 0))
+        self._wordCount = max(0, checkInt(count, 0))
         return
 
-    def setParaCount(self, theCount):
+    def setParaCount(self, count):
         """Set the paragraph count, and ensure that it is an integer.
         """
-        self._paraCount = max(0, checkInt(theCount, 0))
+        self._paraCount = max(0, checkInt(count, 0))
         return
 
-    def setCursorPos(self, thePosition):
+    def setCursorPos(self, position):
         """Set the cursor position, and ensure that it is an integer.
         """
-        self._cursorPos = max(0, checkInt(thePosition, 0))
+        self._cursorPos = max(0, checkInt(position, 0))
         return
 
     def saveInitialCount(self):

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -29,7 +29,7 @@ from lxml import etree
 
 from novelwriter.enum import nwItemType, nwItemClass, nwItemLayout
 from novelwriter.common import (
-    checkInt, isHandle, isItemClass, isItemLayout, isItemType
+    checkInt, isHandle, isItemClass, isItemLayout, isItemType, simplified
 )
 from novelwriter.constants import nwLabels, nwLists, trConst
 
@@ -305,7 +305,7 @@ class NWItem():
         """Set the item name.
         """
         if isinstance(theName, str):
-            self._name = theName.strip()
+            self._name = simplified(theName)
         else:
             self._name = ""
         return

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -44,7 +44,7 @@ from novelwriter.enum import nwItemType, nwItemClass, nwItemLayout, nwAlert
 from novelwriter.error import logException
 from novelwriter.common import (
     checkString, checkBool, checkInt, isHandle, formatTimeStamp,
-    makeFileNameSafe, hexToInt
+    makeFileNameSafe, hexToInt, simplified
 )
 from novelwriter.constants import nwLists, trConst, nwFiles, nwLabels
 
@@ -534,14 +534,16 @@ class NWProject():
                     if xItem.text is None:
                         continue
                     if xItem.tag == "name":
-                        logger.verbose("Working Title: '%s'", xItem.text)
-                        self.projName = xItem.text
+                        self.projName = checkString(simplified(xItem.text), "")
+                        logger.verbose("Working Title: '%s'", self.projName)
                     elif xItem.tag == "title":
-                        logger.verbose("Title is '%s'", xItem.text)
-                        self.bookTitle = xItem.text
+                        self.bookTitle = checkString(simplified(xItem.text), "")
+                        logger.verbose("Title is '%s'", self.bookTitle)
                     elif xItem.tag == "author":
-                        logger.verbose("Author: '%s'", xItem.text)
-                        self.bookAuthors.append(xItem.text)
+                        author = checkString(simplified(xItem.text), "")
+                        if author:
+                            self.bookAuthors.append(author)
+                            logger.verbose("Author: '%s'", author)
                     elif xItem.tag == "saveCount":
                         self.saveCount = checkInt(xItem.text, 0)
                     elif xItem.tag == "autoCount":
@@ -956,14 +958,14 @@ class NWProject():
         """Set the project name (working title), This is the the title
         used for backup files etc.
         """
-        self.projName = projName.strip()
+        self.projName = simplified(projName)
         self.setProjectChanged(True)
         return True
 
     def setBookTitle(self, bookTitle):
         """Set the book title, that is, the title to include in exports.
         """
-        self.bookTitle = bookTitle.strip()
+        self.bookTitle = simplified(bookTitle)
         self.setProjectChanged(True)
         return True
 
@@ -975,7 +977,7 @@ class NWProject():
 
         self.bookAuthors = []
         for bookAuthor in bookAuthors.splitlines():
-            bookAuthor = bookAuthor.strip()
+            bookAuthor = simplified(bookAuthor)
             if bookAuthor == "":
                 continue
             self.bookAuthors.append(bookAuthor)
@@ -1114,7 +1116,9 @@ class NWProject():
     def setAutoReplace(self, autoReplace):
         """Update the auto-replace dictionary.
         """
-        self.autoReplace = autoReplace
+        self.autoReplace = {}
+        for key, entry in autoReplace.items():
+            self.autoReplace[key] = simplified(entry)
         self.setProjectChanged(True)
         return True
 
@@ -1123,7 +1127,9 @@ class NWProject():
         """
         for valKey, valEntry in titleFormat.items():
             if valKey in self.titleFormat:
-                self.titleFormat[valKey] = checkString(valEntry, self.titleFormat[valKey])
+                self.titleFormat[valKey] = checkString(
+                    simplified(valEntry), self.titleFormat[valKey]
+                )
         return True
 
     def setProjectChanged(self, bValue):

--- a/tests/reference/guiProjSettings_Dialog_nwProject.nwx
+++ b/tests/reference/guiProjSettings_Dialog_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.7-alpha0" hexVersion="0x010700a0" fileVersion="1.4" timeStamp="2022-04-16 13:57:03">
+<novelWriterXML appVersion="1.7-alpha0" hexVersion="0x010700a0" fileVersion="1.4" timeStamp="2022-04-16 16:54:15">
   <project>
     <name>Project Name</name>
     <title>Project Title</title>
@@ -23,7 +23,7 @@
     <autoReplace>
       <entry key="A">B</entry>
       <entry key="C">D</entry>
-      <entry key="This">With This Stuff </entry>
+      <entry key="This">With This Stuff</entry>
     </autoReplace>
     <titleFormat>
       <title>%title%</title>

--- a/tests/test_core/test_core_item.py
+++ b/tests/test_core/test_core_item.py
@@ -44,6 +44,8 @@ def testCoreItem_Setters(mockGUI, constData):
     assert theItem.itemName == "A Name"
     theItem.setName("\t A Name   ")
     assert theItem.itemName == "A Name"
+    theItem.setName("\t A\t\u2009\u202f\u2002\u2003\u2028\u2029Name   ")
+    assert theItem.itemName == "A Name"
     theItem.setName(123)
     assert theItem.itemName == ""
 


### PR DESCRIPTION
**Summary:**

Since XML doesn't handle multiple spaces in text in a predictable manner, the item labels should use the new `simplified` function on all text labels. The same should apply to other user-defined strings in the project.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
