### PR TITLE
Block adding spaces before colon in certain meta data cases

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1982,18 +1982,34 @@ class GuiDocEditor(QTextEdit):
 
         tCheck = tInsert
         if tCheck in self.mainConf.fmtPadBefore:
-            nDelete = max(nDelete, 1)
-            tInsert = self._typPadChar + tInsert
+            if self.allowSpaceBeforeColon(theText, tCheck):
+                nDelete = max(nDelete, 1)
+                tInsert = self._typPadChar + tInsert
 
         if tCheck in self.mainConf.fmtPadAfter:
-            nDelete = max(nDelete, 1)
-            tInsert = tInsert + self._typPadChar
+            if self.allowSpaceBeforeColon(theText, tCheck):
+                nDelete = max(nDelete, 1)
+                tInsert = tInsert + self._typPadChar
 
         if nDelete > 0:
             theCursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor, nDelete)
             theCursor.insertText(tInsert)
 
         return
+
+    @staticmethod
+    def _allowSpaceBeforeColon(text, char):
+        """Special checker function only used by the insert space
+        feature for French, Spanish, etc, so it doesn't insert a
+        sapce before colons in meta data lines.
+        """
+        if char == ":" and len(text) > 1:
+            if text[0] == "@":
+                return False
+            if text[0] == "%":
+                if text[1:].lstrip()[:9].lower() == "synopsis:":
+                    return False
+        return True
 
     def _updateHeaders(self, checkPos=False, checkLevel=False):
         """Update the headers record and return True if anything

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1189,7 +1189,7 @@ def testGuiEditor_Tags(qtbot, monkeypatch, nwGUI, nwMinimal, ipsumText):
 
 
 @pytest.mark.gui
-def testGuiEditor_WordCounters(qtbot, monkeypatch, caplog, nwGUI, nwMinimal, ipsumText):
+def testGuiEditor_WordCounters(qtbot, monkeypatch, nwGUI, nwMinimal, ipsumText):
     """Test saving text from the editor.
     """
     # Block message box
@@ -1488,3 +1488,30 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, nwLipsum):
     # qtbot.stopForInteraction()
 
 # END Test testGuiEditor_Search
+
+
+@pytest.mark.gui
+def testGuiEditor_StaticMethods():
+    """Test the document editor's static methods.
+    """
+    # Check the method that decides if it is allowed to insert a space
+    # before a colon using the French, Spanish, etc language feature
+    assert GuiDocEditor._allowSpaceBeforeColon("", "") is True
+    assert GuiDocEditor._allowSpaceBeforeColon("", ":") is True
+    assert GuiDocEditor._allowSpaceBeforeColon("some text", ":") is True
+
+    assert GuiDocEditor._allowSpaceBeforeColon("@:", ":") is False
+    assert GuiDocEditor._allowSpaceBeforeColon("@>", ">") is True
+
+    assert GuiDocEditor._allowSpaceBeforeColon("%", ":") is True
+    assert GuiDocEditor._allowSpaceBeforeColon("%:", ":") is True
+    assert GuiDocEditor._allowSpaceBeforeColon("%synopsis:", ":") is False
+    assert GuiDocEditor._allowSpaceBeforeColon("%Synopsis:", ":") is False
+    assert GuiDocEditor._allowSpaceBeforeColon("% synopsis:", ":") is False
+    assert GuiDocEditor._allowSpaceBeforeColon("% Synopsis:", ":") is False
+    assert GuiDocEditor._allowSpaceBeforeColon("%  synopsis:", ":") is False
+    assert GuiDocEditor._allowSpaceBeforeColon("%  Synopsis:", ":") is False
+    assert GuiDocEditor._allowSpaceBeforeColon("%synopsis :", ":") is True
+    assert GuiDocEditor._allowSpaceBeforeColon("%Synopsis :", ":") is True
+
+# END Test testGuiEditor_MinorMethods

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1514,4 +1514,4 @@ def testGuiEditor_StaticMethods():
     assert GuiDocEditor._allowSpaceBeforeColon("%synopsis :", ":") is True
     assert GuiDocEditor._allowSpaceBeforeColon("%Synopsis :", ":") is True
 
-# END Test testGuiEditor_MinorMethods
+# END Test testGuiEditor_StaticMethods


### PR DESCRIPTION
**Summary:**

The feature used for some languages, like French and Spanish, to automatically add spaces before some characters, should not run for colon when the colon is used for a meta data tag or in the synopsis keyword.

This PR adds a check for that. The check is only run in the cases were the feature is triggered on a keypress.

**Related Issue(s):**

Closes #1090

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
