### PR TITLE
WIP Type Hinting of novelwriter.core

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -22,16 +22,20 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from __future__ import annotations
 
+import logging as _logging
 import sys
 import getopt
-import logging
+
 
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, QErrorMessage
 
 from novelwriter.error import exceptionHandler, logException
 from novelwriter.config import Config
+
+from novelwriter.logging import getLogger, VERBOSE
 
 ##
 #  Version Scheme
@@ -72,34 +76,8 @@ __helpurl__    = "https://github.com/vkbo/novelWriter/discussions"
 __releaseurl__ = "https://github.com/vkbo/novelWriter/releases/latest"
 __docurl__     = "https://novelwriter.readthedocs.io"
 
-##
-#  Logging
-# =========
-#  Standard used for logging levels in novelWriter:
-#    CRITICAL  Use for errors that result in termination of the program
-#    ERROR     Use when an action fails, but execution continues
-#    WARNING   When something unexpected, but non-critical happens
-#    INFO      Any useful user information like open, save, exit initiated
-#  ----------- SPAM Threshold : Output above should be minimal -----------------
-#    DEBUG     Use for descriptions of main program flow
-#    VERBOSE   Use for outputting values and program flow details
-##
 
-# Add verbose logging level
-VERBOSE = 5
-logging.addLevelName(VERBOSE, "VERBOSE")
-
-
-def logVerbose(self, message, *args, **kws):
-    if self.isEnabledFor(VERBOSE):
-        self._log(VERBOSE, message, args, **kws)
-
-
-logging.Logger.verbose = logVerbose
-
-# Initiating logging
-logger = logging.getLogger(__name__)
-
+logger = getLogger(__name__)
 
 ##
 #  Main Program
@@ -109,7 +87,7 @@ logger = logging.getLogger(__name__)
 CONFIG = Config()
 
 
-def main(sysArgs=None):
+def main(sysArgs: list[str] | None = None):
     """Parse command line, set up logging, and launch main GUI.
     """
     if sysArgs is None:
@@ -150,7 +128,7 @@ def main(sysArgs=None):
     )
 
     # Defaults
-    logLevel = logging.WARN
+    logLevel = _logging.WARN
     logFormat = "{levelname:8}  {message:}"
     confPath = None
     dataPath = None
@@ -177,9 +155,9 @@ def main(sysArgs=None):
             print("novelWriter Version %s [%s]" % (__version__, __date__))
             sys.exit(0)
         elif inOpt == "--info":
-            logLevel = logging.INFO
+            logLevel = _logging.INFO
         elif inOpt == "--debug":
-            logLevel = logging.DEBUG
+            logLevel = _logging.DEBUG
             logFormat  = "[{asctime:}]  {filename:>17}:{lineno:<4d}  {levelname:8}  {message:}"
         elif inOpt == "--verbose":
             logLevel = VERBOSE
@@ -197,10 +175,10 @@ def main(sysArgs=None):
     CONFIG.cmdOpen = cmdOpen
 
     # Set Logging
-    cHandle = logging.StreamHandler()
-    cHandle.setFormatter(logging.Formatter(fmt=logFormat, style="{"))
+    cHandle = _logging.StreamHandler()
+    cHandle.setFormatter(_logging.Formatter(fmt=logFormat, style="{"))
 
-    pkgLogger = logging.getLogger(__package__)
+    pkgLogger = _logging.getLogger(__package__)
     pkgLogger.addHandler(cHandle)
     pkgLogger.setLevel(logLevel)
 
@@ -253,7 +231,7 @@ def main(sysArgs=None):
 
     if CONFIG.osDarwin:
         try:
-            from Foundation import NSBundle
+            from Foundation import NSBundle  # type: ignore
             bundle = NSBundle.mainBundle()
             info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
             info["CFBundleName"] = "novelWriter"
@@ -265,7 +243,7 @@ def main(sysArgs=None):
         try:
             import ctypes
             appID = f"io.novelwriter.{__version__}"
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appID)
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appID)  # type: ignore
         except Exception:
             logger.error("Failed to set application name")
             logException()

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -33,12 +33,7 @@ from datetime import datetime
 from configparser import ConfigParser
 import sys
 
-if sys.version_info >= (3, 10):
-    from typing import Literal, TypeGuard
-else:
-    from typing_extensions import Literal, TypeGuard
-
-from typing import Any, AnyStr, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import qApp, QWidget
@@ -48,14 +43,21 @@ from novelwriter.error import logException
 from novelwriter.constants import nwConst, nwUnicode
 from novelwriter.logging import getLogger
 
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import Final, Literal, TypeGuard
+    else:
+        from typing_extensions import Final, Literal, TypeGuard
+
+    from typing import Any, AnyStr, TypeVar
+    _DefaultT = TypeVar('_DefaultT')
+
 logger = getLogger(__name__)
 
 
 # =============================================================================================== #
 #  Checker Functions
 # =============================================================================================== #
-_DefaultT = TypeVar('_DefaultT')
-
 
 @overload
 def checkString(
@@ -633,12 +635,12 @@ def getGuiItem(objName: str) -> QWidget | None:
 
 class NWConfigParser(ConfigParser):
 
-    CNF_STR:   Literal[0] = 0
-    CNF_INT:   Literal[1] = 1
-    CNF_FLOAT: Literal[2] = 2
-    CNF_BOOL:  Literal[3] = 3
-    CNF_S_LST: Literal[4] = 4
-    CNF_I_LST: Literal[5] = 5
+    CNF_STR:   Final[Literal[0]] = 0
+    CNF_INT:   Final[Literal[1]] = 1
+    CNF_FLOAT: Final[Literal[2]] = 2
+    CNF_BOOL:  Final[Literal[3]] = 3
+    CNF_S_LST: Final[Literal[4]] = 4
+    CNF_I_LST: Final[Literal[5]] = 5
 
     def __init__(self) -> None:
         super().__init__()

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
         from typing_extensions import Final, Literal, TypeGuard
 
     from typing import Any, AnyStr, TypeVar
+
     _DefaultT = TypeVar('_DefaultT')
 
 logger = getLogger(__name__)
@@ -61,7 +62,7 @@ logger = getLogger(__name__)
 
 @overload
 def checkString(
-    value: str | None,
+    value: Any,
     default: _DefaultT,
     allowNone: Literal[False] = False
 ) -> str | _DefaultT:
@@ -70,10 +71,10 @@ def checkString(
 
 @overload
 def checkString(
-    value: str | None,
-    default: _DefaultT,
-    allowNone: Literal[True]
-) -> str | _DefaultT | None:
+    value: Any,
+    default: str | None,
+    allowNone: bool
+) -> str | None:
     ...
 
 
@@ -89,7 +90,7 @@ def checkString(value, default, allowNone=False):
 
 @overload
 def checkInt(
-    value: int | str | None,
+    value: Any,
     default: _DefaultT,
     allowNone: Literal[False] = False
 ) -> int | _DefaultT:
@@ -98,10 +99,10 @@ def checkInt(
 
 @overload
 def checkInt(
-    value: int | str | None,
-    default: _DefaultT,
-    allowNone: Literal[True]
-) -> int | _DefaultT | None:
+    value: Any,
+    default: int | None,
+    allowNone: bool
+) -> int | None:
     ...
 
 
@@ -120,7 +121,7 @@ def checkInt(value, default, allowNone=False):
 
 @overload
 def checkFloat(
-    value: float | str | None,
+    value: Any,
     default: _DefaultT,
     allowNone: Literal[False] = False
 ) -> float | _DefaultT:
@@ -129,10 +130,10 @@ def checkFloat(
 
 @overload
 def checkFloat(
-    value: float | str | None,
-    default: _DefaultT,
-    allowNone: Literal[True]
-) -> float | _DefaultT | None:
+    value: Any,
+    default: float | None,
+    allowNone: bool
+) -> float | None:
     ...
 
 
@@ -151,7 +152,7 @@ def checkFloat(value, default, allowNone=False):
 
 @overload
 def checkBool(
-    value: bool | str | None,
+    value: Any,
     default: _DefaultT,
     allowNone: Literal[False] = False
 ) -> bool | _DefaultT:
@@ -160,10 +161,10 @@ def checkBool(
 
 @overload
 def checkBool(
-    value: bool | str | None,
-    default: _DefaultT,
-    allowNone: Literal[True]
-) -> bool | _DefaultT | None:
+    value: Any,
+    default: bool | None,
+    allowNone: bool
+) -> bool | None:
     ...
 
 
@@ -196,7 +197,7 @@ def checkBool(value, default, allowNone=False):
 
 @overload
 def checkHandle(
-    value: str | None,
+    value: Any,
     default: _DefaultT,
     allowNone: Literal[False] = False
 ) -> str | _DefaultT:
@@ -205,10 +206,10 @@ def checkHandle(
 
 @overload
 def checkHandle(
-    value: str | None,
-    default: _DefaultT,
-    allowNone: Literal[True]
-) -> str | _DefaultT | None:
+    value: Any,
+    default: str | None,
+    allowNone: bool
+) -> str | None:
     ...
 
 
@@ -228,7 +229,7 @@ def checkHandle(value, default, allowNone=False):
 #  Validator Functions
 # =============================================================================================== #
 
-def isHandle(value: str | None) -> TypeGuard[str]:
+def isHandle(value: Any) -> TypeGuard[str]:
     """Check if a string is a valid novelWriter handle.
     Note: This is case sensitive. Must be lower case!
     """
@@ -242,7 +243,7 @@ def isHandle(value: str | None) -> TypeGuard[str]:
     return True
 
 
-def isTitleTag(value: str) -> TypeGuard[str]:
+def isTitleTag(value: Any) -> TypeGuard[str]:
     """Check if a string is a valid title string.
     """
     if not isinstance(value, str):
@@ -275,7 +276,7 @@ def isItemLayout(value: str) -> bool:
     return value in nwItemLayout.__members__
 
 
-def hexToInt(value: str, default: _DefaultT = 0) -> int | _DefaultT:
+def hexToInt(value: Any, default: int = 0) -> int:
     """Convert a hex string to an integer.
     """
     if isinstance(value, str):
@@ -286,7 +287,7 @@ def hexToInt(value: str, default: _DefaultT = 0) -> int | _DefaultT:
     return default
 
 
-def checkIntRange(value: int, first: int, last: int, default: _DefaultT) -> int | _DefaultT:
+def checkIntRange(value: Any, first: int, last: int, default: int) -> int:
     """Check that an int is in a given range. If it isn't, return the
     default value.
     """
@@ -302,7 +303,7 @@ def minmax(value: int, minVal: int, maxVal: int) -> int:
     return min(maxVal, max(minVal, value))
 
 
-def checkIntTuple(value: int, valid: tuple[int], default: _DefaultT) -> int | _DefaultT:
+def checkIntTuple(value: Any, valid: tuple[int, ...], default: _DefaultT) -> int | _DefaultT:
     """Check that an int is an element of a tuple. If it isn't, return
     the default value.
     """
@@ -680,14 +681,14 @@ class NWConfigParser(ConfigParser):
     ##
 
     @overload
-    def _unpackList(self, value: str, default: _DefaultT, type: Literal[4]) -> list[str]:
+    def _unpackList(self, value: str, default: Any, type: Literal[4]) -> list[str]:
         ...
 
     @overload
-    def _unpackList(self, value: str, default: _DefaultT, type: Literal[5]) -> list[str]:
+    def _unpackList(self, value: str, default: Any, type: Literal[5]) -> list[str]:
         ...
 
-    def _unpackList(self, value: str, default: _DefaultT, type: int) -> list[str] | list[int]:
+    def _unpackList(self, value, default, type):
         """Unpack a comma-separated string of items into a list.
         """
         inList: list[str] = value.split(",")
@@ -751,9 +752,9 @@ class NWConfigParser(ConfigParser):
         self,
         section: str,
         option: str,
-        default: _DefaultT,
+        default: Any,
         type: Literal[4]
-    ) -> list[str] | _DefaultT:
+    ) -> list[str]:
         ...
 
     @overload
@@ -761,18 +762,12 @@ class NWConfigParser(ConfigParser):
         self,
         section: str,
         option: str,
-        default: _DefaultT,
+        default: Any,
         type: Literal[5]
-    ) -> list[int] | _DefaultT:
+    ) -> list[int]:
         ...
 
-    def _parseLine(
-        self,
-        section: str,
-        option: str,
-        default: _DefaultT,
-        type: int
-    ) -> str | int | float | bool | list[str] | list[int] | _DefaultT:
+    def _parseLine(self, section, option, default, type):
         """Parse a line and return the correct datatype.
         """
         if self.has_option(section, option):

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -23,27 +23,57 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+from __future__ import annotations
+
 import os
 import json
 import hashlib
-import logging
 
 from datetime import datetime
 from configparser import ConfigParser
+import sys
+
+if sys.version_info >= (3, 10):
+    from typing import Literal, TypeGuard
+else:
+    from typing_extensions import Literal, TypeGuard
+
+from typing import Any, AnyStr, TypeVar, overload
 
 from PyQt5.QtCore import QCoreApplication
-from PyQt5.QtWidgets import qApp
+from PyQt5.QtWidgets import qApp, QWidget
 
 from novelwriter.enum import nwItemClass, nwItemType, nwItemLayout
 from novelwriter.error import logException
 from novelwriter.constants import nwConst, nwUnicode
+from novelwriter.logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 # =============================================================================================== #
 #  Checker Functions
 # =============================================================================================== #
+_DefaultT = TypeVar('_DefaultT')
+
+
+@overload
+def checkString(
+    value: str | None,
+    default: _DefaultT,
+    allowNone: Literal[False] = False
+) -> str | _DefaultT:
+    ...
+
+
+@overload
+def checkString(
+    value: str | None,
+    default: _DefaultT,
+    allowNone: Literal[True]
+) -> str | _DefaultT | None:
+    ...
+
 
 def checkString(value, default, allowNone=False):
     """Check if a variable is a string or a None.
@@ -55,15 +85,53 @@ def checkString(value, default, allowNone=False):
     return default
 
 
+@overload
+def checkInt(
+    value: int | str | None,
+    default: _DefaultT,
+    allowNone: Literal[False] = False
+) -> int | _DefaultT:
+    ...
+
+
+@overload
+def checkInt(
+    value: int | str | None,
+    default: _DefaultT,
+    allowNone: Literal[True]
+) -> int | _DefaultT | None:
+    ...
+
+
 def checkInt(value, default, allowNone=False):
     """Check if a variable is an integer or a None.
     """
     if allowNone and (value is None or value == "None"):
         return None
+    elif (value is None or value == "None"):
+        return default
     try:
         return int(value)
     except Exception:
         return default
+
+
+@overload
+def checkFloat(
+    value: float | str | None,
+    default: _DefaultT,
+    allowNone: Literal[False] = False
+) -> float | _DefaultT:
+    ...
+
+
+@overload
+def checkFloat(
+    value: float | str | None,
+    default: _DefaultT,
+    allowNone: Literal[True]
+) -> float | _DefaultT | None:
+    ...
 
 
 def checkFloat(value, default, allowNone=False):
@@ -71,10 +139,30 @@ def checkFloat(value, default, allowNone=False):
     """
     if allowNone and (value is None or value == "None"):
         return None
+    elif value is None or value == "None":
+        return default
     try:
         return float(value)
     except Exception:
         return default
+
+
+@overload
+def checkBool(
+    value: bool | str | None,
+    default: _DefaultT,
+    allowNone: Literal[False] = False
+) -> bool | _DefaultT:
+    ...
+
+
+@overload
+def checkBool(
+    value: bool | str | None,
+    default: _DefaultT,
+    allowNone: Literal[True]
+) -> bool | _DefaultT | None:
+    ...
 
 
 def checkBool(value, default, allowNone=False):
@@ -82,6 +170,8 @@ def checkBool(value, default, allowNone=False):
     """
     if allowNone and (value is None or value == "None"):
         return None
+    elif value is None or value == "None":
+        return default
 
     if isinstance(value, str):
         if value == "True":
@@ -102,11 +192,31 @@ def checkBool(value, default, allowNone=False):
     return default
 
 
+@overload
+def checkHandle(
+    value: str | None,
+    default: _DefaultT,
+    allowNone: Literal[False] = False
+) -> str | _DefaultT:
+    ...
+
+
+@overload
+def checkHandle(
+    value: str | None,
+    default: _DefaultT,
+    allowNone: Literal[True]
+) -> str | _DefaultT | None:
+    ...
+
+
 def checkHandle(value, default, allowNone=False):
     """Check if a value is a handle.
     """
     if allowNone and (value is None or value == "None"):
         return None
+    elif value is None or value == "None":
+        return default
     if isHandle(value):
         return str(value)
     return default
@@ -116,7 +226,7 @@ def checkHandle(value, default, allowNone=False):
 #  Validator Functions
 # =============================================================================================== #
 
-def isHandle(value):
+def isHandle(value: str | None) -> TypeGuard[str]:
     """Check if a string is a valid novelWriter handle.
     Note: This is case sensitive. Must be lower case!
     """
@@ -130,7 +240,7 @@ def isHandle(value):
     return True
 
 
-def isTitleTag(value):
+def isTitleTag(value: str) -> TypeGuard[str]:
     """Check if a string is a valid title string.
     """
     if not isinstance(value, str):
@@ -145,25 +255,25 @@ def isTitleTag(value):
     return True
 
 
-def isItemClass(value):
+def isItemClass(value: str) -> bool:
     """Check if a string is a valid nwItemClass identifier.
     """
     return value in nwItemClass.__members__
 
 
-def isItemType(value):
+def isItemType(value: str) -> bool:
     """Check if a string is a valid nwItemType identifier.
     """
     return value in nwItemType.__members__
 
 
-def isItemLayout(value):
+def isItemLayout(value: str) -> bool:
     """Check if a string is a valid nwItemLayout identifier.
     """
     return value in nwItemLayout.__members__
 
 
-def hexToInt(value, default=0):
+def hexToInt(value: str, default: _DefaultT = 0) -> int | _DefaultT:
     """Convert a hex string to an integer.
     """
     if isinstance(value, str):
@@ -174,7 +284,7 @@ def hexToInt(value, default=0):
     return default
 
 
-def checkIntRange(value, first, last, default):
+def checkIntRange(value: int, first: int, last: int, default: _DefaultT) -> int | _DefaultT:
     """Check that an int is in a given range. If it isn't, return the
     default value.
     """
@@ -184,13 +294,13 @@ def checkIntRange(value, first, last, default):
     return default
 
 
-def minmax(value, minVal, maxVal):
+def minmax(value: int, minVal: int, maxVal: int) -> int:
     """Make sure an integer is between min and max value (inclusive).
     """
     return min(maxVal, max(minVal, value))
 
 
-def checkIntTuple(value, valid, default):
+def checkIntTuple(value: int, valid: tuple[int], default: _DefaultT) -> int | _DefaultT:
     """Check that an int is an element of a tuple. If it isn't, return
     the default value.
     """
@@ -204,13 +314,13 @@ def checkIntTuple(value, valid, default):
 #  Formatting Functions
 # =============================================================================================== #
 
-def formatInt(value):
+def formatInt(value: int) -> str:
     """Formats an integer with k, M, G etc.
     """
     if not isinstance(value, int):
         return "ERR"
 
-    theVal = float(value)
+    theVal: float = float(value)
     if theVal > 1000.0:
         for pF in ["k", "M", "G", "T", "P", "E"]:
             theVal /= 1000.0
@@ -225,7 +335,7 @@ def formatInt(value):
     return str(value)
 
 
-def formatTimeStamp(theTime, fileSafe=False):
+def formatTimeStamp(theTime: float, fileSafe=False) -> str:
     """Take a number (on the format returned by time.time()) and convert
     it to a timestamp string.
     """
@@ -235,7 +345,7 @@ def formatTimeStamp(theTime, fileSafe=False):
         return datetime.fromtimestamp(theTime).strftime(nwConst.FMT_TSTAMP)
 
 
-def formatTime(tS):
+def formatTime(tS: int) -> str:
     """Format a time in seconds in HH:MM:SS format or d-HH:MM:SS format
     if a full day or longer.
     """
@@ -251,27 +361,27 @@ def formatTime(tS):
 #  String Functions
 # =============================================================================================== #
 
-def simplified(string):
+def simplified(string: str) -> str:
     """Take a string an strip leading and trailing whitespaces, and
     replace all occurences of (multiple) whitespaces with a 0x20 space.
     """
     return " ".join(str(string).strip().split())
 
 
-def splitVersionNumber(value):
+def splitVersionNumber(value: str) -> list[int]:
     """Split a version string on the form aa.bb.cc into major, minor
     and patch, and computes an integer value aabbcc.
     """
     if not isinstance(value, str):
         return [0, 0, 0, 0]
 
-    vMajor = 0
-    vMinor = 0
-    vPatch = 0
-    vInt = 0
+    vMajor: int = 0
+    vMinor: int = 0
+    vPatch: int = 0
+    vInt: int = 0
 
-    vBits = value.split(".")
-    nBits = len(vBits)
+    vBits: list[str] = value.split(".")
+    nBits: int = len(vBits)
 
     if nBits > 0:
         vMajor = checkInt(vBits[0], 0)
@@ -285,11 +395,11 @@ def splitVersionNumber(value):
     return [vMajor, vMinor, vPatch, vInt]
 
 
-def transferCase(theSource, theTarget):
+def transferCase(theSource: str, theTarget: str) -> str:
     """Transfers the case of the source word to the target word. This
     will consider all upper or lower, and first char capitalisation.
     """
-    theResult = theTarget
+    theResult: str = theTarget
 
     if not isinstance(theSource, str) or not isinstance(theTarget, str):
         return theResult
@@ -307,7 +417,7 @@ def transferCase(theSource, theTarget):
     return theResult
 
 
-def fuzzyTime(secDiff):
+def fuzzyTime(secDiff: int | float) -> str:
     """Converts a time difference in seconds into a fuzzy time string.
     """
     if secDiff < 0:
@@ -368,7 +478,7 @@ def fuzzyTime(secDiff):
         ).format(int(round(secDiff/31557600)))
 
 
-def numberToRoman(numVal, toLower=False):
+def numberToRoman(numVal: int, toLower=False) -> str:
     """Convert an integer to a Roman number.
     """
     if not isinstance(numVal, int):
@@ -376,14 +486,14 @@ def numberToRoman(numVal, toLower=False):
     if numVal < 1 or numVal > 4999:
         return "OOR"
 
-    theValues = [
+    theValues: list[tuple[int, str]] = [
         (1000, "M"), (900, "CM"), (500, "D"), (400, "CD"), (100, "C"), (90, "XC"),
         (50, "L"), (40, "XL"), (10, "X"), (9, "IX"), (5, "V"), (4, "IV"), (1, "I"),
     ]
 
-    romNum = ""
+    romNum: str = ""
     for theDiv, theSym in theValues:
-        n = numVal//theDiv
+        n: int = numVal//theDiv
         romNum += n*theSym
         numVal -= n*theDiv
         if numVal <= 0:
@@ -396,22 +506,22 @@ def numberToRoman(numVal, toLower=False):
 #  Encoder Functions
 # =============================================================================================== #
 
-def jsonEncode(data, n=0, nmax=0):
+def jsonEncode(data: dict | list | tuple, n=0, nmax=0) -> str:
     """Encode a dictionary, list or tuple as a json object or array, and
     indent from level n up to a max level nmax if nmax is larger than 0.
     """
     if not isinstance(data, (dict, list, tuple)):
         return "[]"
 
-    buffer = []
-    indent = ""
+    buffer: list[str] = []
+    indent: str = ""
 
     for chunk in json.JSONEncoder().iterencode(data):
         if chunk == "":  # pragma: no cover
             # Just a precaution
             continue
 
-        first = chunk[0]
+        first: str = chunk[0]
         if chunk in ("{}", "[]"):
             buffer.append(chunk)
 
@@ -447,13 +557,13 @@ def jsonEncode(data, n=0, nmax=0):
 #  File and File System Functions
 # =============================================================================================== #
 
-def readTextFile(filePath):
+def readTextFile(filePath: AnyStr) -> str:
     """Read the content of a text file in a robust manner.
     """
     if not os.path.isfile(filePath):
         return ""
 
-    fileText = ""
+    fileText: str = ""
     try:
         with open(filePath, mode="r", encoding="utf-8") as inFile:
             fileText = inFile.read()
@@ -465,23 +575,23 @@ def readTextFile(filePath):
     return fileText
 
 
-def makeFileNameSafe(value):
+def makeFileNameSafe(value: object) -> str:
     """Returns a filename safe string of the value.
     """
-    cleanName = ""
+    cleanName: str = ""
     for c in str(value).strip():
         if c.isalpha() or c.isdigit() or c == " ":
             cleanName += c
     return cleanName
 
 
-def sha256sum(filePath):
+def sha256sum(filePath: AnyStr) -> str | None:
     """Make a shasum of a file using a buffer.
     Based on: https://stackoverflow.com/a/44873382/5825851
     """
-    hDigest = hashlib.sha256()
-    bData = bytearray(65536)
-    mData = memoryview(bData)
+    hDigest: hashlib._Hash = hashlib.sha256()
+    bData: bytearray = bytearray(65536)
+    mData: memoryview = memoryview(bData)
     try:
         with open(filePath, mode="rb", buffering=0) as inFile:
             for n in iter(lambda: inFile.readinto(mData), 0):
@@ -494,11 +604,21 @@ def sha256sum(filePath):
     return hDigest.hexdigest()
 
 
+def isStrList(val: list[Any]) -> TypeGuard[list[str]]:
+    """Determines whether all objects in the list are strings"""
+    return all(isinstance(x, str) for x in val)
+
+
+def isIntList(val: list[Any]) -> TypeGuard[list[int]]:
+    """Determines whether all objects in the list are integers"""
+    return all(isinstance(x, int) for x in val)
+
+
 # =============================================================================================== #
 #  Other Functions
 # =============================================================================================== #
 
-def getGuiItem(objName):
+def getGuiItem(objName: str) -> QWidget | None:
     """Returns a QtWidget based on its objectName.
     """
     for qWidget in qApp.topLevelWidgets():
@@ -513,42 +633,42 @@ def getGuiItem(objName):
 
 class NWConfigParser(ConfigParser):
 
-    CNF_STR   = 0
-    CNF_INT   = 1
-    CNF_FLOAT = 2
-    CNF_BOOL  = 3
-    CNF_S_LST = 4
-    CNF_I_LST = 5
+    CNF_STR:   Literal[0] = 0
+    CNF_INT:   Literal[1] = 1
+    CNF_FLOAT: Literal[2] = 2
+    CNF_BOOL:  Literal[3] = 3
+    CNF_S_LST: Literal[4] = 4
+    CNF_I_LST: Literal[5] = 5
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
-    def rdStr(self, section, option, default):
+    def rdStr(self, section: str, option: str, default: str) -> str:
         """Read string value.
         """
         return self._parseLine(section, option, default, self.CNF_STR)
 
-    def rdInt(self, section, option, default):
+    def rdInt(self, section: str, option: str, default: int) -> int:
         """Read integer value.
         """
         return self._parseLine(section, option, default, self.CNF_INT)
 
-    def rdFlt(self, section, option, default):
+    def rdFlt(self, section: str, option: str, default: float) -> float:
         """Read float value.
         """
         return self._parseLine(section, option, default, self.CNF_FLOAT)
 
-    def rdBool(self, section, option, default):
+    def rdBool(self, section: str, option: str, default: bool) -> bool:
         """Read boolean value.
         """
         return self._parseLine(section, option, default, self.CNF_BOOL)
 
-    def rdStrList(self, section, option, default):
+    def rdStrList(self, section: str, option: str, default: list[str]) -> list[str]:
         """Read string list.
         """
         return self._parseLine(section, option, default, self.CNF_S_LST)
 
-    def rdIntList(self, section, option, default):
+    def rdIntList(self, section: str, option: str, default: list[int]) -> list[int]:
         """Read integer list.
         """
         return self._parseLine(section, option, default, self.CNF_I_LST)
@@ -557,11 +677,21 @@ class NWConfigParser(ConfigParser):
     #  Internal Functions
     ##
 
-    def _unpackList(self, value, default, type):
+    @overload
+    def _unpackList(self, value: str, default: _DefaultT, type: Literal[4]) -> list[str]:
+        ...
+
+    @overload
+    def _unpackList(self, value: str, default: _DefaultT, type: Literal[5]) -> list[str]:
+        ...
+
+    def _unpackList(self, value: str, default: _DefaultT, type: int) -> list[str] | list[int]:
         """Unpack a comma-separated string of items into a list.
         """
-        inList = value.split(",")
-        outList = []
+        inList: list[str] = value.split(",")
+
+        outList: list[Any] = []
+
         if isinstance(default, list):
             outList = default.copy()
         for i in range(min(len(inList), len(outList))):
@@ -574,7 +704,73 @@ class NWConfigParser(ConfigParser):
                 continue
         return outList
 
-    def _parseLine(self, section, option, default, type):
+    @overload
+    def _parseLine(
+        self,
+        section: str,
+        option: str,
+        default: _DefaultT,
+        type: Literal[0]
+    ) -> str | _DefaultT:
+        ...
+
+    @overload
+    def _parseLine(
+        self,
+        section: str,
+        option: str,
+        default: _DefaultT,
+        type: Literal[1]
+    ) -> int | _DefaultT:
+        ...
+
+    @overload
+    def _parseLine(
+        self,
+        section: str,
+        option: str,
+        default: _DefaultT,
+        type: Literal[2]
+    ) -> float | _DefaultT:
+        ...
+
+    @overload
+    def _parseLine(
+        self,
+        section: str,
+        option: str,
+        default: _DefaultT,
+        type: Literal[3]
+    ) -> bool | _DefaultT:
+        ...
+
+    @overload
+    def _parseLine(
+        self,
+        section: str,
+        option: str,
+        default: _DefaultT,
+        type: Literal[4]
+    ) -> list[str] | _DefaultT:
+        ...
+
+    @overload
+    def _parseLine(
+        self,
+        section: str,
+        option: str,
+        default: _DefaultT,
+        type: Literal[5]
+    ) -> list[int] | _DefaultT:
+        ...
+
+    def _parseLine(
+        self,
+        section: str,
+        option: str,
+        default: _DefaultT,
+        type: int
+    ) -> str | int | float | bool | list[str] | list[int] | _DefaultT:
         """Parse a line and return the correct datatype.
         """
         if self.has_option(section, option):

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -27,11 +27,6 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info >= (3, 10):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 from typing import TYPE_CHECKING
 
 from lxml import etree
@@ -44,6 +39,11 @@ from novelwriter.constants import nwLabels, trConst
 from novelwriter.logging import getLogger, VerboseLogger
 
 if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
+
     from PyQt5.QtGui import QIcon
     from novelwriter.core.project import NWProject
 

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -336,8 +336,8 @@ class NWItem():
             stIcon: QIcon = self.theProject.statusItems.icon(self._status)
         elif self.theProject.importItems is not None:
             assert self._import is not None
-            stName: str = self.theProject.importItems.name(self._import)
-            stIcon: QIcon = self.theProject.importItems.icon(self._import)
+            stName = self.theProject.importItems.name(self._import)
+            stIcon = self.theProject.importItems.icon(self._import)
         else:
             raise Exception("This is a bug!")
         return stName, stIcon

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -349,7 +349,7 @@ class NWProject():
 
         titlePage: str = "#! %s\n\n" % (self.bookTitle if self.bookTitle else self.projName)
         if self.bookAuthors:
-            titlePage: str = "%s>> %s %s <<\n" % (titlePage, self.tr("By"), self.getAuthors())
+            titlePage = "%s>> %s %s <<\n" % (titlePage, self.tr("By"), self.getAuthors())
 
         aDoc: NWDoc = NWDoc(self, hTitlePage)
         aDoc.writeDocument(titlePage)
@@ -359,11 +359,11 @@ class NWProject():
             # single chapter with a single scene.
             hChapter: str | None = self.newFile(self.tr("New Chapter"), hNovelRoot)
             assert hChapter is not None
-            aDoc: NWDoc = NWDoc(self, hChapter)
+            aDoc = NWDoc(self, hChapter)
             aDoc.writeDocument("## %s\n\n" % self.tr("New Chapter"))
 
             hScene: str | None = self.newFile(self.tr("New Scene"), hChapter)
-            aDoc: NWDoc = NWDoc(self, hScene)
+            aDoc = NWDoc(self, hScene)
             aDoc.writeDocument("### %s\n\n" % self.tr("New Scene"))
 
             self.newRoot(nwItemClass.PLOT)
@@ -389,7 +389,7 @@ class NWProject():
                     chTitle: str = self.tr("Chapter {0}").format(f"{ch+1:d}")
                     cHandle: str | None = self.newFile(chTitle, hNovelRoot)
                     assert cHandle is not None
-                    aDoc: NWDoc = NWDoc(self, cHandle)
+                    aDoc = NWDoc(self, cHandle)
                     aDoc.writeDocument(f"## {chTitle}\n\n% Synopsis: {chSynop}\n\n")
 
                     # Create chapter scenes
@@ -398,16 +398,16 @@ class NWProject():
                             scTitle: str = self.tr("Scene {0}").format(f"{ch+1:d}.{sc+1:d}")
                             sHandle: str | None = self.newFile(scTitle, cHandle)
                             assert sHandle is not None
-                            aDoc: NWDoc = NWDoc(self, sHandle)
+                            aDoc = NWDoc(self, sHandle)
                             aDoc.writeDocument(f"### {scTitle}\n\n% Synopsis: {scSynop}\n\n")
 
             # Create scenes (no chapters)
             elif numScenes > 0:
                 for sc in range(numScenes):
-                    scTitle: str = self.tr("Scene {0}").format(f"{sc+1:d}")
-                    sHandle: str | None = self.newFile(scTitle, hNovelRoot)
+                    scTitle = self.tr("Scene {0}").format(f"{sc+1:d}")
+                    sHandle = self.newFile(scTitle, hNovelRoot)
                     assert sHandle is not None
-                    aDoc: NWDoc = NWDoc(self, sHandle)
+                    aDoc = NWDoc(self, sHandle)
                     aDoc.writeDocument(f"### {scTitle}\n\n% Synopsis: {scSynop}\n\n")
 
             # Create notes folders
@@ -424,7 +424,7 @@ class NWProject():
                     if addNotes:
                         aHandle: str | None = self.newFile(noteTitles[newRoot], rHandle)
                         ntTag: str = simplified(noteTitles[newRoot]).replace(" ", "")
-                        aDoc: NWDoc = NWDoc(self, aHandle)
+                        aDoc = NWDoc(self, aHandle)
                         aDoc.writeDocument(f"# {noteTitles[newRoot]}\n\n@tag: {ntTag}\n\n")
 
             # Also add the archive and trash folders
@@ -515,7 +515,7 @@ class NWProject():
                     "Attempting to open backup project file instead."
                 ), nwAlert.INFO)
                 try:
-                    nwXML: etree._ElementTree = etree.parse(backFile)
+                    nwXML = etree.parse(backFile)
                 except Exception as exc:
                     self.mainGui.makeAlert(self.tr(
                         "Failed to parse project xml."
@@ -591,7 +591,7 @@ class NWProject():
         # =========================
 
         if hexToInt(hexVersion) > hexToInt(novelwriter.__hexversion__):
-            msgYes: bool = self.mainGui.askQuestion(
+            msgYes = self.mainGui.askQuestion(
                 self.tr("Version Conflict"),
                 self.tr(
                     "This project was saved by a newer version of "
@@ -1289,7 +1289,7 @@ class NWProject():
                 # out hand, so we cap at 10000 items
                 logger.warning("Item '%s' found before its parent", tHandle)
                 iterItems.append(tHandle)
-                nMax: int = min(len(iterItems), 10000)
+                nMax = min(len(iterItems), 10000)
             else:
                 # Item is orphaned
                 logger.error("Item '%s' has no parent in current tree", tHandle)
@@ -1378,7 +1378,7 @@ class NWProject():
 
         langFile: str = os.path.join(self.mainConf.nwLangPath, "project_%s.json" % self.projLang)
         if not os.path.isfile(langFile):
-            langFile: str = os.path.join(self.mainConf.nwLangPath, "project_en_GB.json")
+            langFile = os.path.join(self.mainConf.nwLangPath, "project_en_GB.json")
 
         try:
             with open(langFile, mode="r", encoding="utf-8") as inFile:
@@ -1532,7 +1532,7 @@ class NWProject():
             ).format(len(orphanFiles)), nwAlert.WARN)
         else:
             logger.debug("File check OK")
-            return
+            return True
 
         # Handle orphans
         nOrph: int = 0
@@ -1572,7 +1572,7 @@ class NWProject():
 
             # If the file still has no parent item, skip it
             if oParent is None:
-                noWhere: bool = True
+                noWhere = True
                 continue
 
             orphItem: NWItem = NWItem(self)

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -30,12 +30,7 @@ import json
 import shutil
 import sys
 
-if sys.version_info >= (3, 10):
-    from typing import Final, TypedDict
-else:
-    from typing_extensions import Final, TypedDict
-
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING
 
 import novelwriter
 
@@ -61,15 +56,20 @@ from novelwriter.constants import trConst, nwFiles, nwLabels
 from novelwriter.logging import getLogger
 
 if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import Final, TypedDict
+    else:
+        from typing_extensions import Final, TypedDict
+    from typing import Any, Generator
+
+    class NWStatusImportData(TypedDict):
+        key: str | None
+        name: str
+        cols: tuple[int, int, int]
+
     from novelwriter.guimain import GuiMain
 
 logger = getLogger(__name__)
-
-
-class NWStatusImportData(TypedDict):
-    key: str | None
-    name: str
-    cols: tuple[int, int, int]
 
 
 class NWProject():

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -80,7 +80,7 @@ class NWStatus():
         if self._type == self.STATUS:
             self._prefix: str = "s"
         elif self._type == self.IMPORT:
-            self._prefix: str = "i"
+            self._prefix = "i"
         else:
             raise Exception("This is a bug!")
 

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -29,12 +29,7 @@ from __future__ import annotations
 import random
 import sys
 
-if sys.version_info >= (3, 10):
-    from typing import Final, Literal, TypeAlias, TypedDict, TypeGuard
-else:
-    from typing_extensions import Final, Literal, TypeAlias, TypedDict, TypeGuard
-
-from typing import Dict, Iterator, NamedTuple, Sequence, Tuple, Union
+from typing import TYPE_CHECKING
 
 import novelwriter
 from lxml import etree
@@ -42,24 +37,27 @@ from novelwriter.common import checkInt, checkString, minmax, simplified
 from novelwriter.logging import VerboseLogger, getLogger
 from PyQt5.QtGui import QColor, QIcon, QPixmap
 
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import Final, Literal, TypeAlias, TypedDict, TypeGuard
+    else:
+        from typing_extensions import (Final, Literal, TypeAlias, TypedDict,
+                                       TypeGuard)
+
+    from typing import Dict, Iterator,  Sequence, Tuple
+
+    NWStatusColour: TypeAlias = Tuple[int, int, int]
+
+    class NWStatusData(TypedDict):
+        name: str
+        icon: QIcon
+        cols: NWStatusColour
+        count: int
+
+    NWStatusStore: TypeAlias = Dict[str, NWStatusData]
+
+
 logger: VerboseLogger = getLogger(__name__)
-
-
-class NWColour(NamedTuple):
-    red: int
-    green: int
-    blue: int
-
-
-class NWStatusData(TypedDict):
-    name: str
-    icon: QIcon
-    cols: NWStatusColour
-    count: int
-
-
-NWStatusStore: TypeAlias = Dict[str, NWStatusData]
-NWStatusColour: TypeAlias = Union[NWColour, Tuple[int, int, int]]
 
 
 class NWStatus():
@@ -96,9 +94,9 @@ class NWStatus():
         if not self._isKey(key):
             key = self._newKey()
         if not isinstance(cols, tuple):
-            cols = NWColour(100, 100, 100)
+            cols = (100, 100, 100)
         if len(cols) != 3:
-            cols = NWColour(100, 100, 100)
+            cols = (100, 100, 100)
 
         pixmap: QPixmap = QPixmap(self._iconSize, self._iconSize)
         pixmap.fill(QColor(*cols))
@@ -171,7 +169,7 @@ class NWStatus():
         elif self._default is not None:
             return self._store[self._default]["cols"]
         else:
-            return NWColour(100, 100, 100)
+            return (100, 100, 100)
 
     def count(self, key) -> int:
         """Return the count associated with a given key.
@@ -265,7 +263,7 @@ class NWStatus():
             red: int   = minmax(checkInt(str(xChild.attrib.get("red")), 100), 0, 255)
             green: int = minmax(checkInt(str(xChild.attrib.get("green")), 100), 0, 255)
             blue: int  = minmax(checkInt(str(xChild.attrib.get("blue")), 100), 0, 255)
-            self.write(key, name, NWColour(red, green, blue), count)
+            self.write(key, name, (red, green, blue), count)
 
         return True
 

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -27,8 +27,9 @@ from __future__ import annotations
 
 import os
 import random
+import sys
 
-from typing import Generator
+from typing import TYPE_CHECKING
 
 from lxml import etree
 
@@ -40,14 +41,22 @@ from novelwriter.core.item import NWItem
 
 from novelwriter.logging import getLogger
 
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import Final, Literal
+    else:
+        from typing_extensions import Final, Literal
+
+    from typing import Generator
+
 logger = getLogger(__name__)
 
 
 class NWTree():
 
-    MAX_DEPTH = 1000  # Cap of tree traversing for loops
+    MAX_DEPTH: Final[Literal[1000]] = 1000  # Cap of tree traversing for loops
 
-    def __init__(self, theProject):
+    def __init__(self, theProject) -> None:
 
         self.theProject = theProject
 

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -177,7 +177,7 @@ class NWTree():
                     tItem.itemName,
                 )
                 tocList.append(tocLine)
-                tocLen: int = max(tocLen, len(tocLine))
+                tocLen = max(tocLen, len(tocLine))
 
         try:
             # Dump the text
@@ -237,7 +237,7 @@ class NWTree():
                 tItem.setClassDefaults(iItem.itemClass)
                 return True
             else:
-                iItem: NWItem | None = self.__getitem__(iItem.itemParent)
+                iItem = self.__getitem__(iItem.itemParent)
                 if iItem is None:
                     return False
         else:
@@ -267,7 +267,7 @@ class NWTree():
                     return tTree
                 else:
                     tHandle = tItem.itemParent
-                    tItem: NWItem | None = self.__getitem__(tHandle)
+                    tItem = self.__getitem__(tHandle)
                     if tItem is None:
                         return tTree
                     else:

--- a/novelwriter/logging.py
+++ b/novelwriter/logging.py
@@ -1,0 +1,64 @@
+"""
+novelWriter – Logging
+=======================
+Application logging setup
+split off form __init__.py to make type checking happy
+
+File History:
+Created: 2022-08-15
+
+This file is a part of novelWriter
+Copyright 2018–2022, Veronica Berglyd Olsen
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+from __future__ import annotations
+
+
+import logging
+from typing import cast
+
+
+##
+#  Logging
+# =========
+#  Standard used for logging levels in novelWriter:
+#    CRITICAL  Use for errors that result in termination of the program
+#    ERROR     Use when an action fails, but execution continues
+#    WARNING   When something unexpected, but non-critical happens
+#    INFO      Any useful user information like open, save, exit initiated
+#  ----------- SPAM Threshold : Output above should be minimal -----------------
+#    DEBUG     Use for descriptions of main program flow
+#    VERBOSE   Use for outputting values and program flow details
+##
+
+
+# Add verbose logging level
+VERBOSE = 5
+logging.addLevelName(VERBOSE, "VERBOSE")
+
+class VerboseLogger(logging.Logger):
+
+    def verbose(self, message: object, *args, **kws) -> None:
+        if self.isEnabledFor(VERBOSE):
+            self._log(VERBOSE, message, args, **kws)
+
+logging.setLoggerClass(VerboseLogger)
+
+
+# Initiating logging
+logger: VerboseLogger = cast(VerboseLogger, logging.getLogger())
+
+def getLogger(suffix: str) -> VerboseLogger:
+    return logger.getChild(suffix)

--- a/novelwriter/logging.py
+++ b/novelwriter/logging.py
@@ -48,17 +48,19 @@ from typing import cast
 VERBOSE = 5
 logging.addLevelName(VERBOSE, "VERBOSE")
 
+
 class VerboseLogger(logging.Logger):
 
     def verbose(self, message: object, *args, **kws) -> None:
         if self.isEnabledFor(VERBOSE):
             self._log(VERBOSE, message, args, **kws)
 
-logging.setLoggerClass(VerboseLogger)
 
+logging.setLoggerClass(VerboseLogger)
 
 # Initiating logging
 logger: VerboseLogger = cast(VerboseLogger, logging.getLogger())
+
 
 def getLogger(suffix: str) -> VerboseLogger:
     return logger.getChild(suffix)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,6 @@ pytest-timeout
 pytest-cov
 pytest-qt
 lxml-stubs>=0.4.0
+PyQt5-stubs>=5.15
 typing-extensions>=4.3; python_version < "3.10"
 mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ pytest-timeout
 pytest-cov
 pytest-qt
 lxml-stubs>=0.4.0
+typing-extensions>=4.3; python_version < "3.10"
 mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@ pytest>=4.0.0
 pytest-timeout
 pytest-cov
 pytest-qt
+lxml-stubs>=0.4.0
+mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyqt5>=5.3
 lxml>=4.2.0
 pyenchant>=3.0.0
-typing-extensions>=4.3; python_version < "3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyqt5>=5.3
 lxml>=4.2.0
 pyenchant>=3.0.0
+typing-extensions>=4.3; python_version < "3.10"


### PR DESCRIPTION
<!--
Please check the following before you make a pull request:

* The branch you are making the pull request from (in your own fork) has a unique and descriptive
  name. Do not make a pull request directly from your copy of `main`.
* If you are submitting translation files, only submit the files that you have added translations
  to, not the other .ts files that may have been updated in the process.
* Make sure your contribution follows the style guide and other requirements mentioned in the
  CONTRIBUTING.md file in the repository.
* Fill in the Summary section below, and if relevant, mention the issue numbers related to the PR.
-->

**Summary:**
A Work in Progress branch to add type hints to the core package which are backwards compatible to python 3.7
+ additional requirements for type-hinting included in requirements.txt and requirements-dev.txt

*NOTE*: The type hint style used follows python 3.10 standards however between the use of 
```from __future__ import annotations``` 
and the `typeing_extensions` back-ports the code works on 3.7+
I have been using pyright and mypy from a python 3.7 and 3.10 venv to verify

Files that have type hints completed

* [x] `novelwriter/common.py` common functions
* [ ] `novelwriter/core/__init__.py`
* [ ] `novelwriter/core/document.py`
* [ ] `novelwriter/core/index.py`
* [x] `novelwriter/core/item.py`
* [ ] `novelwriter/core/options.py`
* [x] `novelwriter/core/project.py`
* [ ] `novelwriter/core/spellcheck.py`
* [x] `novelwriter/core/status.py`
* [ ] `novelwriter/core/tokenizer.py`
* [ ] `novelwriter/core/toodt.p`
* [ ] `novelwriter/core/tohtml.py`
* [ ] `novelwriter/core/tomd.py`
* [x] `novelwriter/core/tree.py`

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
