### PR TITLE
Fix the redundant spaces highlight option text in Preferences

### DIFF
--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -902,7 +902,7 @@ class GuiPreferencesSyntax(QWidget):
         self.showMultiSpaces = QSwitch()
         self.showMultiSpaces.setChecked(self.mainConf.showMultiSpaces)
         self.mainForm.addRow(
-            self.tr("Highlight multiple spaces"),
+            self.tr("Highlight multiple or trailing spaces"),
             self.showMultiSpaces,
             self.tr("Applies to the document editor only.")
         )


### PR DESCRIPTION
**Summary:**

The text on the Preferences panel on highlighting multiple or trailing spaces was incomplete.

**Related Issue(s):**

Resolves #1043

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
