### PR TITLE
Make adding new docs smarter

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -221,7 +221,7 @@ class NWIndex:
         if theItem is None:
             logger.info("Not indexing unknown item '%s'", tHandle)
             return False
-        if theItem.itemType != nwItemType.FILE:
+        if not theItem.isFileType():
             logger.info("Not indexing non-file item '%s'", tHandle)
             return False
 
@@ -792,7 +792,7 @@ class ItemIndex:
         for tItem in self.theProject.tree:
             if tItem is None:
                 continue
-            if tItem.itemLayout == nwItemLayout.NOTE:
+            if tItem.isNoteLayout():
                 continue
             if skipExcl and not tItem.isExported:
                 continue

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -292,6 +292,22 @@ class NWItem():
 
         return trConst(nwLabels.ITEM_DESCRIPTION.get(descKey, ""))
 
+    def getImportStatus(self):
+        """Return the relevant importance or status label and icon for
+        the current item based on its class.
+        """
+        if self.isNovelLike():
+            stName = self.theProject.statusItems.name(self._status)
+            stIcon = self.theProject.statusItems.icon(self._status)
+        else:
+            stName = self.theProject.importItems.name(self._import)
+            stIcon = self.theProject.importItems.icon(self._import)
+        return stName, stIcon
+
+    ##
+    #  Checker Methods
+    ##
+
     def isNovelLike(self):
         """Returns true if the item is of a novel-like class.
         """
@@ -307,17 +323,20 @@ class NWItem():
         """
         return self._class in (nwItemClass.NO_CLASS, nwItemClass.ARCHIVE, nwItemClass.TRASH)
 
-    def getImportStatus(self):
-        """Return the relevant importance or status label and icon for
-        the current item based on its class.
-        """
-        if self.isNovelLike():
-            stName = self.theProject.statusItems.name(self._status)
-            stIcon = self.theProject.statusItems.icon(self._status)
-        else:
-            stName = self.theProject.importItems.name(self._import)
-            stIcon = self.theProject.importItems.icon(self._import)
-        return stName, stIcon
+    def isRootType(self):
+        return self._type == nwItemType.ROOT
+
+    def isFolderType(self):
+        return self._type == nwItemType.FOLDER
+
+    def isFileType(self):
+        return self._type == nwItemType.FILE
+
+    def isNoteLayout(self):
+        return self._layout == nwItemLayout.NOTE
+
+    def isDocumentLayout(self):
+        return self._layout == nwItemLayout.DOCUMENT
 
     ##
     #  Special Setters

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -183,7 +183,7 @@ class NWProject():
         tItem = self._projTree[tHandle]
         if tItem is None:
             return False
-        if tItem.itemType != nwItemType.FILE:
+        if not tItem.isFileType():
             return False
 
         newDoc = NWDoc(self, tHandle)

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -29,7 +29,7 @@ import logging
 
 from lxml import etree
 
-from novelwriter.enum import nwItemType, nwItemClass, nwItemLayout
+from novelwriter.enum import nwItemClass, nwItemLayout
 from novelwriter.error import logException
 from novelwriter.common import checkHandle
 from novelwriter.constants import nwFiles
@@ -94,7 +94,7 @@ class NWTree():
         nwItem.setHandle(tHandle)
         nwItem.setParent(pHandle)
 
-        if nwItem.itemType == nwItemType.ROOT:
+        if nwItem.isRootType():
             logger.verbose("Item '%s' is a root item", str(tHandle))
             self._treeRoots[tHandle] = nwItem
             if nwItem.itemClass == nwItemClass.ARCHIVE:
@@ -357,7 +357,7 @@ class NWTree():
         tItem = self.__getitem__(tHandle)
         if tItem is None:
             return False
-        if tItem.itemType != nwItemType.FILE:
+        if not tItem.isFileType():
             logger.error("Item '%s' is not a file", tHandle)
             return False
         if not isinstance(itemLayout, nwItemLayout):

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -183,7 +183,7 @@ class GuiDocMerge(QDialog):
         for sHandle in self.mainGui.projView.getTreeFromHandle(tHandle):
             newItem = QListWidgetItem()
             nwItem  = self.theProject.tree[sHandle]
-            if nwItem.itemType is not nwItemType.FILE:
+            if not nwItem.isFileType():
                 continue
             newItem.setText(nwItem.itemName)
             newItem.setData(Qt.UserRole, sHandle)

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -33,7 +33,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter.core import NWDoc
-from novelwriter.enum import nwAlert, nwItemType
+from novelwriter.enum import nwAlert
 from novelwriter.gui.custom import QHelpLabel
 
 logger = logging.getLogger(__name__)
@@ -235,7 +235,7 @@ class GuiDocSplit(QDialog):
         if nwItem is None:
             return False
 
-        if nwItem.itemType is not nwItemType.FILE:
+        if not nwItem.isFileType():
             self.mainGui.makeAlert(self.tr(
                 "Element selected in the project tree must be a file."
             ), nwAlert.ERROR)

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -30,7 +30,6 @@ from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtGui import QFont, QPixmap
 from PyQt5.QtWidgets import QWidget, QGridLayout, QLabel
 
-from novelwriter.enum import nwItemType
 from novelwriter.constants import trConst, nwLabels
 
 logger = logging.getLogger(__name__)
@@ -247,7 +246,7 @@ class GuiItemDetails(QWidget):
         if len(theLabel) > 100:
             theLabel = theLabel[:96].rstrip()+" ..."
 
-        if nwItem.itemType == nwItemType.FILE:
+        if nwItem.isFileType():
             if nwItem.isExported:
                 self.labelIcon.setPixmap(self._expCheck)
             else:
@@ -284,7 +283,7 @@ class GuiItemDetails(QWidget):
         # Counts
         # ======
 
-        if nwItem.itemType == nwItemType.FILE:
+        if nwItem.isFileType():
             self.cCountData.setText(f"{nwItem.charCount:n}")
             self.wCountData.setText(f"{nwItem.wordCount:n}")
             self.pCountData.setText(f"{nwItem.paraCount:n}")

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -700,7 +700,7 @@ class GuiProjectTree(QTreeWidget):
 
         wCount = self._getItemWordCount(tHandle)
         autoFlush = not bulkAction
-        if nwItemS.itemType == nwItemType.ROOT:
+        if nwItemS.isRootType():
             # Only an empty ROOT folder can be deleted
             logger.debug("User requested a root folder '%s' deleted", tHandle)
             tIndex = self.indexOfTopLevelItem(trItemS)
@@ -716,7 +716,7 @@ class GuiProjectTree(QTreeWidget):
                 ), nwAlert.ERROR)
                 return False
 
-        elif nwItemS.itemType == nwItemType.FOLDER and trItemS.childCount() == 0:
+        elif nwItemS.isFolderType() and trItemS.childCount() == 0:
             # An empty FOLDER is just deleted without any further checks
             logger.debug("User requested an empty folder '%s' deleted", tHandle)
             trItemP = trItemS.parent()
@@ -803,12 +803,12 @@ class GuiProjectTree(QTreeWidget):
         trItem.setIcon(self.C_STATUS, statusIcon)
         trItem.setToolTip(self.C_STATUS, itemStatus)
 
-        if nwItem.itemType == nwItemType.FILE:
+        if nwItem.isFileType():
             trItem.setIcon(
                 self.C_EXPORT, self.mainTheme.getIcon("check" if nwItem.isExported else "cross")
             )
 
-        if self.mainConf.emphLabels and nwItem.itemLayout == nwItemLayout.DOCUMENT:
+        if self.mainConf.emphLabels and nwItem.isDocumentLayout():
             trFont = trItem.font(self.C_NAME)
             trFont.setBold(hLevel == "H1" or hLevel == "H2")
             trFont.setUnderline(hLevel == "H1")
@@ -978,7 +978,7 @@ class GuiProjectTree(QTreeWidget):
         if tItem is None:
             return
 
-        if tItem.itemType == nwItemType.FILE:
+        if tItem.isFileType():
             self.projView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, -1, "")
         else:
             trItem = self._getTreeItem(tHandle)
@@ -1019,7 +1019,7 @@ class GuiProjectTree(QTreeWidget):
         # Document Actions
         # ================
 
-        isFile = tItem.itemType == nwItemType.FILE
+        isFile = tItem.isFileType()
         if isFile:
             ctxMenu.addAction(
                 self.tr("Open Document"),
@@ -1059,7 +1059,7 @@ class GuiProjectTree(QTreeWidget):
                 )
 
         if isFile and tItem.documentAllowed():
-            if tItem.itemLayout == nwItemLayout.NOTE:
+            if tItem.isNoteLayout():
                 ctxMenu.addAction(
                     self.tr("Change to {0}").format(
                         trConst(nwLabels.LAYOUT_NAME[nwItemLayout.DOCUMENT])
@@ -1079,7 +1079,7 @@ class GuiProjectTree(QTreeWidget):
         # Delete Item
         # ===========
 
-        if tItem.itemClass == nwItemClass.TRASH or tItem.itemType == nwItemType.ROOT:
+        if tItem.itemClass == nwItemClass.TRASH or tItem.isRootType():
             ctxMenu.addAction(
                 self.tr("Delete Permanently"), lambda: self.deleteItem(tHandle)
             )
@@ -1118,7 +1118,7 @@ class GuiProjectTree(QTreeWidget):
             if tItem is None:
                 return
 
-            if tItem.itemType == nwItemType.FILE:
+            if tItem.isFileType():
                 self.projView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, -1, "")
 
         return
@@ -1306,7 +1306,7 @@ class GuiProjectTree(QTreeWidget):
 
         self._treeMap[tHandle] = newItem
         if pHandle is None:
-            if nwItem.itemType == nwItemType.ROOT:
+            if nwItem.isRootType():
                 newItem.setFlags(newItem.flags() ^ Qt.ItemIsDragEnabled)
                 self.addTopLevelItem(newItem)
             else:

--- a/novelwriter/tools/build.py
+++ b/novelwriter/tools/build.py
@@ -784,11 +784,11 @@ class GuiBuildNovel(QDialog):
         if not (theItem.isExported or ignoreFlag):
             return False
 
-        isNone  = theItem.itemType != nwItemType.FILE
+        isNone  = not theItem.isFileType()
         isNone |= theItem.itemLayout == nwItemLayout.NO_LAYOUT
         isNone |= theItem.isInactive()
         isNone |= theItem.itemParent is None
-        isNote  = theItem.itemLayout == nwItemLayout.NOTE
+        isNote  = theItem.isNoteLayout()
         isNovel = not isNone and not isNote
 
         if isNone:

--- a/tests/test_core/test_core_item.py
+++ b/tests/test_core/test_core_item.py
@@ -203,12 +203,16 @@ def testCoreItem_Methods(mockGUI):
 
     theItem.setType("ROOT")
     assert theItem.describeMe() == "Root Folder"
+    assert theItem.isRootType() is True
 
     theItem.setType("FOLDER")
     assert theItem.describeMe() == "Folder"
+    assert theItem.isFolderType() is True
 
     theItem.setType("FILE")
     theItem.setLayout("DOCUMENT")
+    assert theItem.isFileType() is True
+    assert theItem.isDocumentLayout() is True
     assert theItem.describeMe() == "Novel Document"
     assert theItem.describeMe("H0") == "Novel Document"
     assert theItem.describeMe("H1") == "Novel Title Page"
@@ -217,6 +221,7 @@ def testCoreItem_Methods(mockGUI):
     assert theItem.describeMe("H4") == "Novel Document"
 
     theItem.setLayout("NOTE")
+    assert theItem.isNoteLayout() is True
     assert theItem.describeMe() == "Project Note"
 
     # Status + Icon


### PR DESCRIPTION
**Summary:**

This PR rewrites the logic that determines if a new item added from the new item menu in the project tree is added as a child or a sibling to the selected item. The rules are as follows:

* If the new item is a plain document, it is added as a child to folders or a document that already has child items.
* If the new item is a chapter, it is added as a child to folders, or partition level documents that already have child items.
* If the new item is a scene, it is added as a child to folders, or chapter or partition level documents that already have child items.
* If the new item is a note, it is added as a child to folders, or any note or document that already have child items.
* If the new item is a folder, it is only added as a child to other folders.

Some conditions are implied here:

* If the selected item is a folder or root folder, all items are added as child items.
* If the selected item is a note, only other notes are added as child items if the selected item already has child items.

In addition to the above logic, some simple checker functions have been added to the NWItem class. Some of the comparison checks against item type and layout have been replaced with these around the code – where it makes sense.

**Related Issue(s):**

Closes #1107

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
