### PR TITLE
Add Shift+Enter to auto-replace

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1992,6 +1992,11 @@ class GuiDocEditor(QTextEdit):
             nDelete = 3
             tInsert = nwUnicode.U_HELLIP
 
+        elif theOne == nwUnicode.U_LSEP:
+            # This resolves issue #1150
+            nDelete = 1
+            tInsert = nwUnicode.U_PSEP
+
         tCheck = tInsert
         if self.mainConf.fmtPadBefore and tCheck in self.mainConf.fmtPadBefore:
             if self._allowSpaceBeforeColon(theText, tCheck):

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.7-beta1" hexVersion="0x010700b1" fileVersion="1.4" timeStamp="2022-07-31 18:38:08">
+<novelWriterXML appVersion="2.0-beta1" hexVersion="0x020000b1" fileVersion="1.4" timeStamp="2022-10-11 22:07:39">
   <project>
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
     <author>Jay Doh</author>
-    <saveCount>1378</saveCount>
+    <saveCount>1380</saveCount>
     <autoCount>236</autoCount>
-    <editTime>69273</editTime>
+    <editTime>69335</editTime>
   </project>
   <settings>
     <doBackup>False</doBackup>
@@ -71,7 +71,7 @@
       <name status="sf24ce6" import="ia857f0" exported="True">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="False" charCount="2687" wordCount="479" paraCount="14" cursorPos="2183"/>
+      <meta expanded="False" charCount="2687" wordCount="479" paraCount="14" cursorPos="67"/>
       <name status="s90e6c9" import="ia857f0" exported="True">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">

--- a/tests/reference/guiEditor_Main_Final_000000000000f.nwd
+++ b/tests/reference/guiEditor_Main_Final_000000000000f.nwd
@@ -21,6 +21,9 @@
 
 This is a paragraph of nonsense text.
 
+This is another paragraph
+with a line separator in it.
+
 This is another paragraph of much longer nonsense text. It is in fact 1 very very NONSENSICAL nonsense text! We can also try replacing “quotes”, even single ‘quotes’ are replaced. Isn’t that nice? We can hyphen-ate, make dashes – and even longer dashes — if we want. Ellipsis? Not a problem either … How about three hyphens — for long dash? It works too.
 
 “Full line double quoted text.”

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="1.7-beta1" hexVersion="0x010700b1" fileVersion="1.4" timeStamp="2022-10-01 22:33:13">
+<novelWriterXML appVersion="2.0-beta1" hexVersion="0x020000b1" fileVersion="1.4" timeStamp="2022-10-11 22:21:42">
   <project>
     <name>New Project</name>
     <title>New Novel</title>
     <author>Jane Doe</author>
     <saveCount>4</saveCount>
     <autoCount>2</autoCount>
-    <editTime>4</editTime>
+    <editTime>5</editTime>
   </project>
   <settings>
     <doBackup>True</doBackup>
@@ -17,8 +17,8 @@
     <lastViewed>None</lastViewed>
     <lastNovel>0000000000008</lastNovel>
     <lastOutline>0000000000008</lastOutline>
-    <lastWordCount>153</lastWordCount>
-    <novelWordCount>126</novelWordCount>
+    <lastWordCount>163</lastWordCount>
+    <novelWordCount>136</novelWordCount>
     <notesWordCount>27</notesWordCount>
     <autoReplace/>
     <titleFormat>
@@ -59,7 +59,7 @@
       <name status="s000000" import="i000004" exported="True">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="False" charCount="728" wordCount="119" paraCount="13" cursorPos="954"/>
+      <meta expanded="False" charCount="781" wordCount="129" paraCount="14" cursorPos="1010"/>
       <name status="s000000" import="i000004" exported="True">New Scene</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="1" type="ROOT" class="PLOT">

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -22,8 +22,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import os
 import pytest
 
-from shutil import copyfile
 from tools import C, cmpFiles, buildTestProject, XML_IGNORE, writeFile
+from shutil import copyfile
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMessageBox, QInputDialog
@@ -31,8 +31,8 @@ from PyQt5.QtWidgets import QMessageBox, QInputDialog
 from novelwriter.gui import GuiDocEditor, GuiNovelView, GuiOutlineView
 from novelwriter.enum import nwItemType, nwView, nwWidget
 from novelwriter.tools import GuiProjectWizard
-from novelwriter.gui.projtree import GuiProjectTree
 from novelwriter.dialogs import GuiEditLabel
+from novelwriter.gui.projtree import GuiProjectTree
 
 keyDelay = 2
 typeDelay = 1
@@ -195,8 +195,6 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     copyfile(projFile, testFile)
     assert cmpFiles(testFile, compFile, ignoreStart=XML_IGNORE)
     qtbot.wait(stepDelay)
-
-    # qtbot.stopForInteraction()
 
     # Re-open project
     assert nwGUI.openProject(fncProj)
@@ -372,6 +370,15 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
     qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
 
+    # Don't allow Shift+Enter to insert a line separator (issue #1150)
+    for c in "This is another paragraph":
+        qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
+    qtbot.keyClick(nwGUI.docEditor, Qt.Key_Enter, modifier=Qt.ShiftModifier, delay=typeDelay)
+    for c in "with a line separator in it.":
+        qtbot.keyClick(nwGUI.docEditor, c, delay=typeDelay)
+    qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
+    qtbot.keyClick(nwGUI.docEditor, Qt.Key_Return, delay=keyDelay)
+
     # Auto-Replace
     # ============
 
@@ -540,7 +547,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, fncProj, refDir, outDir, mock
     copyfile(projFile, testFile)
     assert cmpFiles(testFile, compFile)
 
-    # qtbot.stopForInteraction()
+    # qtbot.stop()
 
 # END Test testGuiMain_Editing
 


### PR DESCRIPTION
**Summary:**

Add the unicode line separator (u2028) to the auto-replace function of the editor, and convert it to a paragraph separator (u2029).

**Related Issue(s):**

Resolves #1150

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
