### PR TITLE
Update context menu entries in project tree

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1048,14 +1048,14 @@ class GuiProjectTree(QTreeWidget):
             )
 
         if tItem.isNovelLike():
-            mStatus = ctxMenu.addMenu(self.tr("Change Status"))
+            mStatus = ctxMenu.addMenu(self.tr("Set Status to ..."))
             for n, (key, entry) in enumerate(self.theProject.statusItems.items()):
                 aStatus = mStatus.addAction(entry["icon"], entry["name"])
                 aStatus.triggered.connect(
                     lambda n, key=key: self._changeItemStatus(tHandle, key)
                 )
         else:
-            mImport = ctxMenu.addMenu(self.tr("Change Importance"))
+            mImport = ctxMenu.addMenu(self.tr("Set Importance to ..."))
             for n, (key, entry) in enumerate(self.theProject.importItems.items()):
                 aImport = mImport.addAction(entry["icon"], entry["name"])
                 aImport.triggered.connect(
@@ -1065,14 +1065,14 @@ class GuiProjectTree(QTreeWidget):
         if isFile and tItem.documentAllowed():
             if tItem.isNoteLayout():
                 ctxMenu.addAction(
-                    self.tr("Change to {0}").format(
+                    self.tr("Convert to {0}").format(
                         trConst(nwLabels.LAYOUT_NAME[nwItemLayout.DOCUMENT])
                     ),
                     lambda: self._changeItemLayout(tHandle, nwItemLayout.DOCUMENT)
                 )
             else:
                 ctxMenu.addAction(
-                    self.tr("Change to {0}").format(
+                    self.tr("Convert to {0}").format(
                         trConst(nwLabels.LAYOUT_NAME[nwItemLayout.NOTE])
                     ),
                     lambda: self._changeItemLayout(tHandle, nwItemLayout.NOTE)

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1019,7 +1019,11 @@ class GuiProjectTree(QTreeWidget):
         # Document Actions
         # ================
 
+        isRoot = tItem.isRootType()
+        isFolder = tItem.isFolderType()
         isFile = tItem.isFileType()
+        isEmpty = selItem.childCount() == 0
+
         if isFile:
             ctxMenu.addAction(
                 self.tr("Open Document"),
@@ -1079,7 +1083,7 @@ class GuiProjectTree(QTreeWidget):
         # Delete Item
         # ===========
 
-        if tItem.itemClass == nwItemClass.TRASH or tItem.isRootType():
+        if tItem.itemClass == nwItemClass.TRASH or isRoot or (isFolder and isEmpty):
             ctxMenu.addAction(
                 self.tr("Delete Permanently"), lambda: self.deleteItem(tHandle)
             )


### PR DESCRIPTION
**Summary:**

This PR makes the following changes:
* The delete item menu entry for empty folders now correctly says "Delete Permanently" instead of "Move to Trash". Issue #1105.
* The menu entries for changing document layout now stays "Convert to" instead of "Change to". It is technically just a change of a setting, but to the user it makes more sense to say convert.
* The menu entries for status and importance now says "Set Status to ..." and "Set Importance to ..." instead of "Change [...] to" which is technically incorrect in the case where the user selects the same value as was previously set.

**Related Issue(s):**

Closes #1105

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
