### PR TITLE
Improve the build scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # novelWriter Changelog
 
-## Version 1.6.2 [2022-08-18]
+## Version 1.6.3 [2022-08-18]
 
 ### Release Notes
 

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.6.2" hexVersion="0x010602f0" fileVersion="1.3" timeStamp="2022-03-20 15:40:34">
+<novelWriterXML appVersion="1.6.2" hexVersion="0x010602f0" fileVersion="1.3" timeStamp="2022-08-18 20:38:04">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>1302</saveCount>
+    <saveCount>1304</saveCount>
     <autoCount>199</autoCount>
-    <editTime>64999</editTime>
+    <editTime>65055</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>

--- a/setup/make_release.sh
+++ b/setup/make_release.sh
@@ -7,6 +7,13 @@ if [ ! -f setup.py ]; then
 fi
 
 echo ""
+echo " Building Dependencies"
+echo "================================================================================"
+echo ""
+python3 setup.py clean-assets
+python3 setup.py qtlrelease manual sample
+
+echo ""
 echo " Building Minimal Packages"
 echo "================================================================================"
 echo ""


### PR DESCRIPTION
**Summary:**

Various improvements to the build pipelines in `setup.py`:
* A command has been added to clear all previously built assets.
* Instead of building assets for each repeated build, it is just required that they exist. This prevents failed assets build from resulting in missing assets in the packages.
* Explicitly clear and rebuild assets in the main build script. This ensures that the files put into the packages are fresh.
* Rename the setup.exe installer for Windows to also include the version of the embedded Python.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
