### PR TITLE
Quick delete empty folders

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -445,6 +445,7 @@ class GuiProjectTree(QTreeWidget):
 
         wCount = self._getItemWordCount(tHandle)
         if nwItemS.itemType == nwItemType.ROOT:
+            # Only an empty ROOT folder can be deleted
             logger.debug("User requested a root folder '%s' deleted", tHandle)
             tIndex = self.indexOfTopLevelItem(trItemS)
             if trItemS.childCount() == 0:
@@ -459,7 +460,17 @@ class GuiProjectTree(QTreeWidget):
                 ), nwAlert.ERROR)
                 return False
 
+        elif nwItemS.itemType == nwItemType.FOLDER and trItemS.childCount() == 0:
+            # An empty FOLDER is just deleted without any further checks
+            logger.debug("User requested an empty folder '%s' deleted", tHandle)
+            trItemP = trItemS.parent()
+            tIndex = trItemP.indexOfChild(trItemS)
+            trItemP.takeChild(tIndex)
+            self._deleteTreeItem(tHandle)
+            self._setTreeChanged(True)
+
         else:
+            # A populated FOLDER or a FILE requires confirmtation
             logger.debug("User requested a file or folder '%s' deleted", tHandle)
             trItemP = trItemS.parent()
             trItemT = self._addTrashRoot()

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -760,8 +760,8 @@ class GuiProjectTree(QTreeWidget):
         return
 
     def dropEvent(self, theEvent):
-        """Overload the drop of dragged item event to check whether the
-        drop is allowed or not. Disallowed drops are cancelled.
+        """Overload the drop item event to ensure relevant data has been
+        updated.
         """
         sHandle = self.getSelectedHandle()
         if sHandle is None:

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -398,6 +398,15 @@ def testGuiProjTree_DeleteItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockR
     assert not os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000015.nwd"))
     assert not os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000016.nwd"))
 
+    # Add an empty folder, which can be deleted with no further restrictions
+    nwTree.setSelectedHandle("0000000000009")
+    assert nwTree.newTreeItem(nwItemType.FOLDER) is True
+    assert nwTree.getTreeFromHandle("0000000000009") == ["0000000000009", "0000000000017"]
+
+    nwTree.setSelectedHandle("0000000000017")
+    assert nwTree.deleteItem("0000000000017") is True
+    assert nwTree.getTreeFromHandle("0000000000009") == ["0000000000009"]
+
     # Empty Trash
     # ===========
 


### PR DESCRIPTION
**Summary:**

Deleting an empty folder should not go through Trash. It can be deleted directly.

**Related Issue(s):**

Resolves #1052

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
