### PR TITLE
Add icon name to xdg mime type just in case

### DIFF
--- a/setup/data/x-novelwriter-project.xml
+++ b/setup/data/x-novelwriter-project.xml
@@ -4,5 +4,6 @@
     <comment>novelWriter Project</comment>
     <sub-class-of type="application/xml"/>
     <glob pattern="*.nwx"/>
+    <icon name="application-x-novelwriter-project"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
Adds the icon name to the mimetype XML, but it still doesn't seem to load on newer versions of Nautilus. Works in other file explorer tools.