### PR TITLE
Force consistency of item settings

### DIFF
--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -239,6 +239,11 @@ class NWItem():
                 # version of novelWriter that doesn't know the tag
                 logger.error("Unknown tag '%s'", xValue.tag)
 
+        # Make some checks to ensure consistency
+        if self._type == nwItemType.ROOT:
+            self._root = self._handle  # Root items are their own ancestor
+            self._parent = None        # Root items cannot have a parent
+
         return True
 
     @staticmethod

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -171,7 +171,7 @@ class NWItem():
         nameAttrib["status"] = str(self._status)
         nameAttrib["import"] = str(self._import)
         if self._type == nwItemType.FILE:
-            nameAttrib["exported"]  = str(self._exported)
+            nameAttrib["exported"] = str(self._exported)
 
         xPack = etree.SubElement(xParent, "item", attrib=itemAttrib)
         self._subPack(xPack, "meta", attrib=metaAttrib)
@@ -243,6 +243,12 @@ class NWItem():
         if self._type == nwItemType.ROOT:
             self._root = self._handle  # Root items are their own ancestor
             self._parent = None        # Root items cannot have a parent
+
+        if self._type != nwItemType.FILE:
+            self._charCount = 0  # Only set for files
+            self._wordCount = 0  # Only set for files
+            self._paraCount = 0  # Only set for files
+            self._cursorPos = 0  # Only set for files
 
         return True
 


### PR DESCRIPTION
**Summary:**

This PR adds some checks to the loading of project items from XML to check that certain settings are consistent.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
