### PR TITLE
Add Expand/Collapse All functionality to project tree

### DIFF
--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -486,8 +486,7 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
     hNovelNote   = "0000000000012"
 
     projTree = nwGUI.projView.projTree
-    projTree._getTreeItem(hNovelRoot).setExpanded(True)
-    projTree._getTreeItem(hChapterDir).setExpanded(True)
+    projTree.setExpandedFromHandle(None, True)
 
     projTree._addTrashRoot()
     hTrashRoot = projTree.theProject.tree.trashRoot()


### PR DESCRIPTION
**Summary:**

Add context menu and project tree menu entries to expand/collapse all items below the selected item. If none are selected, the action is performed on the whole tree.

**Related Issue(s):**

Resolves #1122

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
