### PR TITLE
Rewrite Merge Tool

### DIFF
--- a/novelwriter/core/__init__.py
+++ b/novelwriter/core/__init__.py
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+from novelwriter.core.doctools import DocMerger
 from novelwriter.core.document import NWDoc
 from novelwriter.core.index import countWords
 from novelwriter.core.project import NWProject
@@ -28,6 +29,7 @@ from novelwriter.core.toodt import ToOdt
 from novelwriter.core.tomd import ToMarkdown
 
 __all__ = [
+    "DocMerger",
     "countWords",
     "NWDoc",
     "NWProject",

--- a/novelwriter/core/doctools.py
+++ b/novelwriter/core/doctools.py
@@ -1,0 +1,102 @@
+"""
+novelWriter – Project Document Tools
+====================================
+A collection of tools to create and manipulate documents
+
+File History:
+Created: 2022-10-02 [2.0b1]
+
+This file is a part of novelWriter
+Copyright 2018–2022, Veronica Berglyd Olsen
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# logger.verbose("GuiDocMerge merge button clicked")
+
+# finalOrder = []
+# for i in range(self.listBox.count()):
+#     finalOrder.append(self.listBox.item(i).data(Qt.UserRole))
+
+# if len(finalOrder) == 0:
+#     self.mainGui.makeAlert(self.tr(
+#         "No source documents found. Nothing to do."
+#     ), nwAlert.ERROR)
+#     return False
+
+# theText = ""
+# for tHandle in finalOrder:
+#     inDoc = NWDoc(self.theProject, tHandle)
+#     docText = inDoc.readDocument()
+#     docErr = inDoc.getError()
+#     if docText is None and docErr:
+#         self.mainGui.makeAlert([
+#             self.tr("Failed to open document file."), docErr
+#         ], nwAlert.ERROR)
+#     if docText:
+#         theText += docText.rstrip("\n")+"\n\n"
+
+# if self.sourceItem is None:
+#     self.mainGui.makeAlert(self.tr(
+#         "No source folder selected. Nothing to do."
+#     ), nwAlert.ERROR)
+#     return False
+
+# srcItem = self.theProject.tree[self.sourceItem]
+# if srcItem is None:
+#     self.mainGui.makeAlert(self.tr("Internal error."), nwAlert.ERROR)
+#     return False
+
+# nHandle = self.theProject.newFile(srcItem.itemName, srcItem.itemParent)
+# newItem = self.theProject.tree[nHandle]
+# newItem.setStatus(srcItem.itemStatus)
+# newItem.setImport(srcItem.itemImport)
+
+# outDoc = NWDoc(self.theProject, nHandle)
+# if not outDoc.writeDocument(theText):
+#     self.mainGui.makeAlert([
+#         self.tr("Could not save document."), outDoc.getError()
+#     ], nwAlert.ERROR)
+#     return False
+
+# self.mainGui.projView.revealNewTreeItem(nHandle)
+# self.mainGui.openDocument(nHandle, doScroll=True)
+
+# self._doClose()
+
+
+class DocMerger:
+
+    def __init__(self, theProject):
+
+        self.theProject = theProject
+
+        self._targetDoc = None
+
+        return
+
+    def setTargetDoc(self, tHandle):
+        return
+
+    def createNewDoc(self, docLabel, pHandle, itemLayout):
+        return
+
+    def appendDoc(self, tHandle):
+        return
+
+# END Class DocMerger

--- a/novelwriter/core/doctools.py
+++ b/novelwriter/core/doctools.py
@@ -110,7 +110,7 @@ class DocMerger:
         if docText:
             self._targetText.insert(0, docText)
 
-        status = outDoc.writeDocument("\n\n".join(self._targetText))
+        status = outDoc.writeDocument("\n\n".join(self._targetText) + "\n\n")
         if not status:
             self._error = outDoc.getError()
 

--- a/novelwriter/core/doctools.py
+++ b/novelwriter/core/doctools.py
@@ -25,59 +25,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
 
+from novelwriter.core.document import NWDoc
+
 logger = logging.getLogger(__name__)
-
-# logger.verbose("GuiDocMerge merge button clicked")
-
-# finalOrder = []
-# for i in range(self.listBox.count()):
-#     finalOrder.append(self.listBox.item(i).data(Qt.UserRole))
-
-# if len(finalOrder) == 0:
-#     self.mainGui.makeAlert(self.tr(
-#         "No source documents found. Nothing to do."
-#     ), nwAlert.ERROR)
-#     return False
-
-# theText = ""
-# for tHandle in finalOrder:
-#     inDoc = NWDoc(self.theProject, tHandle)
-#     docText = inDoc.readDocument()
-#     docErr = inDoc.getError()
-#     if docText is None and docErr:
-#         self.mainGui.makeAlert([
-#             self.tr("Failed to open document file."), docErr
-#         ], nwAlert.ERROR)
-#     if docText:
-#         theText += docText.rstrip("\n")+"\n\n"
-
-# if self.sourceItem is None:
-#     self.mainGui.makeAlert(self.tr(
-#         "No source folder selected. Nothing to do."
-#     ), nwAlert.ERROR)
-#     return False
-
-# srcItem = self.theProject.tree[self.sourceItem]
-# if srcItem is None:
-#     self.mainGui.makeAlert(self.tr("Internal error."), nwAlert.ERROR)
-#     return False
-
-# nHandle = self.theProject.newFile(srcItem.itemName, srcItem.itemParent)
-# newItem = self.theProject.tree[nHandle]
-# newItem.setStatus(srcItem.itemStatus)
-# newItem.setImport(srcItem.itemImport)
-
-# outDoc = NWDoc(self.theProject, nHandle)
-# if not outDoc.writeDocument(theText):
-#     self.mainGui.makeAlert([
-#         self.tr("Could not save document."), outDoc.getError()
-#     ], nwAlert.ERROR)
-#     return False
-
-# self.mainGui.projView.revealNewTreeItem(nHandle)
-# self.mainGui.openDocument(nHandle, doScroll=True)
-
-# self._doClose()
 
 
 class DocMerger:
@@ -86,17 +36,84 @@ class DocMerger:
 
         self.theProject = theProject
 
+        self._error = ""
         self._targetDoc = None
+        self._targetText = []
 
         return
+
+    ##
+    #  Methods
+    ##
+
+    def getError(self):
+        """Return any collected errors.
+        """
+        return self._error
 
     def setTargetDoc(self, tHandle):
+        """Set the target document for the merging. Calling this
+        function resets the class.
+        """
+        self._targetDoc = tHandle
+        self._targetText = []
         return
 
-    def createNewDoc(self, docLabel, pHandle, itemLayout):
-        return
+    def newTargetDoc(self, srcHandle, docLabel):
+        """Create a barnd new target document based on a source handle
+        and a new doc label. Calling this function resets the class.
+        """
+        srcItem = self.theProject.tree[srcHandle]
+        if srcItem is None:
+            return None
 
-    def appendDoc(self, tHandle):
-        return
+        newHandle = self.theProject.newFile(docLabel, srcItem.itemParent)
+        newItem = self.theProject.tree[newHandle]
+        newItem.setLayout(srcItem.itemLayout)
+        newItem.setStatus(srcItem.itemStatus)
+        newItem.setImport(srcItem.itemImport)
+
+        self._targetDoc = newHandle
+        self._targetText = []
+
+        return newHandle
+
+    def appendText(self, srcHandle, addComment, cmtPrefix):
+        """Append text from an existing document to the text buffer.
+        """
+        srcItem = self.theProject.tree[srcHandle]
+        if srcItem is None:
+            return False
+
+        inDoc = NWDoc(self.theProject, srcHandle)
+        docText = (inDoc.readDocument() or "").rstrip("\n")
+
+        if addComment:
+            docInfo = srcItem.describeMe("H0")
+            docSt, _ = srcItem.getImportStatus(incIcon=False)
+            cmtLine = f"% {cmtPrefix} {docInfo}: {srcItem.itemName} [{docSt}]\n\n"
+            docText = cmtLine + docText
+
+        self._targetText.append(docText)
+
+        return True
+
+    def writeTargetDoc(self):
+        """Write the accumulated text into the designated target
+        document, appending any existing text.
+        """
+        if self._targetDoc is None:
+            return False
+
+        outDoc = NWDoc(self.theProject, self._targetDoc)
+        docText = (outDoc.readDocument() or "").rstrip("\n")
+        if docText:
+            self._targetText.insert(0, docText)
+
+        status = outDoc.writeDocument("\n\n".join(self._targetText))
+        if not status:
+            self._error = outDoc.getError()
+
+        return status
 
 # END Class DocMerger

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -292,16 +292,16 @@ class NWItem():
 
         return trConst(nwLabels.ITEM_DESCRIPTION.get(descKey, ""))
 
-    def getImportStatus(self):
+    def getImportStatus(self, incIcon=True):
         """Return the relevant importance or status label and icon for
         the current item based on its class.
         """
         if self.isNovelLike():
             stName = self.theProject.statusItems.name(self._status)
-            stIcon = self.theProject.statusItems.icon(self._status)
+            stIcon = self.theProject.statusItems.icon(self._status) if incIcon else None
         else:
             stName = self.theProject.importItems.name(self._import)
-            stIcon = self.theProject.importItems.icon(self._import)
+            stIcon = self.theProject.importItems.icon(self._import) if incIcon else None
         return stName, stIcon
 
     ##

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -176,7 +176,7 @@ class NWProject():
         self._projTree.updateItemData(newItem.itemHandle)
         return newItem.itemHandle
 
-    def writeNewFile(self, tHandle, hLevel, isDocument):
+    def writeNewFile(self, tHandle, hLevel, isDocument, addText=""):
         """Write content to a new document after it is created. This
         will not run if the file exists and is not empty.
         """
@@ -191,7 +191,7 @@ class NWProject():
             return False
 
         hshText = "#"*minmax(hLevel, 1, 4)
-        newText = f"{hshText} {tItem.itemName}\n\n"
+        newText = f"{hshText} {tItem.itemName}\n\n{addText}"
         if tItem.isNovelLike() and isDocument:
             tItem.setLayout(nwItemLayout.DOCUMENT)
         else:

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -202,6 +202,23 @@ class NWProject():
 
         return True
 
+    def removeItem(self, tHandle):
+        """Remove an item from the project. This will delete both the
+        project entry and a document file if it exists.
+        """
+        if self._projTree.checkType(tHandle, nwItemType.FILE):
+            delDoc = NWDoc(self, tHandle)
+            if not delDoc.deleteDocument():
+                self.mainGui.makeAlert([
+                    self.tr("Could not delete document file."), delDoc.getError()
+                ], nwAlert.ERROR)
+                return False
+
+        self._projIndex.deleteHandle(tHandle)
+        del self._projTree[tHandle]
+
+        return True
+
     def trashFolder(self):
         """Add the special trash root folder to the project.
         """

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -1,10 +1,11 @@
 """
-novelWriter – GUI Doc Merge Tool
-================================
-GUI class for merging multiple documents to one document
+novelWriter – GUI Doc Merge Dialog
+==================================
+Custom dialog class for merging documents.
 
 File History:
-Created: 2020-01-23 [0.4.3]
+Created:   2020-01-23 [0.4.3]
+Rewritten: 2022-10-06 [2.0b1]
 
 This file is a part of novelWriter
 Copyright 2018–2022, Veronica Berglyd Olsen
@@ -26,169 +27,131 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import logging
 import novelwriter
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QLabel, QListWidget, QAbstractItemView,
-    QListWidgetItem, QDialogButtonBox
+    QListWidgetItem, QDialogButtonBox, QGridLayout
 )
 
-from novelwriter.core import NWDoc
-from novelwriter.enum import nwAlert, nwItemType
-from novelwriter.gui.custom import QHelpLabel
+from novelwriter.gui.custom import QHelpLabel, QSwitch
 
 logger = logging.getLogger(__name__)
 
 
 class GuiDocMerge(QDialog):
 
-    def __init__(self, mainGui):
-        QDialog.__init__(self, mainGui)
+    def __init__(self, mainGui, sHandle, itemList):
+        super().__init__(parent=mainGui)
 
         logger.debug("Initialising GuiDocMerge ...")
         self.setObjectName("GuiDocMerge")
 
         self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
+        self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
-        self.sourceItem = None
 
-        self.outerBox = QVBoxLayout()
+        self._data = {}
+
         self.setWindowTitle(self.tr("Merge Documents"))
 
         self.headLabel = QLabel("<b>{0}</b>".format(self.tr("Documents to Merge")))
-        self.helpLabel = QHelpLabel(
-            self.tr("Drag and drop items to change the order."), self.mainGui.mainTheme.helpText
-        )
+        self.helpLabel = QHelpLabel(self.tr(
+            "Drag and drop items to change the order, or uncheck to exclude."
+        ), self.mainTheme.helpText)
+
+        iPx = self.mainTheme.baseIconSize
+        hSp = self.mainConf.pxInt(12)
+        vSp = self.mainConf.pxInt(8)
+        bSp = self.mainConf.pxInt(12)
 
         self.listBox = QListWidget()
-        self.listBox.setDragDropMode(QAbstractItemView.InternalMove)
+        self.listBox.setIconSize(QSize(iPx, iPx))
         self.listBox.setMinimumWidth(self.mainConf.pxInt(400))
         self.listBox.setMinimumHeight(self.mainConf.pxInt(180))
+        self.listBox.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.listBox.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.listBox.setDragDropMode(QAbstractItemView.InternalMove)
 
+        # Merge Options
+        self.trashLabel = QLabel(self.tr("Move merged items to Trash"))
+        self.trashSwitch = QSwitch()
+
+        self.optBox = QGridLayout()
+        self.optBox.addWidget(self.trashLabel,  0, 0)
+        self.optBox.addWidget(self.trashSwitch, 0, 1)
+        self.optBox.setHorizontalSpacing(hSp)
+        self.optBox.setColumnStretch(2, 1)
+
+        # Buttons
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        self.buttonBox.accepted.connect(self._doMerge)
-        self.buttonBox.rejected.connect(self._doClose)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
 
+        # Assemble
+        self.outerBox = QVBoxLayout()
         self.outerBox.setSpacing(0)
         self.outerBox.addWidget(self.headLabel)
         self.outerBox.addWidget(self.helpLabel)
-        self.outerBox.addSpacing(self.mainConf.pxInt(8))
+        self.outerBox.addSpacing(vSp)
         self.outerBox.addWidget(self.listBox)
-        self.outerBox.addSpacing(self.mainConf.pxInt(12))
+        self.outerBox.addSpacing(vSp)
+        self.outerBox.addLayout(self.optBox)
+        self.outerBox.addSpacing(bSp)
         self.outerBox.addWidget(self.buttonBox)
         self.setLayout(self.outerBox)
 
-        self.rejected.connect(self._doClose)
-
-        self._populateList()
+        # Load Content
+        self._loadContent(sHandle, itemList)
 
         logger.debug("GuiDocMerge initialisation complete")
 
         return
 
-    ##
-    #  Buttons
-    ##
-
-    def _doMerge(self):
-        """Perform the merge of the files in the selected folder, and
-        create a new file in the same parent folder. The old files are
-        not removed in the merge process, and must be deleted manually.
+    def getData(self):
+        """Return the user's choices.
         """
-        logger.verbose("GuiDocMerge merge button clicked")
-
-        finalOrder = []
+        finalItems = []
         for i in range(self.listBox.count()):
-            finalOrder.append(self.listBox.item(i).data(Qt.UserRole))
+            item = self.listBox.item(i)
+            if item.checkState() == Qt.Checked:
+                finalItems.append(item.data(Qt.UserRole))
 
-        if len(finalOrder) == 0:
-            self.mainGui.makeAlert(self.tr(
-                "No source documents found. Nothing to do."
-            ), nwAlert.ERROR)
-            return False
+        self._data["moveToTrash"] = self.trashSwitch.isChecked()
+        self._data["finalItems"] = finalItems
 
-        theText = ""
-        for tHandle in finalOrder:
-            inDoc = NWDoc(self.theProject, tHandle)
-            docText = inDoc.readDocument()
-            docErr = inDoc.getError()
-            if docText is None and docErr:
-                self.mainGui.makeAlert([
-                    self.tr("Failed to open document file."), docErr
-                ], nwAlert.ERROR)
-            if docText:
-                theText += docText.rstrip("\n")+"\n\n"
-
-        if self.sourceItem is None:
-            self.mainGui.makeAlert(self.tr(
-                "No source folder selected. Nothing to do."
-            ), nwAlert.ERROR)
-            return False
-
-        srcItem = self.theProject.tree[self.sourceItem]
-        if srcItem is None:
-            self.mainGui.makeAlert(self.tr("Internal error."), nwAlert.ERROR)
-            return False
-
-        nHandle = self.theProject.newFile(srcItem.itemName, srcItem.itemParent)
-        newItem = self.theProject.tree[nHandle]
-        newItem.setStatus(srcItem.itemStatus)
-        newItem.setImport(srcItem.itemImport)
-
-        outDoc = NWDoc(self.theProject, nHandle)
-        if not outDoc.writeDocument(theText):
-            self.mainGui.makeAlert([
-                self.tr("Could not save document."), outDoc.getError()
-            ], nwAlert.ERROR)
-            return False
-
-        self.mainGui.projView.revealNewTreeItem(nHandle)
-        self.mainGui.openDocument(nHandle, doScroll=True)
-
-        self._doClose()
-
-        return True
-
-    def _doClose(self):
-        """Close the dialog window without doing anything.
-        """
-        self.close()
-        return
+        return self._data
 
     ##
     #  Internal Functions
     ##
 
-    def _populateList(self):
-        """Get the item selected in the tree, check that it is a folder,
-        and try to find all files associated with it. The valid files
-        are then added to the list view in order. The list itself can be
-        reordered by the user.
+    def _loadContent(self, sHandle, itemList):
+        """Load content from a given list of items.
         """
-        tHandle = self.mainGui.projView.getSelectedHandle()
-        self.sourceItem = tHandle
-        if tHandle is None:
-            return False
+        self._data = {}
+        self._data["sHandle"] = sHandle
+        self._data["origItems"] = itemList
 
-        nwItem = self.theProject.tree[tHandle]
-        if nwItem is None:
-            return False
-
-        if nwItem.itemType is not nwItemType.FOLDER:
-            self.mainGui.makeAlert(self.tr(
-                "Element selected in the project tree must be a folder."
-            ), nwAlert.ERROR)
-            return False
-
-        for sHandle in self.mainGui.projView.getTreeFromHandle(tHandle):
-            newItem = QListWidgetItem()
-            nwItem  = self.theProject.tree[sHandle]
-            if not nwItem.isFileType():
+        self.listBox.clear()
+        for tHandle in itemList:
+            nwItem = self.theProject.tree[tHandle]
+            if nwItem is None or not nwItem.isFileType():
                 continue
+
+            hLevel = self.theProject.index.getHandleHeaderLevel(tHandle)
+            itemIcon = self.mainTheme.getItemIcon(
+                nwItem.itemType, nwItem.itemClass, nwItem.itemLayout, hLevel
+            )
+
+            newItem = QListWidgetItem()
+            newItem.setIcon(itemIcon)
             newItem.setText(nwItem.itemName)
-            newItem.setData(Qt.UserRole, sHandle)
+            newItem.setData(Qt.UserRole, tHandle)
+            newItem.setCheckState(Qt.Checked)
+
             self.listBox.addItem(newItem)
 
-        return True
+        return
 
 # END Class GuiDocMerge

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -29,8 +29,8 @@ import novelwriter
 
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtWidgets import (
-    QDialog, QVBoxLayout, QLabel, QListWidget, QAbstractItemView,
-    QListWidgetItem, QDialogButtonBox, QGridLayout
+    QAbstractItemView, QDialog, QDialogButtonBox, QGridLayout, QLabel,
+    QListWidget, QListWidgetItem, QVBoxLayout,
 )
 
 from novelwriter.gui.custom import QHelpLabel, QSwitch

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -88,6 +88,9 @@ class GuiDocMerge(QDialog):
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
 
+        self.resetButton = self.buttonBox.addButton(QDialogButtonBox.Reset)
+        self.resetButton.clicked.connect(self._resetList)
+
         # Assemble
         self.outerBox = QVBoxLayout()
         self.outerBox.setSpacing(0)
@@ -121,6 +124,19 @@ class GuiDocMerge(QDialog):
         self._data["finalItems"] = finalItems
 
         return self._data
+
+    ##
+    #  Slots
+    ##
+
+    def _resetList(self):
+        """Reset the content of the list box to its original state.
+        """
+        logger.debug("Resetting list box content")
+        sHandle = self._data.get("sHandle", None)
+        itemList = self._data.get("origItems", [])
+        self._loadContent(sHandle, itemList)
+        return
 
     ##
     #  Internal Functions

--- a/novelwriter/gui/custom.py
+++ b/novelwriter/gui/custom.py
@@ -202,7 +202,7 @@ class QConfigLayout(QGridLayout):
 class QHelpLabel(QLabel):
 
     def __init__(self, theText, textCol, fontSize=0.9):
-        QLabel.__init__(self, theText)
+        super().__init__(theText)
 
         if isinstance(textCol, QColor):
             qCol = textCol
@@ -377,7 +377,7 @@ class QSwitch(QAbstractButton):
 class PagedDialog(QDialog):
 
     def __init__(self, parent=None):
-        QDialog.__init__(self, parent=parent)
+        super().__init__(parent=parent)
 
         self._tabBar = VerticalTabBar(self)
         self._tabBar.setExpanding(False)
@@ -410,13 +410,13 @@ class PagedDialog(QDialog):
         return
 
     def addTab(self, widget, label):
-        """Forwards the adding of tabs to the QTabWidget.
+        """Forward the adding of tabs to the QTabWidget.
         """
         self._tabBox.addTab(widget, label)
         return
 
     def addControls(self, buttonBar):
-        """Adds a button bar to the dialog.
+        """Add a button bar to the dialog.
         """
         self._buttonBox.addWidget(buttonBar)
         return
@@ -427,14 +427,14 @@ class PagedDialog(QDialog):
 class VerticalTabBar(QTabBar):
 
     def __init__(self, parent=None):
-        QTabBar.__init__(self, parent=parent)
+        super().__init__(parent=parent)
         self._mW = novelwriter.CONFIG.pxInt(150)
         return
 
     def tabSizeHint(self, index):
-        """Returns a transposed size hint for the rotated bar.
+        """Return a transposed size hint for the rotated bar.
         """
-        tSize = QTabBar.tabSizeHint(self, index)
+        tSize = super().tabSizeHint(index)
         tSize.transpose()
         tSize.setWidth(min(tSize.width(), self._mW))
         return tSize

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -244,11 +244,6 @@ class GuiMainMenu(QMenuBar):
         self.aImportFile.triggered.connect(lambda: self.mainGui.importDocument())
         self.docuMenu.addAction(self.aImportFile)
 
-        # Document > Merge Documents
-        self.aMergeDocs = QAction(self.tr("Merge Folder to Document"), self)
-        self.aMergeDocs.triggered.connect(lambda: self.mainGui.mergeDocuments())
-        self.docuMenu.addAction(self.aMergeDocs)
-
         # Document > Split Document
         self.aSplitDoc = QAction(self.tr("Split Document to Folder"), self)
         self.aSplitDoc.triggered.connect(lambda: self.mainGui.splitDocument())

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -171,7 +171,7 @@ class GuiMainMenu(QMenuBar):
         # Project > Delete
         self.aDeleteItem = QAction(self.tr("Delete Item"), self)
         self.aDeleteItem.setShortcut("Ctrl+Shift+Del")
-        self.aDeleteItem.triggered.connect(lambda: self.mainGui.projView.deleteItem(None))
+        self.aDeleteItem.triggered.connect(lambda: self.mainGui.projView.requestDeleteItem(None))
         self.projMenu.addAction(self.aDeleteItem)
 
         # Project > Empty Trash

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -1048,7 +1048,7 @@ class GuiOutlineDetails(QScrollArea):
             self.titleLabel.setText("<b>%s</b>" % self.tr("Title"))
         self.titleValue.setText(novIdx.title)
 
-        itemStatus, _ = nwItem.getImportStatus()
+        itemStatus, _ = nwItem.getImportStatus(incIcon=False)
 
         self.fileValue.setText(nwItem.itemName)
         self.itemValue.setText(itemStatus)

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -34,7 +34,7 @@ from time import time
 from PyQt5.QtGui import QPalette
 from PyQt5.QtCore import Qt, QSize, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QFrame, QHBoxLayout, QHeaderView, QLabel, QDialog,
+    QAbstractItemView, QDialog, QFrame, QHBoxLayout, QHeaderView, QLabel,
     QMenu, QShortcut, QSizePolicy, QToolButton, QTreeWidget, QTreeWidgetItem,
     QVBoxLayout, QWidget
 )

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -602,7 +602,7 @@ class GuiProjectTree(QTreeWidget):
             self.setTreeItemValues(tHandle)
             self._alertTreeChange(tHandle, flush=False)
 
-        return
+        return True
 
     def saveTreeOrder(self):
         """Build a list of the items in the project tree and send them
@@ -657,11 +657,11 @@ class GuiProjectTree(QTreeWidget):
             return False
 
         if self.theProject.tree.isTrash(tHandle) or nwItem.isRootType():
-            self.permanentlyDeleteItem(tHandle)
+            status = self.permanentlyDeleteItem(tHandle)
         else:
-            self.moveItemToTrash(tHandle)
+            status = self.moveItemToTrash(tHandle)
 
-        return True
+        return status
 
     def emptyTrash(self):
         """Permanently delete all documents in the Trash folder. This
@@ -697,6 +697,7 @@ class GuiProjectTree(QTreeWidget):
             self.tr("Permanently delete {0} file(s) from Trash?").format(nTrash)
         )
         if not msgYes:
+            logger.info("Action cancelled by user")
             return False
 
         logger.verbose("Deleting %d file(s) from Trash", nTrash)
@@ -761,7 +762,7 @@ class GuiProjectTree(QTreeWidget):
 
         return True
 
-    def permanentlyDeleteItem(self, tHandle, askFirst=True, flush=False):
+    def permanentlyDeleteItem(self, tHandle, askFirst=True, flush=True):
         """Permanently delete a tree item from the project and the map.
         Root items are handled a little different than other items.
         """

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -915,7 +915,9 @@ class GuiProjectTree(QTreeWidget):
         dstItem = self._lastMove.get("parent", None)
         dstIndex = self._lastMove.get("index", None)
 
-        if srcItem is None or dstItem is None or dstIndex is None:
+        srcOK = isinstance(srcItem, QTreeWidgetItem)
+        dstOk = isinstance(dstItem, QTreeWidgetItem)
+        if not srcOK or not dstOk or dstIndex is None:
             logger.verbose("No tree move to undo")
             return False
 
@@ -1011,7 +1013,7 @@ class GuiProjectTree(QTreeWidget):
         return
 
     @pyqtSlot("QTreeWidgetItem*", int)
-    def _treeDoubleClick(self, tItem, colNo):
+    def _treeDoubleClick(self, trItem, colNo):
         """Capture a double-click event and either request the document
         for editing if it is a file, or expand/close the node it is not.
         """
@@ -1026,9 +1028,7 @@ class GuiProjectTree(QTreeWidget):
         if tItem.isFileType():
             self.projView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, -1, "")
         else:
-            trItem = self._getTreeItem(tHandle)
-            if trItem is not None:
-                trItem.setExpanded(not trItem.isExpanded())
+            trItem.setExpanded(not trItem.isExpanded())
 
         return
 
@@ -1401,7 +1401,7 @@ class GuiProjectTree(QTreeWidget):
         dlgMerge = GuiDocMerge(self.mainGui, tHandle, itemList)
         dlgMerge.exec_()
 
-        if dlgMerge.result() != QDialog.Accepted:
+        if dlgMerge.result() == QDialog.Accepted:
 
             mrgData = dlgMerge.getData()
             mrgList = mrgData.get("finalItems", [])

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -44,8 +44,8 @@ from novelwriter.gui import (
     GuiViewsBar
 )
 from novelwriter.dialogs import (
-    GuiAbout, GuiDocMerge, GuiDocSplit, GuiPreferences, GuiProjectDetails,
-    GuiProjectLoad, GuiProjectSettings, GuiUpdates, GuiWordList
+    GuiAbout, GuiDocSplit, GuiPreferences, GuiProjectDetails, GuiProjectLoad,
+    GuiProjectSettings, GuiUpdates, GuiWordList
 )
 from novelwriter.tools import (
     GuiBuildNovel, GuiLipsum, GuiProjectWizard, GuiWritingStats
@@ -742,18 +742,6 @@ class GuiMain(QMainWindow):
                 return False
 
         self.docEditor.replaceText(theText)
-
-        return True
-
-    def mergeDocuments(self):
-        """Merge multiple documents to one single new document.
-        """
-        if not self.hasProject:
-            logger.error("No project open")
-            return False
-
-        dlgMerge = GuiDocMerge(self)
-        dlgMerge.exec_()
 
         return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,14 +190,20 @@ def mockRnd(monkeypatch):
     from 0. This one will generate status/importance flags and handles
     in a predictable sequence.
     """
-    def rnd(n):
-        for x in range(n):
-            yield x
+    class MockRnd:
 
-    gen = rnd(1000)
-    monkeypatch.setattr("random.getrandbits", lambda *a: next(gen))
+        def __init__(self):
+            self.reset()
 
-    return
+        def _rnd(self, n):
+            for x in range(n):
+                yield x
+
+        def reset(self):
+            gen = self._rnd(1000)
+            monkeypatch.setattr("random.getrandbits", lambda *a: next(gen))
+
+    return MockRnd()
 
 
 ##

--- a/tests/reference/coreDocTools_DocMerger_0000000000010.nwd
+++ b/tests/reference/coreDocTools_DocMerger_0000000000010.nwd
@@ -1,0 +1,33 @@
+%%~name: Chapter 1
+%%~path: 0000000000008/0000000000010
+%%~kind: NOVEL/DOCUMENT
+## Chapter 1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc maximus justo non dictum commodo. Curabitur lacinia tempor orci vel luctus. Phasellus porta metus eu massa luctus, eget euismod risus rhoncus. Vestibulum sed arcu nisi. Maecenas pretium facilisis velit, vel semper lacus aliquam sit amet. Vestibulum vulputate neque ligula, rhoncus blandit turpis consequat id. Mauris sagittis vehicula imperdiet. Duis sed nunc pretium, ornare purus vel, sodales augue. Maecenas a suscipit risus. Quisque volutpat justo eleifend est ullamcorper fermentum. Donec ullamcorper et tortor a laoreet. Nam id risus nisi. Vivamus non imperdiet erat, sit amet imperdiet felis. Mauris vitae neque et est aliquam scelerisque non non ipsum.
+
+Nullam laoreet lorem nec malesuada vehicula. Vivamus tempus sodales lectus sed viverra. Aenean lacinia sollicitudin quam, quis tempus eros suscipit id. Duis sed rutrum nisi, ut pulvinar magna. Nam et cursus tortor. Phasellus ac odio tellus. Nullam in iaculis ipsum. Vivamus ante sem, ultricies sed varius quis, tristique nec tellus. Nullam eu urna vitae lacus hendrerit gravida. Quisque pulvinar erat ex, id efficitur velit sodales vitae. Proin vestibulum, sapien eget mattis euismod, tortor quam viverra risus, at congue mauris tortor eu nunc. Mauris pellentesque elit leo, quis eleifend sem placerat a. Vivamus iaculis dui eget tellus volutpat, ac varius nisi facilisis.
+
+% Merge Novel Document: Scene 1.1 [New]
+
+### Scene 1.1
+
+Nullam laoreet lorem nec malesuada vehicula. Vivamus tempus sodales lectus sed viverra. Aenean lacinia sollicitudin quam, quis tempus eros suscipit id. Duis sed rutrum nisi, ut pulvinar magna. Nam et cursus tortor. Phasellus ac odio tellus. Nullam in iaculis ipsum. Vivamus ante sem, ultricies sed varius quis, tristique nec tellus. Nullam eu urna vitae lacus hendrerit gravida. Quisque pulvinar erat ex, id efficitur velit sodales vitae. Proin vestibulum, sapien eget mattis euismod, tortor quam viverra risus, at congue mauris tortor eu nunc. Mauris pellentesque elit leo, quis eleifend sem placerat a. Vivamus iaculis dui eget tellus volutpat, ac varius nisi facilisis.
+
+Nullam a nisl magna. Praesent commodo nec diam aliquet vestibulum. In sapien velit, sodales feugiat porta ut, rhoncus a elit. Quisque egestas nisi eu eros laoreet, quis facilisis est pretium. Nullam bibendum sed tellus nec lobortis. Duis elit massa, volutpat a lacinia a, ullamcorper in dui. Suspendisse ac laoreet dui. Curabitur elementum, tortor elementum ultricies laoreet, nunc massa vulputate augue, vitae tincidunt nunc enim eget nisl.
+
+% Merge Novel Document: Scene 1.2 [New]
+
+### Scene 1.2
+
+Nullam a nisl magna. Praesent commodo nec diam aliquet vestibulum. In sapien velit, sodales feugiat porta ut, rhoncus a elit. Quisque egestas nisi eu eros laoreet, quis facilisis est pretium. Nullam bibendum sed tellus nec lobortis. Duis elit massa, volutpat a lacinia a, ullamcorper in dui. Suspendisse ac laoreet dui. Curabitur elementum, tortor elementum ultricies laoreet, nunc massa vulputate augue, vitae tincidunt nunc enim eget nisl.
+
+Pellentesque nibh urna, volutpat et feugiat porta, rutrum sed lectus. Aliquam eget risus id orci tincidunt condimentum et sit amet purus. Curabitur tincidunt odio vel ante feugiat feugiat. Proin nunc lorem, molestie a sapien et, varius elementum nunc. Donec non fermentum nisl. In et massa placerat, faucibus felis eu, congue nisi. Proin sed tortor non lorem mattis cursus. Vestibulum magna neque, bibendum vel nibh et, tincidunt rhoncus nisi. Duis pulvinar mi a quam rutrum maximus. Nunc sollicitudin, urna in cursus facilisis, augue neque imperdiet metus, ac finibus lorem ante id nulla. Sed maximus eleifend justo id feugiat. Cras eget diam vel est blandit tempor nec a leo. Mauris risus est, fringilla in aliquam a, sagittis vel enim. Nullam sodales id erat placerat lobortis.
+
+% Merge Novel Document: Scene 1.3 [New]
+
+### Scene 1.3
+
+Pellentesque nibh urna, volutpat et feugiat porta, rutrum sed lectus. Aliquam eget risus id orci tincidunt condimentum et sit amet purus. Curabitur tincidunt odio vel ante feugiat feugiat. Proin nunc lorem, molestie a sapien et, varius elementum nunc. Donec non fermentum nisl. In et massa placerat, faucibus felis eu, congue nisi. Proin sed tortor non lorem mattis cursus. Vestibulum magna neque, bibendum vel nibh et, tincidunt rhoncus nisi. Duis pulvinar mi a quam rutrum maximus. Nunc sollicitudin, urna in cursus facilisis, augue neque imperdiet metus, ac finibus lorem ante id nulla. Sed maximus eleifend justo id feugiat. Cras eget diam vel est blandit tempor nec a leo. Mauris risus est, fringilla in aliquam a, sagittis vel enim. Nullam sodales id erat placerat lobortis.
+
+Integer ac gravida quam. Quisque eleifend nisl nec pretium tincidunt. Quisque sollicitudin nisi in hendrerit scelerisque. Sed ornare nisl lacus, sit amet consectetur lectus egestas et. Vivamus nec arcu lorem. Donec rhoncus, purus a porta accumsan, nunc lectus iaculis libero, et fringilla tellus augue et velit. Integer varius felis scelerisque, vulputate tellus eu, laoreet justo. Suspendisse sit amet sem vehicula, auctor odio sed, aliquet enim. In ac tortor sed tortor fringilla elementum. Nulla non odio at magna vulputate scelerisque. Nam elementum diam eu rutrum scelerisque. Sed fermentum, felis quis vulputate fermentum, libero metus sollicitudin est, in faucibus purus nulla non dolor. Ut vitae felis porta, feugiat nunc et, bibendum neque. Nullam nec lorem nec metus ullamcorper malesuada ut a nisl. Etiam eget tristique dui. Nulla sed mi finibus, venenatis tellus non, maximus enim.
+

--- a/tests/reference/coreDocTools_DocMerger_0000000000014.nwd
+++ b/tests/reference/coreDocTools_DocMerger_0000000000014.nwd
@@ -1,0 +1,35 @@
+%%~name: All of Chapter 1
+%%~path: 0000000000008/0000000000014
+%%~kind: NOVEL/DOCUMENT
+% Merge Novel Document: Chapter 1 [New]
+
+## Chapter 1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc maximus justo non dictum commodo. Curabitur lacinia tempor orci vel luctus. Phasellus porta metus eu massa luctus, eget euismod risus rhoncus. Vestibulum sed arcu nisi. Maecenas pretium facilisis velit, vel semper lacus aliquam sit amet. Vestibulum vulputate neque ligula, rhoncus blandit turpis consequat id. Mauris sagittis vehicula imperdiet. Duis sed nunc pretium, ornare purus vel, sodales augue. Maecenas a suscipit risus. Quisque volutpat justo eleifend est ullamcorper fermentum. Donec ullamcorper et tortor a laoreet. Nam id risus nisi. Vivamus non imperdiet erat, sit amet imperdiet felis. Mauris vitae neque et est aliquam scelerisque non non ipsum.
+
+Nullam laoreet lorem nec malesuada vehicula. Vivamus tempus sodales lectus sed viverra. Aenean lacinia sollicitudin quam, quis tempus eros suscipit id. Duis sed rutrum nisi, ut pulvinar magna. Nam et cursus tortor. Phasellus ac odio tellus. Nullam in iaculis ipsum. Vivamus ante sem, ultricies sed varius quis, tristique nec tellus. Nullam eu urna vitae lacus hendrerit gravida. Quisque pulvinar erat ex, id efficitur velit sodales vitae. Proin vestibulum, sapien eget mattis euismod, tortor quam viverra risus, at congue mauris tortor eu nunc. Mauris pellentesque elit leo, quis eleifend sem placerat a. Vivamus iaculis dui eget tellus volutpat, ac varius nisi facilisis.
+
+% Merge Novel Document: Scene 1.1 [New]
+
+### Scene 1.1
+
+Nullam laoreet lorem nec malesuada vehicula. Vivamus tempus sodales lectus sed viverra. Aenean lacinia sollicitudin quam, quis tempus eros suscipit id. Duis sed rutrum nisi, ut pulvinar magna. Nam et cursus tortor. Phasellus ac odio tellus. Nullam in iaculis ipsum. Vivamus ante sem, ultricies sed varius quis, tristique nec tellus. Nullam eu urna vitae lacus hendrerit gravida. Quisque pulvinar erat ex, id efficitur velit sodales vitae. Proin vestibulum, sapien eget mattis euismod, tortor quam viverra risus, at congue mauris tortor eu nunc. Mauris pellentesque elit leo, quis eleifend sem placerat a. Vivamus iaculis dui eget tellus volutpat, ac varius nisi facilisis.
+
+Nullam a nisl magna. Praesent commodo nec diam aliquet vestibulum. In sapien velit, sodales feugiat porta ut, rhoncus a elit. Quisque egestas nisi eu eros laoreet, quis facilisis est pretium. Nullam bibendum sed tellus nec lobortis. Duis elit massa, volutpat a lacinia a, ullamcorper in dui. Suspendisse ac laoreet dui. Curabitur elementum, tortor elementum ultricies laoreet, nunc massa vulputate augue, vitae tincidunt nunc enim eget nisl.
+
+% Merge Novel Document: Scene 1.2 [New]
+
+### Scene 1.2
+
+Nullam a nisl magna. Praesent commodo nec diam aliquet vestibulum. In sapien velit, sodales feugiat porta ut, rhoncus a elit. Quisque egestas nisi eu eros laoreet, quis facilisis est pretium. Nullam bibendum sed tellus nec lobortis. Duis elit massa, volutpat a lacinia a, ullamcorper in dui. Suspendisse ac laoreet dui. Curabitur elementum, tortor elementum ultricies laoreet, nunc massa vulputate augue, vitae tincidunt nunc enim eget nisl.
+
+Pellentesque nibh urna, volutpat et feugiat porta, rutrum sed lectus. Aliquam eget risus id orci tincidunt condimentum et sit amet purus. Curabitur tincidunt odio vel ante feugiat feugiat. Proin nunc lorem, molestie a sapien et, varius elementum nunc. Donec non fermentum nisl. In et massa placerat, faucibus felis eu, congue nisi. Proin sed tortor non lorem mattis cursus. Vestibulum magna neque, bibendum vel nibh et, tincidunt rhoncus nisi. Duis pulvinar mi a quam rutrum maximus. Nunc sollicitudin, urna in cursus facilisis, augue neque imperdiet metus, ac finibus lorem ante id nulla. Sed maximus eleifend justo id feugiat. Cras eget diam vel est blandit tempor nec a leo. Mauris risus est, fringilla in aliquam a, sagittis vel enim. Nullam sodales id erat placerat lobortis.
+
+% Merge Novel Document: Scene 1.3 [New]
+
+### Scene 1.3
+
+Pellentesque nibh urna, volutpat et feugiat porta, rutrum sed lectus. Aliquam eget risus id orci tincidunt condimentum et sit amet purus. Curabitur tincidunt odio vel ante feugiat feugiat. Proin nunc lorem, molestie a sapien et, varius elementum nunc. Donec non fermentum nisl. In et massa placerat, faucibus felis eu, congue nisi. Proin sed tortor non lorem mattis cursus. Vestibulum magna neque, bibendum vel nibh et, tincidunt rhoncus nisi. Duis pulvinar mi a quam rutrum maximus. Nunc sollicitudin, urna in cursus facilisis, augue neque imperdiet metus, ac finibus lorem ante id nulla. Sed maximus eleifend justo id feugiat. Cras eget diam vel est blandit tempor nec a leo. Mauris risus est, fringilla in aliquam a, sagittis vel enim. Nullam sodales id erat placerat lobortis.
+
+Integer ac gravida quam. Quisque eleifend nisl nec pretium tincidunt. Quisque sollicitudin nisi in hendrerit scelerisque. Sed ornare nisl lacus, sit amet consectetur lectus egestas et. Vivamus nec arcu lorem. Donec rhoncus, purus a porta accumsan, nunc lectus iaculis libero, et fringilla tellus augue et velit. Integer varius felis scelerisque, vulputate tellus eu, laoreet justo. Suspendisse sit amet sem vehicula, auctor odio sed, aliquet enim. In ac tortor sed tortor fringilla elementum. Nulla non odio at magna vulputate scelerisque. Nam elementum diam eu rutrum scelerisque. Sed fermentum, felis quis vulputate fermentum, libero metus sollicitudin est, in faucibus purus nulla non dolor. Ut vitae felis porta, feugiat nunc et, bibendum neque. Nullam nec lorem nec metus ullamcorper malesuada ut a nisl. Etiam eget tristique dui. Nulla sed mi finibus, venenatis tellus non, maximus enim.
+

--- a/tests/reference/coreProject_NewFileFolder_nwProject.nwx
+++ b/tests/reference/coreProject_NewFileFolder_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.7-beta1" hexVersion="0x010700b1" fileVersion="1.4" timeStamp="2022-07-31 18:40:28">
+<novelWriterXML appVersion="2.0-beta1" hexVersion="0x020000b1" fileVersion="1.4" timeStamp="2022-10-11 21:40:10">
   <project>
     <name>New Project</name>
     <title>New Novel</title>
@@ -17,9 +17,9 @@
     <lastViewed>None</lastViewed>
     <lastNovel>None</lastNovel>
     <lastOutline>None</lastOutline>
-    <lastWordCount>2</lastWordCount>
+    <lastWordCount>4</lastWordCount>
     <novelWordCount>1</novelWordCount>
-    <notesWordCount>1</notesWordCount>
+    <notesWordCount>3</notesWordCount>
     <autoReplace/>
     <titleFormat>
       <title>%title%</title>
@@ -29,62 +29,62 @@
       <section></section>
     </titleFormat>
     <status>
-      <entry key="s000008" count="7" red="100" green="100" blue="100">New</entry>
-      <entry key="s000009" count="0" red="200" green="50" blue="0">Note</entry>
-      <entry key="s00000a" count="0" red="200" green="150" blue="0">Draft</entry>
-      <entry key="s00000b" count="0" red="50" green="200" blue="0">Finished</entry>
+      <entry key="s000000" count="7" red="100" green="100" blue="100">New</entry>
+      <entry key="s000001" count="0" red="200" green="50" blue="0">Note</entry>
+      <entry key="s000002" count="0" red="200" green="150" blue="0">Draft</entry>
+      <entry key="s000003" count="0" red="50" green="200" blue="0">Finished</entry>
     </status>
     <importance>
-      <entry key="i00000c" count="4" red="100" green="100" blue="100">New</entry>
-      <entry key="i00000d" count="0" red="200" green="50" blue="0">Minor</entry>
-      <entry key="i00000e" count="0" red="200" green="150" blue="0">Major</entry>
-      <entry key="i00000f" count="0" red="50" green="200" blue="0">Main</entry>
+      <entry key="i000004" count="4" red="100" green="100" blue="100">New</entry>
+      <entry key="i000005" count="0" red="200" green="50" blue="0">Minor</entry>
+      <entry key="i000006" count="0" red="200" green="150" blue="0">Major</entry>
+      <entry key="i000007" count="0" red="50" green="200" blue="0">Main</entry>
     </importance>
   </settings>
   <content count="11">
-    <item handle="0000000000010" parent="None" root="0000000000010" order="0" type="ROOT" class="NOVEL">
+    <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Novel</name>
+      <name status="s000000" import="i000004">Novel</name>
     </item>
-    <item handle="0000000000011" parent="None" root="0000000000011" order="0" type="ROOT" class="PLOT">
+    <item handle="0000000000009" parent="None" root="0000000000009" order="0" type="ROOT" class="PLOT">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Plot</name>
+      <name status="s000000" import="i000004">Plot</name>
     </item>
-    <item handle="0000000000012" parent="None" root="0000000000012" order="0" type="ROOT" class="CHARACTER">
+    <item handle="000000000000a" parent="None" root="000000000000a" order="0" type="ROOT" class="CHARACTER">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Characters</name>
+      <name status="s000000" import="i000004">Characters</name>
     </item>
-    <item handle="0000000000013" parent="None" root="0000000000013" order="0" type="ROOT" class="WORLD">
+    <item handle="000000000000b" parent="None" root="000000000000b" order="0" type="ROOT" class="WORLD">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">World</name>
+      <name status="s000000" import="i000004">World</name>
     </item>
-    <item handle="0000000000014" parent="0000000000010" root="0000000000010" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+    <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
       <meta expanded="False" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">Title Page</name>
+      <name status="s000000" import="i000004" exported="True">Title Page</name>
     </item>
-    <item handle="0000000000015" parent="0000000000010" root="0000000000010" order="0" type="FOLDER" class="NOVEL">
+    <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">New Chapter</name>
+      <name status="s000000" import="i000004">New Chapter</name>
     </item>
-    <item handle="0000000000016" parent="0000000000015" root="0000000000010" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+    <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
       <meta expanded="False" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">New Chapter</name>
+      <name status="s000000" import="i000004" exported="True">New Chapter</name>
     </item>
-    <item handle="0000000000017" parent="0000000000015" root="0000000000010" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+    <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
       <meta expanded="False" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">New Scene</name>
+      <name status="s000000" import="i000004" exported="True">New Scene</name>
     </item>
-    <item handle="0000000000028" parent="0000000000015" root="0000000000010" order="0" type="FOLDER" class="NOVEL">
+    <item handle="0000000000020" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Stuff</name>
+      <name status="s000000" import="i000004">Stuff</name>
     </item>
-    <item handle="0000000000029" parent="0000000000015" root="0000000000010" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+    <item handle="0000000000021" parent="0000000000020" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
       <meta expanded="False" charCount="5" wordCount="1" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">Hello</name>
+      <name status="s000000" import="i000004" exported="True">Hello</name>
     </item>
-    <item handle="000000000002a" parent="0000000000012" root="0000000000012" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="False" charCount="4" wordCount="1" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">Jane</name>
+    <item handle="0000000000022" parent="000000000000a" root="000000000000a" order="0" type="FILE" class="CHARACTER" layout="NOTE">
+      <meta expanded="False" charCount="11" wordCount="3" paraCount="1" cursorPos="0"/>
+      <name status="s000000" import="i000004" exported="True">Jane</name>
     </item>
   </content>
 </novelWriterXML>

--- a/tests/reference/coreProject_NewRoot_nwProject.nwx
+++ b/tests/reference/coreProject_NewRoot_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.7-beta1" hexVersion="0x010700b1" fileVersion="1.4" timeStamp="2022-07-31 18:40:28">
+<novelWriterXML appVersion="2.0-beta1" hexVersion="0x020000b1" fileVersion="1.4" timeStamp="2022-10-11 21:30:35">
   <project>
     <name>New Project</name>
     <title>New Novel</title>
@@ -29,82 +29,82 @@
       <section></section>
     </titleFormat>
     <status>
-      <entry key="s000008" count="6" red="100" green="100" blue="100">New</entry>
-      <entry key="s000009" count="0" red="200" green="50" blue="0">Note</entry>
-      <entry key="s00000a" count="0" red="200" green="150" blue="0">Draft</entry>
-      <entry key="s00000b" count="0" red="50" green="200" blue="0">Finished</entry>
+      <entry key="s000000" count="6" red="100" green="100" blue="100">New</entry>
+      <entry key="s000001" count="0" red="200" green="50" blue="0">Note</entry>
+      <entry key="s000002" count="0" red="200" green="150" blue="0">Draft</entry>
+      <entry key="s000003" count="0" red="50" green="200" blue="0">Finished</entry>
     </status>
     <importance>
-      <entry key="i00000c" count="10" red="100" green="100" blue="100">New</entry>
-      <entry key="i00000d" count="0" red="200" green="50" blue="0">Minor</entry>
-      <entry key="i00000e" count="0" red="200" green="150" blue="0">Major</entry>
-      <entry key="i00000f" count="0" red="50" green="200" blue="0">Main</entry>
+      <entry key="i000004" count="10" red="100" green="100" blue="100">New</entry>
+      <entry key="i000005" count="0" red="200" green="50" blue="0">Minor</entry>
+      <entry key="i000006" count="0" red="200" green="150" blue="0">Major</entry>
+      <entry key="i000007" count="0" red="50" green="200" blue="0">Main</entry>
     </importance>
   </settings>
   <content count="16">
-    <item handle="0000000000010" parent="None" root="0000000000010" order="0" type="ROOT" class="NOVEL">
+    <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Novel</name>
+      <name status="s000000" import="i000004">Novel</name>
     </item>
-    <item handle="0000000000011" parent="None" root="0000000000011" order="0" type="ROOT" class="PLOT">
+    <item handle="0000000000009" parent="None" root="0000000000009" order="0" type="ROOT" class="PLOT">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Plot</name>
+      <name status="s000000" import="i000004">Plot</name>
     </item>
-    <item handle="0000000000012" parent="None" root="0000000000012" order="0" type="ROOT" class="CHARACTER">
+    <item handle="000000000000a" parent="None" root="000000000000a" order="0" type="ROOT" class="CHARACTER">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Characters</name>
+      <name status="s000000" import="i000004">Characters</name>
     </item>
-    <item handle="0000000000013" parent="None" root="0000000000013" order="0" type="ROOT" class="WORLD">
+    <item handle="000000000000b" parent="None" root="000000000000b" order="0" type="ROOT" class="WORLD">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">World</name>
+      <name status="s000000" import="i000004">World</name>
     </item>
-    <item handle="0000000000014" parent="0000000000010" root="0000000000010" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+    <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
       <meta expanded="False" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">Title Page</name>
+      <name status="s000000" import="i000004" exported="True">Title Page</name>
     </item>
-    <item handle="0000000000015" parent="0000000000010" root="0000000000010" order="0" type="FOLDER" class="NOVEL">
+    <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">New Chapter</name>
+      <name status="s000000" import="i000004">New Chapter</name>
     </item>
-    <item handle="0000000000016" parent="0000000000015" root="0000000000010" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+    <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
       <meta expanded="False" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">New Chapter</name>
+      <name status="s000000" import="i000004" exported="True">New Chapter</name>
     </item>
-    <item handle="0000000000017" parent="0000000000015" root="0000000000010" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+    <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
       <meta expanded="False" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
-      <name status="s000008" import="i00000c" exported="True">New Scene</name>
+      <name status="s000000" import="i000004" exported="True">New Scene</name>
     </item>
-    <item handle="0000000000028" parent="None" root="0000000000028" order="0" type="ROOT" class="NOVEL">
+    <item handle="0000000000020" parent="None" root="0000000000020" order="0" type="ROOT" class="NOVEL">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Novel</name>
+      <name status="s000000" import="i000004">Novel</name>
     </item>
-    <item handle="0000000000029" parent="None" root="0000000000029" order="0" type="ROOT" class="PLOT">
+    <item handle="0000000000021" parent="None" root="0000000000021" order="0" type="ROOT" class="PLOT">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Plot</name>
+      <name status="s000000" import="i000004">Plot</name>
     </item>
-    <item handle="000000000002a" parent="None" root="000000000002a" order="0" type="ROOT" class="CHARACTER">
+    <item handle="0000000000022" parent="None" root="0000000000022" order="0" type="ROOT" class="CHARACTER">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Characters</name>
+      <name status="s000000" import="i000004">Characters</name>
     </item>
-    <item handle="000000000002b" parent="None" root="000000000002b" order="0" type="ROOT" class="WORLD">
+    <item handle="0000000000023" parent="None" root="0000000000023" order="0" type="ROOT" class="WORLD">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Locations</name>
+      <name status="s000000" import="i000004">Locations</name>
     </item>
-    <item handle="000000000002c" parent="None" root="000000000002c" order="0" type="ROOT" class="TIMELINE">
+    <item handle="0000000000024" parent="None" root="0000000000024" order="0" type="ROOT" class="TIMELINE">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Timeline</name>
+      <name status="s000000" import="i000004">Timeline</name>
     </item>
-    <item handle="000000000002d" parent="None" root="000000000002d" order="0" type="ROOT" class="OBJECT">
+    <item handle="0000000000025" parent="None" root="0000000000025" order="0" type="ROOT" class="OBJECT">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Objects</name>
+      <name status="s000000" import="i000004">Objects</name>
     </item>
-    <item handle="000000000002e" parent="None" root="000000000002e" order="0" type="ROOT" class="CUSTOM">
+    <item handle="0000000000026" parent="None" root="0000000000026" order="0" type="ROOT" class="CUSTOM">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Custom</name>
+      <name status="s000000" import="i000004">Custom</name>
     </item>
-    <item handle="000000000002f" parent="None" root="000000000002f" order="0" type="ROOT" class="CUSTOM">
+    <item handle="0000000000027" parent="None" root="0000000000027" order="0" type="ROOT" class="CUSTOM">
       <meta expanded="False"/>
-      <name status="s000008" import="i00000c">Custom</name>
+      <name status="s000000" import="i000004">Custom</name>
     </item>
   </content>
 </novelWriterXML>

--- a/tests/test_core/test_core_doctools.py
+++ b/tests/test_core/test_core_doctools.py
@@ -1,0 +1,120 @@
+"""
+novelWriter – Project Document Tools Tester
+===========================================
+
+This file is a part of novelWriter
+Copyright 2018–2022, Veronica Berglyd Olsen
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import os
+import pytest
+
+from shutil import copyfile
+
+from mock import causeOSError
+from tools import C, buildTestProject, cmpFiles
+
+from novelwriter.core.project import NWProject
+from novelwriter.core.doctools import DocMerger
+
+
+@pytest.mark.core
+def testCoreDocTools_DocMerger(monkeypatch, mockGUI, fncDir, outDir, refDir, mockRnd, ipsumText):
+    """Test the DocMerger utility.
+    """
+    theProject = NWProject(mockGUI)
+    mockRnd.reset()
+    buildTestProject(theProject, fncDir)
+
+    # Create File to Merge
+    # ====================
+
+    hChapter1 = theProject.newFile("Chapter 1", C.hNovelRoot)
+    hSceneOne11 = theProject.newFile("Scene 1.1", hChapter1)
+    hSceneOne12 = theProject.newFile("Scene 1.2", hChapter1)
+    hSceneOne13 = theProject.newFile("Scene 1.3", hChapter1)
+
+    docText1 = "\n\n".join(ipsumText[0:2]) + "\n\n"
+    docText2 = "\n\n".join(ipsumText[1:3]) + "\n\n"
+    docText3 = "\n\n".join(ipsumText[2:4]) + "\n\n"
+    docText4 = "\n\n".join(ipsumText[3:5]) + "\n\n"
+
+    theProject.writeNewFile(hChapter1, 2, True, docText1)
+    theProject.writeNewFile(hSceneOne11, 3, True, docText2)
+    theProject.writeNewFile(hSceneOne12, 3, True, docText3)
+    theProject.writeNewFile(hSceneOne13, 3, True, docText4)
+
+    # Basic Checks
+    # ============
+
+    docMerger = DocMerger(theProject)
+
+    # No writing without a target set
+    assert docMerger.writeTargetDoc() is False
+
+    # Cannot append invalid handle
+    assert docMerger.appendText(C.hInvalid, True, "Merge") is False
+
+    # Cannot create new target from invalid handle
+    assert docMerger.newTargetDoc(C.hInvalid, "Test") is None
+
+    # Merge to New
+    # ============
+
+    saveFile = os.path.join(fncDir, "content", "0000000000014.nwd")
+    testFile = os.path.join(outDir, "coreDocTools_DocMerger_0000000000014.nwd")
+    compFile = os.path.join(refDir, "coreDocTools_DocMerger_0000000000014.nwd")
+
+    assert docMerger.newTargetDoc(hChapter1, "All of Chapter 1") == "0000000000014"
+
+    assert docMerger.appendText(hChapter1, True, "Merge") is True
+    assert docMerger.appendText(hSceneOne11, True, "Merge") is True
+    assert docMerger.appendText(hSceneOne12, True, "Merge") is True
+    assert docMerger.appendText(hSceneOne13, True, "Merge") is True
+
+    # Block writing and check error handling
+    with monkeypatch.context() as mp:
+        mp.setattr("builtins.open", causeOSError)
+        assert docMerger.writeTargetDoc() is False
+        assert not os.path.isfile(saveFile)
+        assert docMerger.getError() != ""
+
+    # Write properly, and compare
+    assert docMerger.writeTargetDoc() is True
+    copyfile(saveFile, testFile)
+    assert cmpFiles(testFile, compFile)
+
+    # Merge into Existing
+    # ===================
+
+    saveFile = os.path.join(fncDir, "content", "0000000000010.nwd")
+    testFile = os.path.join(outDir, "coreDocTools_DocMerger_0000000000010.nwd")
+    compFile = os.path.join(refDir, "coreDocTools_DocMerger_0000000000010.nwd")
+
+    docMerger.setTargetDoc(hChapter1)
+
+    assert docMerger.appendText(hSceneOne11, True, "Merge") is True
+    assert docMerger.appendText(hSceneOne12, True, "Merge") is True
+    assert docMerger.appendText(hSceneOne13, True, "Merge") is True
+
+    assert docMerger.writeTargetDoc() is True
+    copyfile(saveFile, testFile)
+    assert cmpFiles(testFile, compFile)
+
+    # Just for debugging
+    docMerger.writeTargetDoc()
+
+# END Test testCoreDocTools_DocMerger

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -22,9 +22,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import os
 import pytest
 
+from lxml import etree
 from shutil import copyfile
 from zipfile import ZipFile
-from lxml import etree
 
 from tools import cmpFiles, writeFile, readFile, buildTestProject, XML_IGNORE
 from mock import causeOSError

--- a/tests/test_dialogs/test_dlg_docmerge.py
+++ b/tests/test_dialogs/test_dlg_docmerge.py
@@ -21,7 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 
-from tools import buildTestProject
+from tools import buildTestProject, C
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMessageBox
@@ -40,20 +40,15 @@ def testDlgMerge_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     # Create a new project
     buildTestProject(nwGUI, fncProj)
 
-    hInvalid    = "0000000000000"
-    hChapterDir = "000000000000d"
-    hChapterDoc = "000000000000e"
-    hSceneDoc   = "000000000000f"
-
     # Check that the dialog kan handle invalid items
-    nwMerge = GuiDocMerge(nwGUI, hInvalid, [hInvalid])
+    nwMerge = GuiDocMerge(nwGUI, C.hInvalid, [C.hInvalid])
     qtbot.addWidget(nwMerge)
     nwMerge.show()
     assert nwMerge.listBox.count() == 0
     nwMerge.reject()
 
     # Load items from chapter dir
-    nwMerge = GuiDocMerge(nwGUI, hChapterDir, [hChapterDir, hChapterDoc, hSceneDoc])
+    nwMerge = GuiDocMerge(nwGUI, C.hChapterDir, [C.hChapterDir, C.hChapterDoc, C.hSceneDoc])
     qtbot.addWidget(nwMerge)
     nwMerge.show()
 
@@ -62,36 +57,36 @@ def testDlgMerge_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     itemOne = nwMerge.listBox.item(0)
     itemTwo = nwMerge.listBox.item(1)
 
-    assert itemOne.data(Qt.UserRole) == hChapterDoc
-    assert itemTwo.data(Qt.UserRole) == hSceneDoc
+    assert itemOne.data(Qt.UserRole) == C.hChapterDoc
+    assert itemTwo.data(Qt.UserRole) == C.hSceneDoc
 
     assert itemOne.checkState() == Qt.Checked
     assert itemTwo.checkState() == Qt.Checked
 
     data = nwMerge.getData()
-    assert data["sHandle"] == hChapterDir
-    assert data["origItems"] == [hChapterDir, hChapterDoc, hSceneDoc]
+    assert data["sHandle"] == C.hChapterDir
+    assert data["origItems"] == [C.hChapterDir, C.hChapterDoc, C.hSceneDoc]
     assert data["moveToTrash"] is False
-    assert data["finalItems"] == [hChapterDoc, hSceneDoc]
+    assert data["finalItems"] == [C.hChapterDoc, C.hSceneDoc]
 
     # Uncheck second item and toggle trash switch
     itemTwo.setCheckState(Qt.Unchecked)
     nwMerge.trashSwitch.setChecked(True)
 
     data = nwMerge.getData()
-    assert data["sHandle"] == hChapterDir
-    assert data["origItems"] == [hChapterDir, hChapterDoc, hSceneDoc]
+    assert data["sHandle"] == C.hChapterDir
+    assert data["origItems"] == [C.hChapterDir, C.hChapterDoc, C.hSceneDoc]
     assert data["moveToTrash"] is True
-    assert data["finalItems"] == [hChapterDoc]
+    assert data["finalItems"] == [C.hChapterDoc]
 
     # Restore default values
     nwMerge._resetList()
 
     data = nwMerge.getData()
-    assert data["sHandle"] == hChapterDir
-    assert data["origItems"] == [hChapterDir, hChapterDoc, hSceneDoc]
+    assert data["sHandle"] == C.hChapterDir
+    assert data["origItems"] == [C.hChapterDir, C.hChapterDoc, C.hSceneDoc]
     assert data["moveToTrash"] is True
-    assert data["finalItems"] == [hChapterDoc, hSceneDoc]
+    assert data["finalItems"] == [C.hChapterDoc, C.hSceneDoc]
 
     # qtbot.stop()
 

--- a/tests/test_dialogs/test_dlg_docmerge.py
+++ b/tests/test_dialogs/test_dlg_docmerge.py
@@ -19,17 +19,14 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
 import pytest
 
-from mock import causeOSError
-from tools import getGuiItem, readFile, writeFile, buildTestProject
+from tools import buildTestProject
 
-from PyQt5.QtWidgets import QAction, QMessageBox
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QMessageBox
 
-from novelwriter.enum import nwItemType, nwWidget
-from novelwriter.dialogs import GuiDocMerge, GuiEditLabel
-from novelwriter.core.tree import NWTree
+from novelwriter.dialogs import GuiDocMerge
 
 
 @pytest.mark.gui
@@ -39,142 +36,63 @@ def testDlgMerge_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     # Block message box
     monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
     monkeypatch.setattr(QMessageBox, "critical", lambda *a: QMessageBox.Ok)
-    monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
 
     # Create a new project
     buildTestProject(nwGUI, fncProj)
 
-    # Handles for new objects
-    hNovelRoot  = "0000000000008"
+    hInvalid    = "0000000000000"
     hChapterDir = "000000000000d"
-    hChapterOne = "000000000000e"
-    hSceneOne   = "000000000000f"
-    hSceneTwo   = "0000000000010"
-    hSceneThree = "0000000000011"
-    hSceneFour  = "0000000000012"
-    hMergedDoc  = "0000000000023"
+    hChapterDoc = "000000000000e"
+    hSceneDoc   = "000000000000f"
 
-    # Add Project Content
-    nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
-    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
-    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
-    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
-
-    assert nwGUI.saveProject() is True
-    assert nwGUI.closeProject() is True
-
-    tChapterOne = "## Chapter One\n\n% Chapter one comment\n"
-    tSceneOne   = "### Scene One\n\nThere once was a man from Nantucket"
-    tSceneTwo   = "### Scene Two\n\nWho kept all his cash in a bucket."
-    tSceneThree = "### Scene Three\n\n\tBut his daughter, named Nan,  \n\tRan away with a man"
-    tSceneFour  = "### Scene Four\n\nAnd as for the bucket, Nantucket."
-
-    contentDir = os.path.join(fncProj, "content")
-    writeFile(os.path.join(contentDir, hChapterOne+".nwd"), tChapterOne)
-    writeFile(os.path.join(contentDir, hSceneOne+".nwd"), tSceneOne)
-    writeFile(os.path.join(contentDir, hSceneTwo+".nwd"), tSceneTwo)
-    writeFile(os.path.join(contentDir, hSceneThree+".nwd"), tSceneThree)
-    writeFile(os.path.join(contentDir, hSceneFour+".nwd"), tSceneFour)
-
-    assert nwGUI.openProject(fncProj) is True
-
-    # Open the Merge tool
-    nwGUI.switchFocus(nwWidget.TREE)
-    nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
-
-    monkeypatch.setattr(GuiDocMerge, "exec_", lambda *a: None)
-    nwGUI.mainMenu.aMergeDocs.activate(QAction.Trigger)
-    qtbot.waitUntil(lambda: getGuiItem("GuiDocMerge") is not None, timeout=1000)
-
-    nwMerge = getGuiItem("GuiDocMerge")
-    assert isinstance(nwMerge, GuiDocMerge)
+    # Check that the dialog kan handle invalid items
+    nwMerge = GuiDocMerge(nwGUI, hInvalid, [hInvalid])
+    qtbot.addWidget(nwMerge)
     nwMerge.show()
-    qtbot.wait(50)
-
-    # Populate List
-    # =============
-
-    nwMerge.listBox.clear()
     assert nwMerge.listBox.count() == 0
+    nwMerge.reject()
 
-    # No item selected
-    nwGUI.projView.projTree.clearSelection()
-    assert nwMerge._populateList() is False
-    assert nwMerge.listBox.count() == 0
+    # Load items from chapter dir
+    nwMerge = GuiDocMerge(nwGUI, hChapterDir, [hChapterDir, hChapterDoc, hSceneDoc])
+    qtbot.addWidget(nwMerge)
+    nwMerge.show()
 
-    # Non-existing item
-    with monkeypatch.context() as mp:
-        mp.setattr(NWTree, "__getitem__", lambda *a: None)
-        nwGUI.projView.projTree.clearSelection()
-        nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
-        assert nwMerge._populateList() is False
-        assert nwMerge.listBox.count() == 0
+    assert nwMerge.listBox.count() == 2
 
-    # Select a non-folder
-    nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem(hChapterOne).setSelected(True)
-    assert nwMerge._populateList() is False
-    assert nwMerge.listBox.count() == 0
+    itemOne = nwMerge.listBox.item(0)
+    itemTwo = nwMerge.listBox.item(1)
 
-    # Select the chapter folder
-    nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem(hChapterDir).setSelected(True)
-    assert nwMerge._populateList() is True
-    assert nwMerge.listBox.count() == 5
+    assert itemOne.data(Qt.UserRole) == hChapterDoc
+    assert itemTwo.data(Qt.UserRole) == hSceneDoc
 
-    # Merge Documents
-    # ===============
+    assert itemOne.checkState() == Qt.Checked
+    assert itemTwo.checkState() == Qt.Checked
 
-    # First, a successful merge
-    with monkeypatch.context() as mp:
-        mp.setattr(GuiDocMerge, "_doClose", lambda *a: None)
-        assert nwMerge._doMerge() is True
-        assert nwGUI.saveProject() is True
-        mergedFile = os.path.join(contentDir, hMergedDoc+".nwd")
-        assert os.path.isfile(mergedFile)
-        assert readFile(mergedFile) == (
-            "%%%%~name: New Chapter\n"
-            "%%%%~path: %s/%s\n"
-            "%%%%~kind: NOVEL/DOCUMENT\n"
-            "%s\n\n"
-            "%s\n\n"
-            "%s\n\n"
-            "%s\n\n"
-            "%s\n\n"
-        ) % (
-            hNovelRoot,
-            hMergedDoc,
-            tChapterOne.strip(),
-            tSceneOne.strip(),
-            tSceneTwo.strip(),
-            tSceneThree.strip(),
-            tSceneFour.strip(),
-        )
+    data = nwMerge.getData()
+    assert data["sHandle"] == hChapterDir
+    assert data["origItems"] == [hChapterDir, hChapterDoc, hSceneDoc]
+    assert data["moveToTrash"] is False
+    assert data["finalItems"] == [hChapterDoc, hSceneDoc]
 
-    # OS error
-    with monkeypatch.context() as mp:
-        mp.setattr("builtins.open", causeOSError)
-        assert nwMerge._doMerge() is False
+    # Uncheck second item and toggle trash switch
+    itemTwo.setCheckState(Qt.Unchecked)
+    nwMerge.trashSwitch.setChecked(True)
 
-    # Can't find the source item
-    with monkeypatch.context() as mp:
-        mp.setattr(NWTree, "__getitem__", lambda *a: None)
-        assert nwMerge._doMerge() is False
+    data = nwMerge.getData()
+    assert data["sHandle"] == hChapterDir
+    assert data["origItems"] == [hChapterDir, hChapterDoc, hSceneDoc]
+    assert data["moveToTrash"] is True
+    assert data["finalItems"] == [hChapterDoc]
 
-    # No source handle set
-    nwMerge.sourceItem = None
-    assert nwMerge._doMerge() is False
+    # Restore default values
+    nwMerge._resetList()
 
-    # No documents to merge
-    nwMerge.listBox.clear()
-    assert nwMerge._doMerge() is False
+    data = nwMerge.getData()
+    assert data["sHandle"] == hChapterDir
+    assert data["origItems"] == [hChapterDir, hChapterDoc, hSceneDoc]
+    assert data["moveToTrash"] is True
+    assert data["finalItems"] == [hChapterDoc, hSceneDoc]
 
-    # Close up
-    nwMerge._doClose()
-
-    # qtbot.stopForInteraction()
+    # qtbot.stop()
 
 # END Test testDlgMerge_Main

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -504,9 +504,9 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     assert nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None)
     newHandle = nwGUI.projView.getSelectedHandle()
     assert nwGUI.theProject.tree["0000000000020"] is not None
-    assert nwGUI.projView.deleteItem()
+    assert nwGUI.projView.requestDeleteItem()
     assert nwGUI.projView.setSelectedHandle(newHandle)
-    assert nwGUI.projView.deleteItem()
+    assert nwGUI.projView.requestDeleteItem()
     assert nwGUI.theProject.tree["0000000000024"] is not None  # Trash
     assert nwGUI.saveProject()
 

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -54,7 +54,6 @@ def testGuiMain_ProjectBlocker(monkeypatch, nwGUI):
     assert nwGUI.saveDocument() is False
     assert nwGUI.viewDocument(None) is False
     assert nwGUI.importDocument() is False
-    assert nwGUI.mergeDocuments() is False
     assert nwGUI.splitDocument() is False
     assert nwGUI.openSelectedItem() is False
     assert nwGUI.editItemLabel() is False

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -23,7 +23,7 @@ import os
 import pytest
 
 from shutil import copyfile
-from tools import cmpFiles, buildTestProject, XML_IGNORE, writeFile
+from tools import C, cmpFiles, buildTestProject, XML_IGNORE, writeFile
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMessageBox, QInputDialog
@@ -216,14 +216,14 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     assert nwGUI.theProject.spellCheck is False
 
     # Check that tree items have been created
-    assert nwGUI.projView.projTree._getTreeItem("0000000000008") is not None
-    assert nwGUI.projView.projTree._getTreeItem("0000000000009") is not None
-    assert nwGUI.projView.projTree._getTreeItem("000000000000a") is not None
-    assert nwGUI.projView.projTree._getTreeItem("000000000000b") is not None
-    assert nwGUI.projView.projTree._getTreeItem("000000000000c") is not None
-    assert nwGUI.projView.projTree._getTreeItem("000000000000d") is not None
-    assert nwGUI.projView.projTree._getTreeItem("000000000000e") is not None
-    assert nwGUI.projView.projTree._getTreeItem("000000000000f") is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hNovelRoot) is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hPlotRoot) is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hCharRoot) is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hWorldRoot) is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hTitlePage) is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hChapterDir) is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hChapterDoc) is not None
+    assert nwGUI.projView.projTree._getTreeItem(C.hSceneDoc) is not None
 
     nwGUI.mainMenu.aSpellCheck.setChecked(True)
     assert nwGUI.mainMenu._toggleSpellCheck()
@@ -237,7 +237,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     # Add a Character File
     nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem("000000000000a").setSelected(True)
+    nwGUI.projView.projTree._getTreeItem(C.hCharRoot).setSelected(True)
     nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
     assert nwGUI.openSelectedItem()
 
@@ -259,7 +259,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     # Add a Plot File
     nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem("0000000000009").setSelected(True)
+    nwGUI.projView.projTree._getTreeItem(C.hPlotRoot).setSelected(True)
     nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
     assert nwGUI.openSelectedItem()
 
@@ -281,7 +281,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     # Add a World File
     nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem("000000000000b").setSelected(True)
+    nwGUI.projView.projTree._getTreeItem(C.hWorldRoot).setSelected(True)
     nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
     assert nwGUI.openSelectedItem()
 
@@ -312,9 +312,9 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     # Select the 'New Scene' file
     nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem("0000000000008").setExpanded(True)
-    nwGUI.projView.projTree._getTreeItem("000000000000d").setExpanded(True)
-    nwGUI.projView.projTree._getTreeItem("000000000000f").setSelected(True)
+    nwGUI.projView.projTree._getTreeItem(C.hNovelRoot).setExpanded(True)
+    nwGUI.projView.projTree._getTreeItem(C.hChapterDir).setExpanded(True)
+    nwGUI.projView.projTree._getTreeItem(C.hSceneDoc).setSelected(True)
     assert nwGUI.openSelectedItem()
 
     # Type something into the document
@@ -492,8 +492,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
 
     # Open and view the edited document
     nwGUI.switchFocus(nwWidget.VIEWER)
-    assert nwGUI.openDocument("000000000000f")
-    assert nwGUI.viewDocument("000000000000f")
+    assert nwGUI.openDocument(C.hSceneDoc)
+    assert nwGUI.viewDocument(C.hSceneDoc)
     qtbot.wait(stepDelay)
     assert nwGUI.saveProject()
     assert nwGUI.closeDocViewer()
@@ -561,8 +561,8 @@ def testGuiMain_FocusFullMode(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     assert nwGUI.toggleFocusMode() is False
 
     # Open a file in editor and viewer
-    assert nwGUI.openDocument("000000000000f")
-    assert nwGUI.viewDocument("000000000000f")
+    assert nwGUI.openDocument(C.hSceneDoc)
+    assert nwGUI.viewDocument(C.hSceneDoc)
 
     # Enable focus mode
     assert nwGUI.toggleFocusMode() is True

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QTextCursor, QTextBlock
 from PyQt5.QtWidgets import QAction, QFileDialog, QMessageBox
 
-from tools import writeFile, buildTestProject
+from tools import C, writeFile, buildTestProject
 
 from novelwriter.gui.doceditor import GuiDocEditor
 from novelwriter.enum import nwDocAction, nwDocInsert
@@ -467,8 +467,8 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncDir, fncProj, mockRnd):
 
     buildTestProject(nwGUI, fncProj)
 
-    assert nwGUI.projView.projTree._getTreeItem("000000000000f") is not None
-    assert nwGUI.openDocument("000000000000f") is True
+    assert nwGUI.projView.projTree._getTreeItem(C.hSceneDoc) is not None
+    assert nwGUI.openDocument(C.hSceneDoc) is True
     nwGUI.docEditor.clear()
 
     # Test Faulty Inserts
@@ -677,7 +677,7 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncDir, fncProj, mockRnd):
     assert not nwGUI.importDocument()
 
     # Open the document from before, and add some text to it
-    nwGUI.openDocument("000000000000f")
+    nwGUI.openDocument(C.hSceneDoc)
     nwGUI.docEditor.setText("Bar")
     assert nwGUI.docEditor.getText() == "Bar"
 

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -22,7 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import os
 import pytest
 
-from tools import buildTestProject, writeFile
+from tools import C, buildTestProject, writeFile
 
 from PyQt5.QtGui import QFocusEvent
 from PyQt5.QtCore import Qt, QEvent
@@ -46,7 +46,7 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
 
     nwGUI.switchFocus(nwWidget.TREE)
     nwGUI.projView.projTree.clearSelection()
-    nwGUI.projView.projTree._getTreeItem("000000000000a").setSelected(True)
+    nwGUI.projView.projTree._getTreeItem(C.hCharRoot).setSelected(True)
     nwGUI.projView.projTree.newTreeItem(nwItemType.FILE)
 
     writeFile(
@@ -94,7 +94,7 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     assert not topItem.isSelected()
     topItem.setSelected(True)
     assert novelTree.selectedItems()[0] == topItem
-    assert novelView.getSelectedHandle() == ("000000000000c", 0)
+    assert novelView.getSelectedHandle() == (C.hTitlePage, 0)
 
     # Refresh using the slot for the butoom
     novelBar._refreshNovelTree()
@@ -119,7 +119,7 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     assert scItem.isSelected()
     assert nwGUI.docEditor.docHandle() is None
     novelTree._treeDoubleClick(scItem, 0)
-    assert nwGUI.docEditor.docHandle() == "000000000000f"
+    assert nwGUI.docEditor.docHandle() == C.hSceneDoc
 
     # Open item with middle mouse button
     scItem.setSelected(True)
@@ -136,7 +136,7 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
 
     scItem.setData(novelTree.C_TITLE, novelTree.D_HANDLE, oldData)
     qtbot.mouseClick(vPort, Qt.MiddleButton, pos=scRect.center(), delay=10)
-    assert nwGUI.docViewer.docHandle() == "000000000000f"
+    assert nwGUI.docViewer.docHandle() == C.hSceneDoc
 
     # Last Column
     # ===========
@@ -144,26 +144,26 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     novelBar.setLastColType(NovelTreeColumn.HIDDEN)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is True
     assert novelTree.lastColType == NovelTreeColumn.HIDDEN
-    assert novelTree._getLastColumnText("000000000000f", "T000001") == ("", "")
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == ("", "")
 
     novelBar.setLastColType(NovelTreeColumn.POV)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
     assert novelTree.lastColType == NovelTreeColumn.POV
-    assert novelTree._getLastColumnText("000000000000f", "T000001") == (
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == (
         "Jane", "Point of View: Jane"
     )
 
     novelBar.setLastColType(NovelTreeColumn.FOCUS)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
     assert novelTree.lastColType == NovelTreeColumn.FOCUS
-    assert novelTree._getLastColumnText("000000000000f", "T000001") == (
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == (
         "Jane", "Focus: Jane"
     )
 
     novelBar.setLastColType(NovelTreeColumn.PLOT)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
     assert novelTree.lastColType == NovelTreeColumn.PLOT
-    assert novelTree._getLastColumnText("000000000000f", "T000001") == (
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == (
         "", "Plot: "
     )
 

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -22,7 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import os
 import pytest
 
-from tools import buildTestProject
+from tools import C, buildTestProject
 
 from PyQt5.QtWidgets import QMessageBox, QMenu
 
@@ -78,24 +78,24 @@ def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd)
     assert "Did not find anywhere" in caplog.text
 
     # Create new folder as child of Novel folder
-    projView.setSelectedHandle("0000000000008")
+    projView.setSelectedHandle(C.hNovelRoot)
     assert projView.projTree.newTreeItem(nwItemType.FOLDER) is True
-    assert theProject.tree["0000000000011"].itemParent == "0000000000008"
-    assert theProject.tree["0000000000011"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000011"].itemParent == C.hNovelRoot
+    assert theProject.tree["0000000000011"].itemRoot == C.hNovelRoot
     assert theProject.tree["0000000000011"].itemClass == nwItemClass.NOVEL
 
     # Add a new file in the new folder
     projView.setSelectedHandle("0000000000011")
     assert projView.projTree.newTreeItem(nwItemType.FILE) is True
     assert theProject.tree["0000000000012"].itemParent == "0000000000011"
-    assert theProject.tree["0000000000012"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000012"].itemRoot == C.hNovelRoot
     assert theProject.tree["0000000000012"].itemClass == nwItemClass.NOVEL
 
     # Add a new chapter next to the other new file
     projView.setSelectedHandle("0000000000012")
     assert projView.projTree.newTreeItem(nwItemType.FILE, hLevel=2) is True
     assert theProject.tree["0000000000013"].itemParent == "0000000000011"
-    assert theProject.tree["0000000000013"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000013"].itemRoot == C.hNovelRoot
     assert theProject.tree["0000000000013"].itemClass == nwItemClass.NOVEL
     assert nwGUI.openDocument("0000000000013")
     assert nwGUI.docEditor.getText() == "## New Chapter\n\n"
@@ -104,16 +104,16 @@ def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd)
     projView.setSelectedHandle("0000000000012")
     assert projView.projTree.newTreeItem(nwItemType.FILE, hLevel=3) is True
     assert theProject.tree["0000000000014"].itemParent == "0000000000011"
-    assert theProject.tree["0000000000014"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000014"].itemRoot == C.hNovelRoot
     assert theProject.tree["0000000000014"].itemClass == nwItemClass.NOVEL
     assert nwGUI.openDocument("0000000000014")
     assert nwGUI.docEditor.getText() == "### New Scene\n\n"
 
     # Add a new file to the characters folder
-    projView.setSelectedHandle("000000000000a")
+    projView.setSelectedHandle(C.hCharRoot)
     assert projView.projTree.newTreeItem(nwItemType.FILE, hLevel=1, isNote=True) is True
-    assert theProject.tree["0000000000015"].itemParent == "000000000000a"
-    assert theProject.tree["0000000000015"].itemRoot == "000000000000a"
+    assert theProject.tree["0000000000015"].itemParent == C.hCharRoot
+    assert theProject.tree["0000000000015"].itemRoot == C.hCharRoot
     assert theProject.tree["0000000000015"].itemClass == nwItemClass.CHARACTER
     assert nwGUI.openDocument("0000000000015")
     assert nwGUI.docEditor.getText() == "# New Note\n\n"
@@ -145,8 +145,8 @@ def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd)
     # Rename plot folder
     with monkeypatch.context() as mp:
         mp.setattr(GuiEditLabel, "getLabel", lambda *a, **k: ("Stuff", True))
-        projTree.renameTreeItem("0000000000009") is True
-        assert theProject.tree["0000000000009"].itemName == "Stuff"
+        projTree.renameTreeItem(C.hPlotRoot) is True
+        assert theProject.tree[C.hPlotRoot].itemName == "Stuff"
 
     # Rename invalid folder
     projTree.renameTreeItem("0000000000000") is False
@@ -192,12 +192,12 @@ def testGuiProjTree_MoveItems(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
     # ==============
 
     # Add some files
-    nwTree.setSelectedHandle("000000000000d")
+    nwTree.setSelectedHandle(C.hChapterDir)
     assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
     assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
     assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000011", "0000000000012",
     ]
 
@@ -206,75 +206,75 @@ def testGuiProjTree_MoveItems(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
     assert nwTree.projTree.moveTreeItem(1) is False
 
     # Move second item up twice (should give same result)
-    nwTree.setSelectedHandle("000000000000f")
+    nwTree.setSelectedHandle(C.hSceneDoc)
     assert nwTree.projTree.moveTreeItem(-1) is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000f", "000000000000e",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hSceneDoc, C.hChapterDoc,
         "0000000000010", "0000000000011", "0000000000012",
     ]
     assert nwTree.projTree.moveTreeItem(-1) is False
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000f", "000000000000e",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hSceneDoc, C.hChapterDoc,
         "0000000000010", "0000000000011", "0000000000012",
     ]
 
     # Restore
     assert nwTree.projTree.moveTreeItem(1) is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000011", "0000000000012",
     ]
 
     # Move fifth item down twice (should give same result)
     nwTree.setSelectedHandle("0000000000011")
     assert nwTree.projTree.moveTreeItem(1) is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000012", "0000000000011",
     ]
     assert nwTree.projTree.moveTreeItem(1) is False
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000012", "0000000000011",
     ]
 
     # Restore
     assert nwTree.projTree.moveTreeItem(-1) is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000011", "0000000000012",
     ]
 
     # Move down again, and restore via undo
     nwTree.setSelectedHandle("0000000000011")
     assert nwTree.projTree.moveTreeItem(1) is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000012", "0000000000011",
     ]
     assert nwTree.projTree.undoLastMove() is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwTree.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000011", "0000000000012",
     ]
 
     # Root Folder
     # ===========
 
-    nwTree.setSelectedHandle("0000000000008")
-    assert nwGUI.theProject.tree._treeOrder.index("0000000000008") == 0
+    nwTree.setSelectedHandle(C.hNovelRoot)
+    assert nwGUI.theProject.tree._treeOrder.index(C.hNovelRoot) == 0
 
     # Move novel folder up
     assert nwTree.projTree.moveTreeItem(-1) is False
-    assert nwGUI.theProject.tree._treeOrder.index("0000000000008") == 0
+    assert nwGUI.theProject.tree._treeOrder.index(C.hNovelRoot) == 0
 
     # Move novel folder down
     assert nwTree.projTree.moveTreeItem(1) is True
-    assert nwGUI.theProject.tree._treeOrder.index("0000000000008") == 1
+    assert nwGUI.theProject.tree._treeOrder.index(C.hNovelRoot) == 1
 
     # Move novel folder up again
     assert nwTree.projTree.moveTreeItem(-1) is True
-    assert nwGUI.theProject.tree._treeOrder.index("0000000000008") == 0
+    assert nwGUI.theProject.tree._treeOrder.index(C.hNovelRoot) == 0
 
     # Clean up
     # qtbot.stopForInteraction()
@@ -307,12 +307,12 @@ def testGuiProjTree_RequestDeleteItem(qtbot, caplog, monkeypatch, nwGUI, fncDir,
     assert nwView.emptyTrash() is False
 
     # Add some files
-    nwView.setSelectedHandle("000000000000d")
+    nwView.setSelectedHandle(C.hChapterDir)
     assert nwView.projTree.newTreeItem(nwItemType.FILE) is True
     assert nwView.projTree.newTreeItem(nwItemType.FILE) is True
     assert nwView.projTree.newTreeItem(nwItemType.FILE) is True
-    assert nwView.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwView.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010", "0000000000011", "0000000000012",
     ]
 
@@ -337,8 +337,8 @@ def testGuiProjTree_RequestDeleteItem(qtbot, caplog, monkeypatch, nwGUI, fncDir,
     # Delete Root Folders
     # ===================
 
-    assert nwView.requestDeleteItem("0000000000008") is False  # Novel Root is blocked
-    assert nwView.requestDeleteItem("000000000000a") is True   # Character Root
+    assert nwView.requestDeleteItem(C.hNovelRoot) is False  # Novel Root is blocked
+    assert nwView.requestDeleteItem(C.hCharRoot) is True   # Character Root
 
     # Delete File
     # ===========
@@ -352,8 +352,8 @@ def testGuiProjTree_RequestDeleteItem(qtbot, caplog, monkeypatch, nwGUI, fncDir,
     # Delete last two documents, which also adds the trash folder
     assert nwView.requestDeleteItem("0000000000012") is True
     assert nwView.requestDeleteItem("0000000000011") is True
-    assert nwView.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e", "000000000000f",
+    assert nwView.getTreeFromHandle(C.hChapterDir) == [
+        C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010"
     ]
     trashHandle = nwGUI.theProject.tree.trashRoot()
@@ -389,18 +389,14 @@ def testGuiProjTree_MoveItemToTrash(qtbot, caplog, monkeypatch, nwGUI, fncDir, m
     prjDir = os.path.join(fncDir, "project")
     buildTestProject(nwGUI, prjDir)
 
-    hInvalid   = "0000000000000"
-    hNovelRoot = "0000000000008"
-    hTitlePage = "000000000000c"
-
     # Invalid item
     caplog.clear()
-    assert projTree.moveItemToTrash(hInvalid) is False
+    assert projTree.moveItemToTrash(C.hInvalid) is False
     assert "Could not find tree item for deletion" in caplog.text
 
     # Root folders cannot be moved to Trash
     caplog.clear()
-    assert projTree.moveItemToTrash(hNovelRoot) is False
+    assert projTree.moveItemToTrash(C.hNovelRoot) is False
     assert "Root folders cannot be moved to Trash" in caplog.text
 
     # Block adding trash folder
@@ -408,8 +404,8 @@ def testGuiProjTree_MoveItemToTrash(qtbot, caplog, monkeypatch, nwGUI, fncDir, m
     projTree._addTrashRoot = lambda *a: None
 
     caplog.clear()
-    assert projTree.moveItemToTrash(hTitlePage) is False
-    assert theProject.tree.isTrash(hTitlePage) is False
+    assert projTree.moveItemToTrash(C.hTitlePage) is False
+    assert theProject.tree.isTrash(C.hTitlePage) is False
     assert "Could not delete item" in caplog.text
 
     projTree._addTrashRoot = funcPointer
@@ -417,16 +413,16 @@ def testGuiProjTree_MoveItemToTrash(qtbot, caplog, monkeypatch, nwGUI, fncDir, m
     # User cancels action
     with monkeypatch.context() as mp:
         mp.setattr(QMessageBox, "question", lambda *a: QMessageBox.No)
-        assert projTree.moveItemToTrash(hTitlePage) is False
-        assert theProject.tree.isTrash(hTitlePage) is False
+        assert projTree.moveItemToTrash(C.hTitlePage) is False
+        assert theProject.tree.isTrash(C.hTitlePage) is False
 
     # Move a document to Trash
-    assert projTree.moveItemToTrash(hTitlePage) is True
-    assert theProject.tree.isTrash(hTitlePage) is True
+    assert projTree.moveItemToTrash(C.hTitlePage) is True
+    assert theProject.tree.isTrash(C.hTitlePage) is True
 
     # Cannot be moved again
     caplog.clear()
-    assert projTree.moveItemToTrash(hTitlePage) is False
+    assert projTree.moveItemToTrash(C.hTitlePage) is False
     assert "Item is already in the Trash folder" in caplog.text
 
     nwGUI.closeProject()
@@ -452,48 +448,40 @@ def testGuiProjTree_PermanentlyDeleteItem(qtbot, caplog, monkeypatch, nwGUI, fnc
     prjDir = os.path.join(fncDir, "project")
     buildTestProject(nwGUI, prjDir)
 
-    hInvalid    = "0000000000000"
-    hNovelRoot  = "0000000000008"
-    hPlotRoot   = "0000000000009"
-    hTitlePage  = "000000000000c"
-    hChapterDir = "000000000000d"
-    hChapterDoc = "000000000000e"
-    hSceneDoc   = "000000000000f"
-
     # Invalid item
     caplog.clear()
-    assert projTree.permanentlyDeleteItem(hInvalid) is False
+    assert projTree.permanentlyDeleteItem(C.hInvalid) is False
     assert "Could not find tree item for deletion" in caplog.text
 
     # Not deleting root item in use
     caplog.clear()
-    assert projTree.permanentlyDeleteItem(hNovelRoot) is False
+    assert projTree.permanentlyDeleteItem(C.hNovelRoot) is False
     assert "Root folders can only be deleted when they are empty" in caplog.text
-    assert hNovelRoot in theProject.tree
+    assert C.hNovelRoot in theProject.tree
 
     # Deleting unused root item is allowed
     caplog.clear()
-    assert projTree.permanentlyDeleteItem(hPlotRoot) is True
-    assert hPlotRoot not in theProject.tree
+    assert projTree.permanentlyDeleteItem(C.hPlotRoot) is True
+    assert C.hPlotRoot not in theProject.tree
 
     # User cancels action
     with monkeypatch.context() as mp:
         mp.setattr(QMessageBox, "question", lambda *a: QMessageBox.No)
-        assert projTree.permanentlyDeleteItem(hTitlePage) is False
-        assert hTitlePage in theProject.tree
+        assert projTree.permanentlyDeleteItem(C.hTitlePage) is False
+        assert C.hTitlePage in theProject.tree
 
     # Deleting file is OK, and if it is open, it should close
-    assert nwGUI.openDocument(hTitlePage) is True
-    assert nwGUI.docEditor.docHandle() == hTitlePage
-    assert projTree.permanentlyDeleteItem(hTitlePage) is True
-    assert hTitlePage not in theProject.tree
+    assert nwGUI.openDocument(C.hTitlePage) is True
+    assert nwGUI.docEditor.docHandle() == C.hTitlePage
+    assert projTree.permanentlyDeleteItem(C.hTitlePage) is True
+    assert C.hTitlePage not in theProject.tree
     assert nwGUI.docEditor.docHandle() is None
 
     # Deleting folder + files recursiely is ok
-    assert projTree.permanentlyDeleteItem(hChapterDir) is True
-    assert hChapterDir not in theProject.tree
-    assert hChapterDoc not in theProject.tree
-    assert hSceneDoc not in theProject.tree
+    assert projTree.permanentlyDeleteItem(C.hChapterDir) is True
+    assert C.hChapterDir not in theProject.tree
+    assert C.hChapterDoc not in theProject.tree
+    assert C.hSceneDoc not in theProject.tree
 
     nwGUI.closeProject()
 
@@ -523,38 +511,33 @@ def testGuiProjTree_EmptyTrash(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRn
     prjDir = os.path.join(fncDir, "project")
     buildTestProject(nwGUI, prjDir)
 
-    hTitlePage  = "000000000000c"
-    hChapterDir = "000000000000d"
-    hChapterDoc = "000000000000e"
-    hSceneDoc   = "000000000000f"
-
     # No Trash folder
     assert projTree.emptyTrash() is False
 
     # Move some documents to Trash
-    assert projTree.moveItemToTrash(hTitlePage) is True
-    assert projTree.moveItemToTrash(hChapterDir) is True
+    assert projTree.moveItemToTrash(C.hTitlePage) is True
+    assert projTree.moveItemToTrash(C.hChapterDir) is True
 
-    assert theProject.tree.isTrash(hTitlePage) is True
-    assert theProject.tree.isTrash(hChapterDir) is True
-    assert theProject.tree.isTrash(hChapterDoc) is True
-    assert theProject.tree.isTrash(hSceneDoc) is True
+    assert theProject.tree.isTrash(C.hTitlePage) is True
+    assert theProject.tree.isTrash(C.hChapterDir) is True
+    assert theProject.tree.isTrash(C.hChapterDoc) is True
+    assert theProject.tree.isTrash(C.hSceneDoc) is True
 
     # User cancels
     with monkeypatch.context() as mp:
         mp.setattr(QMessageBox, "question", lambda *a: QMessageBox.No)
         assert projTree.emptyTrash() is False
-        assert hTitlePage in theProject.tree
-        assert hChapterDir in theProject.tree
-        assert hChapterDoc in theProject.tree
-        assert hSceneDoc in theProject.tree
+        assert C.hTitlePage in theProject.tree
+        assert C.hChapterDir in theProject.tree
+        assert C.hChapterDoc in theProject.tree
+        assert C.hSceneDoc in theProject.tree
 
     # Run again to empty all items
     assert projTree.emptyTrash() is True
-    assert hTitlePage not in theProject.tree
-    assert hChapterDir not in theProject.tree
-    assert hChapterDoc not in theProject.tree
-    assert hSceneDoc not in theProject.tree
+    assert C.hTitlePage not in theProject.tree
+    assert C.hChapterDir not in theProject.tree
+    assert C.hChapterDoc not in theProject.tree
+    assert C.hSceneDoc not in theProject.tree
 
     # Running Emtpy Trash again is cancelled due to empty folder
     assert projTree.emptyTrash() is False
@@ -584,13 +567,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
     buildTestProject(nwGUI, prjDir)
 
     # Handles for new objects
-    hNovelRoot   = "0000000000008"
-    hTitlePage   = "000000000000c"
-    hChapterDir  = "000000000000d"
-    hChapterFile = "000000000000e"
-    hCharRoot    = "000000000000a"
-    hCharNote    = "0000000000011"
-    hNovelNote   = "0000000000012"
+    hCharNote  = "0000000000011"
+    hNovelNote = "0000000000012"
 
     projTree = nwGUI.projView.projTree
     projTree.setExpandedFromHandle(None, True)
@@ -598,9 +576,9 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
     projTree._addTrashRoot()
     hTrashRoot = projTree.theProject.tree.trashRoot()
 
-    projTree.setSelectedHandle(hCharRoot)
+    projTree.setSelectedHandle(C.hCharRoot)
     projTree.newTreeItem(nwItemType.FILE)
-    projTree.setSelectedHandle(hNovelRoot)
+    projTree.setSelectedHandle(C.hNovelRoot)
     projTree.newTreeItem(nwItemType.FILE, isNote=True)
 
     def itemPos(tHandle):
@@ -611,16 +589,16 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
 
     # Generate the possible menu combinarions
     assert projTree._openContextMenu(itemPos(hTrashRoot)) is True
-    assert projTree._openContextMenu(itemPos(hNovelRoot)) is True
+    assert projTree._openContextMenu(itemPos(C.hNovelRoot)) is True
     assert projTree._openContextMenu(itemPos(hNovelNote)) is True
-    assert projTree._openContextMenu(itemPos(hTitlePage)) is True
-    assert projTree._openContextMenu(itemPos(hChapterDir)) is True
-    assert projTree._openContextMenu(itemPos(hChapterFile)) is True
-    assert projTree._openContextMenu(itemPos(hCharRoot)) is True
+    assert projTree._openContextMenu(itemPos(C.hTitlePage)) is True
+    assert projTree._openContextMenu(itemPos(C.hChapterDir)) is True
+    assert projTree._openContextMenu(itemPos(C.hChapterDoc)) is True
+    assert projTree._openContextMenu(itemPos(C.hCharRoot)) is True
     assert projTree._openContextMenu(itemPos(hCharNote)) is True
 
     # Check the keyboard shortcut handler as well
-    projTree.setSelectedHandle(hNovelRoot)
+    projTree.setSelectedHandle(C.hNovelRoot)
     assert projTree.openContextOnSelected() is True
     projTree.clearSelection()
     assert projTree.openContextOnSelected() is False

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -19,8 +19,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-import pytest
 import os
+import pytest
 
 from tools import buildTestProject
 
@@ -42,113 +42,127 @@ def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd)
     monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
 
-    nwTree = nwGUI.projView
+    projView = nwGUI.projView
+    projTree = nwGUI.projView.projTree
+    theProject = nwGUI.theProject
 
     # Try to add item with no project
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is False
+    assert projView.projTree.newTreeItem(nwItemType.FILE) is False
 
     # Create a project
     prjDir = os.path.join(fncDir, "project")
     buildTestProject(nwGUI, prjDir)
 
     # No itemType set
-    nwTree.projTree.clearSelection()
-    assert nwTree.projTree.newTreeItem(None) is False
+    projView.projTree.clearSelection()
+    assert projView.projTree.newTreeItem(None) is False
 
     # Root Items
     # ==========
 
     # No class set
-    assert nwTree.projTree.newTreeItem(nwItemType.ROOT) is False
+    assert projView.projTree.newTreeItem(nwItemType.ROOT) is False
 
     # Create root item
-    assert nwTree.projTree.newTreeItem(nwItemType.ROOT, nwItemClass.WORLD) is True
-    assert "0000000000010" in nwGUI.theProject.tree
+    assert projView.projTree.newTreeItem(nwItemType.ROOT, nwItemClass.WORLD) is True
+    assert "0000000000010" in theProject.tree
 
     # File/Folder Items
     # =================
 
     # No location selected for new item
-    nwTree.projTree.clearSelection()
+    projView.projTree.clearSelection()
     caplog.clear()
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is False
-    assert nwTree.projTree.newTreeItem(nwItemType.FOLDER) is False
+    assert projView.projTree.newTreeItem(nwItemType.FILE) is False
+    assert projView.projTree.newTreeItem(nwItemType.FOLDER) is False
     assert "Did not find anywhere" in caplog.text
 
     # Create new folder as child of Novel folder
-    nwTree.setSelectedHandle("0000000000008")
-    assert nwTree.projTree.newTreeItem(nwItemType.FOLDER) is True
-    assert nwGUI.theProject.tree["0000000000011"].itemParent == "0000000000008"
-    assert nwGUI.theProject.tree["0000000000011"].itemRoot == "0000000000008"
-    assert nwGUI.theProject.tree["0000000000011"].itemClass == nwItemClass.NOVEL
+    projView.setSelectedHandle("0000000000008")
+    assert projView.projTree.newTreeItem(nwItemType.FOLDER) is True
+    assert theProject.tree["0000000000011"].itemParent == "0000000000008"
+    assert theProject.tree["0000000000011"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000011"].itemClass == nwItemClass.NOVEL
 
     # Add a new file in the new folder
-    nwTree.setSelectedHandle("0000000000011")
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
-    assert nwGUI.theProject.tree["0000000000012"].itemParent == "0000000000011"
-    assert nwGUI.theProject.tree["0000000000012"].itemRoot == "0000000000008"
-    assert nwGUI.theProject.tree["0000000000012"].itemClass == nwItemClass.NOVEL
+    projView.setSelectedHandle("0000000000011")
+    assert projView.projTree.newTreeItem(nwItemType.FILE) is True
+    assert theProject.tree["0000000000012"].itemParent == "0000000000011"
+    assert theProject.tree["0000000000012"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000012"].itemClass == nwItemClass.NOVEL
 
     # Add a new chapter next to the other new file
-    nwTree.setSelectedHandle("0000000000012")
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE, hLevel=2) is True
-    assert nwGUI.theProject.tree["0000000000013"].itemParent == "0000000000011"
-    assert nwGUI.theProject.tree["0000000000013"].itemRoot == "0000000000008"
-    assert nwGUI.theProject.tree["0000000000013"].itemClass == nwItemClass.NOVEL
+    projView.setSelectedHandle("0000000000012")
+    assert projView.projTree.newTreeItem(nwItemType.FILE, hLevel=2) is True
+    assert theProject.tree["0000000000013"].itemParent == "0000000000011"
+    assert theProject.tree["0000000000013"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000013"].itemClass == nwItemClass.NOVEL
     assert nwGUI.openDocument("0000000000013")
     assert nwGUI.docEditor.getText() == "## New Chapter\n\n"
 
     # Add a new scene next to the other new file
-    nwTree.setSelectedHandle("0000000000012")
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE, hLevel=3) is True
-    assert nwGUI.theProject.tree["0000000000014"].itemParent == "0000000000011"
-    assert nwGUI.theProject.tree["0000000000014"].itemRoot == "0000000000008"
-    assert nwGUI.theProject.tree["0000000000014"].itemClass == nwItemClass.NOVEL
+    projView.setSelectedHandle("0000000000012")
+    assert projView.projTree.newTreeItem(nwItemType.FILE, hLevel=3) is True
+    assert theProject.tree["0000000000014"].itemParent == "0000000000011"
+    assert theProject.tree["0000000000014"].itemRoot == "0000000000008"
+    assert theProject.tree["0000000000014"].itemClass == nwItemClass.NOVEL
     assert nwGUI.openDocument("0000000000014")
     assert nwGUI.docEditor.getText() == "### New Scene\n\n"
 
     # Add a new file to the characters folder
-    nwTree.setSelectedHandle("000000000000a")
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE, hLevel=1, isNote=True) is True
-    assert nwGUI.theProject.tree["0000000000015"].itemParent == "000000000000a"
-    assert nwGUI.theProject.tree["0000000000015"].itemRoot == "000000000000a"
-    assert nwGUI.theProject.tree["0000000000015"].itemClass == nwItemClass.CHARACTER
+    projView.setSelectedHandle("000000000000a")
+    assert projView.projTree.newTreeItem(nwItemType.FILE, hLevel=1, isNote=True) is True
+    assert theProject.tree["0000000000015"].itemParent == "000000000000a"
+    assert theProject.tree["0000000000015"].itemRoot == "000000000000a"
+    assert theProject.tree["0000000000015"].itemClass == nwItemClass.CHARACTER
     assert nwGUI.openDocument("0000000000015")
     assert nwGUI.docEditor.getText() == "# New Note\n\n"
 
     # Make sure the sibling folder bug trap works
-    nwTree.setSelectedHandle("0000000000013")
-    nwGUI.theProject.tree["0000000000013"].setParent(None)  # This should not happen
+    projView.setSelectedHandle("0000000000013")
+    theProject.tree["0000000000013"].setParent(None)  # This should not happen
     caplog.clear()
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is False
+    assert projView.projTree.newTreeItem(nwItemType.FILE) is False
     assert "Internal error" in caplog.text
-    nwGUI.theProject.tree["0000000000013"].setParent("0000000000011")
+    theProject.tree["0000000000013"].setParent("0000000000011")
 
     # Cancel during creation
     with monkeypatch.context() as mp:
         mp.setattr(GuiEditLabel, "getLabel", lambda *a, **k: ("", False))
-        nwTree.setSelectedHandle("0000000000013")
-        assert nwTree.projTree.newTreeItem(nwItemType.FILE) is False
+        projView.setSelectedHandle("0000000000013")
+        assert projView.projTree.newTreeItem(nwItemType.FILE) is False
 
     # Get the trash folder
-    nwTree.projTree._addTrashRoot()
-    trashHandle = nwGUI.theProject.trashFolder()
-    nwTree.setSelectedHandle(trashHandle)
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is False
+    projView.projTree._addTrashRoot()
+    trashHandle = theProject.trashFolder()
+    projView.setSelectedHandle(trashHandle)
+    assert projView.projTree.newTreeItem(nwItemType.FILE) is False
     assert "Cannot add new files or folders to the Trash folder" in caplog.text
+
+    # Rename Item
+    # ===========
+
+    # Rename plot folder
+    with monkeypatch.context() as mp:
+        mp.setattr(GuiEditLabel, "getLabel", lambda *a, **k: ("Stuff", True))
+        projTree.renameTreeItem("0000000000009") is True
+        assert theProject.tree["0000000000009"].itemName == "Stuff"
+
+    # Rename invalid folder
+    projTree.renameTreeItem("0000000000000") is False
 
     # Other Checks
     # ============
 
     # Also check error handling in reveal function
-    assert nwTree.revealNewTreeItem("abc") is False
+    assert projView.revealNewTreeItem("abc") is False
 
     # Add an item that cannot be displayed in the tree
-    nHandle = nwGUI.theProject.newFile("Test", None)
-    assert nwTree.revealNewTreeItem(nHandle) is False
+    nHandle = theProject.newFile("Test", None)
+    assert projView.revealNewTreeItem(nHandle) is False
 
     # Clean up
-    # qtbot.stopForInteraction()
+    # qtbot.stop()
     nwGUI.closeProject()
 
 # END Test testGuiProjTree_NewItems
@@ -270,8 +284,8 @@ def testGuiProjTree_MoveItems(qtbot, monkeypatch, nwGUI, fncDir, mockRnd):
 
 
 @pytest.mark.gui
-def testGuiProjTree_DeleteItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd):
-    """Test adding and removing items from the project tree.
+def testGuiProjTree_RequestDeleteItem(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd):
+    """Test external requests for removing items from project tree.
     """
     # Block message box
     monkeypatch.setattr(QMessageBox, "warning", lambda *a: QMessageBox.Yes)
@@ -280,181 +294,274 @@ def testGuiProjTree_DeleteItems(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockR
     monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
 
-    nwTree = nwGUI.projView
+    nwView = nwGUI.projView
 
     # Try to run with no project
-    assert nwTree.emptyTrash() is False
-    assert nwTree.deleteItem() is False
+    assert nwView.requestDeleteItem() is False
 
     # Create a project
     prjDir = os.path.join(fncDir, "project")
     buildTestProject(nwGUI, prjDir)
 
     # Try emptying the trash already now, when there is no trash folder
-    assert nwTree.emptyTrash() is False
+    assert nwView.emptyTrash() is False
 
     # Add some files
-    nwTree.setSelectedHandle("000000000000d")
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
+    nwView.setSelectedHandle("000000000000d")
+    assert nwView.projTree.newTreeItem(nwItemType.FILE) is True
+    assert nwView.projTree.newTreeItem(nwItemType.FILE) is True
+    assert nwView.projTree.newTreeItem(nwItemType.FILE) is True
+    assert nwView.getTreeFromHandle("000000000000d") == [
         "000000000000d", "000000000000e", "000000000000f",
         "0000000000010", "0000000000011", "0000000000012",
     ]
 
     # Delete item without focus -> blocked
     monkeypatch.setattr(GuiProjectTree, "hasFocus", lambda *a: False)
-    nwTree.setSelectedHandle("0000000000012")
-    assert nwTree.deleteItem() is False
+    nwView.setSelectedHandle("0000000000012")
+    assert nwView.requestDeleteItem() is False
     monkeypatch.setattr(GuiProjectTree, "hasFocus", lambda *a: True)
 
     # No selection made
-    nwTree.projTree.clearSelection()
+    nwView.projTree.clearSelection()
     caplog.clear()
-    assert nwTree.deleteItem() is False
+    assert nwView.requestDeleteItem() is False
     assert "no item to delete" in caplog.text
 
     # Not a valid handle
-    nwTree.projTree.clearSelection()
+    nwView.projTree.clearSelection()
     caplog.clear()
-    assert nwTree.deleteItem("0000000000000") is False
-    assert "Could not find tree item" in caplog.text
+    assert nwView.requestDeleteItem("0000000000000") is False
+    assert "No tree item with handle '0000000000000'" in caplog.text
 
-    # Delete Folder/Root
-    # ==================
+    # Delete Root Folders
+    # ===================
 
-    # Deleting non-empty folders is blocked
-    assert nwTree.deleteItem("0000000000008") is False  # Novel Root
-    assert nwTree.deleteItem("000000000000a") is True   # Character Root
+    assert nwView.requestDeleteItem("0000000000008") is False  # Novel Root is blocked
+    assert nwView.requestDeleteItem("000000000000a") is True   # Character Root
 
     # Delete File
     # ===========
 
     # Block adding trash folder
-    funcPointer = nwTree.projTree._addTrashRoot
-    nwTree.projTree._addTrashRoot = lambda *a: None
-    assert nwTree.deleteItem("0000000000012") is False
-    nwTree.projTree._addTrashRoot = funcPointer
+    funcPointer = nwView.projTree._addTrashRoot
+    nwView.projTree._addTrashRoot = lambda *a: None
+    assert nwView.requestDeleteItem("0000000000012") is False
+    nwView.projTree._addTrashRoot = funcPointer
 
     # Delete last two documents, which also adds the trash folder
-    assert nwTree.deleteItem("0000000000012") is True
-    assert nwTree.deleteItem("0000000000011") is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
+    assert nwView.requestDeleteItem("0000000000012") is True
+    assert nwView.requestDeleteItem("0000000000011") is True
+    assert nwView.getTreeFromHandle("000000000000d") == [
         "000000000000d", "000000000000e", "000000000000f",
         "0000000000010"
     ]
     trashHandle = nwGUI.theProject.tree.trashRoot()
-    assert nwTree.getTreeFromHandle(trashHandle) == [
+    assert nwView.getTreeFromHandle(trashHandle) == [
         trashHandle, "0000000000012", "0000000000011"
     ]
 
-    # Delete the first file again (permanent), and ask for permission
-    # Also open the document in the editor, which should trigger a close
-    assert os.path.isfile(os.path.join(prjDir, "content", "0000000000012.nwd"))
-    assert "0000000000012" in nwGUI.theProject.tree
-    assert nwGUI.docEditor.docHandle() is None
-    assert nwGUI.openDocument("0000000000012") is True
-    assert nwGUI.docEditor.docHandle() == "0000000000012"
-    assert nwTree.deleteItem("0000000000012") is True
-    assert nwGUI.docEditor.docHandle() is None
-    assert not os.path.isfile(os.path.join(prjDir, "content", "0000000000012.nwd"))
-    assert "0000000000012" not in nwGUI.theProject.tree
-    assert nwTree.getTreeFromHandle(trashHandle) == [
-        trashHandle, "0000000000011"
-    ]
+    # Try to delete the trash folder
+    caplog.clear()
+    assert nwView.requestDeleteItem("0000000000013") is False
+    assert "Cannot delete the Trash folder" in caplog.text
 
-    # Delete the second file, and skip asking for permission
-    assert os.path.isfile(os.path.join(prjDir, "content", "0000000000011.nwd"))
-    assert "0000000000011" in nwGUI.theProject.tree
-    assert nwTree.deleteItem("0000000000011", alreadyAsked=True) is True
-    assert not os.path.isfile(os.path.join(prjDir, "content", "0000000000011.nwd"))
-    assert "0000000000011" not in nwGUI.theProject.tree
-    assert nwTree.getTreeFromHandle(trashHandle) == [trashHandle]
-
-    # Delete Folder
-    # =============
-
-    trashHandle = nwGUI.theProject.tree.trashRoot()
-
-    # Add a folder with two files
-    nwTree.setSelectedHandle("0000000000009")
-    assert nwTree.projTree.newTreeItem(nwItemType.FOLDER) is True
-    nwTree.setSelectedHandle("0000000000014")
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
-    assert nwTree.projTree.newTreeItem(nwItemType.FILE) is True
-    assert os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000015.nwd"))
-    assert os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000016.nwd"))
-
-    # Delete the folder, which moves everything to Trash
-    assert nwTree.getTreeFromHandle("0000000000014") == [
-        "0000000000014", "0000000000015", "0000000000016"
-    ]
-    assert nwTree.deleteItem("0000000000014") is True
-    assert nwTree.getTreeFromHandle(trashHandle) == [
-        trashHandle, "0000000000014", "0000000000015", "0000000000016"
-    ]
-    assert os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000015.nwd"))
-    assert os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000016.nwd"))
-
-    # Delete again, which should delete folder and all files
-    assert nwTree.deleteItem("0000000000014") is True
-    assert nwTree.getTreeFromHandle(trashHandle) == [trashHandle]
-    assert not os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000015.nwd"))
-    assert not os.path.isfile(os.path.join(fncDir, "project", "content", "0000000000016.nwd"))
-
-    # Add an empty folder, which can be deleted with no further restrictions
-    nwTree.setSelectedHandle("0000000000009")
-    assert nwTree.projTree.newTreeItem(nwItemType.FOLDER) is True
-    assert nwTree.getTreeFromHandle("0000000000009") == ["0000000000009", "0000000000017"]
-
-    nwTree.setSelectedHandle("0000000000017")
-    assert nwTree.deleteItem("0000000000017") is True
-    assert nwTree.getTreeFromHandle("0000000000009") == ["0000000000009"]
-
-    # Empty Trash
-    # ===========
-
-    # Try to empty trash that is already empty
-    assert nwTree.getTreeFromHandle(trashHandle) == [trashHandle]
-    assert nwTree.emptyTrash() is False
-
-    # Move the two remaining scene documents to trash
-    assert nwTree.deleteItem("000000000000f") is True
-    assert nwTree.deleteItem("0000000000010") is True
-    assert nwTree.getTreeFromHandle("000000000000d") == [
-        "000000000000d", "000000000000e"
-    ]
-    assert nwTree.getTreeFromHandle(trashHandle) == [
-        trashHandle, "000000000000f", "0000000000010"
-    ]
-
-    # Empty trash, but select no on question
-    with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "question", lambda *a: QMessageBox.No)
-        assert nwTree.emptyTrash() is False
-
-    # Empty the trash proper
-    assert nwTree.emptyTrash() is True
-    assert nwTree.getTreeFromHandle(trashHandle) == [trashHandle]
-
-    # Try to delete a file, but block the underlying deletion of the file on disk
-    assert os.path.isfile(os.path.join(fncDir, "project", "content", "000000000000e.nwd"))
-    with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.document.NWDoc.deleteDocument", lambda *a: False)
-        assert nwTree.deleteItem("000000000000e") is True
-        assert nwTree.deleteItem("000000000000e") is True
-        assert os.path.isfile(os.path.join(fncDir, "project", "content", "000000000000e.nwd"))
-
-    # Delete proper
-    assert nwTree.projTree._deleteTreeItem("000000000000e") is True
-    assert not os.path.isfile(os.path.join(fncDir, "project", "content", "000000000000e.nwd"))
-
-    # Clean up
-    # qtbot.stopForInteraction()
     nwGUI.closeProject()
 
-# END Test testGuiProjTree_DeleteItems
+# END Test testGuiProjTree_RequestDeleteItem
+
+
+@pytest.mark.gui
+def testGuiProjTree_MoveItemToTrash(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd):
+    """Test moving items to Trash.
+    """
+    # Block message box
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
+
+    theProject = nwGUI.theProject
+    projTree = nwGUI.projView.projTree
+
+    # Create a project
+    prjDir = os.path.join(fncDir, "project")
+    buildTestProject(nwGUI, prjDir)
+
+    hInvalid   = "0000000000000"
+    hNovelRoot = "0000000000008"
+    hTitlePage = "000000000000c"
+
+    # Invalid item
+    caplog.clear()
+    assert projTree.moveItemToTrash(hInvalid) is False
+    assert "Could not find tree item for deletion" in caplog.text
+
+    # Root folders cannot be moved to Trash
+    caplog.clear()
+    assert projTree.moveItemToTrash(hNovelRoot) is False
+    assert "Root folders cannot be moved to Trash" in caplog.text
+
+    # Block adding trash folder
+    funcPointer = projTree._addTrashRoot
+    projTree._addTrashRoot = lambda *a: None
+
+    caplog.clear()
+    assert projTree.moveItemToTrash(hTitlePage) is False
+    assert theProject.tree.isTrash(hTitlePage) is False
+    assert "Could not delete item" in caplog.text
+
+    projTree._addTrashRoot = funcPointer
+
+    # User cancels action
+    with monkeypatch.context() as mp:
+        mp.setattr(QMessageBox, "question", lambda *a: QMessageBox.No)
+        assert projTree.moveItemToTrash(hTitlePage) is False
+        assert theProject.tree.isTrash(hTitlePage) is False
+
+    # Move a document to Trash
+    assert projTree.moveItemToTrash(hTitlePage) is True
+    assert theProject.tree.isTrash(hTitlePage) is True
+
+    # Cannot be moved again
+    caplog.clear()
+    assert projTree.moveItemToTrash(hTitlePage) is False
+    assert "Item is already in the Trash folder" in caplog.text
+
+    nwGUI.closeProject()
+
+# END Test testGuiProjTree_MoveItemToTrash
+
+
+@pytest.mark.gui
+def testGuiProjTree_PermanentlyDeleteItem(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd):
+    """Test permanently deleting items.
+    """
+    # Block message box
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
+
+    theProject = nwGUI.theProject
+    projTree = nwGUI.projView.projTree
+
+    # Create a project
+    prjDir = os.path.join(fncDir, "project")
+    buildTestProject(nwGUI, prjDir)
+
+    hInvalid    = "0000000000000"
+    hNovelRoot  = "0000000000008"
+    hPlotRoot   = "0000000000009"
+    hTitlePage  = "000000000000c"
+    hChapterDir = "000000000000d"
+    hChapterDoc = "000000000000e"
+    hSceneDoc   = "000000000000f"
+
+    # Invalid item
+    caplog.clear()
+    assert projTree.permanentlyDeleteItem(hInvalid) is False
+    assert "Could not find tree item for deletion" in caplog.text
+
+    # Not deleting root item in use
+    caplog.clear()
+    assert projTree.permanentlyDeleteItem(hNovelRoot) is False
+    assert "Root folders can only be deleted when they are empty" in caplog.text
+    assert hNovelRoot in theProject.tree
+
+    # Deleting unused root item is allowed
+    caplog.clear()
+    assert projTree.permanentlyDeleteItem(hPlotRoot) is True
+    assert hPlotRoot not in theProject.tree
+
+    # User cancels action
+    with monkeypatch.context() as mp:
+        mp.setattr(QMessageBox, "question", lambda *a: QMessageBox.No)
+        assert projTree.permanentlyDeleteItem(hTitlePage) is False
+        assert hTitlePage in theProject.tree
+
+    # Deleting file is OK, and if it is open, it should close
+    assert nwGUI.openDocument(hTitlePage) is True
+    assert nwGUI.docEditor.docHandle() == hTitlePage
+    assert projTree.permanentlyDeleteItem(hTitlePage) is True
+    assert hTitlePage not in theProject.tree
+    assert nwGUI.docEditor.docHandle() is None
+
+    # Deleting folder + files recursiely is ok
+    assert projTree.permanentlyDeleteItem(hChapterDir) is True
+    assert hChapterDir not in theProject.tree
+    assert hChapterDoc not in theProject.tree
+    assert hSceneDoc not in theProject.tree
+
+    nwGUI.closeProject()
+
+# END Test testGuiProjTree_PermanentlyDeleteItem
+
+
+@pytest.mark.gui
+def testGuiProjTree_EmptyTrash(qtbot, caplog, monkeypatch, nwGUI, fncDir, mockRnd):
+    """Test emptying Trash.
+    """
+    # Block message box
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
+
+    theProject = nwGUI.theProject
+    projTree = nwGUI.projView.projTree
+
+    # No project open
+    caplog.clear()
+    assert projTree.emptyTrash() is False
+    assert "No project open" in caplog.text
+
+    # Create a project
+    prjDir = os.path.join(fncDir, "project")
+    buildTestProject(nwGUI, prjDir)
+
+    hTitlePage  = "000000000000c"
+    hChapterDir = "000000000000d"
+    hChapterDoc = "000000000000e"
+    hSceneDoc   = "000000000000f"
+
+    # No Trash folder
+    assert projTree.emptyTrash() is False
+
+    # Move some documents to Trash
+    assert projTree.moveItemToTrash(hTitlePage) is True
+    assert projTree.moveItemToTrash(hChapterDir) is True
+
+    assert theProject.tree.isTrash(hTitlePage) is True
+    assert theProject.tree.isTrash(hChapterDir) is True
+    assert theProject.tree.isTrash(hChapterDoc) is True
+    assert theProject.tree.isTrash(hSceneDoc) is True
+
+    # User cancels
+    with monkeypatch.context() as mp:
+        mp.setattr(QMessageBox, "question", lambda *a: QMessageBox.No)
+        assert projTree.emptyTrash() is False
+        assert hTitlePage in theProject.tree
+        assert hChapterDir in theProject.tree
+        assert hChapterDoc in theProject.tree
+        assert hSceneDoc in theProject.tree
+
+    # Run again to empty all items
+    assert projTree.emptyTrash() is True
+    assert hTitlePage not in theProject.tree
+    assert hChapterDir not in theProject.tree
+    assert hChapterDoc not in theProject.tree
+    assert hSceneDoc not in theProject.tree
+
+    # Running Emtpy Trash again is cancelled due to empty folder
+    assert projTree.emptyTrash() is False
+
+    nwGUI.closeProject()
+
+# END Test testGuiProjTree_EmptyTrash
 
 
 @pytest.mark.gui

--- a/tests/test_gui/test_gui_statusbar.py
+++ b/tests/test_gui/test_gui_statusbar.py
@@ -22,7 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import time
 import pytest
 
-from tools import buildTestProject
+from tools import C, buildTestProject
 
 from PyQt5.QtWidgets import QMessageBox
 
@@ -37,7 +37,7 @@ def testGuiStatusBar_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
     monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
 
     buildTestProject(nwGUI, fncProj)
-    cHandle = nwGUI.theProject.newFile("A Note", "000000000000a")
+    cHandle = nwGUI.theProject.newFile("A Note", C.hCharRoot)
     newDoc = NWDoc(nwGUI.theProject, cHandle)
     newDoc.writeDocument("# A Note\n\n")
     nwGUI.projView.revealNewTreeItem(cHandle)

--- a/tests/test_tools/test_tools_lipsum.py
+++ b/tests/test_tools/test_tools_lipsum.py
@@ -21,7 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 
-from tools import getGuiItem, buildTestProject
+from tools import C, getGuiItem, buildTestProject
 
 from PyQt5.QtWidgets import QAction, QMessageBox
 
@@ -41,7 +41,7 @@ def testToolLipsum_Main(qtbot, monkeypatch, nwGUI, fncProj, mockRnd):
 
     # Create a new project
     buildTestProject(nwGUI, fncProj)
-    assert nwGUI.openDocument("000000000000f") is True
+    assert nwGUI.openDocument(C.hSceneDoc) is True
     assert len(nwGUI.docEditor.getText()) == 15
 
     # Open the tool

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -28,6 +28,22 @@ from PyQt5.QtWidgets import qApp
 XML_IGNORE = ("<novelWriterXML", "<saveCount", "<autoCount", "<editTime")
 
 
+class C:
+
+    # Handles from test project when random generator is mocked
+    hInvalid    = "0000000000000"
+    hNovelRoot  = "0000000000008"
+    hPlotRoot   = "0000000000009"
+    hCharRoot   = "000000000000a"
+    hWorldRoot  = "000000000000b"
+    hTitlePage  = "000000000000c"
+    hChapterDir = "000000000000d"
+    hChapterDoc = "000000000000e"
+    hSceneDoc   = "000000000000f"
+
+# END Class C
+
+
 def cmpFiles(fileOne, fileTwo, ignoreLines=None, ignoreStart=None):
     """Compare two files, but optionally ignore lines given by a list.
     """


### PR DESCRIPTION
**Summary:**

This PR completely rewrites the document merge tool. The new implementation uses a simple merge settings dialog, where the choices are made, and the merging itself is handled in the Project Tree class using a `DocMerger` tool in the core sub package. All methods are now accessed via the Project Tree context menu.

This PR also splits up the Project Tree `deleteItem` method into a `moveItemToTrassh` and a `permanentlyDeleteItem` method, with a `requestDeleteItem` function to interact with the main menu. The reason for this being that the old method assumed that a request to delete an item already in the Trash folder meant that it was to be permanently deleted. This meant that calling the method programmatically (as is done by the merge tool) could cause an item to be permanently deleted if it was called twice in a loop. Since certain parts of the delete method is recursive, this was quite possible. Splitting them up means that calling `moveItemToTrassh` will never do anything other than move an item to Trash. This is much safer.

**Related Issue(s):**

Partial of #1072 and #1032

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
