### PR TITLE
Fix missing data path issue when creating themes folders

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -35,7 +35,7 @@ from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import qApp
 
 from novelwriter.enum import nwItemClass, nwItemType, nwItemLayout
-from novelwriter.error import logException
+from novelwriter.error import formatException, logException
 from novelwriter.constants import nwConst, nwUnicode
 
 logger = logging.getLogger(__name__)
@@ -473,6 +473,25 @@ def makeFileNameSafe(value):
         if c.isalpha() or c.isdigit() or c == " ":
             cleanName += c
     return cleanName
+
+
+def ensureFolder(dirPath, parentPath=None, errLog=None):
+    """Make sure a folder exists, and if it doesn't, create it.
+    """
+    try:
+        if parentPath:
+            dirPath = os.path.join(parentPath, dirPath)
+        if not os.path.isdir(dirPath):
+            os.mkdir(dirPath)
+    except Exception as exc:
+        logger.error("Could not create folder: %s", dirPath)
+        logException()
+        if isinstance(errLog, list):
+            errLog.append(f"Could not create folder: {dirPath}")
+            errLog.append(formatException(exc))
+        return False
+
+    return True
 
 
 def sha256sum(filePath):

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -120,10 +120,12 @@ class GuiTheme:
         self._availThemes = {}
         self._availSyntax = {}
 
-        self._listConf(self._availSyntax, os.path.join(self.mainConf.dataPath, "syntax"))
         self._listConf(self._availSyntax, os.path.join(self.mainConf.assetPath, "syntax"))
-        self._listConf(self._availThemes, os.path.join(self.mainConf.dataPath, "themes"))
         self._listConf(self._availThemes, os.path.join(self.mainConf.assetPath, "themes"))
+
+        if self.mainConf.dataPath:  # Not guaranteed to be set
+            self._listConf(self._availSyntax, os.path.join(self.mainConf.dataPath, "syntax"))
+            self._listConf(self._availThemes, os.path.join(self.mainConf.dataPath, "themes"))
 
         self.updateFont()
         self.updateTheme()

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -33,7 +33,8 @@ from novelwriter.common import (
     isTitleTag, isItemClass, isItemType, isItemLayout, hexToInt, checkIntRange,
     minmax, checkIntTuple, formatInt, formatTimeStamp, formatTime, simplified,
     splitVersionNumber, transferCase, fuzzyTime, numberToRoman, jsonEncode,
-    readTextFile, makeFileNameSafe, sha256sum, getGuiItem, NWConfigParser
+    readTextFile, makeFileNameSafe, ensureFolder, sha256sum, getGuiItem,
+    NWConfigParser
 )
 
 
@@ -539,6 +540,32 @@ def testBaseCommon_MakeFileNameSafe():
     assert makeFileNameSafe("aaaa bbbb") == "aaaa bbbb"
 
 # END Test testBaseCommon_MakeFileNameSafe
+
+
+@pytest.mark.base
+def testBaseCommon_EnsureFolder(monkeypatch, fncDir):
+    """Test the ensureFolder function.
+    """
+    newDir1 = os.path.join(fncDir, "newDir1")
+    newDir2 = os.path.join(fncDir, "newDir2")
+    newDir3 = os.path.join(fncDir, "newDir3")
+
+    assert ensureFolder(None) is False
+
+    assert ensureFolder(newDir1) is True
+    assert os.path.isdir(newDir1)
+
+    assert ensureFolder("newDir2", parentPath=fncDir) is True
+    assert os.path.isdir(newDir2)
+
+    with monkeypatch.context() as mp:
+        mp.setattr("os.mkdir", causeOSError)
+        errLog = []
+        assert ensureFolder("newDir3", parentPath=fncDir, errLog=errLog) is False
+        assert errLog[0] == f"Could not create folder: {newDir3}"
+        assert not os.path.isdir(newDir3)
+
+# END Test testBaseCommon_EnsureFolder
 
 
 @pytest.mark.base

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -317,38 +317,6 @@ def testBaseConfig_RecentCache(monkeypatch, tmpConf, tmpDir, fncDir):
 
 
 @pytest.mark.base
-def testBaseConfig_SetPath(tmpConf, tmpDir):
-    """Test path setters.
-    """
-    # Conf Path
-    assert tmpConf.setConfPath(None)
-    assert not tmpConf.setConfPath(os.path.join("somewhere", "over", "the", "rainbow"))
-    assert tmpConf.setConfPath(os.path.join(tmpDir, "novelwriter.conf"))
-    assert tmpConf.confPath == tmpDir
-    assert tmpConf.confFile == "novelwriter.conf"
-    assert not tmpConf.confChanged
-
-    # Data Path
-    assert tmpConf.setDataPath(None)
-    assert not tmpConf.setDataPath(os.path.join("somewhere", "over", "the", "rainbow"))
-    assert tmpConf.setDataPath(tmpDir)
-    assert tmpConf.dataPath == tmpDir
-    assert not tmpConf.confChanged
-
-    # Last Path
-    assert tmpConf.setLastPath(None)
-    assert tmpConf.lastPath == ""
-
-    assert tmpConf.setLastPath(os.path.join(tmpDir, "file.tmp"))
-    assert tmpConf.lastPath == tmpDir
-
-    assert tmpConf.setLastPath("")
-    assert tmpConf.lastPath == ""
-
-# END Test testBaseConfig_SetPath
-
-
-@pytest.mark.base
 def testBaseConfig_SettersGetters(tmpConf, tmpDir, outDir, refDir):
     """Set various sizes and positions
     """


### PR DESCRIPTION
**Summary:**

The folder for custom GUI and syntax themes were attempted created before the data folder for novelWriter was created. This printed four error messages the first tome novelWriter was run on a new system. The problem resolved itself on the second run.

The error was handled, and the folders in question are read-only, so the error was trivial.

In the same PR, the functions to set dataPath and confPath in the main config object have been removed. They are not in use, neither by the app nor the test suite. A new common function to both check for and create folders at the same time, has been added. This is useful also elsewhere in the code.

**Related Issue(s):**

Resolves #1180

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
