### PR TITLE
Give main GUI objects better names

### DIFF
--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -82,7 +82,6 @@ class Tokenizer(ABC):
     def __init__(self, theProject):
 
         self.theProject = theProject
-        self.theParent  = theProject.theParent
         self.mainConf   = novelwriter.CONFIG
 
         # Data Variables

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -49,9 +49,9 @@ class GuiAbout(QDialog):
         logger.debug("Initialising GuiAbout ...")
         self.setObjectName("GuiAbout")
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         self.outerBox = QVBoxLayout()
         self.innerBox = QHBoxLayout()
@@ -63,7 +63,7 @@ class GuiAbout(QDialog):
 
         nPx = self.mainConf.pxInt(96)
         self.nwIcon = QLabel()
-        self.nwIcon.setPixmap(self.mainGui.theTheme.getPixmap("novelwriter", (nPx, nPx)))
+        self.nwIcon.setPixmap(self.mainGui.mainTheme.getPixmap("novelwriter", (nPx, nPx)))
         self.lblName = QLabel("<b>novelWriter</b>")
         self.lblVers = QLabel(f"v{novelwriter.__version__}")
         self.lblDate = QLabel(datetime.strptime(novelwriter.__date__, "%Y-%m-%d").strftime("%x"))
@@ -191,37 +191,37 @@ class GuiAbout(QDialog):
             ])
         )
 
-        theTheme = self.mainGui.theTheme
-        theIcons = self.mainGui.theTheme.theIcons
-        if theTheme.themeName and theTheme.themeAuthor != "N/A":
-            licURL = f"<a href='{theTheme.themeLicenseUrl}'>{theTheme.themeLicense}</a>"
+        mainTheme = self.mainGui.mainTheme
+        iconCache = self.mainGui.mainTheme.iconCache
+        if mainTheme.themeName and mainTheme.themeAuthor != "N/A":
+            licURL = f"<a href='{mainTheme.themeLicenseUrl}'>{mainTheme.themeLicense}</a>"
             aboutMsg += "<h4>{0}</h4><p>{1}</p>".format(
-                self.tr("Theme: {0}").format(theTheme.themeName),
+                self.tr("Theme: {0}").format(mainTheme.themeName),
                 self._wrapTable([
-                    (self.tr("Author"), theTheme.themeAuthor),
-                    (self.tr("Credit"), theTheme.themeCredit),
+                    (self.tr("Author"), mainTheme.themeAuthor),
+                    (self.tr("Credit"), mainTheme.themeCredit),
                     (self.tr("Licence"), licURL),
                 ])
             )
 
-        if theIcons.themeName:
-            licURL = f"<a href='{theIcons.themeLicenseUrl}'>{theIcons.themeLicense}</a>"
+        if iconCache.themeName:
+            licURL = f"<a href='{iconCache.themeLicenseUrl}'>{iconCache.themeLicense}</a>"
             aboutMsg += "<h4>{0}</h4><p>{1}</p>".format(
-                self.tr("Icons: {0}").format(theIcons.themeName),
+                self.tr("Icons: {0}").format(iconCache.themeName),
                 self._wrapTable([
-                    (self.tr("Author"), theIcons.themeAuthor),
-                    (self.tr("Credit"), theIcons.themeCredit),
+                    (self.tr("Author"), iconCache.themeAuthor),
+                    (self.tr("Credit"), iconCache.themeCredit),
                     (self.tr("Licence"), licURL),
                 ])
             )
 
-        if theTheme.syntaxName:
-            licURL = f"<a href='{theTheme.syntaxLicenseUrl}'>{theTheme.syntaxLicense}</a>"
+        if mainTheme.syntaxName:
+            licURL = f"<a href='{mainTheme.syntaxLicenseUrl}'>{mainTheme.syntaxLicense}</a>"
             aboutMsg += "<h4>{0}</h4><p>{1}</p>".format(
-                self.tr("Syntax: {0}").format(theTheme.syntaxName),
+                self.tr("Syntax: {0}").format(mainTheme.syntaxName),
                 self._wrapTable([
-                    (self.tr("Author"), theTheme.syntaxAuthor),
-                    (self.tr("Credit"), theTheme.syntaxCredit),
+                    (self.tr("Author"), mainTheme.syntaxAuthor),
+                    (self.tr("Credit"), mainTheme.syntaxCredit),
                     (self.tr("Licence"), licURL),
                 ])
             )
@@ -279,12 +279,12 @@ class GuiAbout(QDialog):
             "  padding-right: 0.8em;"
             "}}\n"
         ).format(
-            hColR=self.mainGui.theTheme.colHead[0],
-            hColG=self.mainGui.theTheme.colHead[1],
-            hColB=self.mainGui.theTheme.colHead[2],
-            kColR=self.theTheme.colKey[0],
-            kColG=self.theTheme.colKey[1],
-            kColB=self.theTheme.colKey[2],
+            hColR=self.mainGui.mainTheme.colHead[0],
+            hColG=self.mainGui.mainTheme.colHead[1],
+            hColB=self.mainGui.mainTheme.colHead[2],
+            kColR=self.mainTheme.colKey[0],
+            kColG=self.mainTheme.colKey[1],
+            kColB=self.mainTheme.colKey[2],
         )
         self.pageAbout.document().setDefaultStyleSheet(styleSheet)
         self.pageNotes.document().setDefaultStyleSheet(styleSheet)

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -43,15 +43,15 @@ logger = logging.getLogger(__name__)
 
 class GuiAbout(QDialog):
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiAbout ...")
         self.setObjectName("GuiAbout")
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         self.outerBox = QVBoxLayout()
         self.innerBox = QHBoxLayout()
@@ -63,7 +63,7 @@ class GuiAbout(QDialog):
 
         nPx = self.mainConf.pxInt(96)
         self.nwIcon = QLabel()
-        self.nwIcon.setPixmap(self.theParent.theTheme.getPixmap("novelwriter", (nPx, nPx)))
+        self.nwIcon.setPixmap(self.mainGui.theTheme.getPixmap("novelwriter", (nPx, nPx)))
         self.lblName = QLabel("<b>novelWriter</b>")
         self.lblVers = QLabel(f"v{novelwriter.__version__}")
         self.lblDate = QLabel(datetime.strptime(novelwriter.__date__, "%Y-%m-%d").strftime("%x"))
@@ -191,8 +191,8 @@ class GuiAbout(QDialog):
             ])
         )
 
-        theTheme = self.theParent.theTheme
-        theIcons = self.theParent.theTheme.theIcons
+        theTheme = self.mainGui.theTheme
+        theIcons = self.mainGui.theTheme.theIcons
         if theTheme.themeName and theTheme.themeAuthor != "N/A":
             licURL = f"<a href='{theTheme.themeLicenseUrl}'>{theTheme.themeLicense}</a>"
             aboutMsg += "<h4>{0}</h4><p>{1}</p>".format(
@@ -279,9 +279,9 @@ class GuiAbout(QDialog):
             "  padding-right: 0.8em;"
             "}}\n"
         ).format(
-            hColR=self.theParent.theTheme.colHead[0],
-            hColG=self.theParent.theTheme.colHead[1],
-            hColB=self.theParent.theTheme.colHead[2],
+            hColR=self.mainGui.theTheme.colHead[0],
+            hColG=self.mainGui.theTheme.colHead[1],
+            hColB=self.mainGui.theTheme.colHead[2],
             kColR=self.theTheme.colKey[0],
             kColG=self.theTheme.colKey[1],
             kColB=self.theTheme.colKey[2],

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -142,7 +142,7 @@ class GuiDocMerge(QDialog):
             ], nwAlert.ERROR)
             return False
 
-        self.mainGui.treeView.revealNewTreeItem(nHandle)
+        self.mainGui.projView.revealNewTreeItem(nHandle)
         self.mainGui.openDocument(nHandle, doScroll=True)
 
         self._doClose()
@@ -165,7 +165,7 @@ class GuiDocMerge(QDialog):
         are then added to the list view in order. The list itself can be
         reordered by the user.
         """
-        tHandle = self.mainGui.treeView.getSelectedHandle()
+        tHandle = self.mainGui.projView.getSelectedHandle()
         self.sourceItem = tHandle
         if tHandle is None:
             return False
@@ -180,7 +180,7 @@ class GuiDocMerge(QDialog):
             ), nwAlert.ERROR)
             return False
 
-        for sHandle in self.mainGui.treeView.getTreeFromHandle(tHandle):
+        for sHandle in self.mainGui.projView.getTreeFromHandle(tHandle):
             newItem = QListWidgetItem()
             nwItem  = self.theProject.tree[sHandle]
             if nwItem.itemType is not nwItemType.FILE:

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -41,15 +41,15 @@ logger = logging.getLogger(__name__)
 
 class GuiDocMerge(QDialog):
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiDocMerge ...")
         self.setObjectName("GuiDocMerge")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
         self.sourceItem = None
 
         self.outerBox = QVBoxLayout()
@@ -57,7 +57,7 @@ class GuiDocMerge(QDialog):
 
         self.headLabel = QLabel("<b>{0}</b>".format(self.tr("Documents to Merge")))
         self.helpLabel = QHelpLabel(
-            self.tr("Drag and drop items to change the order."), self.theParent.theTheme.helpText
+            self.tr("Drag and drop items to change the order."), self.mainGui.theTheme.helpText
         )
 
         self.listBox = QListWidget()
@@ -102,7 +102,7 @@ class GuiDocMerge(QDialog):
             finalOrder.append(self.listBox.item(i).data(Qt.UserRole))
 
         if len(finalOrder) == 0:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "No source documents found. Nothing to do."
             ), nwAlert.ERROR)
             return False
@@ -113,21 +113,21 @@ class GuiDocMerge(QDialog):
             docText = inDoc.readDocument()
             docErr = inDoc.getError()
             if docText is None and docErr:
-                self.theParent.makeAlert([
+                self.mainGui.makeAlert([
                     self.tr("Failed to open document file."), docErr
                 ], nwAlert.ERROR)
             if docText:
                 theText += docText.rstrip("\n")+"\n\n"
 
         if self.sourceItem is None:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "No source folder selected. Nothing to do."
             ), nwAlert.ERROR)
             return False
 
         srcItem = self.theProject.tree[self.sourceItem]
         if srcItem is None:
-            self.theParent.makeAlert(self.tr("Internal error."), nwAlert.ERROR)
+            self.mainGui.makeAlert(self.tr("Internal error."), nwAlert.ERROR)
             return False
 
         nHandle = self.theProject.newFile(srcItem.itemName, srcItem.itemParent)
@@ -137,13 +137,13 @@ class GuiDocMerge(QDialog):
 
         outDoc = NWDoc(self.theProject, nHandle)
         if not outDoc.writeDocument(theText):
-            self.theParent.makeAlert([
+            self.mainGui.makeAlert([
                 self.tr("Could not save document."), outDoc.getError()
             ], nwAlert.ERROR)
             return False
 
-        self.theParent.treeView.revealNewTreeItem(nHandle)
-        self.theParent.openDocument(nHandle, doScroll=True)
+        self.mainGui.treeView.revealNewTreeItem(nHandle)
+        self.mainGui.openDocument(nHandle, doScroll=True)
 
         self._doClose()
 
@@ -165,7 +165,7 @@ class GuiDocMerge(QDialog):
         are then added to the list view in order. The list itself can be
         reordered by the user.
         """
-        tHandle = self.theParent.treeView.getSelectedHandle()
+        tHandle = self.mainGui.treeView.getSelectedHandle()
         self.sourceItem = tHandle
         if tHandle is None:
             return False
@@ -175,12 +175,12 @@ class GuiDocMerge(QDialog):
             return False
 
         if nwItem.itemType is not nwItemType.FOLDER:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "Element selected in the project tree must be a folder."
             ), nwAlert.ERROR)
             return False
 
-        for sHandle in self.theParent.treeView.getTreeFromHandle(tHandle):
+        for sHandle in self.mainGui.treeView.getTreeFromHandle(tHandle):
             newItem = QListWidgetItem()
             nwItem  = self.theProject.tree[sHandle]
             if nwItem.itemType is not nwItemType.FILE:

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -57,7 +57,7 @@ class GuiDocMerge(QDialog):
 
         self.headLabel = QLabel("<b>{0}</b>".format(self.tr("Documents to Merge")))
         self.helpLabel = QHelpLabel(
-            self.tr("Drag and drop items to change the order."), self.mainGui.theTheme.helpText
+            self.tr("Drag and drop items to change the order."), self.mainGui.mainTheme.helpText
         )
 
         self.listBox = QListWidget()

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -41,15 +41,15 @@ logger = logging.getLogger(__name__)
 
 class GuiDocSplit(QDialog):
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiDocSplit ...")
         self.setObjectName("GuiDocSplit")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
 
         self.sourceItem = None
         self.sourceText = []
@@ -60,7 +60,7 @@ class GuiDocSplit(QDialog):
         self.headLabel = QLabel("<b>{0}</b>".format(self.tr("Document Headers")))
         self.helpLabel = QHelpLabel(
             self.tr("Select the maximum level to split into files."),
-            self.theParent.theTheme.helpText
+            self.mainGui.theTheme.helpText
         )
 
         self.listBox = QListWidget()
@@ -115,14 +115,14 @@ class GuiDocSplit(QDialog):
         logger.verbose("GuiDocSplit split button clicked")
 
         if self.sourceItem is None:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "No source document selected. Nothing to do."
             ), nwAlert.ERROR)
             return False
 
         srcItem = self.theProject.tree[self.sourceItem]
         if srcItem is None:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "Could not parse source document."
             ), nwAlert.ERROR)
             return False
@@ -132,7 +132,7 @@ class GuiDocSplit(QDialog):
 
         docErr = inDoc.getError()
         if theText is None and docErr:
-            self.theParent.makeAlert([
+            self.mainGui.makeAlert([
                 self.tr("Failed to open document file."), docErr
             ], nwAlert.ERROR)
 
@@ -153,12 +153,12 @@ class GuiDocSplit(QDialog):
 
         nFiles = len(finalOrder)
         if nFiles == 0:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "No headers found. Nothing to do."
             ), nwAlert.ERROR)
             return False
 
-        msgYes = self.theParent.askQuestion(
+        msgYes = self.mainGui.askQuestion(
             self.tr("Split Document"),
             "{0}<br><br>{1}".format(
                 self.tr(
@@ -175,7 +175,7 @@ class GuiDocSplit(QDialog):
 
         # Create the folder
         fHandle = self.theProject.newFolder(srcItem.itemName, srcItem.itemParent)
-        self.theParent.treeView.revealNewTreeItem(fHandle)
+        self.mainGui.treeView.revealNewTreeItem(fHandle)
         logger.verbose("Creating folder '%s'", fHandle)
 
         # Loop through, and create the files
@@ -196,12 +196,12 @@ class GuiDocSplit(QDialog):
 
             outDoc = NWDoc(self.theProject, nHandle)
             if not outDoc.writeDocument(theText):
-                self.theParent.makeAlert([
+                self.mainGui.makeAlert([
                     self.tr("Could not save document."), outDoc.getError()
                 ], nwAlert.ERROR)
                 return False
 
-            self.theParent.treeView.revealNewTreeItem(nHandle)
+            self.mainGui.treeView.revealNewTreeItem(nHandle)
 
         self._doClose()
 
@@ -226,7 +226,7 @@ class GuiDocSplit(QDialog):
         """
         self.listBox.clear()
         if self.sourceItem is None:
-            self.sourceItem = self.theParent.treeView.getSelectedHandle()
+            self.sourceItem = self.mainGui.treeView.getSelectedHandle()
 
         if self.sourceItem is None:
             return False
@@ -236,7 +236,7 @@ class GuiDocSplit(QDialog):
             return False
 
         if nwItem.itemType is not nwItemType.FILE:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "Element selected in the project tree must be a file."
             ), nwAlert.ERROR)
             return False

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -175,7 +175,7 @@ class GuiDocSplit(QDialog):
 
         # Create the folder
         fHandle = self.theProject.newFolder(srcItem.itemName, srcItem.itemParent)
-        self.mainGui.treeView.revealNewTreeItem(fHandle)
+        self.mainGui.projView.revealNewTreeItem(fHandle)
         logger.verbose("Creating folder '%s'", fHandle)
 
         # Loop through, and create the files
@@ -201,7 +201,7 @@ class GuiDocSplit(QDialog):
                 ], nwAlert.ERROR)
                 return False
 
-            self.mainGui.treeView.revealNewTreeItem(nHandle)
+            self.mainGui.projView.revealNewTreeItem(nHandle)
 
         self._doClose()
 
@@ -226,7 +226,7 @@ class GuiDocSplit(QDialog):
         """
         self.listBox.clear()
         if self.sourceItem is None:
-            self.sourceItem = self.mainGui.treeView.getSelectedHandle()
+            self.sourceItem = self.mainGui.projView.getSelectedHandle()
 
         if self.sourceItem is None:
             return False

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -60,7 +60,7 @@ class GuiDocSplit(QDialog):
         self.headLabel = QLabel("<b>{0}</b>".format(self.tr("Document Headers")))
         self.helpLabel = QHelpLabel(
             self.tr("Select the maximum level to split into files."),
-            self.mainGui.theTheme.helpText
+            self.mainGui.mainTheme.helpText
         )
 
         self.listBox = QListWidget()

--- a/novelwriter/dialogs/itemeditor.py
+++ b/novelwriter/dialogs/itemeditor.py
@@ -41,15 +41,15 @@ logger = logging.getLogger(__name__)
 
 class GuiItemEditor(QDialog):
 
-    def __init__(self, theParent, tHandle):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui, tHandle):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiItemEditor ...")
         self.setObjectName("GuiItemEditor")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
 
         ##
         #  Build GUI

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -141,13 +141,13 @@ class GuiPreferencesGeneral(QWidget):
     def __init__(self, mainGui):
         QWidget.__init__(self, mainGui)
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         # Look and Feel
@@ -174,7 +174,7 @@ class GuiPreferencesGeneral(QWidget):
         # Select Theme
         self.guiTheme = QComboBox()
         self.guiTheme.setMinimumWidth(minWidth)
-        self.theThemes = self.theTheme.listThemes()
+        self.theThemes = self.mainTheme.listThemes()
         for themeDir, themeName in self.theThemes:
             self.guiTheme.addItem(themeName, themeDir)
         themeIdx = self.guiTheme.findData(self.mainConf.guiTheme)
@@ -190,8 +190,8 @@ class GuiPreferencesGeneral(QWidget):
         # Select Icon Theme
         self.guiIcons = QComboBox()
         self.guiIcons.setMinimumWidth(minWidth)
-        self.theIcons = self.theTheme.theIcons.listThemes()
-        for iconDir, iconName in self.theIcons:
+        self.iconCache = self.mainTheme.iconCache.listThemes()
+        for iconDir, iconName in self.iconCache:
             self.guiIcons.addItem(iconName, iconDir)
         iconIdx = self.guiIcons.findData(self.mainConf.guiIcons)
         if iconIdx != -1:
@@ -206,7 +206,7 @@ class GuiPreferencesGeneral(QWidget):
         # Editor Theme
         self.guiSyntax = QComboBox()
         self.guiSyntax.setMinimumWidth(self.mainConf.pxInt(200))
-        self.theSyntaxes = self.theTheme.listSyntax()
+        self.theSyntaxes = self.mainTheme.listSyntax()
         for syntaxFile, syntaxName in self.theSyntaxes:
             self.guiSyntax.addItem(syntaxName, syntaxFile)
         syntaxIdx = self.guiSyntax.findData(self.mainConf.guiSyntax)
@@ -225,7 +225,7 @@ class GuiPreferencesGeneral(QWidget):
         self.guiFont.setFixedWidth(self.mainConf.pxInt(162))
         self.guiFont.setText(self.mainConf.guiFont)
         self.fontButton = QPushButton("...")
-        self.fontButton.setMaximumWidth(int(2.5*self.theTheme.getTextWidth("...")))
+        self.fontButton.setMaximumWidth(int(2.5*self.mainTheme.getTextWidth("...")))
         self.fontButton.clicked.connect(self._selectFont)
         self.mainForm.addRow(
             self.tr("Font family"),
@@ -347,13 +347,13 @@ class GuiPreferencesProjects(QWidget):
     def __init__(self, mainGui):
         QWidget.__init__(self, mainGui)
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         # Automatic Save
@@ -508,13 +508,13 @@ class GuiPreferencesDocuments(QWidget):
     def __init__(self, mainGui):
         QWidget.__init__(self, mainGui)
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         # Text Style
@@ -527,7 +527,7 @@ class GuiPreferencesDocuments(QWidget):
         self.textFont.setFixedWidth(self.mainConf.pxInt(162))
         self.textFont.setText(self.mainConf.textFont)
         self.fontButton = QPushButton("...")
-        self.fontButton.setMaximumWidth(int(2.5*self.theTheme.getTextWidth("...")))
+        self.fontButton.setMaximumWidth(int(2.5*self.mainTheme.getTextWidth("...")))
         self.fontButton.clicked.connect(self._selectFont)
         self.mainForm.addRow(
             self.tr("Font family"),
@@ -669,13 +669,13 @@ class GuiPreferencesEditor(QWidget):
     def __init__(self, mainGui):
         QWidget.__init__(self, mainGui)
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         mW = self.mainConf.pxInt(250)
@@ -843,13 +843,13 @@ class GuiPreferencesSyntax(QWidget):
     def __init__(self, mainGui):
         QWidget.__init__(self, mainGui)
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         # Quotes & Dialogue
@@ -946,13 +946,13 @@ class GuiPreferencesAutomation(QWidget):
     def __init__(self, mainGui):
         QWidget.__init__(self, mainGui)
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         # Automatic Features
@@ -1103,13 +1103,13 @@ class GuiPreferencesQuotes(QWidget):
     def __init__(self, mainGui):
         QWidget.__init__(self, mainGui)
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         # Quotation Style
@@ -1117,7 +1117,7 @@ class GuiPreferencesQuotes(QWidget):
         self.mainForm.addGroupLabel(self.tr("Quotation Style"))
 
         qWidth = self.mainConf.pxInt(40)
-        bWidth = int(2.5*self.theTheme.getTextWidth("..."))
+        bWidth = int(2.5*self.mainTheme.getTextWidth("..."))
         self.quoteSym = {}
 
         # Single Quote Style

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -107,7 +107,7 @@ class GuiPreferences(PagedDialog):
             ), nwAlert.INFO)
 
         if refreshTree:
-            self.mainGui.treeView.populateTree()
+            self.mainGui.projView.populateTree()
 
         self._saveWindowSize()
         self.accept()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -43,25 +43,25 @@ logger = logging.getLogger(__name__)
 
 class GuiPreferences(PagedDialog):
 
-    def __init__(self, theParent):
-        PagedDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        PagedDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiPreferences ...")
         self.setObjectName("GuiPreferences")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
 
         self.setWindowTitle(self.tr("Preferences"))
 
-        self.tabGeneral  = GuiPreferencesGeneral(self.theParent)
-        self.tabProjects = GuiPreferencesProjects(self.theParent)
-        self.tabDocs     = GuiPreferencesDocuments(self.theParent)
-        self.tabEditor   = GuiPreferencesEditor(self.theParent)
-        self.tabSyntax   = GuiPreferencesSyntax(self.theParent)
-        self.tabAuto     = GuiPreferencesAutomation(self.theParent)
-        self.tabQuote    = GuiPreferencesQuotes(self.theParent)
+        self.tabGeneral  = GuiPreferencesGeneral(self.mainGui)
+        self.tabProjects = GuiPreferencesProjects(self.mainGui)
+        self.tabDocs     = GuiPreferencesDocuments(self.mainGui)
+        self.tabEditor   = GuiPreferencesEditor(self.mainGui)
+        self.tabSyntax   = GuiPreferencesSyntax(self.mainGui)
+        self.tabAuto     = GuiPreferencesAutomation(self.mainGui)
+        self.tabQuote    = GuiPreferencesQuotes(self.mainGui)
 
         self.addTab(self.tabGeneral,  self.tr("General"))
         self.addTab(self.tabProjects, self.tr("Projects"))
@@ -102,12 +102,12 @@ class GuiPreferences(PagedDialog):
         self.tabQuote.saveValues()
 
         if needsRestart:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "Some changes will not be applied until novelWriter has been restarted."
             ), nwAlert.INFO)
 
         if refreshTree:
-            self.theParent.treeView.populateTree()
+            self.mainGui.treeView.populateTree()
 
         self._saveWindowSize()
         self.accept()
@@ -138,12 +138,12 @@ class GuiPreferences(PagedDialog):
 
 class GuiPreferencesGeneral(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # The Form
         self.mainForm = QConfigLayout()
@@ -344,12 +344,12 @@ class GuiPreferencesGeneral(QWidget):
 
 class GuiPreferencesProjects(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # The Form
         self.mainForm = QConfigLayout()
@@ -505,12 +505,12 @@ class GuiPreferencesProjects(QWidget):
 
 class GuiPreferencesDocuments(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # The Form
         self.mainForm = QConfigLayout()
@@ -666,12 +666,12 @@ class GuiPreferencesDocuments(QWidget):
 
 class GuiPreferencesEditor(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # The Form
         self.mainForm = QConfigLayout()
@@ -688,7 +688,7 @@ class GuiPreferencesEditor(QWidget):
         self.spellLanguage = QComboBox(self)
         self.spellLanguage.setMaximumWidth(mW)
 
-        langAvail = self.theParent.docEditor.spEnchant.listDictionaries()
+        langAvail = self.mainGui.docEditor.spEnchant.listDictionaries()
         if self.mainConf.hasEnchant:
             if langAvail:
                 for spTag, spProv in langAvail:
@@ -840,12 +840,12 @@ class GuiPreferencesEditor(QWidget):
 
 class GuiPreferencesSyntax(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # The Form
         self.mainForm = QConfigLayout()
@@ -943,12 +943,12 @@ class GuiPreferencesSyntax(QWidget):
 
 class GuiPreferencesAutomation(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # The Form
         self.mainForm = QConfigLayout()
@@ -1100,12 +1100,12 @@ class GuiPreferencesAutomation(QWidget):
 
 class GuiPreferencesQuotes(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # The Form
         self.mainForm = QConfigLayout()

--- a/novelwriter/dialogs/projdetails.py
+++ b/novelwriter/dialogs/projdetails.py
@@ -43,15 +43,15 @@ logger = logging.getLogger(__name__)
 
 class GuiProjectDetails(PagedDialog):
 
-    def __init__(self, theParent):
-        PagedDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        PagedDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiProjectDetails ...")
         self.setObjectName("GuiProjectDetails")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
 
         self.setWindowTitle(self.tr("Project Details"))
 
@@ -66,8 +66,8 @@ class GuiProjectDetails(PagedDialog):
             self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "winHeight", wH))
         )
 
-        self.tabMain = GuiProjectDetailsMain(self.theParent, self.theProject)
-        self.tabContents = GuiProjectDetailsContents(self.theParent, self.theProject)
+        self.tabMain = GuiProjectDetailsMain(self.mainGui, self.theProject)
+        self.tabContents = GuiProjectDetailsContents(self.mainGui, self.theProject)
 
         self.addTab(self.tabMain, self.tr("Overview"))
         self.addTab(self.tabContents, self.tr("Contents"))
@@ -139,13 +139,13 @@ class GuiProjectDetails(PagedDialog):
 
 class GuiProjectDetailsMain(QWidget):
 
-    def __init__(self, theParent, theProject):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui, theProject):
+        QWidget.__init__(self, mainGui)
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
         self.theProject = theProject
-        self.theTheme   = theParent.theTheme
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
 
         fPx = self.theTheme.fontPixelSize
         fPt = self.theTheme.fontPointSize
@@ -271,13 +271,13 @@ class GuiProjectDetailsContents(QWidget):
     C_PAGE  = 3
     C_PROG  = 4
 
-    def __init__(self, theParent, theProject):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui, theProject):
+        QWidget.__init__(self, mainGui)
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
         self.theProject = theProject
-        self.theTheme   = theParent.theTheme
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
 
         # Internal
         self._theToC = []

--- a/novelwriter/dialogs/projdetails.py
+++ b/novelwriter/dialogs/projdetails.py
@@ -145,10 +145,10 @@ class GuiProjectDetailsMain(QWidget):
         self.mainConf   = novelwriter.CONFIG
         self.theProject = theProject
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
 
-        fPx = self.theTheme.fontPixelSize
-        fPt = self.theTheme.fontPointSize
+        fPx = self.mainTheme.fontPixelSize
+        fPt = self.mainTheme.fontPointSize
         vPx = self.mainConf.pxInt(4)
         hPx = self.mainConf.pxInt(12)
 
@@ -277,12 +277,12 @@ class GuiProjectDetailsContents(QWidget):
         self.mainConf   = novelwriter.CONFIG
         self.theProject = theProject
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
 
         # Internal
         self._theToC = []
 
-        iPx = self.theTheme.baseIconSize
+        iPx = self.mainTheme.baseIconSize
         hPx = self.mainConf.pxInt(12)
         vPx = self.mainConf.pxInt(4)
         pOptions = self.theProject.options
@@ -469,7 +469,7 @@ class GuiProjectDetailsContents(QWidget):
             if tTitle.strip() == "":
                 tTitle = self.tr("Untitled")
 
-            newItem.setIcon(self.C_TITLE, self.theTheme.getIcon("doc_h%d" % tLevel))
+            newItem.setIcon(self.C_TITLE, self.mainTheme.getIcon("doc_h%d" % tLevel))
             newItem.setText(self.C_TITLE, tTitle)
             newItem.setText(self.C_WORDS, f"{wCount:n}")
             newItem.setText(self.C_PAGES, f"{pCount:n}")

--- a/novelwriter/dialogs/projload.py
+++ b/novelwriter/dialogs/projload.py
@@ -61,13 +61,13 @@ class GuiProjectLoad(QDialog):
 
         self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
-        self.theTheme  = mainGui.theTheme
+        self.mainTheme = mainGui.mainTheme
         self.openState = self.NONE_STATE
         self.openPath  = None
 
         sPx = self.mainConf.pxInt(16)
         nPx = self.mainConf.pxInt(96)
-        iPx = self.theTheme.baseIconSize
+        iPx = self.mainTheme.baseIconSize
 
         self.outerBox = QVBoxLayout()
         self.innerBox = QHBoxLayout()
@@ -80,7 +80,7 @@ class GuiProjectLoad(QDialog):
         self.setModal(True)
 
         self.nwIcon = QLabel()
-        self.nwIcon.setPixmap(self.mainGui.theTheme.getPixmap("novelwriter", (nPx, nPx)))
+        self.nwIcon.setPixmap(self.mainGui.mainTheme.getPixmap("novelwriter", (nPx, nPx)))
         self.innerBox.addWidget(self.nwIcon, 0, Qt.AlignTop)
 
         self.projectForm = QGridLayout()
@@ -110,7 +110,7 @@ class GuiProjectLoad(QDialog):
         self.selPath.setReadOnly(True)
 
         self.browseButton = QPushButton("...")
-        self.browseButton.setMaximumWidth(int(2.5*self.theTheme.getTextWidth("...")))
+        self.browseButton.setMaximumWidth(int(2.5*self.mainTheme.getTextWidth("...")))
         self.browseButton.clicked.connect(self._doBrowse)
 
         self.projectForm.addWidget(self.lblRecent,    0, 0, 1, 3)
@@ -280,7 +280,7 @@ class GuiProjectLoad(QDialog):
         sortList = sorted(dataList, key=lambda x: x[1], reverse=True)
         for theTitle, theTime, theWords, projPath in sortList:
             newItem = QTreeWidgetItem([""]*4)
-            newItem.setIcon(self.C_NAME,  self.mainGui.theTheme.getIcon("proj_nwx"))
+            newItem.setIcon(self.C_NAME,  self.mainGui.mainTheme.getIcon("proj_nwx"))
             newItem.setText(self.C_NAME,  theTitle)
             newItem.setData(self.C_NAME,  Qt.UserRole, projPath)
             newItem.setText(self.C_COUNT, formatInt(theWords))
@@ -288,7 +288,7 @@ class GuiProjectLoad(QDialog):
             newItem.setTextAlignment(self.C_NAME,  Qt.AlignLeft  | Qt.AlignVCenter)
             newItem.setTextAlignment(self.C_COUNT, Qt.AlignRight | Qt.AlignVCenter)
             newItem.setTextAlignment(self.C_TIME,  Qt.AlignRight | Qt.AlignVCenter)
-            newItem.setFont(self.C_TIME, self.theTheme.guiFontFixed)
+            newItem.setFont(self.C_TIME, self.mainTheme.guiFontFixed)
             self.listBox.addTopLevelItem(newItem)
 
         if self.listBox.topLevelItemCount() > 0:

--- a/novelwriter/dialogs/projload.py
+++ b/novelwriter/dialogs/projload.py
@@ -53,15 +53,15 @@ class GuiProjectLoad(QDialog):
     C_COUNT = 1
     C_TIME  = 2
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiProjectLoad ...")
         self.setObjectName("GuiProjectLoad")
 
         self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainGui   = mainGui
+        self.theTheme  = mainGui.theTheme
         self.openState = self.NONE_STATE
         self.openPath  = None
 
@@ -80,7 +80,7 @@ class GuiProjectLoad(QDialog):
         self.setModal(True)
 
         self.nwIcon = QLabel()
-        self.nwIcon.setPixmap(self.theParent.theTheme.getPixmap("novelwriter", (nPx, nPx)))
+        self.nwIcon.setPixmap(self.mainGui.theTheme.getPixmap("novelwriter", (nPx, nPx)))
         self.innerBox.addWidget(self.nwIcon, 0, Qt.AlignTop)
 
         self.projectForm = QGridLayout()
@@ -225,7 +225,7 @@ class GuiProjectLoad(QDialog):
         selList = self.listBox.selectedItems()
         if selList:
             projName = selList[0].text(self.C_NAME)
-            msgYes = self.theParent.askQuestion(
+            msgYes = self.mainGui.askQuestion(
                 self.tr("Remove Entry"),
                 self.tr(
                     "Remove '{0}' from the recent projects list? "
@@ -280,7 +280,7 @@ class GuiProjectLoad(QDialog):
         sortList = sorted(dataList, key=lambda x: x[1], reverse=True)
         for theTitle, theTime, theWords, projPath in sortList:
             newItem = QTreeWidgetItem([""]*4)
-            newItem.setIcon(self.C_NAME,  self.theParent.theTheme.getIcon("proj_nwx"))
+            newItem.setIcon(self.C_NAME,  self.mainGui.theTheme.getIcon("proj_nwx"))
             newItem.setText(self.C_NAME,  theTitle)
             newItem.setData(self.C_NAME,  Qt.UserRole, projPath)
             newItem.setText(self.C_COUNT, formatInt(theWords))

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -175,13 +175,13 @@ class GuiProjectEditMain(QWidget):
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.mainGui.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainGui.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
         self.mainForm.addGroupLabel(self.tr("Project Settings"))
 
         xW = self.mainConf.pxInt(250)
-        xH = round(4.8*self.mainGui.theTheme.fontPixelSize)
+        xH = round(4.8*self.mainGui.mainTheme.fontPixelSize)
 
         self.editName = QLineEdit()
         self.editName.setMaxLength(200)
@@ -262,7 +262,7 @@ class GuiProjectEditStatus(QWidget):
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = theProject
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
 
         if isStatus:
             self.theStatus = self.theProject.statusItems
@@ -281,7 +281,7 @@ class GuiProjectEditStatus(QWidget):
         self.colChanged = False
         self.selColour  = QColor(100, 100, 100)
 
-        self.iPx = self.theTheme.baseIconSize
+        self.iPx = self.mainTheme.baseIconSize
 
         # The List
         # ========
@@ -300,16 +300,16 @@ class GuiProjectEditStatus(QWidget):
         # List Controls
         # =============
 
-        self.addButton = QPushButton(self.theTheme.getIcon("add"), "")
+        self.addButton = QPushButton(self.mainTheme.getIcon("add"), "")
         self.addButton.clicked.connect(self._newItem)
 
-        self.delButton = QPushButton(self.theTheme.getIcon("remove"), "")
+        self.delButton = QPushButton(self.mainTheme.getIcon("remove"), "")
         self.delButton.clicked.connect(self._delItem)
 
-        self.upButton = QPushButton(self.theTheme.getIcon("up"), "")
+        self.upButton = QPushButton(self.mainTheme.getIcon("up"), "")
         self.upButton.clicked.connect(lambda: self._moveItem(-1))
 
-        self.dnButton = QPushButton(self.theTheme.getIcon("down"), "")
+        self.dnButton = QPushButton(self.mainTheme.getIcon("down"), "")
         self.dnButton.clicked.connect(lambda: self._moveItem(1))
 
         # Edit Form
@@ -532,7 +532,7 @@ class GuiProjectEditReplace(QWidget):
 
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = theProject
         self.arChanged  = False
 
@@ -563,10 +563,10 @@ class GuiProjectEditReplace(QWidget):
         # List Controls
         # =============
 
-        self.addButton = QPushButton(self.theTheme.getIcon("add"), "")
+        self.addButton = QPushButton(self.mainTheme.getIcon("add"), "")
         self.addButton.clicked.connect(self._addEntry)
 
-        self.delButton = QPushButton(self.theTheme.getIcon("remove"), "")
+        self.delButton = QPushButton(self.mainTheme.getIcon("remove"), "")
         self.delButton.clicked.connect(self._delEntry)
 
         # Edit Form

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -43,15 +43,15 @@ logger = logging.getLogger(__name__)
 
 class GuiProjectSettings(PagedDialog):
 
-    def __init__(self, theParent):
-        PagedDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        PagedDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiProjectSettings ...")
         self.setObjectName("GuiProjectSettings")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
 
         self.theProject.countStatus()
         self.setWindowTitle(self.tr("Project Settings"))
@@ -67,10 +67,10 @@ class GuiProjectSettings(PagedDialog):
             self.mainConf.pxInt(pOptions.getInt("GuiProjectSettings", "winHeight", wH))
         )
 
-        self.tabMain    = GuiProjectEditMain(self.theParent, self.theProject)
-        self.tabStatus  = GuiProjectEditStatus(self.theParent, self.theProject, True)
-        self.tabImport  = GuiProjectEditStatus(self.theParent, self.theProject, False)
-        self.tabReplace = GuiProjectEditReplace(self.theParent, self.theProject)
+        self.tabMain    = GuiProjectEditMain(self.mainGui, self.theProject)
+        self.tabStatus  = GuiProjectEditStatus(self.mainGui, self.theProject, True)
+        self.tabImport  = GuiProjectEditStatus(self.mainGui, self.theProject, False)
+        self.tabReplace = GuiProjectEditReplace(self.mainGui, self.theProject)
 
         self.addTab(self.tabMain,    self.tr("Settings"))
         self.addTab(self.tabStatus,  self.tr("Status"))
@@ -121,7 +121,7 @@ class GuiProjectSettings(PagedDialog):
             self.theProject.setImportColours(newList, delList)
 
         if self.tabStatus.colChanged or self.tabImport.colChanged:
-            self.theParent.rebuildTrees()
+            self.mainGui.rebuildTrees()
 
         if self.tabReplace.arChanged:
             newList = self.tabReplace.getNewList()
@@ -166,22 +166,22 @@ class GuiProjectSettings(PagedDialog):
 
 class GuiProjectEditMain(QWidget):
 
-    def __init__(self, theParent, theProject):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui, theProject):
+        QWidget.__init__(self, mainGui)
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
+        self.mainGui    = mainGui
         self.theProject = theProject
 
         # The Form
         self.mainForm = QConfigLayout()
-        self.mainForm.setHelpTextStyle(self.theParent.theTheme.helpText)
+        self.mainForm.setHelpTextStyle(self.mainGui.theTheme.helpText)
         self.setLayout(self.mainForm)
 
         self.mainForm.addGroupLabel(self.tr("Project Settings"))
 
         xW = self.mainConf.pxInt(250)
-        xH = round(4.8*self.theParent.theTheme.fontPixelSize)
+        xH = round(4.8*self.mainGui.theTheme.fontPixelSize)
 
         self.editName = QLineEdit()
         self.editName.setMaxLength(200)
@@ -216,7 +216,7 @@ class GuiProjectEditMain(QWidget):
         self.spellLang = QComboBox(self)
         self.spellLang.setMaximumWidth(xW)
         self.spellLang.addItem(self.tr("Default"), "None")
-        langAvail = self.theParent.docEditor.spEnchant.listDictionaries()
+        langAvail = self.mainGui.docEditor.spEnchant.listDictionaries()
         for spTag, spProv in langAvail:
             qLocal = QLocale(spTag)
             spLang = qLocal.nativeLanguageName().title()
@@ -256,13 +256,13 @@ class GuiProjectEditStatus(QWidget):
     COL_ROLE = Qt.UserRole + 1
     NUM_ROLE = Qt.UserRole + 2
 
-    def __init__(self, theParent, theProject, isStatus):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui, theProject, isStatus):
+        QWidget.__init__(self, mainGui)
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
+        self.mainGui    = mainGui
         self.theProject = theProject
-        self.theTheme   = theParent.theTheme
+        self.theTheme   = mainGui.theTheme
 
         if isStatus:
             self.theStatus = self.theProject.statusItems
@@ -411,7 +411,7 @@ class GuiProjectEditStatus(QWidget):
         if selItem is not None:
             iRow = self.listBox.indexOfTopLevelItem(selItem)
             if selItem.data(self.COL_LABEL, self.NUM_ROLE) > 0:
-                self.theParent.makeAlert(self.tr(
+                self.mainGui.makeAlert(self.tr(
                     "Cannot delete a status item that is in use."
                 ), nwAlert.ERROR)
             else:
@@ -527,12 +527,12 @@ class GuiProjectEditReplace(QWidget):
     COL_KEY  = 0
     COL_REPL = 1
 
-    def __init__(self, theParent, theProject):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui, theProject):
+        QWidget.__init__(self, mainGui)
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
         self.theProject = theProject
         self.arChanged  = False
 

--- a/novelwriter/dialogs/quotes.py
+++ b/novelwriter/dialogs/quotes.py
@@ -42,8 +42,8 @@ class GuiQuoteSelect(QDialog):
 
     selectedQuote = ""
 
-    def __init__(self, theParent=None, currentQuote='"'):
-        QDialog.__init__(self, parent=theParent)
+    def __init__(self, parent=None, currentQuote='"'):
+        QDialog.__init__(self, parent=parent)
 
         self.mainConf = novelwriter.CONFIG
 

--- a/novelwriter/dialogs/updates.py
+++ b/novelwriter/dialogs/updates.py
@@ -61,7 +61,7 @@ class GuiUpdates(QDialog):
 
         # Left Box
         self.nwIcon = QLabel()
-        self.nwIcon.setPixmap(self.mainGui.theTheme.getPixmap("novelwriter", (nPx, nPx)))
+        self.nwIcon.setPixmap(self.mainGui.mainTheme.getPixmap("novelwriter", (nPx, nPx)))
 
         self.leftBox = QVBoxLayout()
         self.leftBox.addWidget(self.nwIcon)

--- a/novelwriter/dialogs/updates.py
+++ b/novelwriter/dialogs/updates.py
@@ -43,14 +43,14 @@ logger = logging.getLogger(__name__)
 
 class GuiUpdates(QDialog):
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiUpdates ...")
         self.setObjectName("GuiUpdates")
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
 
         self.setWindowTitle(self.tr("Check for Updates"))
 
@@ -61,7 +61,7 @@ class GuiUpdates(QDialog):
 
         # Left Box
         self.nwIcon = QLabel()
-        self.nwIcon.setPixmap(self.theParent.theTheme.getPixmap("novelwriter", (nPx, nPx)))
+        self.nwIcon.setPixmap(self.mainGui.theTheme.getPixmap("novelwriter", (nPx, nPx)))
 
         self.leftBox = QVBoxLayout()
         self.leftBox.addWidget(self.nwIcon)

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -42,16 +42,16 @@ logger = logging.getLogger(__name__)
 
 class GuiWordList(QDialog):
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiWordList ...")
         self.setObjectName("GuiWordList")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
+        self.theProject = mainGui.theProject
 
         self.setWindowTitle(self.tr("Project Word List"))
 
@@ -121,13 +121,13 @@ class GuiWordList(QDialog):
         """
         newWord = self.newEntry.text().strip()
         if newWord == "":
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "Cannot add a blank word."
             ), nwAlert.ERROR)
             return False
 
         if self.listBox.findItems(newWord, Qt.MatchExactly):
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "The word '{0}' is already in the word list."
             ).format(newWord), nwAlert.ERROR)
             return False

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -50,7 +50,7 @@ class GuiWordList(QDialog):
 
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
 
         self.setWindowTitle(self.tr("Project Word List"))
@@ -78,10 +78,10 @@ class GuiWordList(QDialog):
 
         self.newEntry = QLineEdit()
 
-        self.addButton = QPushButton(self.theTheme.getIcon("add"), "")
+        self.addButton = QPushButton(self.mainTheme.getIcon("add"), "")
         self.addButton.clicked.connect(self._doAdd)
 
-        self.delButton = QPushButton(self.theTheme.getIcon("remove"), "")
+        self.delButton = QPushButton(self.mainTheme.getIcon("remove"), "")
         self.delButton.clicked.connect(self._doDelete)
 
         self.editBox = QHBoxLayout()

--- a/novelwriter/gui/__init__.py
+++ b/novelwriter/gui/__init__.py
@@ -24,7 +24,7 @@ from novelwriter.gui.docviewer import GuiDocViewer, GuiDocViewDetails
 from novelwriter.gui.itemdetails import GuiItemDetails
 from novelwriter.gui.mainmenu import GuiMainMenu
 from novelwriter.gui.noveltree import GuiNovelTree
-from novelwriter.gui.outline import GuiOutline
+from novelwriter.gui.outline import GuiOutlineView
 from novelwriter.gui.projtree import GuiProjectView
 from novelwriter.gui.statusbar import GuiMainStatus
 from novelwriter.gui.theme import GuiTheme
@@ -38,7 +38,7 @@ __all__ = [
     "GuiMainMenu",
     "GuiMainStatus",
     "GuiNovelTree",
-    "GuiOutline",
+    "GuiOutlineView",
     "GuiProjectView",
     "GuiTheme",
     "GuiViewsBar",

--- a/novelwriter/gui/custom.py
+++ b/novelwriter/gui/custom.py
@@ -376,8 +376,8 @@ class QSwitch(QAbstractButton):
 
 class PagedDialog(QDialog):
 
-    def __init__(self, theParent=None):
-        QDialog.__init__(self, parent=theParent)
+    def __init__(self, parent=None):
+        QDialog.__init__(self, parent=parent)
 
         self._tabBar = VerticalTabBar(self)
         self._tabBar.setExpanding(False)
@@ -426,8 +426,8 @@ class PagedDialog(QDialog):
 
 class VerticalTabBar(QTabBar):
 
-    def __init__(self, theParent=None):
-        QTabBar.__init__(self, parent=theParent)
+    def __init__(self, parent=None):
+        QTabBar.__init__(self, parent=parent)
         self._mW = novelwriter.CONFIG.pxInt(150)
         return
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -80,7 +80,7 @@ class GuiDocEditor(QTextEdit):
         # Class Variables
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
 
         self._nwDocument = None
@@ -239,10 +239,10 @@ class GuiDocEditor(QTextEdit):
         if self.mainConf.textFont is None:
             # If none is defined, set a default font
             theFont = QFont()
-            if self.mainConf.osWindows and "Arial" in self.theTheme.guiFontDB.families():
+            if self.mainConf.osWindows and "Arial" in self.mainTheme.guiFontDB.families():
                 theFont.setFamily("Arial")
                 theFont.setPointSize(12)
-            elif self.mainConf.osDarwin and "Courier" in self.theTheme.guiFontDB.families():
+            elif self.mainConf.osDarwin and "Courier" in self.mainTheme.guiFontDB.families():
                 theFont.setFamily("Courier")
                 theFont.setPointSize(12)
             else:
@@ -257,14 +257,14 @@ class GuiDocEditor(QTextEdit):
 
         # Set the widget colours to match syntax theme
         mainPalette = self.palette()
-        mainPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        mainPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
-        mainPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        mainPalette.setColor(QPalette.Window, QColor(*self.mainTheme.colBack))
+        mainPalette.setColor(QPalette.Base, QColor(*self.mainTheme.colBack))
+        mainPalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
         self.setPalette(mainPalette)
 
         docPalette = self.viewport().palette()
-        docPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
-        docPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        docPalette.setColor(QPalette.Base, QColor(*self.mainTheme.colBack))
+        docPalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
         self.viewport().setPalette(docPalette)
 
         self.docHeader.matchColours()
@@ -2189,7 +2189,7 @@ class GuiDocEditSearch(QFrame):
         self.docEditor  = docEditor
         self.mainGui    = docEditor.mainGui
         self.theProject = docEditor.theProject
-        self.theTheme   = docEditor.theTheme
+        self.mainTheme  = docEditor.mainTheme
 
         self.repVisible  = False
         self.isCaseSense = self.mainConf.searchCase
@@ -2200,9 +2200,9 @@ class GuiDocEditSearch(QFrame):
         self.doMatchCap  = self.mainConf.searchMatchCap
 
         mPx = self.mainConf.pxInt(6)
-        tPx = int(0.8*self.theTheme.fontPixelSize)
-        self.boxFont = self.theTheme.guiFont
-        self.boxFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
+        tPx = int(0.8*self.mainTheme.fontPixelSize)
+        self.boxFont = self.mainTheme.guiFont
+        self.boxFont.setPointSizeF(0.9*self.mainTheme.fontPointSize)
 
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
@@ -2236,38 +2236,38 @@ class GuiDocEditSearch(QFrame):
 
         self.resultLabel = QLabel("?/?")
         self.resultLabel.setFont(self.boxFont)
-        self.resultLabel.setMinimumWidth(self.theTheme.getTextWidth("?/?", self.boxFont))
+        self.resultLabel.setMinimumWidth(self.mainTheme.getTextWidth("?/?", self.boxFont))
 
         self.toggleCase = QAction(self.tr("Case Sensitive"), self)
-        self.toggleCase.setIcon(self.theTheme.getIcon("search_case"))
+        self.toggleCase.setIcon(self.mainTheme.getIcon("search_case"))
         self.toggleCase.setCheckable(True)
         self.toggleCase.setChecked(self.isCaseSense)
         self.toggleCase.toggled.connect(self._doToggleCase)
         self.searchOpt.addAction(self.toggleCase)
 
         self.toggleWord = QAction(self.tr("Whole Words Only"), self)
-        self.toggleWord.setIcon(self.theTheme.getIcon("search_word"))
+        self.toggleWord.setIcon(self.mainTheme.getIcon("search_word"))
         self.toggleWord.setCheckable(True)
         self.toggleWord.setChecked(self.isWholeWord)
         self.toggleWord.toggled.connect(self._doToggleWord)
         self.searchOpt.addAction(self.toggleWord)
 
         self.toggleRegEx = QAction(self.tr("RegEx Mode"), self)
-        self.toggleRegEx.setIcon(self.theTheme.getIcon("search_regex"))
+        self.toggleRegEx.setIcon(self.mainTheme.getIcon("search_regex"))
         self.toggleRegEx.setCheckable(True)
         self.toggleRegEx.setChecked(self.isRegEx)
         self.toggleRegEx.toggled.connect(self._doToggleRegEx)
         self.searchOpt.addAction(self.toggleRegEx)
 
         self.toggleLoop = QAction(self.tr("Loop Search"), self)
-        self.toggleLoop.setIcon(self.theTheme.getIcon("search_loop"))
+        self.toggleLoop.setIcon(self.mainTheme.getIcon("search_loop"))
         self.toggleLoop.setCheckable(True)
         self.toggleLoop.setChecked(self.doLoop)
         self.toggleLoop.toggled.connect(self._doToggleLoop)
         self.searchOpt.addAction(self.toggleLoop)
 
         self.toggleProject = QAction(self.tr("Search Next File"), self)
-        self.toggleProject.setIcon(self.theTheme.getIcon("search_project"))
+        self.toggleProject.setIcon(self.mainTheme.getIcon("search_project"))
         self.toggleProject.setCheckable(True)
         self.toggleProject.setChecked(self.doNextFile)
         self.toggleProject.toggled.connect(self._doToggleProject)
@@ -2276,7 +2276,7 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addSeparator()
 
         self.toggleMatchCap = QAction(self.tr("Preserve Case"), self)
-        self.toggleMatchCap.setIcon(self.theTheme.getIcon("search_preserve"))
+        self.toggleMatchCap.setIcon(self.mainTheme.getIcon("search_preserve"))
         self.toggleMatchCap.setCheckable(True)
         self.toggleMatchCap.setChecked(self.doMatchCap)
         self.toggleMatchCap.toggled.connect(self._doToggleMatchCap)
@@ -2285,7 +2285,7 @@ class GuiDocEditSearch(QFrame):
         self.searchOpt.addSeparator()
 
         self.cancelSearch = QAction(self.tr("Close Search"), self)
-        self.cancelSearch.setIcon(self.theTheme.getIcon("search_cancel"))
+        self.cancelSearch.setIcon(self.mainTheme.getIcon("search_cancel"))
         self.cancelSearch.triggered.connect(self._doClose)
         self.searchOpt.addAction(self.cancelSearch)
 
@@ -2300,12 +2300,12 @@ class GuiDocEditSearch(QFrame):
         self.showReplace.setStyleSheet("QToolButton {border: none; background: transparent;}")
         self.showReplace.toggled.connect(self._doToggleReplace)
 
-        self.searchButton = QPushButton(self.theTheme.getIcon("search"), "")
+        self.searchButton = QPushButton(self.mainTheme.getIcon("search"), "")
         self.searchButton.setFixedSize(QSize(bPx, bPx))
         self.searchButton.setToolTip(self.tr("Find in current document"))
         self.searchButton.clicked.connect(self._doSearch)
 
-        self.replaceButton = QPushButton(self.theTheme.getIcon("search_replace"), "")
+        self.replaceButton = QPushButton(self.mainTheme.getIcon("search_replace"), "")
         self.replaceButton.setFixedSize(QSize(bPx, bPx))
         self.replaceButton.setToolTip(self.tr("Find and replace in current document"))
         self.replaceButton.clicked.connect(self._doReplace)
@@ -2424,7 +2424,7 @@ class GuiDocEditSearch(QFrame):
         """
         currRes = "?" if currRes is None else currRes
         resCount = "?" if resCount is None else "1000+" if resCount > 1000 else resCount
-        minWidth = self.theTheme.getTextWidth(f"{resCount}//{resCount}", self.boxFont)
+        minWidth = self.mainTheme.getTextWidth(f"{resCount}//{resCount}", self.boxFont)
         self.resultLabel.setText(f"{currRes}/{resCount}")
         self.resultLabel.setMinimumWidth(minWidth)
         self.adjustSize()
@@ -2577,11 +2577,11 @@ class GuiDocEditHeader(QWidget):
         self.docEditor  = docEditor
         self.mainGui    = docEditor.mainGui
         self.theProject = docEditor.theProject
-        self.theTheme   = docEditor.theTheme
+        self.mainTheme  = docEditor.mainTheme
 
         self._docHandle = None
 
-        fPx = int(0.9*self.theTheme.fontPixelSize)
+        fPx = int(0.9*self.mainTheme.fontPixelSize)
         hSp = self.mainConf.pxInt(6)
 
         # Main Widget Settings
@@ -2598,17 +2598,17 @@ class GuiDocEditHeader(QWidget):
         self.theTitle.setFixedHeight(fPx)
 
         lblFont = self.theTitle.font()
-        lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
+        lblFont.setPointSizeF(0.9*self.mainTheme.fontPointSize)
         self.theTitle.setFont(lblFont)
 
         buttonStyle = (
             "QToolButton {{border: none; background: transparent;}} "
             "QToolButton:hover {{border: none; background: rgba({0},{1},{2},0.2);}}"
-        ).format(*self.theTheme.colText)
+        ).format(*self.mainTheme.colText)
 
         # Buttons
         self.editButton = QToolButton(self)
-        self.editButton.setIcon(self.theTheme.getIcon("edit"))
+        self.editButton.setIcon(self.mainTheme.getIcon("edit"))
         self.editButton.setContentsMargins(0, 0, 0, 0)
         self.editButton.setIconSize(QSize(fPx, fPx))
         self.editButton.setFixedSize(fPx, fPx)
@@ -2619,7 +2619,7 @@ class GuiDocEditHeader(QWidget):
         self.editButton.clicked.connect(self._editDocument)
 
         self.searchButton = QToolButton(self)
-        self.searchButton.setIcon(self.theTheme.getIcon("search"))
+        self.searchButton.setIcon(self.mainTheme.getIcon("search"))
         self.searchButton.setContentsMargins(0, 0, 0, 0)
         self.searchButton.setIconSize(QSize(fPx, fPx))
         self.searchButton.setFixedSize(fPx, fPx)
@@ -2630,7 +2630,7 @@ class GuiDocEditHeader(QWidget):
         self.searchButton.clicked.connect(self._searchDocument)
 
         self.minmaxButton = QToolButton(self)
-        self.minmaxButton.setIcon(self.theTheme.getIcon("maximise"))
+        self.minmaxButton.setIcon(self.mainTheme.getIcon("maximise"))
         self.minmaxButton.setContentsMargins(0, 0, 0, 0)
         self.minmaxButton.setIconSize(QSize(fPx, fPx))
         self.minmaxButton.setFixedSize(fPx, fPx)
@@ -2641,7 +2641,7 @@ class GuiDocEditHeader(QWidget):
         self.minmaxButton.clicked.connect(self._minmaxDocument)
 
         self.closeButton = QToolButton(self)
-        self.closeButton.setIcon(self.theTheme.getIcon("close"))
+        self.closeButton.setIcon(self.mainTheme.getIcon("close"))
         self.closeButton.setContentsMargins(0, 0, 0, 0)
         self.closeButton.setIconSize(QSize(fPx, fPx))
         self.closeButton.setFixedSize(fPx, fPx)
@@ -2684,9 +2684,9 @@ class GuiDocEditHeader(QWidget):
         theme rather than the main GUI.
         """
         thePalette = QPalette()
-        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Window, QColor(*self.mainTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.mainTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
 
         self.setPalette(thePalette)
         self.theTitle.setPalette(thePalette)
@@ -2734,9 +2734,9 @@ class GuiDocEditHeader(QWidget):
         toggleFocusMode function and should not be activated directly.
         """
         if self.mainGui.isFocusMode:
-            self.minmaxButton.setIcon(self.theTheme.getIcon("minimise"))
+            self.minmaxButton.setIcon(self.mainTheme.getIcon("minimise"))
         else:
-            self.minmaxButton.setIcon(self.theTheme.getIcon("maximise"))
+            self.minmaxButton.setIcon(self.mainTheme.getIcon("maximise"))
         return
 
     ##
@@ -2801,20 +2801,20 @@ class GuiDocEditFooter(QWidget):
         self.docEditor  = docEditor
         self.mainGui    = docEditor.mainGui
         self.theProject = docEditor.theProject
-        self.theTheme   = docEditor.theTheme
+        self.mainTheme  = docEditor.mainTheme
 
         self._theItem   = None
         self._docHandle = None
 
         self._docSelection = False
 
-        self.sPx = int(round(0.9*self.theTheme.baseIconSize))
-        fPx = int(0.9*self.theTheme.fontPixelSize)
+        self.sPx = int(round(0.9*self.mainTheme.baseIconSize))
+        fPx = int(0.9*self.mainTheme.fontPixelSize)
         bSp = self.mainConf.pxInt(4)
         hSp = self.mainConf.pxInt(6)
 
         lblFont = self.font()
-        lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
+        lblFont.setPointSizeF(0.9*self.mainTheme.fontPointSize)
 
         # Main Widget Settings
         self.setContentsMargins(0, 0, 0, 0)
@@ -2837,7 +2837,7 @@ class GuiDocEditFooter(QWidget):
 
         # Lines
         self.linesIcon = QLabel("")
-        self.linesIcon.setPixmap(self.theTheme.getPixmap("status_lines", (self.sPx, self.sPx)))
+        self.linesIcon.setPixmap(self.mainTheme.getPixmap("status_lines", (self.sPx, self.sPx)))
         self.linesIcon.setContentsMargins(0, 0, 0, 0)
         self.linesIcon.setFixedHeight(self.sPx)
         self.linesIcon.setAlignment(Qt.AlignLeft | Qt.AlignTop)
@@ -2853,7 +2853,7 @@ class GuiDocEditFooter(QWidget):
 
         # Words
         self.wordsIcon = QLabel("")
-        self.wordsIcon.setPixmap(self.theTheme.getPixmap("status_stats", (self.sPx, self.sPx)))
+        self.wordsIcon.setPixmap(self.mainTheme.getPixmap("status_stats", (self.sPx, self.sPx)))
         self.wordsIcon.setContentsMargins(0, 0, 0, 0)
         self.wordsIcon.setFixedHeight(self.sPx)
         self.wordsIcon.setAlignment(Qt.AlignLeft | Qt.AlignTop)
@@ -2905,9 +2905,9 @@ class GuiDocEditFooter(QWidget):
         theme rather than the main GUI.
         """
         thePalette = QPalette()
-        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Window, QColor(*self.mainTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.mainTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
 
         self.setPalette(thePalette)
         self.statusText.setPalette(thePalette)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -517,8 +517,8 @@ class GuiDocEditor(QTextEdit):
             self.mainGui.novelView.updateWordCounts(tHandle)
 
         if oldHeader != newHeader:
-            self.mainGui.treeView.setTreeItemValues(tHandle)
-            self.mainGui.treeMeta.updateViewBox(tHandle)
+            self.mainGui.projView.setTreeItemValues(tHandle)
+            self.mainGui.itemDetails.updateViewBox(tHandle)
             self.docFooter.updateInfo()
 
         # Update the status bar
@@ -2779,7 +2779,7 @@ class GuiDocEditHeader(QWidget):
         """Capture a click on the title and ensure that the item is
         selected in the project tree.
         """
-        self.mainGui.treeView.setSelectedHandle(self._docHandle, doScroll=True)
+        self.mainGui.projView.setSelectedHandle(self._docHandle, doScroll=True)
         return
 
 # END Class GuiDocEditHeader

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -54,7 +54,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self.theDoc     = theDoc
         self.spEnchant  = spEnchant
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
         self.theHandle  = None
         self.spellCheck = False
@@ -87,24 +87,24 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         """
         logger.debug("Setting up highlighting rules")
 
-        self.colHead   = QColor(*self.theTheme.colHead)
-        self.colHeadH  = QColor(*self.theTheme.colHeadH)
-        self.colDialN  = QColor(*self.theTheme.colDialN)
-        self.colDialD  = QColor(*self.theTheme.colDialD)
-        self.colDialS  = QColor(*self.theTheme.colDialS)
-        self.colHidden = QColor(*self.theTheme.colHidden)
-        self.colKey    = QColor(*self.theTheme.colKey)
-        self.colVal    = QColor(*self.theTheme.colVal)
-        self.colSpell  = QColor(*self.theTheme.colSpell)
-        self.colError  = QColor(*self.theTheme.colError)
-        self.colRepTag = QColor(*self.theTheme.colRepTag)
-        self.colMod    = QColor(*self.theTheme.colMod)
-        self.colBreak  = QColor(*self.theTheme.colEmph)
+        self.colHead   = QColor(*self.mainTheme.colHead)
+        self.colHeadH  = QColor(*self.mainTheme.colHeadH)
+        self.colDialN  = QColor(*self.mainTheme.colDialN)
+        self.colDialD  = QColor(*self.mainTheme.colDialD)
+        self.colDialS  = QColor(*self.mainTheme.colDialS)
+        self.colHidden = QColor(*self.mainTheme.colHidden)
+        self.colKey    = QColor(*self.mainTheme.colKey)
+        self.colVal    = QColor(*self.mainTheme.colVal)
+        self.colSpell  = QColor(*self.mainTheme.colSpell)
+        self.colError  = QColor(*self.mainTheme.colError)
+        self.colRepTag = QColor(*self.mainTheme.colRepTag)
+        self.colMod    = QColor(*self.mainTheme.colMod)
+        self.colBreak  = QColor(*self.mainTheme.colEmph)
         self.colBreak.setAlpha(64)
 
         self.colEmph = None
         if self.mainConf.highlightEmph:
-            self.colEmph = QColor(*self.theTheme.colEmph)
+            self.colEmph = QColor(*self.mainTheme.colEmph)
 
         self.hStyles = {
             "header1":   self._makeFormat(self.colHead, "bold", 1.8),

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -46,16 +46,16 @@ class GuiDocHighlighter(QSyntaxHighlighter):
     BLOCK_META  = 2
     BLOCK_TITLE = 4
 
-    def __init__(self, theDoc, theParent, spEnchant):
+    def __init__(self, theDoc, mainGui, spEnchant):
         QSyntaxHighlighter.__init__(self, theDoc)
 
         logger.debug("Initialising GuiDocHighlighter ...")
         self.mainConf   = novelwriter.CONFIG
         self.theDoc     = theDoc
         self.spEnchant  = spEnchant
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
+        self.theProject = mainGui.theProject
         self.theHandle  = None
         self.spellCheck = False
         self.spellRx    = None
@@ -288,7 +288,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         if theText.startswith("@"):  # Keywords and commands
             self.setCurrentBlockState(self.BLOCK_META)
             pIndex = self.theProject.index
-            tItem = self.theParent.theProject.tree[self.theHandle]
+            tItem = self.mainGui.theProject.tree[self.theHandle]
             isValid, theBits, thePos = pIndex.scanThis(theText)
             isGood = pIndex.checkThese(theBits, tItem)
             if isValid:

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -61,7 +61,7 @@ class GuiDocViewer(QTextBrowser):
         # Class Variables
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
 
         # Internal Variables
@@ -118,14 +118,14 @@ class GuiDocViewer(QTextBrowser):
 
         # Set the widget colours to match syntax theme
         mainPalette = self.palette()
-        mainPalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        mainPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
-        mainPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        mainPalette.setColor(QPalette.Window, QColor(*self.mainTheme.colBack))
+        mainPalette.setColor(QPalette.Base, QColor(*self.mainTheme.colBack))
+        mainPalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
         self.setPalette(mainPalette)
 
         docPalette = self.viewport().palette()
-        docPalette.setColor(QPalette.Base, QColor(*self.theTheme.colBack))
-        docPalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        docPalette.setColor(QPalette.Base, QColor(*self.mainTheme.colBack))
+        docPalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
         self.viewport().setPalette(docPalette)
 
         self.docHeader.matchColours()
@@ -539,27 +539,27 @@ class GuiDocViewer(QTextBrowser):
             "  text-align: center;"
             "}}\n"
         ).format(
-            tColR=self.theTheme.colText[0],
-            tColG=self.theTheme.colText[1],
-            tColB=self.theTheme.colText[2],
-            hColR=self.theTheme.colHead[0],
-            hColG=self.theTheme.colHead[1],
-            hColB=self.theTheme.colHead[2],
-            aColR=self.theTheme.colVal[0],
-            aColG=self.theTheme.colVal[1],
-            aColB=self.theTheme.colVal[2],
-            eColR=self.theTheme.colEmph[0],
-            eColG=self.theTheme.colEmph[1],
-            eColB=self.theTheme.colEmph[2],
-            kColR=self.theTheme.colKey[0],
-            kColG=self.theTheme.colKey[1],
-            kColB=self.theTheme.colKey[2],
-            cColR=self.theTheme.colHidden[0],
-            cColG=self.theTheme.colHidden[1],
-            cColB=self.theTheme.colHidden[2],
-            mColR=self.theTheme.colMod[0],
-            mColG=self.theTheme.colMod[1],
-            mColB=self.theTheme.colMod[2],
+            tColR=self.mainTheme.colText[0],
+            tColG=self.mainTheme.colText[1],
+            tColB=self.mainTheme.colText[2],
+            hColR=self.mainTheme.colHead[0],
+            hColG=self.mainTheme.colHead[1],
+            hColB=self.mainTheme.colHead[2],
+            aColR=self.mainTheme.colVal[0],
+            aColG=self.mainTheme.colVal[1],
+            aColB=self.mainTheme.colVal[2],
+            eColR=self.mainTheme.colEmph[0],
+            eColG=self.mainTheme.colEmph[1],
+            eColB=self.mainTheme.colEmph[2],
+            kColR=self.mainTheme.colKey[0],
+            kColG=self.mainTheme.colKey[1],
+            kColB=self.mainTheme.colKey[2],
+            cColR=self.mainTheme.colHidden[0],
+            cColG=self.mainTheme.colHidden[1],
+            cColB=self.mainTheme.colHidden[2],
+            mColR=self.mainTheme.colMod[0],
+            mColG=self.mainTheme.colMod[1],
+            mColB=self.mainTheme.colMod[2],
         )
         self.document().setDefaultStyleSheet(styleSheet)
 
@@ -716,12 +716,12 @@ class GuiDocViewHeader(QWidget):
         self.docViewer  = docViewer
         self.mainGui    = docViewer.mainGui
         self.theProject = docViewer.theProject
-        self.theTheme   = docViewer.theTheme
+        self.mainTheme  = docViewer.mainTheme
 
         # Internal Variables
         self._docHandle = None
 
-        fPx = int(0.9*self.theTheme.fontPixelSize)
+        fPx = int(0.9*self.mainTheme.fontPixelSize)
         hSp = self.mainConf.pxInt(6)
 
         # Main Widget Settings
@@ -738,17 +738,17 @@ class GuiDocViewHeader(QWidget):
         self.theTitle.setFixedHeight(fPx)
 
         lblFont = self.theTitle.font()
-        lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
+        lblFont.setPointSizeF(0.9*self.mainTheme.fontPointSize)
         self.theTitle.setFont(lblFont)
 
         buttonStyle = (
             "QToolButton {{border: none; background: transparent;}} "
             "QToolButton:hover {{border: none; background: rgba({0},{1},{2},0.2);}}"
-        ).format(*self.theTheme.colText)
+        ).format(*self.mainTheme.colText)
 
         # Buttons
         self.backButton = QToolButton(self)
-        self.backButton.setIcon(self.theTheme.getIcon("backward"))
+        self.backButton.setIcon(self.mainTheme.getIcon("backward"))
         self.backButton.setContentsMargins(0, 0, 0, 0)
         self.backButton.setIconSize(QSize(fPx, fPx))
         self.backButton.setFixedSize(fPx, fPx)
@@ -759,7 +759,7 @@ class GuiDocViewHeader(QWidget):
         self.backButton.clicked.connect(self.docViewer.navBackward)
 
         self.forwardButton = QToolButton(self)
-        self.forwardButton.setIcon(self.theTheme.getIcon("forward"))
+        self.forwardButton.setIcon(self.mainTheme.getIcon("forward"))
         self.forwardButton.setContentsMargins(0, 0, 0, 0)
         self.forwardButton.setIconSize(QSize(fPx, fPx))
         self.forwardButton.setFixedSize(fPx, fPx)
@@ -770,7 +770,7 @@ class GuiDocViewHeader(QWidget):
         self.forwardButton.clicked.connect(self.docViewer.navForward)
 
         self.refreshButton = QToolButton(self)
-        self.refreshButton.setIcon(self.theTheme.getIcon("refresh"))
+        self.refreshButton.setIcon(self.mainTheme.getIcon("refresh"))
         self.refreshButton.setContentsMargins(0, 0, 0, 0)
         self.refreshButton.setIconSize(QSize(fPx, fPx))
         self.refreshButton.setFixedSize(fPx, fPx)
@@ -781,7 +781,7 @@ class GuiDocViewHeader(QWidget):
         self.refreshButton.clicked.connect(self._refreshDocument)
 
         self.closeButton = QToolButton(self)
-        self.closeButton.setIcon(self.theTheme.getIcon("close"))
+        self.closeButton.setIcon(self.mainTheme.getIcon("close"))
         self.closeButton.setContentsMargins(0, 0, 0, 0)
         self.closeButton.setIconSize(QSize(fPx, fPx))
         self.closeButton.setFixedSize(fPx, fPx)
@@ -824,9 +824,9 @@ class GuiDocViewHeader(QWidget):
         theme rather than the main GUI.
         """
         thePalette = QPalette()
-        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Window, QColor(*self.mainTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.mainTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
 
         self.setPalette(thePalette)
         self.theTitle.setPalette(thePalette)
@@ -922,25 +922,25 @@ class GuiDocViewFooter(QWidget):
         self.mainConf  = novelwriter.CONFIG
         self.docViewer = docViewer
         self.mainGui   = docViewer.mainGui
-        self.theTheme  = docViewer.theTheme
+        self.mainTheme = docViewer.mainTheme
         self.viewMeta  = docViewer.mainGui.viewMeta
 
         # Internal Variables
         self._docHandle = None
 
-        fPx = int(0.9*self.theTheme.fontPixelSize)
+        fPx = int(0.9*self.mainTheme.fontPixelSize)
         bSp = self.mainConf.pxInt(2)
         hSp = self.mainConf.pxInt(8)
 
         # Icons
-        stickyOn  = self.theTheme.getPixmap("sticky-on", (fPx, fPx))
-        stickyOff = self.theTheme.getPixmap("sticky-off", (fPx, fPx))
+        stickyOn  = self.mainTheme.getPixmap("sticky-on", (fPx, fPx))
+        stickyOff = self.mainTheme.getPixmap("sticky-off", (fPx, fPx))
         stickyIcon = QIcon()
         stickyIcon.addPixmap(stickyOn, QIcon.Normal, QIcon.On)
         stickyIcon.addPixmap(stickyOff, QIcon.Normal, QIcon.Off)
 
-        bulletOn  = self.theTheme.getPixmap("bullet-on", (fPx, fPx))
-        bulletOff = self.theTheme.getPixmap("bullet-off", (fPx, fPx))
+        bulletOn  = self.mainTheme.getPixmap("bullet-on", (fPx, fPx))
+        bulletOff = self.mainTheme.getPixmap("bullet-off", (fPx, fPx))
         bulletIcon = QIcon()
         bulletIcon.addPixmap(bulletOn, QIcon.Normal, QIcon.On)
         bulletIcon.addPixmap(bulletOff, QIcon.Normal, QIcon.Off)
@@ -952,13 +952,13 @@ class GuiDocViewFooter(QWidget):
         buttonStyle = (
             "QToolButton {{border: none; background: transparent;}} "
             "QToolButton:hover {{border: none; background: rgba({0},{1},{2},0.2);}}"
-        ).format(*self.theTheme.colText)
+        ).format(*self.mainTheme.colText)
 
         # Show/Hide Details
         self.showHide = QToolButton(self)
         self.showHide.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.showHide.setStyleSheet(buttonStyle)
-        self.showHide.setIcon(self.theTheme.getIcon("reference"))
+        self.showHide.setIcon(self.mainTheme.getIcon("reference"))
         self.showHide.setIconSize(QSize(fPx, fPx))
         self.showHide.setFixedSize(QSize(fPx, fPx))
         self.showHide.clicked.connect(self._doShowHide)
@@ -1039,7 +1039,7 @@ class GuiDocViewFooter(QWidget):
         self.lblSynopsis.setAlignment(Qt.AlignLeft | Qt.AlignTop)
 
         lblFont = self.font()
-        lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
+        lblFont.setPointSizeF(0.9*self.mainTheme.fontPointSize)
         self.lblRefs.setFont(lblFont)
         self.lblSticky.setFont(lblFont)
         self.lblComments.setFont(lblFont)
@@ -1084,9 +1084,9 @@ class GuiDocViewFooter(QWidget):
         theme rather than the main GUI.
         """
         thePalette = QPalette()
-        thePalette.setColor(QPalette.Window, QColor(*self.theTheme.colBack))
-        thePalette.setColor(QPalette.WindowText, QColor(*self.theTheme.colText))
-        thePalette.setColor(QPalette.Text, QColor(*self.theTheme.colText))
+        thePalette.setColor(QPalette.Window, QColor(*self.mainTheme.colBack))
+        thePalette.setColor(QPalette.WindowText, QColor(*self.mainTheme.colText))
+        thePalette.setColor(QPalette.Text, QColor(*self.mainTheme.colText))
 
         self.setPalette(thePalette)
         self.lblRefs.setPalette(thePalette)
@@ -1147,7 +1147,7 @@ class GuiDocViewDetails(QScrollArea):
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
 
         self.refList = QLabel("")
         self.refList.setWordWrap(True)
@@ -1156,7 +1156,7 @@ class GuiDocViewDetails(QScrollArea):
         self.refList.linkActivated.connect(self._linkClicked)
 
         self.linkStyle = "style='color: rgb({0},{1},{2})'".format(
-            *self.theTheme.colLink
+            *self.mainTheme.colLink
         )
 
         # Assemble

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -53,16 +53,16 @@ class GuiDocViewer(QTextBrowser):
 
     loadDocumentTagRequest = pyqtSignal(str, Enum)
 
-    def __init__(self, theParent):
-        QTextBrowser.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QTextBrowser.__init__(self, mainGui)
 
         logger.debug("Initialising GuiDocViewer ...")
 
         # Class Variables
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
+        self.theProject = mainGui.theProject
 
         # Internal Variables
         self._docHandle = None
@@ -221,7 +221,7 @@ class GuiDocViewer(QTextBrowser):
         self.updateDocMargins()
 
         # Make sure the main GUI knows we changed the content
-        self.theParent.viewMeta.refreshReferences(tHandle)
+        self.mainGui.viewMeta.refreshReferences(tHandle)
 
         # Since we change the content while it may still be rendering, we mark
         # the document dirty again to make sure it's re-rendered properly.
@@ -714,7 +714,7 @@ class GuiDocViewHeader(QWidget):
 
         self.mainConf   = novelwriter.CONFIG
         self.docViewer  = docViewer
-        self.theParent  = docViewer.theParent
+        self.mainGui    = docViewer.mainGui
         self.theProject = docViewer.theProject
         self.theTheme   = docViewer.theTheme
 
@@ -882,14 +882,14 @@ class GuiDocViewHeader(QWidget):
     def _closeDocument(self):
         """Trigger the close editor/viewer on the main window.
         """
-        self.theParent.closeDocViewer()
+        self.mainGui.closeDocViewer()
         return
 
     def _refreshDocument(self):
         """Reload the content of the document.
         """
-        if self.docViewer.docHandle() == self.theParent.docEditor.docHandle():
-            self.theParent.saveDocument()
+        if self.docViewer.docHandle() == self.mainGui.docEditor.docHandle():
+            self.mainGui.saveDocument()
         self.docViewer.reloadText()
         return
 
@@ -901,7 +901,7 @@ class GuiDocViewHeader(QWidget):
         """Capture a click on the title and ensure that the item is
         selected in the project tree.
         """
-        self.theParent.treeView.setSelectedHandle(self._docHandle, doScroll=True)
+        self.mainGui.treeView.setSelectedHandle(self._docHandle, doScroll=True)
         return
 
 # END Class GuiDocViewHeader
@@ -921,9 +921,9 @@ class GuiDocViewFooter(QWidget):
 
         self.mainConf  = novelwriter.CONFIG
         self.docViewer = docViewer
-        self.theParent = docViewer.theParent
+        self.mainGui   = docViewer.mainGui
         self.theTheme  = docViewer.theTheme
-        self.viewMeta  = docViewer.theParent.viewMeta
+        self.viewMeta  = docViewer.mainGui.viewMeta
 
         # Internal Variables
         self._docHandle = None
@@ -1140,14 +1140,14 @@ class GuiDocViewFooter(QWidget):
 
 class GuiDocViewDetails(QScrollArea):
 
-    def __init__(self, theParent):
-        QScrollArea.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QScrollArea.__init__(self, mainGui)
 
         logger.debug("Initialising GuiDocViewDetails ...")
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
-        self.theTheme   = theParent.theTheme
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
+        self.theTheme   = mainGui.theTheme
 
         self.refList = QLabel("")
         self.refList.setWordWrap(True)
@@ -1181,7 +1181,7 @@ class GuiDocViewDetails(QScrollArea):
         """Update the current list of document references from the
         project index.
         """
-        if self.theParent.docViewer.stickyRef:
+        if self.mainGui.docViewer.stickyRef:
             return
 
         theRefs = self.theProject.index.getBackReferenceList(tHandle)
@@ -1209,7 +1209,7 @@ class GuiDocViewDetails(QScrollArea):
         if len(theLink) == 21:
             tHandle = theLink[:13]
             tAnchor = theLink[13:]
-            self.theParent.viewDocument(tHandle, tAnchor)
+            self.mainGui.viewDocument(tHandle, tAnchor)
         return
 
 # END Class GuiDocViewDetails

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -901,7 +901,7 @@ class GuiDocViewHeader(QWidget):
         """Capture a click on the title and ensure that the item is
         selected in the project tree.
         """
-        self.mainGui.treeView.setSelectedHandle(self._docHandle, doScroll=True)
+        self.mainGui.projView.setSelectedHandle(self._docHandle, doScroll=True)
         return
 
 # END Class GuiDocViewHeader

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -45,7 +45,7 @@ class GuiItemDetails(QWidget):
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
 
         # Internal Variables
         self._itemHandle  = None
@@ -54,11 +54,11 @@ class GuiItemDetails(QWidget):
         hSp = self.mainConf.pxInt(6)
         vSp = self.mainConf.pxInt(1)
         mPx = self.mainConf.pxInt(6)
-        iPx = self.theTheme.baseIconSize
-        fPt = self.theTheme.fontPointSize
+        iPx = self.mainTheme.baseIconSize
+        fPt = self.mainTheme.fontPointSize
 
-        self._expCheck = self.theTheme.getPixmap("check", (iPx, iPx))
-        self._expCross = self.theTheme.getPixmap("cross", (iPx, iPx))
+        self._expCheck = self.mainTheme.getPixmap("check", (iPx, iPx))
+        self._expCross = self.mainTheme.getPixmap("cross", (iPx, iPx))
 
         fntLabel = QFont()
         fntLabel.setBold(True)
@@ -181,8 +181,8 @@ class GuiItemDetails(QWidget):
         self.setLayout(self.mainBox)
 
         # Make sure the columns for flags and counts don't resize too often
-        flagWidth  = self.theTheme.getTextWidth("Mm", fntValue)
-        countWidth = self.theTheme.getTextWidth("99,999", fntValue)
+        flagWidth  = self.mainTheme.getTextWidth("Mm", fntValue)
+        countWidth = self.mainTheme.getTextWidth("99,999", fntValue)
         self.mainBox.setColumnMinimumWidth(1, flagWidth)
         self.mainBox.setColumnMinimumWidth(4, countWidth)
 
@@ -238,7 +238,7 @@ class GuiItemDetails(QWidget):
             return
 
         self._itemHandle = tHandle
-        iPx = int(round(0.8*self.theTheme.baseIconSize))
+        iPx = int(round(0.8*self.mainTheme.baseIconSize))
 
         # Label
         # =====
@@ -267,7 +267,7 @@ class GuiItemDetails(QWidget):
         # Class
         # =====
 
-        classIcon = self.theTheme.getIcon(nwLabels.CLASS_ICON[nwItem.itemClass])
+        classIcon = self.mainTheme.getIcon(nwLabels.CLASS_ICON[nwItem.itemClass])
         self.classIcon.setPixmap(classIcon.pixmap(iPx, iPx))
         self.classData.setText(trConst(nwLabels.CLASS_NAME[nwItem.itemClass]))
 
@@ -275,7 +275,7 @@ class GuiItemDetails(QWidget):
         # ======
 
         hLevel = self.theProject.index.getHandleHeaderLevel(tHandle)
-        usageIcon = self.theTheme.getItemIcon(
+        usageIcon = self.mainTheme.getItemIcon(
             nwItem.itemType, nwItem.itemClass, nwItem.itemLayout, hLevel
         )
         self.usageIcon.setPixmap(usageIcon.pixmap(iPx, iPx))

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -38,14 +38,14 @@ logger = logging.getLogger(__name__)
 
 class GuiItemDetails(QWidget):
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
         logger.debug("Initialising GuiItemDetails ...")
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
-        self.theTheme   = theParent.theTheme
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
+        self.theTheme   = mainGui.theTheme
 
         # Internal Variables
         self._itemHandle  = None

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -171,12 +171,12 @@ class GuiMainMenu(QMenuBar):
         # Project > Delete
         self.aDeleteItem = QAction(self.tr("Delete Item"), self)
         self.aDeleteItem.setShortcut("Ctrl+Shift+Del")
-        self.aDeleteItem.triggered.connect(lambda: self.mainGui.treeView.deleteItem(None))
+        self.aDeleteItem.triggered.connect(lambda: self.mainGui.projView.deleteItem(None))
         self.projMenu.addAction(self.aDeleteItem)
 
         # Project > Empty Trash
         self.aEmptyTrash = QAction(self.tr("Empty Trash"), self)
-        self.aEmptyTrash.triggered.connect(lambda: self.mainGui.treeView.emptyTrash())
+        self.aEmptyTrash.triggered.connect(lambda: self.mainGui.projView.emptyTrash())
         self.projMenu.addAction(self.aEmptyTrash)
 
         # Project > Separator

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -41,13 +41,13 @@ logger = logging.getLogger(__name__)
 
 class GuiMainMenu(QMenuBar):
 
-    def __init__(self, theParent):
-        QMenuBar.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QMenuBar.__init__(self, mainGui)
 
         logger.debug("Initialising GuiMainMenu ...")
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theProject = mainGui.theProject
 
         # Build Menu
         self._buildProjectMenu()
@@ -61,9 +61,9 @@ class GuiMainMenu(QMenuBar):
         self._buildHelpMenu()
 
         # Function Pointers
-        self._docAction     = self.theParent.passDocumentAction
-        self._docInsert     = self.theParent.docEditor.insertText
-        self._insertKeyWord = self.theParent.docEditor.insertKeyWord
+        self._docAction     = self.mainGui.passDocumentAction
+        self._docInsert     = self.mainGui.docEditor.insertText
+        self._insertKeyWord = self.mainGui.docEditor.insertKeyWord
 
         logger.debug("GuiMainMenu initialisation complete")
 
@@ -94,7 +94,7 @@ class GuiMainMenu(QMenuBar):
         flag is handled by the document editor class, so we make no
         decision, just pass a None to the function and let it decide.
         """
-        self.theParent.docEditor.toggleSpellCheck(None)
+        self.mainGui.docEditor.toggleSpellCheck(None)
         return True
 
     def _openWebsite(self, theUrl):
@@ -123,25 +123,25 @@ class GuiMainMenu(QMenuBar):
 
         # Project > New Project
         self.aNewProject = QAction(self.tr("New Project"), self)
-        self.aNewProject.triggered.connect(lambda: self.theParent.newProject(None))
+        self.aNewProject.triggered.connect(lambda: self.mainGui.newProject(None))
         self.projMenu.addAction(self.aNewProject)
 
         # Project > Open Project
         self.aOpenProject = QAction(self.tr("Open Project"), self)
         self.aOpenProject.setShortcut("Ctrl+Shift+O")
-        self.aOpenProject.triggered.connect(lambda: self.theParent.showProjectLoadDialog())
+        self.aOpenProject.triggered.connect(lambda: self.mainGui.showProjectLoadDialog())
         self.projMenu.addAction(self.aOpenProject)
 
         # Project > Save Project
         self.aSaveProject = QAction(self.tr("Save Project"), self)
         self.aSaveProject.setShortcut("Ctrl+Shift+S")
-        self.aSaveProject.triggered.connect(lambda: self.theParent.saveProject())
+        self.aSaveProject.triggered.connect(lambda: self.mainGui.saveProject())
         self.projMenu.addAction(self.aSaveProject)
 
         # Project > Close Project
         self.aCloseProject = QAction(self.tr("Close Project"), self)
         self.aCloseProject.setShortcut("Ctrl+Shift+W")
-        self.aCloseProject.triggered.connect(lambda: self.theParent.closeProject(False))
+        self.aCloseProject.triggered.connect(lambda: self.mainGui.closeProject(False))
         self.projMenu.addAction(self.aCloseProject)
 
         # Project > Separator
@@ -150,13 +150,13 @@ class GuiMainMenu(QMenuBar):
         # Project > Project Settings
         self.aProjectSettings = QAction(self.tr("Project Settings"), self)
         self.aProjectSettings.setShortcut("Ctrl+Shift+,")
-        self.aProjectSettings.triggered.connect(lambda: self.theParent.showProjectSettingsDialog())
+        self.aProjectSettings.triggered.connect(lambda: self.mainGui.showProjectSettingsDialog())
         self.projMenu.addAction(self.aProjectSettings)
 
         # Project > Project Details
         self.aProjectDetails = QAction(self.tr("Project Details"), self)
         self.aProjectDetails.setShortcut("Shift+F6")
-        self.aProjectDetails.triggered.connect(lambda: self.theParent.showProjectDetailsDialog())
+        self.aProjectDetails.triggered.connect(lambda: self.mainGui.showProjectDetailsDialog())
         self.projMenu.addAction(self.aProjectDetails)
 
         # Project > Separator
@@ -165,18 +165,18 @@ class GuiMainMenu(QMenuBar):
         # Project > Edit
         self.aEditItem = QAction(self.tr("Edit Item"), self)
         self.aEditItem.setShortcuts(["Ctrl+E", "F2"])
-        self.aEditItem.triggered.connect(lambda: self.theParent.editItem(None))
+        self.aEditItem.triggered.connect(lambda: self.mainGui.editItem(None))
         self.projMenu.addAction(self.aEditItem)
 
         # Project > Delete
         self.aDeleteItem = QAction(self.tr("Delete Item"), self)
         self.aDeleteItem.setShortcut("Ctrl+Shift+Del")
-        self.aDeleteItem.triggered.connect(lambda: self.theParent.treeView.deleteItem(None))
+        self.aDeleteItem.triggered.connect(lambda: self.mainGui.treeView.deleteItem(None))
         self.projMenu.addAction(self.aDeleteItem)
 
         # Project > Empty Trash
         self.aEmptyTrash = QAction(self.tr("Empty Trash"), self)
-        self.aEmptyTrash.triggered.connect(lambda: self.theParent.treeView.emptyTrash())
+        self.aEmptyTrash.triggered.connect(lambda: self.mainGui.treeView.emptyTrash())
         self.projMenu.addAction(self.aEmptyTrash)
 
         # Project > Separator
@@ -186,7 +186,7 @@ class GuiMainMenu(QMenuBar):
         self.aExitNW = QAction(self.tr("Exit"), self)
         self.aExitNW.setShortcut("Ctrl+Q")
         self.aExitNW.setMenuRole(QAction.QuitRole)
-        self.aExitNW.triggered.connect(lambda: self.theParent.closeMain())
+        self.aExitNW.triggered.connect(lambda: self.mainGui.closeMain())
         self.projMenu.addAction(self.aExitNW)
 
         return
@@ -200,19 +200,19 @@ class GuiMainMenu(QMenuBar):
         # Document > Open
         self.aOpenDoc = QAction(self.tr("Open Document"), self)
         self.aOpenDoc.setShortcut("Ctrl+O")
-        self.aOpenDoc.triggered.connect(lambda: self.theParent.openSelectedItem())
+        self.aOpenDoc.triggered.connect(lambda: self.mainGui.openSelectedItem())
         self.docuMenu.addAction(self.aOpenDoc)
 
         # Document > Save
         self.aSaveDoc = QAction(self.tr("Save Document"), self)
         self.aSaveDoc.setShortcut("Ctrl+S")
-        self.aSaveDoc.triggered.connect(lambda: self.theParent.saveDocument())
+        self.aSaveDoc.triggered.connect(lambda: self.mainGui.saveDocument())
         self.docuMenu.addAction(self.aSaveDoc)
 
         # Document > Close
         self.aCloseDoc = QAction(self.tr("Close Document"), self)
         self.aCloseDoc.setShortcut("Ctrl+W")
-        self.aCloseDoc.triggered.connect(lambda: self.theParent.closeDocEditor())
+        self.aCloseDoc.triggered.connect(lambda: self.mainGui.closeDocEditor())
         self.docuMenu.addAction(self.aCloseDoc)
 
         # Document > Separator
@@ -221,13 +221,13 @@ class GuiMainMenu(QMenuBar):
         # Document > Preview
         self.aViewDoc = QAction(self.tr("View Document"), self)
         self.aViewDoc.setShortcut("Ctrl+R")
-        self.aViewDoc.triggered.connect(lambda: self.theParent.viewDocument(None))
+        self.aViewDoc.triggered.connect(lambda: self.mainGui.viewDocument(None))
         self.docuMenu.addAction(self.aViewDoc)
 
         # Document > Close Preview
         self.aCloseView = QAction(self.tr("Close Document View"), self)
         self.aCloseView.setShortcut("Ctrl+Shift+R")
-        self.aCloseView.triggered.connect(lambda: self.theParent.closeDocViewer())
+        self.aCloseView.triggered.connect(lambda: self.mainGui.closeDocViewer())
         self.docuMenu.addAction(self.aCloseView)
 
         # Document > Separator
@@ -235,23 +235,23 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Show File Details
         self.aFileDetails = QAction(self.tr("Show File Details"), self)
-        self.aFileDetails.triggered.connect(lambda: self.theParent.docEditor.revealLocation())
+        self.aFileDetails.triggered.connect(lambda: self.mainGui.docEditor.revealLocation())
         self.docuMenu.addAction(self.aFileDetails)
 
         # Document > Import From File
         self.aImportFile = QAction(self.tr("Import Text from File"), self)
         self.aImportFile.setShortcut("Ctrl+Shift+I")
-        self.aImportFile.triggered.connect(lambda: self.theParent.importDocument())
+        self.aImportFile.triggered.connect(lambda: self.mainGui.importDocument())
         self.docuMenu.addAction(self.aImportFile)
 
         # Document > Merge Documents
         self.aMergeDocs = QAction(self.tr("Merge Folder to Document"), self)
-        self.aMergeDocs.triggered.connect(lambda: self.theParent.mergeDocuments())
+        self.aMergeDocs.triggered.connect(lambda: self.mainGui.mergeDocuments())
         self.docuMenu.addAction(self.aMergeDocs)
 
         # Document > Split Document
         self.aSplitDoc = QAction(self.tr("Split Document to Folder"), self)
-        self.aSplitDoc.triggered.connect(lambda: self.theParent.splitDocument())
+        self.aSplitDoc.triggered.connect(lambda: self.mainGui.splitDocument())
         self.docuMenu.addAction(self.aSplitDoc)
 
         return
@@ -324,7 +324,7 @@ class GuiMainMenu(QMenuBar):
             self.aFocusTree.setShortcut("Ctrl+Alt+1")
         else:
             self.aFocusTree.setShortcut("Alt+1")
-        self.aFocusTree.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.TREE))
+        self.aFocusTree.triggered.connect(lambda: self.mainGui.switchFocus(nwWidget.TREE))
         self.viewMenu.addAction(self.aFocusTree)
 
         # View > Document Pane 1
@@ -333,7 +333,7 @@ class GuiMainMenu(QMenuBar):
             self.aFocusEditor.setShortcut("Ctrl+Alt+2")
         else:
             self.aFocusEditor.setShortcut("Alt+2")
-        self.aFocusEditor.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.EDITOR))
+        self.aFocusEditor.triggered.connect(lambda: self.mainGui.switchFocus(nwWidget.EDITOR))
         self.viewMenu.addAction(self.aFocusEditor)
 
         # View > Document Pane 2
@@ -342,7 +342,7 @@ class GuiMainMenu(QMenuBar):
             self.aFocusView.setShortcut("Ctrl+Alt+3")
         else:
             self.aFocusView.setShortcut("Alt+3")
-        self.aFocusView.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.VIEWER))
+        self.aFocusView.triggered.connect(lambda: self.mainGui.switchFocus(nwWidget.VIEWER))
         self.viewMenu.addAction(self.aFocusView)
 
         # View > Outline
@@ -351,7 +351,7 @@ class GuiMainMenu(QMenuBar):
             self.aFocusOutline.setShortcut("Ctrl+Alt+4")
         else:
             self.aFocusOutline.setShortcut("Alt+4")
-        self.aFocusOutline.triggered.connect(lambda: self.theParent.switchFocus(nwWidget.OUTLINE))
+        self.aFocusOutline.triggered.connect(lambda: self.mainGui.switchFocus(nwWidget.OUTLINE))
         self.viewMenu.addAction(self.aFocusOutline)
 
         # View > Separator
@@ -360,13 +360,13 @@ class GuiMainMenu(QMenuBar):
         # View > Go Backward
         self.aViewPrev = QAction(self.tr("Navigate Backward"), self)
         self.aViewPrev.setShortcut("Alt+Left")
-        self.aViewPrev.triggered.connect(lambda: self.theParent.docViewer.navBackward())
+        self.aViewPrev.triggered.connect(lambda: self.mainGui.docViewer.navBackward())
         self.viewMenu.addAction(self.aViewPrev)
 
         # View > Go Forward
         self.aViewNext = QAction(self.tr("Navigate Forward"), self)
         self.aViewNext.setShortcut("Alt+Right")
-        self.aViewNext.triggered.connect(lambda: self.theParent.docViewer.navForward())
+        self.aViewNext.triggered.connect(lambda: self.mainGui.docViewer.navForward())
         self.viewMenu.addAction(self.aViewNext)
 
         # View > Separator
@@ -376,14 +376,14 @@ class GuiMainMenu(QMenuBar):
         self.aFocusMode = QAction(self.tr("Focus Mode"), self)
         self.aFocusMode.setShortcut("F8")
         self.aFocusMode.setCheckable(True)
-        self.aFocusMode.setChecked(self.theParent.isFocusMode)
-        self.aFocusMode.triggered.connect(lambda: self.theParent.toggleFocusMode())
+        self.aFocusMode.setChecked(self.mainGui.isFocusMode)
+        self.aFocusMode.triggered.connect(lambda: self.mainGui.toggleFocusMode())
         self.viewMenu.addAction(self.aFocusMode)
 
         # View > Toggle Full Screen
         self.aFullScreen = QAction(self.tr("Full Screen Mode"), self)
         self.aFullScreen.setShortcut("F11")
-        self.aFullScreen.triggered.connect(lambda: self.theParent.toggleFullScreenMode())
+        self.aFullScreen.triggered.connect(lambda: self.mainGui.toggleFullScreenMode())
         self.viewMenu.addAction(self.aFullScreen)
 
         return
@@ -588,7 +588,7 @@ class GuiMainMenu(QMenuBar):
 
         # Insert > Placeholder Text
         self.aLipsumText = QAction(self.tr("Placeholder Text"), self)
-        self.aLipsumText.triggered.connect(lambda: self.theParent.showLoremIpsumDialog())
+        self.aLipsumText.triggered.connect(lambda: self.mainGui.showLoremIpsumDialog())
         self.insertMenu.addAction(self.aLipsumText)
 
         return
@@ -752,7 +752,7 @@ class GuiMainMenu(QMenuBar):
         # Search > Find
         self.aFind = QAction(self.tr("Find"), self)
         self.aFind.setShortcut("Ctrl+F")
-        self.aFind.triggered.connect(lambda: self.theParent.docEditor.beginSearch())
+        self.aFind.triggered.connect(lambda: self.mainGui.docEditor.beginSearch())
         self.srcMenu.addAction(self.aFind)
 
         # Search > Replace
@@ -761,7 +761,7 @@ class GuiMainMenu(QMenuBar):
             self.aReplace.setShortcut("Ctrl+=")
         else:
             self.aReplace.setShortcut("Ctrl+H")
-        self.aReplace.triggered.connect(lambda: self.theParent.docEditor.beginReplace())
+        self.aReplace.triggered.connect(lambda: self.mainGui.docEditor.beginReplace())
         self.srcMenu.addAction(self.aReplace)
 
         # Search > Find Next
@@ -770,7 +770,7 @@ class GuiMainMenu(QMenuBar):
             self.aFindNext.setShortcuts(["Ctrl+G", "F3"])
         else:
             self.aFindNext.setShortcuts(["F3", "Ctrl+G"])
-        self.aFindNext.triggered.connect(lambda: self.theParent.docEditor.findNext())
+        self.aFindNext.triggered.connect(lambda: self.mainGui.docEditor.findNext())
         self.srcMenu.addAction(self.aFindNext)
 
         # Search > Find Prev
@@ -779,13 +779,13 @@ class GuiMainMenu(QMenuBar):
             self.aFindPrev.setShortcuts(["Ctrl+Shift+G", "Shift+F3"])
         else:
             self.aFindPrev.setShortcuts(["Shift+F3", "Ctrl+Shift+G"])
-        self.aFindPrev.triggered.connect(lambda: self.theParent.docEditor.findNext(goBack=True))
+        self.aFindPrev.triggered.connect(lambda: self.mainGui.docEditor.findNext(goBack=True))
         self.srcMenu.addAction(self.aFindPrev)
 
         # Search > Replace Next
         self.aReplaceNext = QAction(self.tr("Replace Next"), self)
         self.aReplaceNext.setShortcut("Ctrl+Shift+1")
-        self.aReplaceNext.triggered.connect(lambda: self.theParent.docEditor.replaceNext())
+        self.aReplaceNext.triggered.connect(lambda: self.mainGui.docEditor.replaceNext())
         self.srcMenu.addAction(self.aReplaceNext)
 
         return
@@ -807,12 +807,12 @@ class GuiMainMenu(QMenuBar):
         # Tools > Re-Run Spell Check
         self.aReRunSpell = QAction(self.tr("Re-Run Spell Check"), self)
         self.aReRunSpell.setShortcut("F7")
-        self.aReRunSpell.triggered.connect(lambda: self.theParent.docEditor.spellCheckDocument())
+        self.aReRunSpell.triggered.connect(lambda: self.mainGui.docEditor.spellCheckDocument())
         self.toolsMenu.addAction(self.aReRunSpell)
 
         # Tools > Project Word List
         self.aEditWordList = QAction(self.tr("Project Word List"), self)
-        self.aEditWordList.triggered.connect(lambda: self.theParent.showProjectWordListDialog())
+        self.aEditWordList.triggered.connect(lambda: self.mainGui.showProjectWordListDialog())
         self.toolsMenu.addAction(self.aEditWordList)
 
         # Tools > Separator
@@ -821,7 +821,7 @@ class GuiMainMenu(QMenuBar):
         # Tools > Rebuild Indices
         self.aRebuildIndex = QAction(self.tr("Rebuild Index"), self)
         self.aRebuildIndex.setShortcut("F9")
-        self.aRebuildIndex.triggered.connect(lambda: self.theParent.rebuildIndex())
+        self.aRebuildIndex.triggered.connect(lambda: self.mainGui.rebuildIndex())
         self.toolsMenu.addAction(self.aRebuildIndex)
 
         # Tools > Separator
@@ -835,20 +835,20 @@ class GuiMainMenu(QMenuBar):
         # Tools > Export Project
         self.aBuildProject = QAction(self.tr("Build Novel Project"), self)
         self.aBuildProject.setShortcut("F5")
-        self.aBuildProject.triggered.connect(lambda: self.theParent.showBuildProjectDialog())
+        self.aBuildProject.triggered.connect(lambda: self.mainGui.showBuildProjectDialog())
         self.toolsMenu.addAction(self.aBuildProject)
 
         # Tools > Writing Stats
         self.aWritingStats = QAction(self.tr("Writing Statistics"), self)
         self.aWritingStats.setShortcut("F6")
-        self.aWritingStats.triggered.connect(lambda: self.theParent.showWritingStatsDialog())
+        self.aWritingStats.triggered.connect(lambda: self.mainGui.showWritingStatsDialog())
         self.toolsMenu.addAction(self.aWritingStats)
 
         # Tools > Settings
         self.aPreferences = QAction(self.tr("Preferences"), self)
         self.aPreferences.setShortcut("Ctrl+,")
         self.aPreferences.setMenuRole(QAction.PreferencesRole)
-        self.aPreferences.triggered.connect(lambda: self.theParent.showPreferencesDialog())
+        self.aPreferences.triggered.connect(lambda: self.mainGui.showPreferencesDialog())
         self.toolsMenu.addAction(self.aPreferences)
 
         return
@@ -862,13 +862,13 @@ class GuiMainMenu(QMenuBar):
         # Help > About
         self.aAboutNW = QAction(self.tr("About novelWriter"), self)
         self.aAboutNW.setMenuRole(QAction.AboutRole)
-        self.aAboutNW.triggered.connect(lambda: self.theParent.showAboutNWDialog())
+        self.aAboutNW.triggered.connect(lambda: self.mainGui.showAboutNWDialog())
         self.helpMenu.addAction(self.aAboutNW)
 
         # Help > About Qt5
         self.aAboutQt = QAction(self.tr("About Qt5"), self)
         self.aAboutQt.setMenuRole(QAction.AboutQtRole)
-        self.aAboutQt.triggered.connect(lambda: self.theParent.showAboutQtDialog())
+        self.aAboutQt.triggered.connect(lambda: self.mainGui.showAboutQtDialog())
         self.helpMenu.addAction(self.aAboutQt)
 
         # Help > Separator
@@ -915,7 +915,7 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Check for Updates
         self.aUpdates = QAction(self.tr("Check for New Release"), self)
-        self.aUpdates.triggered.connect(lambda: self.theParent.showUpdatesDialog())
+        self.aUpdates.triggered.connect(lambda: self.mainGui.showUpdatesDialog())
         self.helpMenu.addAction(self.aUpdates)
 
         return

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -135,7 +135,7 @@ class GuiNovelTree(QTreeWidget):
         """Called whenever the Novel tab is activated.
         """
         logger.verbose("Requesting refresh of the novel tree")
-        treeChanged = self.mainGui.treeView.changedSince(self._lastBuild)
+        treeChanged = self.mainGui.projView.changedSince(self._lastBuild)
         indexChanged = self.theProject.index.indexChangedSince(self._lastBuild)
         if not (treeChanged or indexChanged or overRide):
             logger.verbose("No changes have been made to the novel index")
@@ -233,7 +233,7 @@ class GuiNovelTree(QTreeWidget):
         selItems = self.selectedItems()
         if selItems:
             tHandle = selItems[0].data(self.C_TITLE, Qt.UserRole)[0]
-            self.mainGui.treeMeta.updateViewBox(tHandle)
+            self.mainGui.itemDetails.updateViewBox(tHandle)
 
         return
 

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -45,15 +45,15 @@ class GuiNovelTree(QTreeWidget):
     C_WORDS = 1
     C_POV   = 2
 
-    def __init__(self, theParent):
-        QTreeWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QTreeWidget.__init__(self, mainGui)
 
         logger.debug("Initialising GuiNovelTree ...")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
+        self.theProject = mainGui.theProject
 
         # Internal Variables
         self._treeMap   = {}
@@ -135,7 +135,7 @@ class GuiNovelTree(QTreeWidget):
         """Called whenever the Novel tab is activated.
         """
         logger.verbose("Requesting refresh of the novel tree")
-        treeChanged = self.theParent.treeView.changedSince(self._lastBuild)
+        treeChanged = self.mainGui.treeView.changedSince(self._lastBuild)
         indexChanged = self.theProject.index.indexChangedSince(self._lastBuild)
         if not (treeChanged or indexChanged or overRide):
             logger.verbose("No changes have been made to the novel index")
@@ -209,7 +209,7 @@ class GuiNovelTree(QTreeWidget):
             if tHandle is None:
                 return
 
-            self.theParent.viewDocument(tHandle)
+            self.mainGui.viewDocument(tHandle)
 
         return
 
@@ -223,7 +223,7 @@ class GuiNovelTree(QTreeWidget):
         document editor.
         """
         tHandle, tLine = self.getSelectedHandle()
-        self.theParent.openDocument(tHandle, tLine=tLine-1, doScroll=True)
+        self.mainGui.openDocument(tHandle, tLine=tLine-1, doScroll=True)
         return
 
     def _itemSelected(self):
@@ -233,7 +233,7 @@ class GuiNovelTree(QTreeWidget):
         selItems = self.selectedItems()
         if selItems:
             tHandle = selItems[0].data(self.C_TITLE, Qt.UserRole)[0]
-            self.theParent.treeMeta.updateViewBox(tHandle)
+            self.mainGui.treeMeta.updateViewBox(tHandle)
 
         return
 

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -52,7 +52,7 @@ class GuiNovelTree(QTreeWidget):
 
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
 
         # Internal Variables
@@ -60,7 +60,7 @@ class GuiNovelTree(QTreeWidget):
         self._lastBuild = 0
 
         # Build GUI
-        iPx = self.theTheme.baseIconSize
+        iPx = self.mainTheme.baseIconSize
         self.setFrameStyle(QFrame.NoFrame)
         self.setIconSize(QSize(iPx, iPx))
         self.setIndentation(iPx)
@@ -309,7 +309,7 @@ class GuiNovelTree(QTreeWidget):
 
         newItem.setText(self.C_TITLE, novIdx.title)
         newItem.setData(self.C_TITLE, Qt.UserRole, theData)
-        newItem.setIcon(self.C_TITLE, self.theTheme.getIcon(hIcon))
+        newItem.setIcon(self.C_TITLE, self.mainTheme.getIcon(hIcon))
         newItem.setText(self.C_WORDS, f"{wC:n}")
         newItem.setTextAlignment(self.C_WORDS, Qt.AlignRight)
 

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -179,7 +179,7 @@ class GuiOutlineToolBar(QToolBar):
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = theOutline.mainGui
         self.theProject = theOutline.mainGui.theProject
-        self.theTheme   = theOutline.mainGui.theTheme
+        self.mainTheme  = theOutline.mainGui.mainTheme
 
         iPx = self.mainConf.pxInt(22)
         mPx = self.mainConf.pxInt(12)
@@ -202,7 +202,7 @@ class GuiOutlineToolBar(QToolBar):
 
         # Actions
         self.aRefresh = QAction(self.tr("Refresh"), self)
-        self.aRefresh.setIcon(self.theTheme.getIcon("refresh"))
+        self.aRefresh.setIcon(self.mainTheme.getIcon("refresh"))
         self.aRefresh.triggered.connect(self._refreshRequested)
 
         # Column Menu
@@ -212,7 +212,7 @@ class GuiOutlineToolBar(QToolBar):
         )
 
         self.tbColumns = QToolButton(self)
-        self.tbColumns.setIcon(self.theTheme.getIcon("menu"))
+        self.tbColumns.setIcon(self.mainTheme.getIcon("menu"))
         self.tbColumns.setMenu(self.mColumns)
         self.tbColumns.setPopupMode(QToolButton.InstantPopup)
 
@@ -236,7 +236,7 @@ class GuiOutlineToolBar(QToolBar):
         """Fill the novel combo box with a list of all novel folders.
         """
         self.novelValue.clear()
-        tIcon = self.theTheme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
+        tIcon = self.mainTheme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
         for tHandle, nwItem in self.theProject.tree.iterRoots(nwItemClass.NOVEL):
             self.novelValue.addItem(tIcon, nwItem.itemName, tHandle)
         self.novelValue.insertSeparator(self.novelValue.count())
@@ -324,7 +324,7 @@ class GuiOutlineTree(QTreeWidget):
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = theOutline.mainGui
         self.theProject = theOutline.mainGui.theProject
-        self.theTheme   = theOutline.mainGui.theTheme
+        self.mainTheme  = theOutline.mainGui.mainTheme
 
         self.setFrameStyle(QFrame.NoFrame)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
@@ -334,7 +334,7 @@ class GuiOutlineTree(QTreeWidget):
         self.itemDoubleClicked.connect(self._treeDoubleClick)
         self.itemSelectionChanged.connect(self._itemSelected)
 
-        iPx = self.theTheme.baseIconSize
+        iPx = self.mainTheme.baseIconSize
         self.setIconSize(QSize(iPx, iPx))
         self.setIndentation(iPx)
 
@@ -682,7 +682,7 @@ class GuiOutlineTree(QTreeWidget):
         hIcon = "doc_%s" % novIdx.level.lower()
 
         hLevel = self.theProject.index.getHandleHeaderLevel(tHandle)
-        dIcon = self.theTheme.getItemIcon(nwItemType.FILE, None, nwItemLayout.DOCUMENT, hLevel)
+        dIcon = self.mainTheme.getItemIcon(nwItemType.FILE, None, nwItemLayout.DOCUMENT, hLevel)
 
         cC = int(novIdx.charCount)
         wC = int(novIdx.wordCount)
@@ -690,7 +690,7 @@ class GuiOutlineTree(QTreeWidget):
 
         newItem.setText(self._colIdx[nwOutline.TITLE],  novIdx.title)
         newItem.setData(self._colIdx[nwOutline.TITLE],  Qt.UserRole, tHandle)
-        newItem.setIcon(self._colIdx[nwOutline.TITLE],  self.theTheme.getIcon(hIcon))
+        newItem.setIcon(self._colIdx[nwOutline.TITLE],  self.mainTheme.getIcon(hIcon))
         newItem.setText(self._colIdx[nwOutline.LEVEL],  novIdx.level)
         newItem.setText(self._colIdx[nwOutline.LABEL],  nwItem.itemName)
         newItem.setIcon(self._colIdx[nwOutline.LABEL],  dIcon)
@@ -784,12 +784,12 @@ class GuiOutlineDetails(QScrollArea):
         self.theOutline = theOutline
         self.mainGui    = theOutline.mainGui
         self.theProject = theOutline.mainGui.theProject
-        self.theTheme   = theOutline.mainGui.theTheme
+        self.mainTheme  = theOutline.mainGui.mainTheme
 
         # Sizes
-        minTitle = 30*self.theTheme.textNWidth
-        maxTitle = 40*self.theTheme.textNWidth
-        wCount = self.theTheme.getTextWidth("999,999")
+        minTitle = 30*self.mainTheme.textNWidth
+        maxTitle = 40*self.mainTheme.textNWidth
+        wCount = self.mainTheme.getTextWidth("999,999")
         hSpace = int(self.mainConf.pxInt(10))
         vSpace = int(self.mainConf.pxInt(4))
 

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -56,11 +56,11 @@ class GuiOutline(QWidget):
 
     loadDocumentTagRequest = pyqtSignal(str, Enum)
 
-    def __init__(self, theParent):
-        QWidget.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWidget.__init__(self, mainGui)
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
 
         # Build GUI
         self.outlineBar  = GuiOutlineToolBar(self)
@@ -177,9 +177,9 @@ class GuiOutlineToolBar(QToolBar):
         logger.debug("Initialising GuiOutlineToolBar ...")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theOutline.theParent
-        self.theProject = theOutline.theParent.theProject
-        self.theTheme   = theOutline.theParent.theTheme
+        self.mainGui    = theOutline.mainGui
+        self.theProject = theOutline.mainGui.theProject
+        self.theTheme   = theOutline.mainGui.theTheme
 
         iPx = self.mainConf.pxInt(22)
         mPx = self.mainConf.pxInt(12)
@@ -322,9 +322,9 @@ class GuiOutlineView(QTreeWidget):
         logger.debug("Initialising GuiOutlineView ...")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theOutline.theParent
-        self.theProject = theOutline.theParent.theProject
-        self.theTheme   = theOutline.theParent.theTheme
+        self.mainGui    = theOutline.mainGui
+        self.theProject = theOutline.mainGui.theProject
+        self.theTheme   = theOutline.mainGui.theTheme
 
         self.setFrameStyle(QFrame.NoFrame)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
@@ -464,7 +464,7 @@ class GuiOutlineView(QTreeWidget):
         document editor.
         """
         tHandle, tLine = self.getSelectedHandle()
-        self.theParent.openDocument(tHandle, tLine=tLine - 1, doScroll=True)
+        self.mainGui.openDocument(tHandle, tLine=tLine - 1, doScroll=True)
         return
 
     @pyqtSlot()
@@ -782,9 +782,9 @@ class GuiOutlineDetails(QScrollArea):
 
         self.mainConf   = novelwriter.CONFIG
         self.theOutline = theOutline
-        self.theParent  = theOutline.theParent
-        self.theProject = theOutline.theParent.theProject
-        self.theTheme   = theOutline.theParent.theTheme
+        self.mainGui    = theOutline.mainGui
+        self.theProject = theOutline.mainGui.theProject
+        self.theTheme   = theOutline.mainGui.theTheme
 
         # Sizes
         minTitle = 30*self.theTheme.textNWidth

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -4,9 +4,9 @@ novelWriter – GUI Project Outline
 GUI class for the project outline view
 
 File History:
-Created: 2022-05-15 [1.7b1] GuiOutline
+Created: 2022-05-15 [1.7b1] GuiOutlineView
 Created: 2022-05-22 [1.7b1] GuiOutlineToolBar
-Created: 2019-11-16 [0.4.1] GuiOutlineView
+Created: 2019-11-16 [0.4.1] GuiOutlineTree
 Created: 2019-11-16 [0.4.1] GuiOutlineHeaderMenu
 Created: 2020-06-02 [0.7.0] GuiOutlineDetails
 
@@ -52,7 +52,7 @@ from novelwriter.constants import trConst, nwKeyWords, nwLabels
 logger = logging.getLogger(__name__)
 
 
-class GuiOutline(QWidget):
+class GuiOutlineView(QWidget):
 
     loadDocumentTagRequest = pyqtSignal(str, Enum)
 
@@ -64,11 +64,11 @@ class GuiOutline(QWidget):
 
         # Build GUI
         self.outlineBar  = GuiOutlineToolBar(self)
-        self.outlineView = GuiOutlineView(self)
+        self.outlineTree = GuiOutlineTree(self)
         self.outlineData = GuiOutlineDetails(self)
 
         self.splitOutline = QSplitter(Qt.Vertical)
-        self.splitOutline.addWidget(self.outlineView)
+        self.splitOutline.addWidget(self.outlineTree)
         self.splitOutline.addWidget(self.outlineData)
         self.splitOutline.setSizes(self.mainConf.getOutlinePanePos())
 
@@ -81,14 +81,14 @@ class GuiOutline(QWidget):
         self.setLayout(self.outerBox)
 
         # Connect Signals
-        self.outlineView.hiddenStateChanged.connect(self._updateMenuColumns)
-        self.outlineView.activeItemChanged.connect(self.outlineData.showItem)
+        self.outlineTree.hiddenStateChanged.connect(self._updateMenuColumns)
+        self.outlineTree.activeItemChanged.connect(self.outlineData.showItem)
         self.outlineData.itemTagClicked.connect(self._tagClicked)
         self.outlineBar.loadNovelRootRequest.connect(self._rootItemChanged)
-        self.outlineBar.viewColumnToggled.connect(self.outlineView.menuColumnToggled)
+        self.outlineBar.viewColumnToggled.connect(self.outlineTree.menuColumnToggled)
 
         # Function Mappings
-        self.getSelectedHandle = self.outlineView.getSelectedHandle
+        self.getSelectedHandle = self.outlineTree.getSelectedHandle
 
         return
 
@@ -104,24 +104,24 @@ class GuiOutline(QWidget):
         return
 
     def initOutline(self):
-        self.outlineView.initOutline()
+        self.outlineTree.initOutline()
         self.outlineData.initDetails()
         return
 
     def closeOutline(self):
-        self.outlineView.closeOutline()
+        self.outlineTree.closeOutline()
         self.outlineData.updateClasses()
         return
 
     def refreshView(self, overRide=False, novelChanged=False):
-        self.outlineView.refreshTree(overRide=overRide, novelChanged=novelChanged)
+        self.outlineTree.refreshTree(overRide=overRide, novelChanged=novelChanged)
         return
 
     def treeFocus(self):
-        return self.outlineView.hasFocus()
+        return self.outlineTree.hasFocus()
 
     def setTreeFocus(self):
-        return self.outlineView.setFocus()
+        return self.outlineTree.setFocus()
 
     ##
     #  Public Slots
@@ -145,7 +145,7 @@ class GuiOutline(QWidget):
         checkboxes whenever a signal is received that the hidden state
         of columns has changed.
         """
-        self.outlineBar.setColumnHiddenState(self.outlineView.hiddenColumns)
+        self.outlineBar.setColumnHiddenState(self.outlineTree.hiddenColumns)
         return
 
     @pyqtSlot(str)
@@ -160,10 +160,10 @@ class GuiOutline(QWidget):
     def _rootItemChanged(self, handle):
         """The root novel handle has changed or needs to be refreshed.
         """
-        self.outlineView.refreshTree(rootHandle=(handle or None), overRide=True)
+        self.outlineTree.refreshTree(rootHandle=(handle or None), overRide=True)
         return
 
-# END Class GuiOutline
+# END Class GuiOutlineView
 
 
 class GuiOutlineToolBar(QToolBar):
@@ -271,7 +271,7 @@ class GuiOutlineToolBar(QToolBar):
 # END Class GuiOutlineToolBar
 
 
-class GuiOutlineView(QTreeWidget):
+class GuiOutlineTree(QTreeWidget):
 
     DEF_WIDTH = {
         nwOutline.TITLE:  200,
@@ -319,7 +319,7 @@ class GuiOutlineView(QTreeWidget):
     def __init__(self, theOutline):
         QTreeWidget.__init__(self, theOutline)
 
-        logger.debug("Initialising GuiOutlineView ...")
+        logger.debug("Initialising GuiOutlineTree ...")
 
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = theOutline.mainGui
@@ -355,7 +355,7 @@ class GuiOutlineView(QTreeWidget):
 
         self.hiddenStateChanged.emit()
 
-        logger.debug("GuiOutlineView initialisation complete")
+        logger.debug("GuiOutlineTree initialisation complete")
 
         return
 
@@ -717,7 +717,7 @@ class GuiOutlineView(QTreeWidget):
 
         return newItem
 
-# END Class GuiOutlineView
+# END Class GuiOutlineTree
 
 
 class GuiOutlineHeaderMenu(QMenu):

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -169,9 +169,9 @@ class GuiProjectToolBar(QWidget):
         self.projTree   = projView.projTree
         self.mainGui    = projView.mainGui
         self.theProject = projView.mainGui.theProject
-        self.theTheme   = projView.mainGui.theTheme
+        self.mainTheme  = projView.mainGui.mainTheme
 
-        iPx = self.theTheme.baseIconSize
+        iPx = self.mainTheme.baseIconSize
         mPx = self.mainConf.pxInt(4)
 
         self.setContentsMargins(0, 0, 0, 0)
@@ -195,14 +195,14 @@ class GuiProjectToolBar(QWidget):
         # Move Buttons
         self.tbMoveU = QToolButton(self)
         self.tbMoveU.setToolTip("%s [Ctrl+Up]" % self.tr("Move Up"))
-        self.tbMoveU.setIcon(self.theTheme.getIcon("up"))
+        self.tbMoveU.setIcon(self.mainTheme.getIcon("up"))
         self.tbMoveU.setIconSize(QSize(iPx, iPx))
         self.tbMoveU.setStyleSheet(buttonStyle)
         self.tbMoveU.clicked.connect(lambda: self.projTree.moveTreeItem(-1))
 
         self.tbMoveD = QToolButton(self)
         self.tbMoveD.setToolTip("%s [Ctrl+Down]" % self.tr("Move Down"))
-        self.tbMoveD.setIcon(self.theTheme.getIcon("down"))
+        self.tbMoveD.setIcon(self.mainTheme.getIcon("down"))
         self.tbMoveD.setIconSize(QSize(iPx, iPx))
         self.tbMoveD.setStyleSheet(buttonStyle)
         self.tbMoveD.clicked.connect(lambda: self.projTree.moveTreeItem(1))
@@ -211,31 +211,31 @@ class GuiProjectToolBar(QWidget):
         self.mAdd = QMenu()
 
         self.aAddEmpty = self.mAdd.addAction(trConst(nwLabels.ITEM_DESCRIPTION["document"]))
-        self.aAddEmpty.setIcon(self.theTheme.getIcon("proj_document"))
+        self.aAddEmpty.setIcon(self.mainTheme.getIcon("proj_document"))
         self.aAddEmpty.triggered.connect(
             lambda: self.projTree.newTreeItem(nwItemType.FILE, hLevel=0, isNote=False)
         )
 
         self.aAddChap = self.mAdd.addAction(trConst(nwLabels.ITEM_DESCRIPTION["doc_h2"]))
-        self.aAddChap.setIcon(self.theTheme.getIcon("proj_chapter"))
+        self.aAddChap.setIcon(self.mainTheme.getIcon("proj_chapter"))
         self.aAddChap.triggered.connect(
             lambda: self.projTree.newTreeItem(nwItemType.FILE, hLevel=2, isNote=False)
         )
 
         self.aAddScene = self.mAdd.addAction(trConst(nwLabels.ITEM_DESCRIPTION["doc_h3"]))
-        self.aAddScene.setIcon(self.theTheme.getIcon("proj_scene"))
+        self.aAddScene.setIcon(self.mainTheme.getIcon("proj_scene"))
         self.aAddScene.triggered.connect(
             lambda: self.projTree.newTreeItem(nwItemType.FILE, hLevel=3, isNote=False)
         )
 
         self.aAddNote = self.mAdd.addAction(trConst(nwLabels.ITEM_DESCRIPTION["note"]))
-        self.aAddNote.setIcon(self.theTheme.getIcon("proj_note"))
+        self.aAddNote.setIcon(self.mainTheme.getIcon("proj_note"))
         self.aAddNote.triggered.connect(
             lambda: self.projTree.newTreeItem(nwItemType.FILE, hLevel=1, isNote=True)
         )
 
         self.aAddFolder = self.mAdd.addAction(trConst(nwLabels.ITEM_DESCRIPTION["folder"]))
-        self.aAddFolder.setIcon(self.theTheme.getIcon("proj_folder"))
+        self.aAddFolder.setIcon(self.mainTheme.getIcon("proj_folder"))
         self.aAddFolder.triggered.connect(
             lambda: self.projTree.newTreeItem(nwItemType.FOLDER)
         )
@@ -255,7 +255,7 @@ class GuiProjectToolBar(QWidget):
         self.tbAdd = QToolButton(self)
         self.tbAdd.setToolTip("%s [Ctrl+N]" % self.tr("Add Item"))
         self.tbAdd.setShortcut("Ctrl+N")
-        self.tbAdd.setIcon(self.theTheme.getIcon("add"))
+        self.tbAdd.setIcon(self.mainTheme.getIcon("add"))
         self.tbAdd.setIconSize(QSize(iPx, iPx))
         self.tbAdd.setStyleSheet(buttonStyle)
         self.tbAdd.setMenu(self.mAdd)
@@ -272,7 +272,7 @@ class GuiProjectToolBar(QWidget):
 
         self.tbMore = QToolButton(self)
         self.tbMore.setToolTip(self.tr("More Options"))
-        self.tbMore.setIcon(self.theTheme.getIcon("menu"))
+        self.tbMore.setIcon(self.mainTheme.getIcon("menu"))
         self.tbMore.setIconSize(QSize(iPx, iPx))
         self.tbMore.setStyleSheet(buttonStyle)
         self.tbMore.setMenu(self.mMore)
@@ -302,7 +302,7 @@ class GuiProjectToolBar(QWidget):
         """Add a menu entry for a root folder of a given class.
         """
         aNew = self.mAddRoot.addAction(trConst(nwLabels.CLASS_NAME[itemClass]))
-        aNew.setIcon(self.theTheme.getIcon(nwLabels.CLASS_ICON[itemClass]))
+        aNew.setIcon(self.mainTheme.getIcon(nwLabels.CLASS_ICON[itemClass]))
         aNew.triggered.connect(lambda: self.projTree.newTreeItem(nwItemType.ROOT, itemClass))
         self.mAddRoot.addAction(aNew)
 
@@ -324,7 +324,7 @@ class GuiProjectTree(QTreeWidget):
         self.mainConf   = novelwriter.CONFIG
         self.projView   = projView
         self.mainGui    = projView.mainGui
-        self.theTheme   = projView.mainGui.theTheme
+        self.mainTheme   = projView.mainGui.mainTheme
         self.theProject = projView.mainGui.theProject
 
         # Internal Variables
@@ -341,7 +341,7 @@ class GuiProjectTree(QTreeWidget):
         self.customContextMenuRequested.connect(self._openContextMenu)
 
         # Tree Settings
-        iPx = self.theTheme.baseIconSize
+        iPx = self.mainTheme.baseIconSize
         cMg = self.mainConf.pxInt(6)
         self.setIconSize(QSize(iPx, iPx))
         self.setFrameStyle(QFrame.NoFrame)
@@ -779,13 +779,13 @@ class GuiProjectTree(QTreeWidget):
         expIcon = QIcon()
         if nwItem.itemType == nwItemType.FILE:
             if nwItem.isExported:
-                expIcon = self.theTheme.getIcon("check")
+                expIcon = self.mainTheme.getIcon("check")
             else:
-                expIcon = self.theTheme.getIcon("cross")
+                expIcon = self.mainTheme.getIcon("cross")
 
         itemStatus, statusIcon = nwItem.getImportStatus()
         hLevel = self.theProject.index.getHandleHeaderLevel(tHandle)
-        itemIcon = self.theTheme.getItemIcon(
+        itemIcon = self.mainTheme.getItemIcon(
             nwItem.itemType, nwItem.itemClass, nwItem.itemLayout, hLevel
         )
 

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -48,15 +48,15 @@ class GuiMainStatus(QStatusBar):
 
         self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
-        self.theTheme  = mainGui.theTheme
+        self.mainTheme = mainGui.mainTheme
         self.refTime   = None
         self.userIdle  = False
 
-        colNone = QColor(*self.theTheme.statNone)
-        colTrue = QColor(*self.theTheme.statUnsaved)
-        colFalse = QColor(*self.theTheme.statSaved)
+        colNone = QColor(*self.mainTheme.statNone)
+        colTrue = QColor(*self.mainTheme.statUnsaved)
+        colFalse = QColor(*self.mainTheme.statSaved)
 
-        iPx = self.theTheme.baseIconSize
+        iPx = self.mainTheme.baseIconSize
 
         # Permanent Widgets
         # =================
@@ -66,7 +66,7 @@ class GuiMainStatus(QStatusBar):
         # The Spell Checker Language
         self.langIcon = QLabel("")
         self.langText = QLabel(self.tr("None"))
-        self.langIcon.setPixmap(self.theTheme.getPixmap("status_lang", (iPx, iPx)))
+        self.langIcon.setPixmap(self.mainTheme.getPixmap("status_lang", (iPx, iPx)))
         self.langIcon.setContentsMargins(0, 0, 0, 0)
         self.langText.setContentsMargins(0, 0, xM, 0)
         self.addPermanentWidget(self.langIcon)
@@ -91,7 +91,7 @@ class GuiMainStatus(QStatusBar):
         # The Project and Session Stats
         self.statsIcon = QLabel()
         self.statsText = QLabel("")
-        self.statsIcon.setPixmap(self.theTheme.getPixmap("status_stats", (iPx, iPx)))
+        self.statsIcon.setPixmap(self.mainTheme.getPixmap("status_stats", (iPx, iPx)))
         self.statsIcon.setContentsMargins(0, 0, 0, 0)
         self.statsText.setContentsMargins(0, 0, xM, 0)
         self.addPermanentWidget(self.statsIcon)
@@ -99,14 +99,14 @@ class GuiMainStatus(QStatusBar):
 
         # The Session Clock
         # Set the mimimum width so the label doesn't rescale every second
-        self.timePixmap = self.theTheme.getPixmap("status_time", (iPx, iPx))
-        self.idlePixmap = self.theTheme.getPixmap("status_idle", (iPx, iPx))
+        self.timePixmap = self.mainTheme.getPixmap("status_time", (iPx, iPx))
+        self.idlePixmap = self.mainTheme.getPixmap("status_idle", (iPx, iPx))
 
         self.timeIcon = QLabel()
         self.timeText = QLabel("")
         self.timeIcon.setPixmap(self.timePixmap)
         self.timeText.setToolTip(self.tr("Session Time"))
-        self.timeText.setMinimumWidth(self.theTheme.getTextWidth("00:00:00:"))
+        self.timeText.setMinimumWidth(self.mainTheme.getTextWidth("00:00:00:"))
         self.timeIcon.setContentsMargins(0, 0, 0, 0)
         self.timeText.setContentsMargins(0, 0, 0, 0)
         self.addPermanentWidget(self.timeIcon)

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -41,14 +41,14 @@ logger = logging.getLogger(__name__)
 
 class GuiMainStatus(QStatusBar):
 
-    def __init__(self, theParent):
-        QStatusBar.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QStatusBar.__init__(self, mainGui)
 
         logger.debug("Initialising GuiMainStatus ...")
 
         self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainGui   = mainGui
+        self.theTheme  = mainGui.theTheme
         self.refTime   = None
         self.userIdle  = False
 

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -54,7 +54,7 @@ class GuiTheme:
     def __init__(self):
 
         self.mainConf = novelwriter.CONFIG
-        self.theIcons = GuiIcons(self)
+        self.iconCache = GuiIcons(self)
 
         # Loaded Theme Settings
         # =====================
@@ -127,13 +127,13 @@ class GuiTheme:
 
         self.updateFont()
         self.updateTheme()
-        self.theIcons.updateTheme()
+        self.iconCache.updateTheme()
 
         # Icon Functions
-        self.getIcon = self.theIcons.getIcon
-        self.getPixmap = self.theIcons.getPixmap
-        self.getItemIcon = self.theIcons.getItemIcon
-        self.loadDecoration = self.theIcons.loadDecoration
+        self.getIcon = self.iconCache.getIcon
+        self.getPixmap = self.iconCache.getPixmap
+        self.getItemIcon = self.iconCache.getItemIcon
+        self.loadDecoration = self.iconCache.loadDecoration
 
         # Extract Other Info
         self.guiDPI = qApp.primaryScreen().logicalDotsPerInchX()
@@ -478,10 +478,10 @@ class GuiIcons:
         "wiz-back": "wizard-back.jpg",
     }
 
-    def __init__(self, theTheme):
+    def __init__(self, mainTheme):
 
         self.mainConf = novelwriter.CONFIG
-        self.theTheme = theTheme
+        self.mainTheme = mainTheme
 
         # Storage
         self._qIcons    = {}

--- a/novelwriter/gui/viewsbar.py
+++ b/novelwriter/gui/viewsbar.py
@@ -45,16 +45,16 @@ class GuiViewsBar(QToolBar):
 
         logger.debug("Initialising GuiViewsBar ...")
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         # Style
         iPx = self.mainConf.pxInt(22)
         mPx = self.mainConf.pxInt(60)
 
-        lblFont = self.theTheme.guiFont
-        lblFont.setPointSizeF(0.65*self.theTheme.fontPointSize)
+        lblFont = self.mainTheme.guiFont
+        lblFont.setPointSizeF(0.65*self.mainTheme.fontPointSize)
 
         self.setMovable(False)
         self.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
@@ -70,37 +70,37 @@ class GuiViewsBar(QToolBar):
         self.aProject = QAction(self.tr("Project"))
         self.aProject.setFont(lblFont)
         self.aProject.setToolTip(self.tr("Show project tree and editor"))
-        self.aProject.setIcon(self.theTheme.getIcon("view_editor"))
+        self.aProject.setIcon(self.mainTheme.getIcon("view_editor"))
         self.aProject.triggered.connect(lambda: self.viewChangeRequested.emit(nwView.PROJECT))
 
         self.aNovel = QAction(self.tr("Novel"))
         self.aNovel.setFont(lblFont)
         self.aNovel.setToolTip(self.tr("Show novel tree and editor"))
-        self.aNovel.setIcon(self.theTheme.getIcon("view_novel"))
+        self.aNovel.setIcon(self.mainTheme.getIcon("view_novel"))
         self.aNovel.triggered.connect(lambda: self.viewChangeRequested.emit(nwView.NOVEL))
 
         self.aOutline = QAction(self.tr("Outline"))
         self.aOutline.setFont(lblFont)
         self.aOutline.setToolTip(self.tr("Show novel outline"))
-        self.aOutline.setIcon(self.theTheme.getIcon("view_outline"))
+        self.aOutline.setIcon(self.mainTheme.getIcon("view_outline"))
         self.aOutline.triggered.connect(lambda: self.viewChangeRequested.emit(nwView.OUTLINE))
 
         self.aBuild = QAction(self.tr("Build"))
         self.aBuild.setFont(lblFont)
         self.aBuild.setToolTip(self.tr("Build novel project"))
-        self.aBuild.setIcon(self.theTheme.getIcon("view_build"))
+        self.aBuild.setIcon(self.mainTheme.getIcon("view_build"))
         self.aBuild.triggered.connect(lambda: self.mainGui.showBuildProjectDialog())
 
         self.aDetails = QAction(self.tr("Details"))
         self.aDetails.setFont(lblFont)
         self.aDetails.setToolTip(self.tr("Show project details"))
-        self.aDetails.setIcon(self.theTheme.getIcon("proj_details"))
+        self.aDetails.setIcon(self.mainTheme.getIcon("proj_details"))
         self.aDetails.triggered.connect(lambda: self.mainGui.showProjectDetailsDialog())
 
         self.aStats = QAction(self.tr("Stats"))
         self.aStats.setFont(lblFont)
         self.aStats.setToolTip(self.tr("Show project statistics"))
-        self.aStats.setIcon(self.theTheme.getIcon("proj_stats"))
+        self.aStats.setIcon(self.mainTheme.getIcon("proj_stats"))
         self.aStats.triggered.connect(lambda: self.mainGui.showWritingStatsDialog())
 
         # Settings Menu
@@ -117,7 +117,7 @@ class GuiViewsBar(QToolBar):
         self.tbSettings = QToolButton(self)
         self.tbSettings.setFont(lblFont)
         self.tbSettings.setText(self.tr("Settings"))
-        self.tbSettings.setIcon(self.theTheme.getIcon("settings"))
+        self.tbSettings.setIcon(self.mainTheme.getIcon("settings"))
         self.tbSettings.setMenu(self.mSettings)
         self.tbSettings.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
         self.tbSettings.setPopupMode(QToolButton.InstantPopup)

--- a/novelwriter/gui/viewsbar.py
+++ b/novelwriter/gui/viewsbar.py
@@ -40,14 +40,14 @@ class GuiViewsBar(QToolBar):
 
     viewChangeRequested = pyqtSignal(nwView)
 
-    def __init__(self, theParent):
-        QToolBar.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QToolBar.__init__(self, mainGui)
 
         logger.debug("Initialising GuiViewsBar ...")
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         # Style
         iPx = self.mainConf.pxInt(22)
@@ -89,29 +89,29 @@ class GuiViewsBar(QToolBar):
         self.aBuild.setFont(lblFont)
         self.aBuild.setToolTip(self.tr("Build novel project"))
         self.aBuild.setIcon(self.theTheme.getIcon("view_build"))
-        self.aBuild.triggered.connect(lambda: self.theParent.showBuildProjectDialog())
+        self.aBuild.triggered.connect(lambda: self.mainGui.showBuildProjectDialog())
 
         self.aDetails = QAction(self.tr("Details"))
         self.aDetails.setFont(lblFont)
         self.aDetails.setToolTip(self.tr("Show project details"))
         self.aDetails.setIcon(self.theTheme.getIcon("proj_details"))
-        self.aDetails.triggered.connect(lambda: self.theParent.showProjectDetailsDialog())
+        self.aDetails.triggered.connect(lambda: self.mainGui.showProjectDetailsDialog())
 
         self.aStats = QAction(self.tr("Stats"))
         self.aStats.setFont(lblFont)
         self.aStats.setToolTip(self.tr("Show project statistics"))
         self.aStats.setIcon(self.theTheme.getIcon("proj_stats"))
-        self.aStats.triggered.connect(lambda: self.theParent.showWritingStatsDialog())
+        self.aStats.triggered.connect(lambda: self.mainGui.showWritingStatsDialog())
 
         # Settings Menu
         self.mSettings = QMenu()
 
         self.aPrjSettings = QAction(self.tr("Project Settings"))
-        self.aPrjSettings.triggered.connect(lambda: self.theParent.showProjectSettingsDialog())
+        self.aPrjSettings.triggered.connect(lambda: self.mainGui.showProjectSettingsDialog())
         self.mSettings.addAction(self.aPrjSettings)
 
         self.aPreferences = QAction(self.tr("Preferences"))
-        self.aPreferences.triggered.connect(lambda: self.theParent.showPreferencesDialog())
+        self.aPreferences.triggered.connect(lambda: self.mainGui.showPreferencesDialog())
         self.mSettings.addAction(self.aPreferences)
 
         self.tbSettings = QToolButton(self)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -84,7 +84,7 @@ class GuiMain(QMainWindow):
         # ============
 
         # Core Classes and Settings
-        self.theTheme    = GuiTheme()
+        self.mainTheme   = GuiTheme()
         self.theProject  = NWProject(self)
         self.hasProject  = False
         self.isFocusMode = False
@@ -915,7 +915,7 @@ class GuiMain(QMainWindow):
         if dlgConf.result() == QDialog.Accepted:
             logger.debug("Applying new preferences")
             self.initMain()
-            self.theTheme.updateTheme()
+            self.mainTheme.updateTheme()
             self.saveDocument()
             self.docEditor.initEditor()
             self.docViewer.initViewer()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -104,20 +104,20 @@ class GuiMain(QMainWindow):
         hWd = self.mainConf.pxInt(4)
 
         # Main GUI Elements
-        self.statusBar = GuiMainStatus(self)
-        self.treeView  = GuiProjectView(self)
-        self.novelView = GuiNovelTree(self)
-        self.docEditor = GuiDocEditor(self)
-        self.viewMeta  = GuiDocViewDetails(self)
-        self.docViewer = GuiDocViewer(self)
-        self.treeMeta  = GuiItemDetails(self)
-        self.projView  = GuiOutline(self)
-        self.mainMenu  = GuiMainMenu(self)
-        self.viewsBar  = GuiViewsBar(self)
+        self.statusBar   = GuiMainStatus(self)
+        self.projView    = GuiProjectView(self)
+        self.novelView   = GuiNovelTree(self)
+        self.docEditor   = GuiDocEditor(self)
+        self.viewMeta    = GuiDocViewDetails(self)
+        self.docViewer   = GuiDocViewer(self)
+        self.itemDetails = GuiItemDetails(self)
+        self.outlineView = GuiOutline(self)
+        self.mainMenu    = GuiMainMenu(self)
+        self.viewsBar    = GuiViewsBar(self)
 
         # Project Tree Stack
         self.projStack = QStackedWidget()
-        self.projStack.addWidget(self.treeView)
+        self.projStack.addWidget(self.projView)
         self.projStack.addWidget(self.novelView)
         self.projStack.currentChanged.connect(self._projStackChanged)
 
@@ -127,7 +127,7 @@ class GuiMain(QMainWindow):
         self.treeBox.setContentsMargins(0, 0, 0, 0)
         self.treeBox.setSpacing(mPx)
         self.treeBox.addWidget(self.projStack)
-        self.treeBox.addWidget(self.treeMeta)
+        self.treeBox.addWidget(self.itemDetails)
         self.treePane.setLayout(self.treeBox)
 
         # Splitter : Document Viewer / Document Meta
@@ -154,7 +154,7 @@ class GuiMain(QMainWindow):
         # Main Stack : Editor / Outline
         self.mainStack = QStackedWidget()
         self.mainStack.addWidget(self.splitMain)
-        self.mainStack.addWidget(self.projView)
+        self.mainStack.addWidget(self.outlineView)
         self.mainStack.currentChanged.connect(self._mainStackChanged)
 
         # Indices of Splitter Widgets
@@ -167,8 +167,8 @@ class GuiMain(QMainWindow):
 
         # Indices of Tab Widgets
         self.idxEditorView  = self.mainStack.indexOf(self.splitMain)
-        self.idxOutlineView = self.mainStack.indexOf(self.projView)
-        self.idxTreeView    = self.projStack.indexOf(self.treeView)
+        self.idxOutlineView = self.mainStack.indexOf(self.outlineView)
+        self.idxProjView    = self.projStack.indexOf(self.projView)
         self.idxNovelView   = self.projStack.indexOf(self.novelView)
 
         # Splitter Behaviour
@@ -197,24 +197,24 @@ class GuiMain(QMainWindow):
 
         self.viewsBar.viewChangeRequested.connect(self._changeView)
 
-        self.treeView.selectedItemChanged.connect(self.treeMeta.updateViewBox)
-        self.treeView.openDocumentRequest.connect(self._openDocument)
-        self.treeView.novelItemChanged.connect(self._treeNovelItemChanged)
-        self.treeView.wordCountsChanged.connect(self._updateStatusWordCount)
-        self.treeView.treeItemChanged.connect(self.docEditor.updateDocInfo)
-        self.treeView.treeItemChanged.connect(self.docViewer.updateDocInfo)
-        self.treeView.treeItemChanged.connect(self.treeMeta.updateViewBox)
-        self.treeView.rootFolderChanged.connect(self.projView.updateRootItem)
+        self.projView.selectedItemChanged.connect(self.itemDetails.updateViewBox)
+        self.projView.openDocumentRequest.connect(self._openDocument)
+        self.projView.novelItemChanged.connect(self._treeNovelItemChanged)
+        self.projView.wordCountsChanged.connect(self._updateStatusWordCount)
+        self.projView.treeItemChanged.connect(self.docEditor.updateDocInfo)
+        self.projView.treeItemChanged.connect(self.docViewer.updateDocInfo)
+        self.projView.treeItemChanged.connect(self.itemDetails.updateViewBox)
+        self.projView.rootFolderChanged.connect(self.outlineView.updateRootItem)
 
         self.docEditor.spellDictionaryChanged.connect(self.statusBar.setLanguage)
         self.docEditor.docEditedStatusChanged.connect(self.statusBar.doUpdateDocumentStatus)
-        self.docEditor.docCountsChanged.connect(self.treeMeta.updateCounts)
-        self.docEditor.docCountsChanged.connect(self.treeView.updateCounts)
+        self.docEditor.docCountsChanged.connect(self.itemDetails.updateCounts)
+        self.docEditor.docCountsChanged.connect(self.projView.updateCounts)
         self.docEditor.loadDocumentTagRequest.connect(self._followTag)
 
         self.docViewer.loadDocumentTagRequest.connect(self._followTag)
 
-        self.projView.loadDocumentTagRequest.connect(self._followTag)
+        self.outlineView.loadDocumentTagRequest.connect(self._followTag)
 
         # Finalise Initialisation
         # =======================
@@ -291,15 +291,15 @@ class GuiMain(QMainWindow):
         """Wrapper function to clear all sub-elements of the main GUI.
         """
         # Project Area
-        self.treeView.clearProject()
+        self.projView.clearProject()
         self.novelView.clearTree()
-        self.treeMeta.clearDetails()
+        self.itemDetails.clearDetails()
 
         # Work Area
         self.docEditor.clearEditor()
         self.docEditor.setDictionaries()
         self.closeDocViewer()
-        self.projView.clearOutline()
+        self.outlineView.clearOutline()
 
         # General
         self.statusBar.clearStatus()
@@ -361,7 +361,7 @@ class GuiMain(QMainWindow):
             self.rebuildTrees()
             self.saveProject()
             self.docEditor.setDictionaries()
-            self.projView.updateRootItem(None)
+            self.outlineView.updateRootItem(None)
             self.rebuildIndex(beQuiet=True)
             self.statusBar.setRefTime(self.theProject.projOpened)
             self.statusBar.setProjectStatus(nwState.GOOD)
@@ -417,7 +417,7 @@ class GuiMain(QMainWindow):
         if saveOK:
             self.closeDocument()
             self.docViewer.clearNavHistory()
-            self.projView.closeOutline()
+            self.outlineView.closeOutline()
 
             self.theProject.closeProject(self.idleTime)
             self.idleRefTime = time()
@@ -508,7 +508,7 @@ class GuiMain(QMainWindow):
         self.docEditor.setDictionaries()
         self.docEditor.toggleSpellCheck(self.theProject.spellCheck)
         self.statusBar.setRefTime(self.theProject.projOpened)
-        self.projView.updateRootItem(None)
+        self.outlineView.updateRootItem(None)
         self._updateStatusWordCount()
 
         # Restore previously open documents, if any
@@ -541,7 +541,7 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return False
 
-        self.treeView.saveProjectTree()
+        self.projView.saveProjectTree()
         if self.theProject.saveProject(autoSave=autoSave):
             self.theProject.index.saveIndex()
 
@@ -586,7 +586,7 @@ class GuiMain(QMainWindow):
             if changeFocus:
                 self.docEditor.setFocus()
             self.theProject.setLastEdited(tHandle)
-            self.treeView.setSelectedHandle(tHandle, doScroll=doScroll)
+            self.projView.setSelectedHandle(tHandle, doScroll=doScroll)
         else:
             return False
 
@@ -652,7 +652,7 @@ class GuiMain(QMainWindow):
                 self.saveDocument()
             else:
                 logger.verbose("Trying selected document")
-                tHandle = self.treeView.getSelectedHandle()
+                tHandle = self.projView.getSelectedHandle()
 
             if tHandle is None:
                 logger.verbose("Trying last viewed document")
@@ -789,12 +789,12 @@ class GuiMain(QMainWindow):
 
         tHandle = None
         tLine = None
-        if self.treeView.treeFocus():
-            tHandle = self.treeView.getSelectedHandle()
+        if self.projView.treeFocus():
+            tHandle = self.projView.getSelectedHandle()
         elif self.novelView.hasFocus():
             tHandle, tLine = self.novelView.getSelectedHandle()
-        elif self.projView.treeFocus():
-            tHandle, tLine = self.projView.getSelectedHandle()
+        elif self.outlineView.treeFocus():
+            tHandle, tLine = self.outlineView.getSelectedHandle()
         else:
             logger.warning("No item selected")
             return False
@@ -815,16 +815,16 @@ class GuiMain(QMainWindow):
             if self.docEditor.anyFocus() or self.isFocusMode:
                 tHandle = self.docEditor.docHandle()
             else:
-                tHandle = self.treeView.getSelectedHandle()
+                tHandle = self.projView.getSelectedHandle()
         if tHandle:
-            return self.treeView.editTreeItem(tHandle)
+            return self.projView.editTreeItem(tHandle)
 
         return False
 
     def rebuildTrees(self):
         """Rebuild the project tree.
         """
-        self.treeView.populateTree()
+        self.projView.populateTree()
         self.novelView.refreshTree()
         return
 
@@ -847,7 +847,7 @@ class GuiMain(QMainWindow):
         qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
         tStart = time()
 
-        self.treeView.saveProjectTree()
+        self.projView.saveProjectTree()
         self.theProject.index.clearIndex()
 
         for tItem in self.theProject.tree:
@@ -857,8 +857,8 @@ class GuiMain(QMainWindow):
             logger.verbose("Indexing '%s'", tItem.itemName)
             if self.theProject.index.reIndexHandle(tItem.itemHandle):
                 # Update Word Counts
-                self.treeView.propagateCount(tItem.itemHandle, tItem.wordCount, countChildren=True)
-                self.treeView.setTreeItemValues(tItem.itemHandle)
+                self.projView.propagateCount(tItem.itemHandle, tItem.wordCount, countChildren=True)
+                self.projView.setTreeItemValues(tItem.itemHandle)
 
         tEnd = time()
         self.setStatus(
@@ -919,9 +919,9 @@ class GuiMain(QMainWindow):
             self.saveDocument()
             self.docEditor.initEditor()
             self.docViewer.initViewer()
-            self.treeView.initSettings()
+            self.projView.initSettings()
             self.novelView.initTree()
-            self.projView.initOutline()
+            self.outlineView.initOutline()
             self._updateStatusWordCount()
 
         return
@@ -940,7 +940,7 @@ class GuiMain(QMainWindow):
             logger.debug("Applying new project settings")
             if dlgProj.spellChanged:
                 self.docEditor.setDictionaries()
-            self.treeMeta.refreshDetails()
+            self.itemDetails.refreshDetails()
             self._updateWindowTitle(self.theProject.projName)
 
         return True
@@ -1156,7 +1156,7 @@ class GuiMain(QMainWindow):
         if not self.isFocusMode:
             self.mainConf.setMainPanePos(self.splitMain.sizes())
             self.mainConf.setDocPanePos(self.splitDocs.sizes())
-            self.mainConf.setOutlinePanePos(self.projView.splitSizes())
+            self.mainConf.setOutlinePanePos(self.outlineView.splitSizes())
             if self.viewMeta.isVisible():
                 self.mainConf.setViewPanePos(self.splitView.sizes())
 
@@ -1180,8 +1180,8 @@ class GuiMain(QMainWindow):
         """
         if paneNo == nwWidget.TREE:
             tabIdx = self.projStack.currentIndex()
-            if tabIdx == self.idxTreeView:
-                self.treeView.setFocus()
+            if tabIdx == self.idxProjView:
+                self.projView.setFocus()
             elif tabIdx == self.idxNovelView:
                 self.novelView.setFocus()
         elif paneNo == nwWidget.EDITOR:
@@ -1192,7 +1192,7 @@ class GuiMain(QMainWindow):
             self.docViewer.setFocus()
         elif paneNo == nwWidget.OUTLINE:
             self._changeView(nwView.OUTLINE)
-            self.projView.setTreeFocus()
+            self.outlineView.setTreeFocus()
         return
 
     def closeDocEditor(self):
@@ -1490,14 +1490,14 @@ class GuiMain(QMainWindow):
 
         elif view == nwView.PROJECT:
             self.mainStack.setCurrentWidget(self.splitMain)
-            self.projStack.setCurrentWidget(self.treeView)
+            self.projStack.setCurrentWidget(self.projView)
 
         elif view == nwView.NOVEL:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.novelView)
 
         elif view == nwView.OUTLINE:
-            self.mainStack.setCurrentWidget(self.projView)
+            self.mainStack.setCurrentWidget(self.outlineView)
 
         return
 
@@ -1551,7 +1551,7 @@ class GuiMain(QMainWindow):
         if self.mainStack.currentIndex() == self.idxOutlineView:
             logger.verbose("Novel tree changed while Outline tab active")
             if self.hasProject:
-                self.projView.refreshView(novelChanged=True)
+                self.outlineView.refreshView(novelChanged=True)
 
         return
 
@@ -1584,7 +1584,7 @@ class GuiMain(QMainWindow):
         elif tabIndex == self.idxOutlineView:
             logger.verbose("Project outline tab activated")
             if self.hasProject:
-                self.projView.refreshView()
+                self.outlineView.refreshView()
 
         return
 
@@ -1594,9 +1594,9 @@ class GuiMain(QMainWindow):
         """
         sHandle = None
 
-        if tabIndex == self.idxTreeView:
+        if tabIndex == self.idxProjView:
             logger.verbose("Project tree tab activated")
-            sHandle = self.treeView.getSelectedHandle()
+            sHandle = self.projView.getSelectedHandle()
 
         elif tabIndex == self.idxNovelView:
             logger.verbose("Novel tree tab activated")
@@ -1604,7 +1604,7 @@ class GuiMain(QMainWindow):
                 self.novelView.refreshTree()
                 sHandle, _ = self.novelView.getSelectedHandle()
 
-        self.treeMeta.updateViewBox(sHandle)
+        self.itemDetails.updateViewBox(sHandle)
 
         return
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -40,7 +40,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter.gui import (
     GuiDocEditor, GuiDocViewDetails, GuiDocViewer, GuiItemDetails, GuiMainMenu,
-    GuiMainStatus, GuiNovelTree, GuiOutline, GuiProjectView, GuiTheme,
+    GuiMainStatus, GuiNovelTree, GuiOutlineView, GuiProjectView, GuiTheme,
     GuiViewsBar
 )
 from novelwriter.dialogs import (
@@ -111,7 +111,7 @@ class GuiMain(QMainWindow):
         self.viewMeta    = GuiDocViewDetails(self)
         self.docViewer   = GuiDocViewer(self)
         self.itemDetails = GuiItemDetails(self)
-        self.outlineView = GuiOutline(self)
+        self.outlineView = GuiOutlineView(self)
         self.mainMenu    = GuiMainMenu(self)
         self.viewsBar    = GuiViewsBar(self)
 

--- a/novelwriter/tools/build.py
+++ b/novelwriter/tools/build.py
@@ -65,16 +65,16 @@ class GuiBuildNovel(QDialog):
     FMT_JSON_H = 8  # HTML5 wrapped in JSON
     FMT_JSON_M = 9  # nW Markdown wrapped in JSON
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiBuildNovel ...")
         self.setObjectName("GuiBuildNovel")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
+        self.theProject = mainGui.theProject
 
         self.htmlText  = []  # List of html documents
         self.htmlStyle = []  # List of html styles
@@ -711,7 +711,7 @@ class GuiBuildNovel(QDialog):
             bldObj.initDocument()
 
         # Make sure the project and document is up to date
-        self.theParent.saveDocument()
+        self.mainGui.saveDocument()
 
         self.buildProgress.setMaximum(len(self.theProject.tree))
         self.buildProgress.setValue(0)
@@ -760,7 +760,7 @@ class GuiBuildNovel(QDialog):
         logger.debug("Built project in %.3f ms", 1000*(tEnd - tStart))
 
         if bldObj.errData:
-            self.theParent.makeAlert([
+            self.mainGui.makeAlert([
                 self.tr("There were problems when building the project:")
             ] + bldObj.errData, nwAlert.ERROR)
 
@@ -1003,11 +1003,11 @@ class GuiBuildNovel(QDialog):
         # ==============
 
         if wSuccess:
-            self.theParent.makeAlert([
+            self.mainGui.makeAlert([
                 self.tr("{0} file successfully written to:").format(textFmt), savePath
             ], nwAlert.INFO)
         else:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "Failed to write {0} file. {1}"
             ).format(textFmt, errMsg), nwAlert.ERROR)
 
@@ -1193,18 +1193,18 @@ class GuiBuildNovel(QDialog):
 
 class GuiBuildNovelDocView(QTextBrowser):
 
-    def __init__(self, theParent, theProject):
-        QTextBrowser.__init__(self, theParent)
+    def __init__(self, mainGui, theProject):
+        QTextBrowser.__init__(self, mainGui)
 
         logger.debug("Initialising GuiBuildNovelDocView ...")
 
         self.mainConf   = novelwriter.CONFIG
         self.theProject = theProject
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
         self.buildTime  = 0
 
-        self.setMinimumWidth(40*self.theParent.theTheme.textNWidth)
+        self.setMinimumWidth(40*self.mainGui.theTheme.textNWidth)
         self.setOpenExternalLinks(False)
 
         self.document().setDocumentMargin(self.mainConf.getTextMargin())

--- a/novelwriter/tools/build.py
+++ b/novelwriter/tools/build.py
@@ -73,7 +73,7 @@ class GuiBuildNovel(QDialog):
 
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
 
         self.htmlText  = []  # List of html documents
@@ -93,7 +93,7 @@ class GuiBuildNovel(QDialog):
 
         self.docView = GuiBuildNovelDocView(self, self.theProject)
 
-        hS = self.theTheme.fontPixelSize
+        hS = self.mainTheme.fontPixelSize
         wS = 2*hS
 
         # Title Formats
@@ -238,11 +238,11 @@ class GuiBuildNovel(QDialog):
             pOptions.getString("GuiBuildNovel", "textFont", self.mainConf.textFont)
         )
         self.fontButton = QPushButton("...")
-        self.fontButton.setMaximumWidth(int(2.5*self.theTheme.getTextWidth("...")))
+        self.fontButton.setMaximumWidth(int(2.5*self.mainTheme.getTextWidth("...")))
         self.fontButton.clicked.connect(self._selectFont)
 
         self.textSize = QSpinBox(self)
-        self.textSize.setFixedWidth(6*self.theTheme.textNWidth)
+        self.textSize.setFixedWidth(6*self.mainTheme.textNWidth)
         self.textSize.setMinimum(6)
         self.textSize.setMaximum(72)
         self.textSize.setSingleStep(1)
@@ -251,7 +251,7 @@ class GuiBuildNovel(QDialog):
         )
 
         self.lineHeight = QDoubleSpinBox(self)
-        self.lineHeight.setFixedWidth(6*self.theTheme.textNWidth)
+        self.lineHeight.setFixedWidth(6*self.mainTheme.textNWidth)
         self.lineHeight.setMinimum(0.8)
         self.lineHeight.setMaximum(3.0)
         self.lineHeight.setSingleStep(0.05)
@@ -1201,10 +1201,10 @@ class GuiBuildNovelDocView(QTextBrowser):
         self.mainConf   = novelwriter.CONFIG
         self.theProject = theProject
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.buildTime  = 0
 
-        self.setMinimumWidth(40*self.mainGui.theTheme.textNWidth)
+        self.setMinimumWidth(40*self.mainGui.mainTheme.textNWidth)
         self.setOpenExternalLinks(False)
 
         self.document().setDocumentMargin(self.mainConf.getTextMargin())
@@ -1238,9 +1238,9 @@ class GuiBuildNovelDocView(QTextBrowser):
         lblPalette.setColor(QPalette.Foreground, lblPalette.toolTipText().color())
 
         lblFont = self.font()
-        lblFont.setPointSizeF(0.9*self.theTheme.fontPointSize)
+        lblFont.setPointSizeF(0.9*self.mainTheme.fontPointSize)
 
-        fPx = int(1.1*self.theTheme.fontPixelSize)
+        fPx = int(1.1*self.mainTheme.fontPixelSize)
 
         self.theTitle = QLabel("", self)
         self.theTitle.setIndent(0)

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -48,9 +48,9 @@ class GuiLipsum(QDialog):
         logger.debug("Initialising GuiLipsum ...")
         self.setObjectName("GuiLipsum")
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
         self.setWindowTitle(self.tr("Insert Placeholder Text"))
 
@@ -61,7 +61,7 @@ class GuiLipsum(QDialog):
         nPx = self.mainConf.pxInt(64)
         vSp = self.mainConf.pxInt(4)
         self.docIcon = QLabel()
-        self.docIcon.setPixmap(self.mainGui.theTheme.getPixmap("proj_document", (nPx, nPx)))
+        self.docIcon.setPixmap(self.mainTheme.getPixmap("proj_document", (nPx, nPx)))
 
         self.leftBox = QVBoxLayout()
         self.leftBox.setSpacing(vSp)

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -42,15 +42,15 @@ logger = logging.getLogger(__name__)
 
 class GuiLipsum(QDialog):
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiLipsum ...")
         self.setObjectName("GuiLipsum")
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         self.setWindowTitle(self.tr("Insert Placeholder Text"))
 
@@ -61,7 +61,7 @@ class GuiLipsum(QDialog):
         nPx = self.mainConf.pxInt(64)
         vSp = self.mainConf.pxInt(4)
         self.docIcon = QLabel()
-        self.docIcon.setPixmap(self.theParent.theTheme.getPixmap("proj_document", (nPx, nPx)))
+        self.docIcon.setPixmap(self.mainGui.theTheme.getPixmap("proj_document", (nPx, nPx)))
 
         self.leftBox = QVBoxLayout()
         self.leftBox.setSpacing(vSp)
@@ -129,7 +129,7 @@ class GuiLipsum(QDialog):
         pCount = self.paraCount.value()
         inText = "\n\n".join(lipsumText[0:pCount]) + "\n\n"
 
-        self.theParent.docEditor.insertText(inText)
+        self.mainGui.docEditor.insertText(inText)
 
         return
 

--- a/novelwriter/tools/projwizard.py
+++ b/novelwriter/tools/projwizard.py
@@ -54,11 +54,11 @@ class GuiProjectWizard(QWizard):
         logger.debug("Initialising GuiProjectWizard ...")
         self.setObjectName("GuiProjectWizard")
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
-        self.theTheme = mainGui.theTheme
+        self.mainConf  = novelwriter.CONFIG
+        self.mainGui   = mainGui
+        self.mainTheme = mainGui.mainTheme
 
-        self.sideImage = self.theTheme.loadDecoration(
+        self.sideImage = self.mainTheme.loadDecoration(
             "wiz-back", None, self.mainConf.pxInt(370)
         )
         self.setWizardStyle(QWizard.ModernStyle)
@@ -92,7 +92,7 @@ class ProjWizardIntroPage(QWizardPage):
 
         self.mainConf  = novelwriter.CONFIG
         self.theWizard = theWizard
-        self.theTheme  = theWizard.theTheme
+        self.mainTheme = theWizard.mainTheme
 
         self.setTitle(self.tr("Create New Project"))
         self.theText = QLabel(self.tr(
@@ -107,7 +107,7 @@ class ProjWizardIntroPage(QWizardPage):
             "Peter Mitterhofer", "CC BY-SA 4.0"
         ))
         lblFont = self.imgCredit.font()
-        lblFont.setPointSizeF(0.6*self.theTheme.fontPointSize)
+        lblFont.setPointSizeF(0.6*self.mainTheme.fontPointSize)
         self.imgCredit.setFont(lblFont)
 
         xW = self.mainConf.pxInt(300)
@@ -162,7 +162,7 @@ class ProjWizardFolderPage(QWizardPage):
 
         self.mainConf  = novelwriter.CONFIG
         self.theWizard = theWizard
-        self.theTheme  = theWizard.theTheme
+        self.mainTheme = theWizard.mainTheme
 
         self.setTitle(self.tr("Select Project Folder"))
         self.theText = QLabel(self.tr(
@@ -180,7 +180,7 @@ class ProjWizardFolderPage(QWizardPage):
         self.projPath.setPlaceholderText(self.tr("Required"))
 
         self.browseButton = QPushButton("...")
-        self.browseButton.setMaximumWidth(int(2.5*self.theTheme.getTextWidth("...")))
+        self.browseButton.setMaximumWidth(int(2.5*self.mainTheme.getTextWidth("...")))
         self.browseButton.clicked.connect(self._doBrowse)
 
         self.errLabel = QLabel("")

--- a/novelwriter/tools/projwizard.py
+++ b/novelwriter/tools/projwizard.py
@@ -48,15 +48,15 @@ PAGE_FINAL  = 4
 
 class GuiProjectWizard(QWizard):
 
-    def __init__(self, theParent):
-        QWizard.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QWizard.__init__(self, mainGui)
 
         logger.debug("Initialising GuiProjectWizard ...")
         self.setObjectName("GuiProjectWizard")
 
-        self.mainConf  = novelwriter.CONFIG
-        self.theParent = theParent
-        self.theTheme  = theParent.theTheme
+        self.mainConf = novelwriter.CONFIG
+        self.mainGui  = mainGui
+        self.theTheme = mainGui.theTheme
 
         self.sideImage = self.theTheme.loadDecoration(
             "wiz-back", None, self.mainConf.pxInt(370)

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -65,7 +65,7 @@ class GuiWritingStats(QDialog):
 
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
-        self.theTheme   = mainGui.theTheme
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
 
         self.logData    = []
@@ -125,7 +125,7 @@ class GuiWritingStats(QDialog):
         self.listBox.setSortingEnabled(True)
 
         # Word Bar
-        self.barHeight = int(round(0.5*self.theTheme.fontPixelSize))
+        self.barHeight = int(round(0.5*self.mainTheme.fontPixelSize))
         self.barWidth = self.mainConf.pxInt(200)
         self.barImage = QPixmap(self.barHeight, self.barHeight)
         self.barImage.fill(self.palette().highlight().color())
@@ -136,27 +136,27 @@ class GuiWritingStats(QDialog):
         self.infoBox.setLayout(self.infoForm)
 
         self.labelTotal = QLabel(formatTime(0))
-        self.labelTotal.setFont(self.theTheme.guiFontFixed)
+        self.labelTotal.setFont(self.mainTheme.guiFontFixed)
         self.labelTotal.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.labelIdleT = QLabel(formatTime(0))
-        self.labelIdleT.setFont(self.theTheme.guiFontFixed)
+        self.labelIdleT.setFont(self.mainTheme.guiFontFixed)
         self.labelIdleT.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.labelFilter = QLabel(formatTime(0))
-        self.labelFilter.setFont(self.theTheme.guiFontFixed)
+        self.labelFilter.setFont(self.mainTheme.guiFontFixed)
         self.labelFilter.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.novelWords = QLabel("0")
-        self.novelWords.setFont(self.theTheme.guiFontFixed)
+        self.novelWords.setFont(self.mainTheme.guiFontFixed)
         self.novelWords.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.notesWords = QLabel("0")
-        self.notesWords.setFont(self.theTheme.guiFontFixed)
+        self.notesWords.setFont(self.mainTheme.guiFontFixed)
         self.notesWords.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         self.totalWords = QLabel("0")
-        self.totalWords.setFont(self.theTheme.guiFontFixed)
+        self.totalWords.setFont(self.mainTheme.guiFontFixed)
         self.totalWords.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
 
         lblTTime   = QLabel(self.tr("Total Time:"))
@@ -183,7 +183,7 @@ class GuiWritingStats(QDialog):
         self.infoForm.setRowStretch(6, 1)
 
         # Filter Options
-        sPx = self.theTheme.baseIconSize
+        sPx = self.mainTheme.baseIconSize
 
         self.filterBox = QGroupBox(self.tr("Filters"), self)
         self.filterForm = QGridLayout(self)
@@ -605,13 +605,13 @@ class GuiWritingStats(QDialog):
             newItem.setTextAlignment(self.C_COUNT, Qt.AlignRight)
             newItem.setTextAlignment(self.C_BAR, Qt.AlignLeft | Qt.AlignVCenter)
 
-            newItem.setFont(self.C_TIME, self.theTheme.guiFontFixed)
-            newItem.setFont(self.C_LENGTH, self.theTheme.guiFontFixed)
-            newItem.setFont(self.C_COUNT, self.theTheme.guiFontFixed)
+            newItem.setFont(self.C_TIME, self.mainTheme.guiFontFixed)
+            newItem.setFont(self.C_LENGTH, self.mainTheme.guiFontFixed)
+            newItem.setFont(self.C_COUNT, self.mainTheme.guiFontFixed)
             if showIdleTime:
-                newItem.setFont(self.C_IDLE, self.theTheme.guiFontFixed)
+                newItem.setFont(self.C_IDLE, self.mainTheme.guiFontFixed)
             else:
-                newItem.setFont(self.C_IDLE, self.theTheme.guiFont)
+                newItem.setFont(self.C_IDLE, self.mainTheme.guiFont)
 
             self.listBox.addTopLevelItem(newItem)
             self.timeFilter += sDiff

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -57,16 +57,16 @@ class GuiWritingStats(QDialog):
     FMT_JSON = 0
     FMT_CSV  = 1
 
-    def __init__(self, theParent):
-        QDialog.__init__(self, theParent)
+    def __init__(self, mainGui):
+        QDialog.__init__(self, mainGui)
 
         logger.debug("Initialising GuiWritingStats ...")
         self.setObjectName("GuiWritingStats")
 
         self.mainConf   = novelwriter.CONFIG
-        self.theParent  = theParent
-        self.theTheme   = theParent.theTheme
-        self.theProject = theParent.theProject
+        self.mainGui    = mainGui
+        self.theTheme   = mainGui.theTheme
+        self.theProject = mainGui.theProject
 
         self.logData    = []
         self.filterData = []
@@ -411,11 +411,11 @@ class GuiWritingStats(QDialog):
 
         # Report to user
         if wSuccess:
-            self.theParent.makeAlert([
+            self.mainGui.makeAlert([
                 self.tr("{0} file successfully written to:").format(textFmt), savePath
             ], nwAlert.INFO)
         else:
-            self.theParent.makeAlert([
+            self.mainGui.makeAlert([
                 self.tr("Failed to write {0} file.").format(textFmt), errMsg
             ], nwAlert.ERROR)
 
@@ -478,7 +478,7 @@ class GuiWritingStats(QDialog):
                     self.logData.append((dStart, sDiff, wcNovel, wcNotes, sIdle))
 
         except Exception as exc:
-            self.theParent.makeAlert(self.tr(
+            self.mainGui.makeAlert(self.tr(
                 "Failed to read session log file."
             ), nwAlert.ERROR, exception=exc)
             return False

--- a/tests/test_dialogs/test_dlg_about.py
+++ b/tests/test_dialogs/test_dlg_about.py
@@ -36,8 +36,8 @@ def testDlgAbout_NWDialog(qtbot, monkeypatch, nwGUI):
     monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
 
     # NW About
-    nwGUI.theTheme.themeName = "A Theme"
-    nwGUI.theTheme.themeAuthor = "An Author"
+    nwGUI.mainTheme.themeName = "A Theme"
+    nwGUI.mainTheme.themeAuthor = "An Author"
     assert nwGUI.showAboutNWDialog(showNotes=True) is True
 
     qtbot.waitUntil(lambda: getGuiItem("GuiAbout") is not None, timeout=1000)

--- a/tests/test_dialogs/test_dlg_docmerge.py
+++ b/tests/test_dialogs/test_dlg_docmerge.py
@@ -57,11 +57,11 @@ def testDlgMerge_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     # Add Project Content
     monkeypatch.setattr(GuiItemEditor, "exec_", lambda *a: QDialog.Accepted)
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem(hChapterDir).setSelected(True)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
 
     assert nwGUI.saveProject() is True
     assert nwGUI.closeProject() is True
@@ -83,8 +83,8 @@ def testDlgMerge_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
 
     # Open the Merge tool
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem(hChapterDir).setSelected(True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
 
     monkeypatch.setattr(GuiDocMerge, "exec_", lambda *a: None)
     nwGUI.mainMenu.aMergeDocs.activate(QAction.Trigger)
@@ -102,27 +102,27 @@ def testDlgMerge_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     assert nwMerge.listBox.count() == 0
 
     # No item selected
-    nwGUI.treeView.projTree.clearSelection()
+    nwGUI.projView.projTree.clearSelection()
     assert nwMerge._populateList() is False
     assert nwMerge.listBox.count() == 0
 
     # Non-existing item
     with monkeypatch.context() as mp:
         mp.setattr(NWTree, "__getitem__", lambda *a: None)
-        nwGUI.treeView.projTree.clearSelection()
-        nwGUI.treeView.projTree._getTreeItem(hChapterDir).setSelected(True)
+        nwGUI.projView.projTree.clearSelection()
+        nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
         assert nwMerge._populateList() is False
         assert nwMerge.listBox.count() == 0
 
     # Select a non-folder
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem(hChapterOne).setSelected(True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem(hChapterOne).setSelected(True)
     assert nwMerge._populateList() is False
     assert nwMerge.listBox.count() == 0
 
     # Select the chapter folder
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem(hChapterDir).setSelected(True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
     assert nwMerge._populateList() is True
     assert nwMerge.listBox.count() == 5
 

--- a/tests/test_dialogs/test_dlg_docsplit.py
+++ b/tests/test_dialogs/test_dlg_docsplit.py
@@ -61,9 +61,9 @@ def testDlgSplit_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     # Add Project Content
     monkeypatch.setattr(GuiItemEditor, "exec_", lambda *a: QDialog.Accepted)
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem(hNovelRoot).setSelected(True)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem(hNovelRoot).setSelected(True)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
 
     assert nwGUI.saveProject() is True
     assert nwGUI.closeProject() is True
@@ -90,8 +90,8 @@ def testDlgSplit_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
 
     # Open the Split tool
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem(hToSplit).setSelected(True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem(hToSplit).setSelected(True)
 
     monkeypatch.setattr(GuiDocSplit, "exec_", lambda *a: None)
     nwGUI.mainMenu.aSplitDoc.activate(QAction.Trigger)
@@ -110,7 +110,7 @@ def testDlgSplit_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
 
     # No item selected
     nwSplit.sourceItem = None
-    nwGUI.treeView.projTree.clearSelection()
+    nwGUI.projView.projTree.clearSelection()
     assert nwSplit._populateList() is False
     assert nwSplit.listBox.count() == 0
 
@@ -118,15 +118,15 @@ def testDlgSplit_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     with monkeypatch.context() as mp:
         mp.setattr(NWTree, "__getitem__", lambda *a: None)
         nwSplit.sourceItem = None
-        nwGUI.treeView.projTree.clearSelection()
-        nwGUI.treeView.projTree._getTreeItem(hToSplit).setSelected(True)
+        nwGUI.projView.projTree.clearSelection()
+        nwGUI.projView.projTree._getTreeItem(hToSplit).setSelected(True)
         assert nwSplit._populateList() is False
         assert nwSplit.listBox.count() == 0
 
     # Select a non-file
     nwSplit.sourceItem = None
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem(hChapterDir).setSelected(True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
     assert nwSplit._populateList() is False
     assert nwSplit.listBox.count() == 0
 

--- a/tests/test_dialogs/test_dlg_itemeditor.py
+++ b/tests/test_dialogs/test_dlg_itemeditor.py
@@ -52,7 +52,7 @@ def testDlgItemEditor_Dialog(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     tHandle = "000000000000f"
 
     # No Selection
-    nwGUI.treeView.projTree.clearSelection()
+    nwGUI.projView.projTree.clearSelection()
     assert nwGUI.editItem() is False
 
     # Force opening from editor
@@ -164,9 +164,9 @@ def testDlgItemEditor_Note(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     assert nwGUI.theProject.importItems.name(importKeys[1]) == "Minor"
 
     # Create Note
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem("000000000000a").setSelected(True)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem("000000000000a").setSelected(True)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
 
     # Open Note
     assert nwGUI.openDocument("0000000000010")

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1147,7 +1147,7 @@ def testGuiEditor_Tags(qtbot, monkeypatch, nwGUI, nwMinimal, ipsumText):
     assert nwGUI.openDocument(cHandle) is True
     assert nwGUI.docEditor.replaceText(theText) is True
     assert nwGUI.saveDocument() is True
-    assert nwGUI.treeView.revealNewTreeItem(cHandle)
+    assert nwGUI.projView.revealNewTreeItem(cHandle)
     nwGUI.docEditor.updateTagHighLighting()
 
     # Follow Tag

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -51,12 +51,12 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, nwLipsum):
     assert nwGUI.theProject.index._itemIndex._items != {}
 
     # Select a document in the project tree
-    nwGUI.treeView.setSelectedHandle("88243afbe5ed8")
+    nwGUI.projView.setSelectedHandle("88243afbe5ed8")
 
     # Middle-click the selected item
-    theItem = nwGUI.treeView.projTree._getTreeItem("88243afbe5ed8")
-    theRect = nwGUI.treeView.projTree.visualItemRect(theItem)
-    qtbot.mouseClick(nwGUI.treeView.projTree.viewport(), Qt.MidButton, pos=theRect.center())
+    theItem = nwGUI.projView.projTree._getTreeItem("88243afbe5ed8")
+    theRect = nwGUI.projView.projTree.visualItemRect(theItem)
+    qtbot.mouseClick(nwGUI.projView.projTree.viewport(), Qt.MidButton, pos=theRect.center())
     assert nwGUI.docViewer.docHandle() == "88243afbe5ed8"
 
     # Reload the text
@@ -117,7 +117,7 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, nwLipsum):
     assert nwGUI.docViewer.docAction(nwDocAction.COPY) is False
 
     # Open again via menu
-    assert nwGUI.treeView.setSelectedHandle("88243afbe5ed8")
+    assert nwGUI.projView.setSelectedHandle("88243afbe5ed8")
     nwGUI.mainMenu.aViewDoc.activate(QAction.Trigger)
 
     # Select "Bod" link

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -28,7 +28,7 @@ from tools import cmpFiles, buildTestProject, XML_IGNORE, writeFile
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMessageBox, QDialog, QInputDialog
 
-from novelwriter.gui import GuiDocEditor, GuiNovelTree, GuiOutline
+from novelwriter.gui import GuiDocEditor, GuiNovelTree, GuiOutlineView
 from novelwriter.enum import nwItemType, nwWidget
 from novelwriter.tools import GuiProjectWizard
 from novelwriter.gui.projtree import GuiProjectTree
@@ -147,12 +147,12 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     # Project Outline has focus
     nwGUI.switchFocus(nwWidget.OUTLINE)
     with monkeypatch.context() as mp:
-        mp.setattr(GuiOutline, "treeFocus", lambda *a: True)
+        mp.setattr(GuiOutlineView, "treeFocus", lambda *a: True)
         assert nwGUI.docEditor.docHandle() is None
-        actItem = nwGUI.outlineView.outlineView.topLevelItem(0)
+        actItem = nwGUI.outlineView.outlineTree.topLevelItem(0)
         chpItem = actItem.child(0)
         selItem = chpItem.child(0)
-        nwGUI.outlineView.outlineView.setCurrentItem(selItem)
+        nwGUI.outlineView.outlineTree.setCurrentItem(selItem)
         nwGUI._keyPressReturn()
         assert nwGUI.docEditor.docHandle() == sHandle
         assert nwGUI.closeDocument() is True

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -125,7 +125,7 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     with monkeypatch.context() as mp:
         mp.setattr(GuiProjectTree, "hasFocus", lambda *a: True)
         assert nwGUI.docEditor.docHandle() is None
-        nwGUI.treeView.projTree._getTreeItem(sHandle).setSelected(True)
+        nwGUI.projView.projTree._getTreeItem(sHandle).setSelected(True)
         nwGUI._keyPressReturn()
         assert nwGUI.docEditor.docHandle() == sHandle
         assert nwGUI.closeDocument() is True
@@ -149,10 +149,10 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     with monkeypatch.context() as mp:
         mp.setattr(GuiOutline, "treeFocus", lambda *a: True)
         assert nwGUI.docEditor.docHandle() is None
-        actItem = nwGUI.projView.outlineView.topLevelItem(0)
+        actItem = nwGUI.outlineView.outlineView.topLevelItem(0)
         chpItem = actItem.child(0)
         selItem = chpItem.child(0)
-        nwGUI.projView.outlineView.setCurrentItem(selItem)
+        nwGUI.outlineView.outlineView.setCurrentItem(selItem)
         nwGUI._keyPressReturn()
         assert nwGUI.docEditor.docHandle() == sHandle
         assert nwGUI.closeDocument() is True
@@ -220,14 +220,14 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     assert nwGUI.theProject.spellCheck is False
 
     # Check that tree items have been created
-    assert nwGUI.treeView.projTree._getTreeItem("0000000000008") is not None
-    assert nwGUI.treeView.projTree._getTreeItem("0000000000009") is not None
-    assert nwGUI.treeView.projTree._getTreeItem("000000000000a") is not None
-    assert nwGUI.treeView.projTree._getTreeItem("000000000000b") is not None
-    assert nwGUI.treeView.projTree._getTreeItem("000000000000c") is not None
-    assert nwGUI.treeView.projTree._getTreeItem("000000000000d") is not None
-    assert nwGUI.treeView.projTree._getTreeItem("000000000000e") is not None
-    assert nwGUI.treeView.projTree._getTreeItem("000000000000f") is not None
+    assert nwGUI.projView.projTree._getTreeItem("0000000000008") is not None
+    assert nwGUI.projView.projTree._getTreeItem("0000000000009") is not None
+    assert nwGUI.projView.projTree._getTreeItem("000000000000a") is not None
+    assert nwGUI.projView.projTree._getTreeItem("000000000000b") is not None
+    assert nwGUI.projView.projTree._getTreeItem("000000000000c") is not None
+    assert nwGUI.projView.projTree._getTreeItem("000000000000d") is not None
+    assert nwGUI.projView.projTree._getTreeItem("000000000000e") is not None
+    assert nwGUI.projView.projTree._getTreeItem("000000000000f") is not None
 
     nwGUI.mainMenu.aSpellCheck.setChecked(True)
     assert nwGUI.mainMenu._toggleSpellCheck()
@@ -240,9 +240,9 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
 
     # Add a Character File
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem("000000000000a").setSelected(True)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem("000000000000a").setSelected(True)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
@@ -262,9 +262,9 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
 
     # Add a Plot File
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem("0000000000009").setSelected(True)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem("0000000000009").setSelected(True)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
@@ -284,9 +284,9 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
 
     # Add a World File
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem("000000000000b").setSelected(True)
-    nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem("000000000000b").setSelected(True)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
     assert nwGUI.openSelectedItem()
 
     # Add Some Text
@@ -315,10 +315,10 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
 
     # Select the 'New Scene' file
     nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.treeView.projTree.clearSelection()
-    nwGUI.treeView.projTree._getTreeItem("0000000000008").setExpanded(True)
-    nwGUI.treeView.projTree._getTreeItem("000000000000d").setExpanded(True)
-    nwGUI.treeView.projTree._getTreeItem("000000000000f").setSelected(True)
+    nwGUI.projView.projTree.clearSelection()
+    nwGUI.projView.projTree._getTreeItem("0000000000008").setExpanded(True)
+    nwGUI.projView.projTree._getTreeItem("000000000000d").setExpanded(True)
+    nwGUI.projView.projTree._getTreeItem("000000000000f").setSelected(True)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
@@ -461,12 +461,12 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     qtbot.wait(stepDelay)
 
     # Check a Quick Create and Delete
-    assert nwGUI.treeView.projTree.newTreeItem(nwItemType.FILE, None)
-    newHandle = nwGUI.treeView.getSelectedHandle()
+    assert nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None)
+    newHandle = nwGUI.projView.getSelectedHandle()
     assert nwGUI.theProject.tree["0000000000020"] is not None
-    assert nwGUI.treeView.deleteItem()
-    assert nwGUI.treeView.setSelectedHandle(newHandle)
-    assert nwGUI.treeView.deleteItem()
+    assert nwGUI.projView.deleteItem()
+    assert nwGUI.projView.setSelectedHandle(newHandle)
+    assert nwGUI.projView.deleteItem()
     assert nwGUI.theProject.tree["0000000000024"] is not None  # Trash
     assert nwGUI.saveProject()
 

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -467,7 +467,7 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncDir, fncProj, mockRnd):
 
     buildTestProject(nwGUI, fncProj)
 
-    assert nwGUI.treeView.projTree._getTreeItem("000000000000f") is not None
+    assert nwGUI.projView.projTree._getTreeItem("000000000000f") is not None
     assert nwGUI.openDocument("000000000000f") is True
     nwGUI.docEditor.clear()
 

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -46,57 +46,57 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, fncDir):
     nwGUI.rebuildIndex()
     nwGUI._changeView(nwView.OUTLINE)
 
-    outlineMain = nwGUI.outlineView
-    outlineView = outlineMain.outlineView
-    outlineData = outlineMain.outlineData
-    outlineMenu = outlineMain.outlineBar.mColumns
+    outlineView = nwGUI.outlineView
+    outlineTree = outlineView.outlineTree
+    outlineData = outlineView.outlineData
+    outlineMenu = outlineView.outlineBar.mColumns
 
     # Toggle scrollbars
     nwGUI.mainConf.hideVScroll = True
     nwGUI.mainConf.hideHScroll = True
-    outlineMain.initOutline()
-    assert outlineView.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
-    assert outlineView.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
+    outlineView.initOutline()
+    assert outlineTree.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
+    assert outlineTree.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert outlineData.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert outlineData.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
 
     nwGUI.mainConf.hideVScroll = False
     nwGUI.mainConf.hideHScroll = False
-    outlineMain.initOutline()
-    assert outlineView.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-    assert outlineView.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
+    outlineView.initOutline()
+    assert outlineTree.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
+    assert outlineTree.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
     assert outlineData.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
     assert outlineData.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
 
     # Check focus
     with monkeypatch.context() as mp:
         mp.setattr(QWidget, "hasFocus", lambda *a: True)
-        assert outlineMain.treeFocus() is True
+        assert outlineView.treeFocus() is True
 
-    outlineMain.setTreeFocus()  # Can't check. just ensures that it doesn't error
+    outlineView.setTreeFocus()  # Can't check. just ensures that it doesn't error
 
     # Option State
     # ============
     pOptions = nwGUI.theProject.options
     colNames = [h.name for h in nwOutline]
     colItems = [h for h in nwOutline]
-    colWidth = {h: outlineView.DEF_WIDTH[h] for h in nwOutline}
-    colHidden = {h: outlineView.DEF_HIDDEN[h] for h in nwOutline}
+    colWidth = {h: outlineTree.DEF_WIDTH[h] for h in nwOutline}
+    colHidden = {h: outlineTree.DEF_HIDDEN[h] for h in nwOutline}
 
-    assert outlineView.topLevelItemCount() > 0
+    assert outlineTree.topLevelItemCount() > 0
 
     # Save header state not allowed
-    outlineView._lastBuild = 0
-    outlineView._saveHeaderState()
+    outlineTree._lastBuild = 0
+    outlineTree._saveHeaderState()
     assert pOptions.getValue("GuiOutline", "headerOrder", []) == []
 
     # Allow saving header state
-    outlineView._lastBuild = time.time()
-    outlineView._saveHeaderState()
+    outlineTree._lastBuild = time.time()
+    outlineTree._saveHeaderState()
     assert pOptions.getValue("GuiOutline", "headerOrder", []) == colNames
-    assert outlineView._treeOrder == colItems
-    assert outlineView._colWidth == colWidth
-    assert outlineView._colHidden == colHidden
+    assert outlineTree._treeOrder == colItems
+    assert outlineTree._colWidth == colWidth
+    assert outlineTree._colHidden == colHidden
 
     # Get default values
     optItems = pOptions.getValue("GuiOutline", "headerOrder", [])
@@ -105,49 +105,49 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, fncDir):
 
     # Add invalid column name
     pOptions.setValue("GuiOutline", "headerOrder", optItems + ["blabla"])
-    outlineView._loadHeaderState()
-    assert outlineView._treeOrder == colItems
-    assert outlineView._colHidden == colHidden
+    outlineTree._loadHeaderState()
+    assert outlineTree._treeOrder == colItems
+    assert outlineTree._colHidden == colHidden
 
     # Add duplicate column name
     pOptions.setValue("GuiOutline", "headerOrder", optItems + [optItems[-1]])
-    outlineView._loadHeaderState()
-    assert outlineView._treeOrder == colItems
-    assert outlineView._colHidden == colHidden
+    outlineTree._loadHeaderState()
+    assert outlineTree._treeOrder == colItems
+    assert outlineTree._colHidden == colHidden
 
     # Invalid column width data
     pOptions.setValue("GuiOutline", "headerOrder", optItems)
     pOptions.setValue("GuiOutline", "columnWidth", {"blabla": None})
-    outlineView._loadHeaderState()
-    assert outlineView._treeOrder == colItems
-    assert outlineView._colHidden == colHidden
+    outlineTree._loadHeaderState()
+    assert outlineTree._treeOrder == colItems
+    assert outlineTree._colHidden == colHidden
 
     # Invalid column width data
     pOptions.setValue("GuiOutline", "headerOrder", optItems)
     pOptions.setValue("GuiOutline", "columnWidth", optWidth)
     pOptions.setValue("GuiOutline", "columnHidden", {"bloabla": None})
-    outlineView._loadHeaderState()
-    assert outlineView._treeOrder == colItems
-    assert outlineView._colHidden == colHidden
+    outlineTree._loadHeaderState()
+    assert outlineTree._treeOrder == colItems
+    assert outlineTree._colHidden == colHidden
 
     # Valid settings
     pOptions.setValue("GuiOutline", "headerOrder", optItems)
     pOptions.setValue("GuiOutline", "columnWidth", optWidth)
     pOptions.setValue("GuiOutline", "columnHidden", optHidden)
-    outlineView._loadHeaderState()
-    assert outlineView._treeOrder == colItems
-    assert outlineView._colHidden == colHidden
+    outlineTree._loadHeaderState()
+    assert outlineTree._treeOrder == colItems
+    assert outlineTree._colHidden == colHidden
 
     # Header Menu
     # ===========
 
     # Trigger the menu entry for all hidden columns
     for hItem in nwOutline:
-        if outlineView.DEF_HIDDEN[hItem]:
+        if outlineTree.DEF_HIDDEN[hItem]:
             outlineMenu.actionMap[hItem].activate(QAction.Trigger)
 
     # Now no columns should be hidden
-    outlineView._saveHeaderState()
+    outlineTree._saveHeaderState()
     assert not any(pOptions.getValue("GuiOutline", "columnHidden", None).values())
 
     # qtbot.stop()
@@ -169,10 +169,10 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
     nwGUI.rebuildIndex()
     nwGUI._changeView(nwView.OUTLINE)
 
-    outlineMain = nwGUI.outlineView
-    outlineBar  = outlineMain.outlineBar
-    outlineView = outlineMain.outlineView
-    outlineData = outlineMain.outlineData
+    outlineView = nwGUI.outlineView
+    outlineBar  = outlineView.outlineBar
+    outlineTree = outlineView.outlineTree
+    outlineData = outlineView.outlineData
 
     lipHandle = "b3643d0f92e32"
 
@@ -218,10 +218,10 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
     # =============
 
     # First Item
-    outlineView.refreshTree()
-    selItem = outlineView.topLevelItem(0)
+    outlineTree.refreshTree()
+    selItem = outlineTree.topLevelItem(0)
 
-    outlineView.setCurrentItem(selItem)
+    outlineTree.setCurrentItem(selItem)
     assert outlineData.titleLabel.text() == "<b>Title</b>"
     assert outlineData.titleValue.text() == "Lorem Ipsum"
     assert outlineData.fileValue.text() == "Lorem Ipsum"
@@ -232,12 +232,12 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
     assert outlineData.pCValue.text() == "3"
 
     # Scene One
-    actItem = outlineView.topLevelItem(1)
+    actItem = outlineTree.topLevelItem(1)
     chpItem = actItem.child(0)
     selItem = chpItem.child(0)
 
-    outlineView.setCurrentItem(selItem)
-    tHandle, tLine = outlineView.getSelectedHandle()
+    outlineTree.setCurrentItem(selItem)
+    tHandle, tLine = outlineTree.getSelectedHandle()
     assert tHandle == "88243afbe5ed8"
     assert tLine == 0
 
@@ -248,17 +248,17 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
 
     # Click POV Link
     assert outlineData.povKeyValue.text() == "<a href='Bod'>Bod</a>"
-    outlineMain._tagClicked("Bod")
+    outlineView._tagClicked("Bod")
     assert nwGUI.docViewer.docHandle() == "4c4f28287af27"
 
     # Scene One, Section Two
-    actItem = outlineView.topLevelItem(1)
+    actItem = outlineTree.topLevelItem(1)
     chpItem = actItem.child(0)
     scnItem = chpItem.child(0)
     selItem = scnItem.child(0)
 
-    outlineView.setCurrentItem(selItem)
-    tHandle, tLine = outlineView.getSelectedHandle()
+    outlineTree.setCurrentItem(selItem)
+    tHandle, tLine = outlineTree.getSelectedHandle()
     assert tHandle == "88243afbe5ed8"
     assert tLine == 12
 
@@ -267,7 +267,7 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
     assert outlineData.fileValue.text() == "Scene One"
     assert outlineData.itemValue.text() == "Finished"
 
-    outlineView._treeDoubleClick(selItem, 0)
+    outlineTree._treeDoubleClick(selItem, 0)
     assert nwGUI.docEditor.docHandle() == "88243afbe5ed8"
 
     # qtbot.stop()

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -46,7 +46,7 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, fncDir):
     nwGUI.rebuildIndex()
     nwGUI._changeView(nwView.OUTLINE)
 
-    outlineMain = nwGUI.projView
+    outlineMain = nwGUI.outlineView
     outlineView = outlineMain.outlineView
     outlineData = outlineMain.outlineData
     outlineMenu = outlineMain.outlineBar.mColumns
@@ -54,7 +54,7 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, fncDir):
     # Toggle scrollbars
     nwGUI.mainConf.hideVScroll = True
     nwGUI.mainConf.hideHScroll = True
-    nwGUI.projView.initOutline()
+    outlineMain.initOutline()
     assert outlineView.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert outlineView.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert outlineData.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
@@ -62,7 +62,7 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, fncDir):
 
     nwGUI.mainConf.hideVScroll = False
     nwGUI.mainConf.hideHScroll = False
-    nwGUI.projView.initOutline()
+    outlineMain.initOutline()
     assert outlineView.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
     assert outlineView.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
     assert outlineData.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
@@ -169,8 +169,8 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
     nwGUI.rebuildIndex()
     nwGUI._changeView(nwView.OUTLINE)
 
-    outlineMain = nwGUI.projView
-    outlineBar = outlineMain.outlineBar
+    outlineMain = nwGUI.outlineView
+    outlineBar  = outlineMain.outlineBar
     outlineView = outlineMain.outlineView
     outlineData = outlineMain.outlineData
 
@@ -183,7 +183,7 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
 
     # Add a second novel folder
     newHandle = nwGUI.theProject.newRoot(nwItemClass.NOVEL)
-    nwGUI.treeView.revealNewTreeItem(newHandle)
+    nwGUI.projView.revealNewTreeItem(newHandle)
 
     # Check new values in dropdown list
     assert outlineBar.novelValue.itemData(0) == lipHandle
@@ -202,7 +202,7 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
         aHandle = nwGUI.theProject.newFile(dTitle, newHandle)
         hHash = "#"*hLevel
         writeFile(os.path.join(nwLipsum, "content", f"{aHandle}.nwd"), f"{hHash} {dTitle}\n\n")
-        nwGUI.treeView.revealNewTreeItem(aHandle)
+        nwGUI.projView.revealNewTreeItem(aHandle)
 
     nwGUI.rebuildIndex()
 
@@ -248,7 +248,7 @@ def testGuiOutline_Content(qtbot, monkeypatch, nwGUI, nwLipsum):
 
     # Click POV Link
     assert outlineData.povKeyValue.text() == "<a href='Bod'>Bod</a>"
-    nwGUI.projView._tagClicked("Bod")
+    outlineMain._tagClicked("Bod")
     assert nwGUI.docViewer.docHandle() == "4c4f28287af27"
 
     # Scene One, Section Two

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -41,7 +41,7 @@ def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd)
     monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
     monkeypatch.setattr(QInputDialog, "getText", lambda *a, text: (text, True))
 
-    nwTree = nwGUI.treeView
+    nwTree = nwGUI.projView
 
     # Try to add item with no project
     assert nwTree.projTree.newTreeItem(nwItemType.FILE) is False
@@ -164,7 +164,7 @@ def testGuiProjTree_MoveItems(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
     monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
     monkeypatch.setattr(QInputDialog, "getText", lambda *a, text: (text, True))
 
-    nwTree = nwGUI.treeView
+    nwTree = nwGUI.projView
 
     # Try to move item with no project
     assert nwTree.projTree.moveTreeItem(1) is False
@@ -279,7 +279,7 @@ def testGuiProjTree_DeleteItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockR
     monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
     monkeypatch.setattr(QInputDialog, "getText", lambda *a, text: (text, True))
 
-    nwTree = nwGUI.treeView
+    nwTree = nwGUI.projView
 
     # Try to run with no project
     assert nwTree.emptyTrash() is False
@@ -482,7 +482,7 @@ def testGuiProjTree_ContextMenu(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockR
     hCharNote    = "0000000000011"
     hNovelNote   = "0000000000012"
 
-    projTree = nwGUI.treeView.projTree
+    projTree = nwGUI.projView.projTree
     projTree._getTreeItem(hNovelRoot).setExpanded(True)
     projTree._getTreeItem(hChapterDir).setExpanded(True)
 

--- a/tests/test_gui/test_gui_statusbar.py
+++ b/tests/test_gui/test_gui_statusbar.py
@@ -40,7 +40,7 @@ def testGuiStatusBar_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     cHandle = nwGUI.theProject.newFile("A Note", "000000000000a")
     newDoc = NWDoc(nwGUI.theProject, cHandle)
     newDoc.writeDocument("# A Note\n\n")
-    nwGUI.treeView.revealNewTreeItem(cHandle)
+    nwGUI.projView.revealNewTreeItem(cHandle)
     nwGUI.rebuildIndex(beQuiet=True)
 
     # Reference Time

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -93,82 +93,82 @@ def testGuiTheme_Main(qtbot, monkeypatch, nwMinimal, tmpDir):
     assert thePalette.link().color()            == QColor(44, 152, 247)
     assert thePalette.linkVisited().color()     == QColor(44, 152, 247)
 
-    assert nwGUI.theTheme.statNone    == [150, 152, 150]
-    assert nwGUI.theTheme.statSaved   == [39, 135, 78]
-    assert nwGUI.theTheme.statUnsaved == [138, 32, 32]
+    assert nwGUI.mainTheme.statNone    == [150, 152, 150]
+    assert nwGUI.mainTheme.statSaved   == [39, 135, 78]
+    assert nwGUI.mainTheme.statUnsaved == [138, 32, 32]
 
     # Check Syntax Colours
-    assert nwGUI.theTheme.colBack   == [45, 45, 45]
-    assert nwGUI.theTheme.colText   == [204, 204, 204]
-    assert nwGUI.theTheme.colLink   == [102, 153, 204]
-    assert nwGUI.theTheme.colHead   == [102, 153, 204]
-    assert nwGUI.theTheme.colHeadH  == [102, 153, 204]
-    assert nwGUI.theTheme.colEmph   == [249, 145, 57]
-    assert nwGUI.theTheme.colDialN  == [242, 119, 122]
-    assert nwGUI.theTheme.colDialD  == [153, 204, 153]
-    assert nwGUI.theTheme.colDialS  == [255, 204, 102]
-    assert nwGUI.theTheme.colHidden == [153, 153, 153]
-    assert nwGUI.theTheme.colKey    == [242, 119, 122]
-    assert nwGUI.theTheme.colVal    == [204, 153, 204]
-    assert nwGUI.theTheme.colSpell  == [242, 119, 122]
-    assert nwGUI.theTheme.colError  == [153, 204, 153]
-    assert nwGUI.theTheme.colRepTag == [102, 204, 204]
-    assert nwGUI.theTheme.colMod    == [249, 145, 57]
+    assert nwGUI.mainTheme.colBack   == [45, 45, 45]
+    assert nwGUI.mainTheme.colText   == [204, 204, 204]
+    assert nwGUI.mainTheme.colLink   == [102, 153, 204]
+    assert nwGUI.mainTheme.colHead   == [102, 153, 204]
+    assert nwGUI.mainTheme.colHeadH  == [102, 153, 204]
+    assert nwGUI.mainTheme.colEmph   == [249, 145, 57]
+    assert nwGUI.mainTheme.colDialN  == [242, 119, 122]
+    assert nwGUI.mainTheme.colDialD  == [153, 204, 153]
+    assert nwGUI.mainTheme.colDialS  == [255, 204, 102]
+    assert nwGUI.mainTheme.colHidden == [153, 153, 153]
+    assert nwGUI.mainTheme.colKey    == [242, 119, 122]
+    assert nwGUI.mainTheme.colVal    == [204, 153, 204]
+    assert nwGUI.mainTheme.colSpell  == [242, 119, 122]
+    assert nwGUI.mainTheme.colError  == [153, 204, 153]
+    assert nwGUI.mainTheme.colRepTag == [102, 204, 204]
+    assert nwGUI.mainTheme.colMod    == [249, 145, 57]
 
     # Test Icon class
-    theIcons = nwGUI.theTheme.theIcons
+    iconCache = nwGUI.mainTheme.iconCache
     novelwriter.CONFIG.guiIcons = "invalid"
-    assert theIcons.updateTheme() is True
+    assert iconCache.updateTheme() is True
     assert novelwriter.CONFIG.guiIcons == "typicons_light"
 
     # Ask for a non-existent key
-    anImg = theIcons.loadDecoration("nonsense", 20, 20)
+    anImg = iconCache.loadDecoration("nonsense", 20, 20)
     assert isinstance(anImg, QPixmap)
     assert anImg.isNull()
 
     # Add a non-existent file and request it
-    theIcons.DECO_MAP["nonsense"] = "nofile.jpg"
-    anImg = theIcons.loadDecoration("nonsense", 20, 20)
+    iconCache.DECO_MAP["nonsense"] = "nofile.jpg"
+    anImg = iconCache.loadDecoration("nonsense", 20, 20)
     assert isinstance(anImg, QPixmap)
     assert anImg.isNull()
 
     # Get a real image, with different size parameters
-    anImg = theIcons.loadDecoration("wiz-back", 20, None)
+    anImg = iconCache.loadDecoration("wiz-back", 20, None)
     assert isinstance(anImg, QPixmap)
     assert not anImg.isNull()
     assert anImg.width() == 20
     assert anImg.height() >= 56
 
-    anImg = theIcons.loadDecoration("wiz-back", None, 70)
+    anImg = iconCache.loadDecoration("wiz-back", None, 70)
     assert isinstance(anImg, QPixmap)
     assert not anImg.isNull()
     assert anImg.height() == 70
     assert anImg.width() >= 24
 
-    anImg = theIcons.loadDecoration("wiz-back", 30, 70)
+    anImg = iconCache.loadDecoration("wiz-back", 30, 70)
     assert isinstance(anImg, QPixmap)
     assert not anImg.isNull()
     assert anImg.height() == 70
     assert anImg.width() == 30
 
-    anImg = theIcons.loadDecoration("wiz-back", None, None)
+    anImg = iconCache.loadDecoration("wiz-back", None, None)
     assert isinstance(anImg, QPixmap)
     assert not anImg.isNull()
     assert anImg.height() >= 1500
     assert anImg.width() >= 500
 
     # Load icons
-    anIcon = theIcons.getIcon("nonsense")
+    anIcon = iconCache.getIcon("nonsense")
     assert isinstance(anIcon, QIcon)
     assert anIcon.isNull()
 
-    anIcon = theIcons.getIcon("novelwriter")
+    anIcon = iconCache.getIcon("novelwriter")
     assert isinstance(anIcon, QIcon)
     assert not anIcon.isNull()
 
     # Check return empty icon if file not found
-    theIcons.ICON_KEYS.add("testicon3")
-    anIcon = theIcons.getIcon("testicon3")
+    iconCache.ICON_KEYS.add("testicon3")
+    anIcon = iconCache.getIcon("testicon3")
     assert isinstance(anIcon, QIcon)
     assert anIcon.isNull()
 


### PR DESCRIPTION
**Summary:**

This is purely code maintenance. The main GUI objects are given more sensible and consistent names that are easier to remember when coding.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
