### PR TITLE
Appimage Distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -837,19 +837,19 @@ def makeForLaunchpad(doSign=False, isFirst=False, isSnapshot=False):
 
 
 ##
-#  Make Appimage (build-appimage)
+#  Make AppImage (build-appimage)
 ##
 
-def makeAppimage(sysArgs):
+def makeAppImage(sysArgs):
     """Build an Appimage
     """
 
+    import glob
     import argparse
     import platform
-    import glob
 
     try:
-        import python_appimage
+        import python_appimage  # noqa F401
     except ImportError:
         print(
             "ERROR: Package 'python-appimage' is missing on this system.\n"
@@ -858,21 +858,19 @@ def makeAppimage(sysArgs):
         sys.exit(1)
 
     print("")
-    print("Build Appimage")
+    print("Build AppImage")
     print("==============")
     print("")
 
-    plat = platform.machine()
-
     parser = argparse.ArgumentParser(
         prog="build_appimage",
-        description="Build an Appimage",
+        description="Build an AppImage",
         epilog="see https://appimage.org/ for more details",
     )
     parser.add_argument(
         "--linux-tag",
         nargs="?",
-        default=f"manylinux2010_{plat}",
+        default=f"manylinux2010_{platform.machine()}",
         help=(
             "linux compatibility tag (e.g. manylinux1_x86_64) \n"
             "see https://python-appimage.readthedocs.io/en/latest/#available-python-appimages \n"
@@ -891,7 +889,7 @@ def makeAppimage(sysArgs):
     # Version Info
     # ============
 
-    numVers, hexVers, relDate = extractVersion()
+    numVers, _, relDate = extractVersion()
     pkgVers = compactVersion(numVers)
     relDate = datetime.datetime.strptime(relDate, "%Y-%m-%d")
     print("")
@@ -928,7 +926,7 @@ def makeAppimage(sysArgs):
     outFiles = glob.glob(f"{bldDir}/*.AppImage")
 
     if outFiles:
-        print("Removing old Appimages")
+        print("Removing old AppImages")
         print("")
         for image in outFiles:
             try:
@@ -1036,11 +1034,12 @@ def makeAppimage(sysArgs):
     # ==============
 
     try:
-        subprocess.call(
-            ["python", "-m", "python_appimage", "build", "app",
-             "-l", linuxTag, "-p", pythonVer, "appimage"], cwd=bldDir)
+        subprocess.call([
+            sys.executable, "-m", "python_appimage", "build", "app",
+            "-l", linuxTag, "-p", pythonVer, "appimage"
+        ], cwd=bldDir)
     except Exception as exc:
-        print("Appimage build: FAILED")
+        print("AppImage build: FAILED")
         print("")
         print(str(exc))
         print("")
@@ -1804,6 +1803,8 @@ if __name__ == "__main__":
         "                   Add --snapshot to make a snapshot package.",
         "    build-win-exe  Build a setup.exe file with Python embedded for Windows.",
         "                   The package must be built from a minimal windows zip file.",
+        "    build-appimage Build an AppImage. Argument --linux-tag defaults to",
+        "                   manylinux1_x86_64 / i386, and --python-version to 3.10.",
         "",
         "System Install:",
         "",
@@ -1905,7 +1906,7 @@ if __name__ == "__main__":
     if "build-appimage" in sys.argv:
         sys.argv.remove("build-appimage")
         if hostOS == OS_LINUX:
-            sys.argv = makeAppimage(sys.argv)  # Build appimage and prune it's args
+            sys.argv = makeAppImage(sys.argv)  # Build appimage and prune its args
         else:
             print("ERROR: Command 'build-appimage' can only be used on Linux")
             sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -197,6 +197,7 @@ def cleanBuildDirs():
     removeFolder("dist")
     removeFolder("dist_deb")
     removeFolder("dist_minimal")
+    removeFolder("dist_appimage")
     removeFolder("novelWriter.egg-info")
 
     print("")
@@ -863,17 +864,24 @@ def makeAppimage(sysArgs):
 
     plat = platform.machine()
 
-    parser = argparse.ArgumentParser(prog='build_appimage',
-                                     description='Build an Appimage',
-                                     epilog='see https://appimage.org/ for more details')
-    parser.add_argument('--linux-tag', nargs='?', default=f"manylinux2010_{plat}",
-                        help=(
-                            'linux compatibility tag (e.g. manylinux1_x86_64) \n'
-                            'see https://python-appimage.readthedocs.io/en/latest/#available-python-appimages \n'
-                            'and https://github.com/pypa/manylinux for a list of valid tags'
-                        ))
-    parser.add_argument('--python-version', nargs='?', default='3.10',
-                        help='python version (e.g. 3.10)')
+    parser = argparse.ArgumentParser(
+        prog="build_appimage",
+        description="Build an Appimage",
+        epilog="see https://appimage.org/ for more details",
+    )
+    parser.add_argument(
+        "--linux-tag",
+        nargs="?",
+        default=f"manylinux2010_{plat}",
+        help=(
+            "linux compatibility tag (e.g. manylinux1_x86_64) \n"
+            "see https://python-appimage.readthedocs.io/en/latest/#available-python-appimages \n"
+            "and https://github.com/pypa/manylinux for a list of valid tags"
+        ),
+    )
+    parser.add_argument(
+        "--python-version", nargs="?", default="3.10", help="python version (e.g. 3.10)"
+    )
 
     args, unparsedArgs = parser.parse_known_args(sysArgs)
 

--- a/setup.py
+++ b/setup.py
@@ -866,16 +866,16 @@ def makeAppimage(sysArgs):
     parser = argparse.ArgumentParser(prog='build_appimage',
                                      description='Build an Appimage',
                                      epilog='see https://appimage.org/ for more details')
-    parser.add_argument('-l', '--linux-tag', nargs='?', default=f"manylinux2014_{plat}",
+    parser.add_argument('--linux-tag', nargs='?', default=f"manylinux2010_{plat}",
                         help=(
                             'linux compatibility tag (e.g. manylinux1_x86_64) \n'
                             'see https://python-appimage.readthedocs.io/en/latest/#available-python-appimages \n'
                             'and https://github.com/pypa/manylinux for a list of valid tags'
                         ))
-    parser.add_argument('-p', '--python-version', nargs='?', default='3.11',
-                        help='python version (e.g. 3.11)')
+    parser.add_argument('--python-version', nargs='?', default='3.10',
+                        help='python version (e.g. 3.10)')
 
-    args, unknown = parser.parse_known_args(sysArgs)
+    args, unparsedArgs = parser.parse_known_args(sysArgs)
 
     linuxTag = args.linux_tag
     pythonVer = args.python_version
@@ -1047,7 +1047,7 @@ def makeAppimage(sysArgs):
     toUpload(outFile)
     toUpload(shaFile)
 
-    return
+    return unparsedArgs
 
 ##
 #  Make Windows Setup EXE (build-win-exe)
@@ -1897,9 +1897,9 @@ if __name__ == "__main__":
     if "build-appimage" in sys.argv:
         sys.argv.remove("build-appimage")
         if hostOS == OS_LINUX:
-            makeAppimage(sys.argv)
+            sys.argv = makeAppimage(sys.argv)  # Build appimage and prune it's args
         else:
-            print("ERROR: Command 'build-ubuntu' can only be used on Linux")
+            print("ERROR: Command 'build-appimage' can only be used on Linux")
             sys.exit(1)
 
     # General Installers

--- a/setup/data/novelwriter.desktop
+++ b/setup/data/novelwriter.desktop
@@ -1,10 +1,9 @@
 [Desktop Entry]
 Type=Application
-Encoding=UTF-8
 Name=novelWriter
 Comment=A markdown-like text editor for planning and writing novels
 Exec=novelwriter %f
 Icon=novelwriter
 Categories=Qt;Office;WordProcessor;
 Terminal=false
-MimeType=application/x-novelwriter-project
+MimeType=application/x-novelwriter-project;

--- a/setup/description_short.txt
+++ b/setup/description_short.txt
@@ -2,5 +2,5 @@ novelWriter is a plain text editor designed for writing novels assembled from
 many smaller text documents. It uses a minimal formatting syntax inspired by
 Markdown, and adds a meta data syntax for comments, synopsis, and
 cross-referencing. It's designed to be a simple text editor that allows for
-easy organisation of text and notes, using human readable text files as
+easy organization of text and notes, using human readable text files as
 storage for robustness.

--- a/setup/description_short.txt
+++ b/setup/description_short.txt
@@ -2,5 +2,5 @@ novelWriter is a plain text editor designed for writing novels assembled from
 many smaller text documents. It uses a minimal formatting syntax inspired by
 Markdown, and adds a meta data syntax for comments, synopsis, and
 cross-referencing. It's designed to be a simple text editor that allows for
-easy organization of text and notes, using human readable text files as
+easy organisation of text and notes, using human readable text files as
 storage for robustness.

--- a/setup/novelwriter.appdata.xml
+++ b/setup/novelwriter.appdata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+	<id>novelwriter</id>
+	<metadata_license>GPL-3.0</metadata_license>
+	<project_license>GPL-3.0</project_license>
+	<name>novelWriter</name>
+	<summary>A markdown-like text editor for planning and writing novels</summary>
+	<description>
+		<p>{description}</p>
+	</description>
+	<launchable type="desktop-id">novelwriter.desktop</launchable>
+	<url type="homepage">https://novelwriter.io/</url>
+	<screenshots>
+		<screenshot type="default">
+			<image>https://novelwriter.io/images/screenshot-multi.png</image>
+		</screenshot>
+	</screenshots>
+	<provides>
+		<id>novelwriter.desktop</id>
+	</provides>
+</component>


### PR DESCRIPTION
**Summary:**

Adds a `build-appimage` command to the setup.py that builds off the existing `build-debian` command to package the source and then writes the appropriate metadata files to a `dist_appimage` directory.

requires `python-appimage` package to be installed via pip to succeed.

**Related Issue(s):**

#1091 

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
