### PR TITLE
Update wizard custom page functionality

### DIFF
--- a/novelwriter/tools/projwizard.py
+++ b/novelwriter/tools/projwizard.py
@@ -334,13 +334,18 @@ class ProjWizardCustomPage(QWizardPage):
 
         # Root Folders
         self.addPlot = QSwitch()
-        self.addChar = QSwitch()
-        self.addWorld = QSwitch()
-        self.addNotes = QSwitch()
-
         self.addPlot.setChecked(True)
+        self.addPlot.clicked.connect(self._syncSwitches)
+
+        self.addChar = QSwitch()
         self.addChar.setChecked(True)
+        self.addChar.clicked.connect(self._syncSwitches)
+
+        self.addWorld = QSwitch()
         self.addWorld.setChecked(False)
+        self.addWorld.clicked.connect(self._syncSwitches)
+
+        self.addNotes = QSwitch()
         self.addNotes.setChecked(False)
 
         # Generate Content
@@ -389,6 +394,20 @@ class ProjWizardCustomPage(QWizardPage):
         self.outerBox.addStretch(1)
         self.setLayout(self.outerBox)
 
+        return
+
+    ##
+    #  Internal Functions
+    ##
+
+    def _syncSwitches(self):
+        """Check if the add notes option should also be switched off.
+        """
+        addPlot = self.addPlot.isChecked()
+        addChar = self.addChar.isChecked()
+        addWorld = self.addWorld.isChecked()
+        if not (addPlot or addChar or addWorld):
+            self.addNotes.setChecked(False)
         return
 
 # END Class ProjWizardCustomPage

--- a/tests/test_tools/test_tools_projwizard.py
+++ b/tests/test_tools/test_tools_projwizard.py
@@ -202,6 +202,14 @@ def testToolProjectWizard_Run(qtbot, monkeypatch, nwGUI, fncDir, prjType):
         assert isinstance(customPage, ProjWizardCustomPage)
         assert nwWiz.button(QWizard.NextButton).isEnabled()
 
+        # Make sure the fourth option is also turned off
+        customPage.addPlot.setChecked(False)
+        customPage.addChar.setChecked(False)
+        customPage.addWorld.setChecked(False)
+        customPage._syncSwitches()
+        assert not customPage.addNotes.isChecked()
+
+        # Switch everything back on again
         customPage.addPlot.setChecked(True)
         customPage.addChar.setChecked(True)
         customPage.addWorld.setChecked(True)


### PR DESCRIPTION
**Summary:**

This PR adds a check that if all note folder switches are turned off on the custom options page of the New Project Wizard, the add notes switch is also turned off.

**Related Issue(s):**

Resolves #1192

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
