### PR TITLE
Remove existing space when auto-inserting space

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -111,7 +111,6 @@ class GuiDocEditor(QTextEdit):
         self._typSQOpen  = "'"
         self._typSQClose = "'"
         self._typPadChar = " "
-        self._doSpacePad = False
 
         # Core Elements and Signals
         qDoc = self.document()
@@ -222,7 +221,6 @@ class GuiDocEditor(QTextEdit):
         self._nonWord += "".join(self.mainConf.fmtSingleQuotes)
 
         # Typography
-        self._doSpacePad = bool(self.mainConf.fmtPadBefore) or bool(self.mainConf.fmtPadAfter)
         if self.mainConf.fmtPadThin:
             self._typPadChar = nwUnicode.U_THNBSP
         else:
@@ -1994,21 +1992,20 @@ class GuiDocEditor(QTextEdit):
             nDelete = 3
             tInsert = nwUnicode.U_HELLIP
 
-        if self._doSpacePad:
-            tCheck = tInsert
-            if tCheck in self.mainConf.fmtPadBefore:
-                if self._allowSpaceBeforeColon(theText, tCheck):
-                    nDelete = max(nDelete, 1)
-                    chkPos = thePos - nDelete - 1
-                    if chkPos >= 0 and theText[chkPos].isspace():
-                        # Strip existing space before inserting a new (#1061)
-                        nDelete += 1
-                    tInsert = self._typPadChar + tInsert
+        tCheck = tInsert
+        if self.mainConf.fmtPadBefore and tCheck in self.mainConf.fmtPadBefore:
+            if self._allowSpaceBeforeColon(theText, tCheck):
+                nDelete = max(nDelete, 1)
+                chkPos = thePos - nDelete - 1
+                if chkPos >= 0 and theText[chkPos].isspace():
+                    # Strip existing space before inserting a new (#1061)
+                    nDelete += 1
+                tInsert = self._typPadChar + tInsert
 
-            if tCheck in self.mainConf.fmtPadAfter:
-                if self._allowSpaceBeforeColon(theText, tCheck):
-                    nDelete = max(nDelete, 1)
-                    tInsert = tInsert + self._typPadChar
+        if self.mainConf.fmtPadAfter and tCheck in self.mainConf.fmtPadAfter:
+            if self._allowSpaceBeforeColon(theText, tCheck):
+                nDelete = max(nDelete, 1)
+                tInsert = tInsert + self._typPadChar
 
         if nDelete > 0:
             theCursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor, nDelete)

--- a/tests/reference/guiEditor_Main_Final_000000000000f.nwd
+++ b/tests/reference/guiEditor_Main_Final_000000000000f.nwd
@@ -35,6 +35,8 @@ Some “ double quoted text with spaces padded ”.
 
 Add space before this colon : See?
 
+But don’t add a double space : See?
+
 	“Tab-indented text”
 
 >“Paragraph-indented text”

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.7-beta1" hexVersion="0x010700b1" fileVersion="1.4" timeStamp="2022-09-29 19:57:40">
+<novelWriterXML appVersion="1.7-beta1" hexVersion="0x010700b1" fileVersion="1.4" timeStamp="2022-10-01 22:33:13">
   <project>
     <name>New Project</name>
     <title>New Novel</title>
@@ -17,8 +17,8 @@
     <lastViewed>None</lastViewed>
     <lastNovel>0000000000008</lastNovel>
     <lastOutline>0000000000008</lastOutline>
-    <lastWordCount>145</lastWordCount>
-    <novelWordCount>118</novelWordCount>
+    <lastWordCount>153</lastWordCount>
+    <novelWordCount>126</novelWordCount>
     <notesWordCount>27</notesWordCount>
     <autoReplace/>
     <titleFormat>
@@ -59,7 +59,7 @@
       <name status="s000000" import="i000004" exported="True">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="False" charCount="693" wordCount="111" paraCount="12" cursorPos="917"/>
+      <meta expanded="False" charCount="728" wordCount="119" paraCount="13" cursorPos="954"/>
       <name status="s000000" import="i000004" exported="True">New Scene</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="1" type="ROOT" class="PLOT">

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -412,7 +412,6 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     # Insert spaces before and after quotes
     nwGUI.mainConf.fmtPadBefore = "\u201d"
     nwGUI.mainConf.fmtPadAfter = "\u201c"
-    nwGUI.docEditor.initEditor()
 
     for c in "Some \"double quoted text with spaces padded\".":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -421,11 +420,9 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
 
     nwGUI.mainConf.fmtPadBefore = ""
     nwGUI.mainConf.fmtPadAfter = ""
-    nwGUI.docEditor.initEditor()
 
     # Insert spaces before colon, but ignore tags and synopsis
     nwGUI.mainConf.fmtPadBefore = ":"
-    nwGUI.docEditor.initEditor()
 
     for c in "@object: NoSpaceAdded":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -448,7 +445,6 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
 
     nwGUI.mainConf.fmtPadBefore = ""
-    nwGUI.docEditor.initEditor()
 
     # Indent and Align
     # ================

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -412,6 +412,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     # Insert spaces before and after quotes
     nwGUI.mainConf.fmtPadBefore = "\u201d"
     nwGUI.mainConf.fmtPadAfter = "\u201c"
+    nwGUI.docEditor.initEditor()
 
     for c in "Some \"double quoted text with spaces padded\".":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -420,9 +421,11 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
 
     nwGUI.mainConf.fmtPadBefore = ""
     nwGUI.mainConf.fmtPadAfter = ""
+    nwGUI.docEditor.initEditor()
 
     # Insert spaces before colon, but ignore tags and synopsis
     nwGUI.mainConf.fmtPadBefore = ":"
+    nwGUI.docEditor.initEditor()
 
     for c in "@object: NoSpaceAdded":
         qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
@@ -439,7 +442,13 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
 
+    for c in "But don't add a double space : See?":
+        qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
+    qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
+    qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
+
     nwGUI.mainConf.fmtPadBefore = ""
+    nwGUI.docEditor.initEditor()
 
     # Indent and Align
     # ================


### PR DESCRIPTION
**Summary:**

This PR adds a simple look-back check to see if the character before the one that triggered the insertion of a non-breaking space was also a space character. If so, that character is removed before the new space is inserted.

**Related Issue(s):**

Resolves #1061

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
