### PR TITLE
Fix clipping of cursor due to no document margin

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -92,6 +92,7 @@ class GuiDocEditor(QTextEdit):
 
         self._spellCheck = False  # Flag for spell checking enabled
         self._nonWord    = "\"'"  # Characters to not include in spell checking
+        self._vpMargin   = 0      # The editor viewport margin, set during init
 
         # Document Variables
         self._charCount  = 0      # Character count
@@ -271,9 +272,12 @@ class GuiDocEditor(QTextEdit):
         self.docFooter.matchColours()
 
         # Set default text margins
-        cM = self.mainConf.getTextMargin()
-        qDoc.setDocumentMargin(0)
-        self.setViewportMargins(cM, cM, cM, cM)
+        # Due to cursor visibility, a part of the margin must be
+        # allocated to the document itself. See issue #1112.
+        cW = self.cursorWidth()
+        qDoc.setDocumentMargin(cW)
+        self._vpMargin = max(self.mainConf.getTextMargin() - cW, 0)
+        self.setViewportMargins(self._vpMargin, self._vpMargin, self._vpMargin, self._vpMargin)
 
         # Also set the document text options for the document text flow
         theOpt = QTextOption()
@@ -537,7 +541,6 @@ class GuiDocEditor(QTextEdit):
         """
         wW = self.width()
         wH = self.height()
-        cM = self.mainConf.getTextMargin()
 
         vBar = self.verticalScrollBar()
         sW = vBar.width() if vBar.isVisible() else 0
@@ -545,10 +548,10 @@ class GuiDocEditor(QTextEdit):
         hBar = self.horizontalScrollBar()
         sH = hBar.height() if hBar.isVisible() else 0
 
-        tM = cM
+        tM = self._vpMargin
         if self.mainConf.textWidth > 0 or self.mainGui.isFocusMode:
             tW = self.mainConf.getTextWidth(self.mainGui.isFocusMode)
-            tM = max((wW - sW - tW)//2, cM)
+            tM = max((wW - sW - tW)//2, self._vpMargin)
 
         tB = self.frameWidth()
         tW = wW - 2*tB - sW
@@ -565,8 +568,8 @@ class GuiDocEditor(QTextEdit):
             rL = wW - sW - rW - 2*tB
             self.docSearch.move(rL, 2*tB)
 
-        uM = max(cM, tH, rH)
-        lM = max(cM, fH)
+        uM = max(self._vpMargin, tH, rH)
+        lM = max(self._vpMargin, fH)
         self.setViewportMargins(tM, uM, tM, lM)
 
         return


### PR DESCRIPTION
**Summary:**

The editor has the document margin set to 0, but the cursor requires at least one cursor width of margin in order to be visible when it reaches the right hand edge of the document.

This PR reduces the user-defined margin by the width of the cursor, which is used for the viewport, and sets the document margin to the subtracted width.

**Related Issue(s):**

Resolves #1112

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
