### PR TITLE
Set build language for Open Document files

### DIFF
--- a/novelwriter/tools/build.py
+++ b/novelwriter/tools/build.py
@@ -659,6 +659,7 @@ class GuiBuildNovel(QDialog):
         fmtUnnumbered = self.fmtUnnumbered.text()
         fmtScene      = self.fmtScene.text()
         fmtSection    = self.fmtSection.text()
+        buildLang     = self.buildLang.currentData()
         hideScene     = self.hideScene.isChecked()
         hideSection   = self.hideSection.isChecked()
         textFont      = self.textFont.text()
@@ -676,7 +677,7 @@ class GuiBuildNovel(QDialog):
         replaceUCode  = self.replaceUCode.isChecked()
 
         # The language lookup dict is reloaded if needed
-        self.theProject.setProjectLang(self.buildLang.currentData())
+        self.theProject.setProjectLang(buildLang)
 
         # Get font information
         fontInfo = QFontInfo(QFont(textFont, textSize))
@@ -706,6 +707,7 @@ class GuiBuildNovel(QDialog):
 
         if isOdt:
             bldObj.setColourHeaders(not noStyling)
+            bldObj.setLanguage(buildLang)
             bldObj.initDocument()
 
         # Make sure the project and document is up to date


### PR DESCRIPTION
**Summary:**

Fix build language not being forwarded to the ODT document class.

**Related Issue(s):**

Closes #1073

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
