### PR TITLE
Fix handling of empty spellcheck language string

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Packages (apt)
         run: |
           sudo apt update
-          sudo apt install libenchant-dev qttools5-dev-tools
+          sudo apt install libenchant-dev qttools5-dev-tools aspell-en
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Install Dependencies (pip)

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -360,7 +360,7 @@ class Config:
         # Check the availability of optional packages
         self._checkOptionalPackages()
 
-        if self.spellLanguage is None:
+        if not self.spellLanguage:
             self.spellLanguage = "en"
 
         # Look for a PDF version of the manual

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -718,7 +718,7 @@ class GuiDocEditor(QTextEdit):
                 ), nwAlert.INFO)
             theMode = False
 
-        if self.spEnchant.spellLanguage() is None:
+        if self.spEnchant.spellLanguage is None:
             theMode = False
 
         self._spellCheck = theMode

--- a/tests/test_core/test_core_spellcheck.py
+++ b/tests/test_core/test_core_spellcheck.py
@@ -37,7 +37,7 @@ def testCoreSpell_FakeEnchant(monkeypatch):
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "enchant", None)
         spChk = NWSpellEnchant()
-        spChk.setLanguage("en", "")
+        spChk.setLanguage("en_US", "")
         assert isinstance(spChk._theDict, FakeEnchant)
 
     # Request a non-existent dictionary
@@ -85,9 +85,9 @@ def testCoreSpell_Enchant(monkeypatch, fncDir):
 
     # Load the proper enchant package (twice)
     spChk = NWSpellEnchant()
-    spChk.setLanguage("en", wList)
-    spChk.setLanguage("en", wList)
-    assert spChk.spellLanguage == "en"
+    spChk.setLanguage("en_US", wList)
+    spChk.setLanguage("en_US", wList)
+    assert spChk.spellLanguage == "en_US"
 
     # Add a word to the user's dictionary
     assert spChk._readProjectDictionary("stuff") is False
@@ -127,7 +127,7 @@ def testCoreSpell_Enchant(monkeypatch, fncDir):
     assert len(dList) > 0
 
     aTag, aName = spChk.describeDict()
-    assert aTag == "en"
+    assert aTag == "en_US"
     assert aName != ""
 
 # END Test testCoreSpell_Enchant
@@ -146,7 +146,7 @@ def testCoreSpell_SessionWords(fncDir):
 
     spChk = NWSpellEnchant()
 
-    spChk.setLanguage("en", wList1)
+    spChk.setLanguage("en_US", wList1)
     assert spChk.checkWord("a_word") is True
     assert spChk.checkWord("b_word") is True
     assert spChk.checkWord("c_word") is True
@@ -154,7 +154,7 @@ def testCoreSpell_SessionWords(fncDir):
     assert spChk.checkWord("e_word") is False
     assert spChk.checkWord("f_word") is False
 
-    spChk.setLanguage("en", wList2)
+    spChk.setLanguage("en_US", wList2)
     assert spChk.checkWord("a_word") is False
     assert spChk.checkWord("b_word") is False
     assert spChk.checkWord("c_word") is False

--- a/tests/test_core/test_core_spellcheck.py
+++ b/tests/test_core/test_core_spellcheck.py
@@ -26,29 +26,57 @@ import pytest
 from mock import causeOSError
 from tools import readFile, writeFile
 
-from novelwriter.core.spellcheck import NWSpellEnchant
+from novelwriter.core.spellcheck import FakeEnchant, NWSpellEnchant
 
 
 @pytest.mark.core
-def testCoreSpell_Enchant(monkeypatch, tmpDir):
-    """Test the pyenchant spell checker
+def testCoreSpell_FakeEnchant(monkeypatch):
+    """Test the FakeEnchant spell checker fallback.
     """
-    wList = os.path.join(tmpDir, "wordlist.txt")
-    writeFile(wList, "a_word\nb_word\nc_word\n")
-
-    # Block the enchant package (and trigger the default class)
+    # Make package import fail
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "enchant", None)
         spChk = NWSpellEnchant()
+        spChk.setLanguage("en", "")
+        assert isinstance(spChk._theDict, FakeEnchant)
 
-        spChk.setLanguage("en", wList)
-        assert spChk.setLanguage("", "") is None
-        assert spChk.checkWord("") is True
-        assert spChk.suggestWords("") == []
+    # Request a non-existent dictionary
+    spChk = NWSpellEnchant()
+    spChk.setLanguage("whatchamajig", "")
+    assert isinstance(spChk._theDict, FakeEnchant)
+
+    # Request an emety language string
+    # See issue https://github.com/vkbo/novelWriter/issues/1096
+    spChk = NWSpellEnchant()
+    spChk.setLanguage("", "")
+    assert isinstance(spChk._theDict, FakeEnchant)
+
+    # FakeEnchant should handle requests
+    fkChk = FakeEnchant()
+    assert fkChk.tag == ""
+    assert fkChk.provider.name == ""
+    assert fkChk.check("whatchamajig") is True
+    assert fkChk.suggest("whatchamajig") == []
+    assert fkChk.add_to_session("whatchamajig") is None
+
+# END Test testCoreSpell_FakeEnchant
+
+
+@pytest.mark.core
+def testCoreSpell_Enchant(monkeypatch, fncDir):
+    """Test the pyenchant spell checker.
+    """
+    wList = os.path.join(fncDir, "wordlist.txt")
+    writeFile(wList, "a_word\nb_word\nc_word\n")
+
+    # Break the enchant package, and check error handling
+    with monkeypatch.context() as mp:
+        mp.setitem(sys.modules, "enchant", None)
+        spChk = NWSpellEnchant()
         assert spChk.listDictionaries() == []
         assert spChk.describeDict() == ("", "")
 
-    # Break the enchant package, and check error handling
+    # Set the dict to None, and check dictionary call error handling
     spChk = NWSpellEnchant()
     spChk.theDict = None
     assert spChk.checkWord("word") is True
@@ -59,6 +87,7 @@ def testCoreSpell_Enchant(monkeypatch, tmpDir):
     spChk = NWSpellEnchant()
     spChk.setLanguage("en", wList)
     spChk.setLanguage("en", wList)
+    assert spChk.spellLanguage == "en"
 
     # Add a word to the user's dictionary
     assert spChk._readProjectDictionary("stuff") is False
@@ -102,3 +131,35 @@ def testCoreSpell_Enchant(monkeypatch, tmpDir):
     assert aName != ""
 
 # END Test testCoreSpell_Enchant
+
+
+@pytest.mark.core
+def testCoreSpell_SessionWords(fncDir):
+    """Test the handling of the custom word list in the spell checker.
+    New project sessions should not inherit the project word list from
+    other sessions, so this test checks that they don't bleed through.
+    """
+    wList1 = os.path.join(fncDir, "wordlist1.txt")
+    wList2 = os.path.join(fncDir, "wordlist2.txt")
+    writeFile(wList1, "a_word\nb_word\nc_word\n")
+    writeFile(wList2, "d_word\ne_word\nf_word\n")
+
+    spChk = NWSpellEnchant()
+
+    spChk.setLanguage("en", wList1)
+    assert spChk.checkWord("a_word") is True
+    assert spChk.checkWord("b_word") is True
+    assert spChk.checkWord("c_word") is True
+    assert spChk.checkWord("d_word") is False
+    assert spChk.checkWord("e_word") is False
+    assert spChk.checkWord("f_word") is False
+
+    spChk.setLanguage("en", wList2)
+    assert spChk.checkWord("a_word") is False
+    assert spChk.checkWord("b_word") is False
+    assert spChk.checkWord("c_word") is False
+    assert spChk.checkWord("d_word") is True
+    assert spChk.checkWord("e_word") is True
+    assert spChk.checkWord("f_word") is True
+
+# END Test testCoreSpell_SessionWords

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -439,7 +439,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir):
     testFile = os.path.join(outDir, "guiEditor_Main_Final_nwProject.nwx")
     compFile = os.path.join(refDir, "guiEditor_Main_Final_nwProject.nwx")
     copyfile(projFile, testFile)
-    assert cmpFiles(testFile, compFile, [2, 6, 7, 8])
+    assert cmpFiles(testFile, compFile, [2, 6, 7, 8, 13])
 
     projFile = os.path.join(fncProj, "content", "031b4af5197ec.nwd")
     testFile = os.path.join(outDir, "guiEditor_Main_Final_031b4af5197ec.nwd")


### PR DESCRIPTION
**Summary:**

The pyenchant package will accept an empty string as a language tag when requesting a dictionary, but the returned object will raise errors. See issue #1096.

This PR fixes this issue, and cleans up the way the dictionary object is set up. Test coverage is also improved.

**Related Issue(s):**

Closes #1096

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
