### PR TITLE
Allow moving split document to trash

### DIFF
--- a/novelwriter/core/doctools.py
+++ b/novelwriter/core/doctools.py
@@ -192,7 +192,7 @@ class DocSplitter:
         """An iterator that will write each document in the buffer, and
         return its new handle, parent handle, and sibling handle.
         """
-        if self._srcHandle is None:
+        if self._srcHandle is None or self._srcItem is None:
             return
 
         pHandle = self._parHandle
@@ -223,6 +223,10 @@ class DocSplitter:
 
             dHandle = self.theProject.newFile(docLabel, pHandle)
             hHandle[hLevel] = dHandle
+
+            newItem = self.theProject.tree[dHandle]
+            newItem.setStatus(self._srcItem.itemStatus)
+            newItem.setImport(self._srcItem.itemImport)
 
             outDoc = NWDoc(self.theProject, dHandle)
             status = outDoc.writeDocument("\n".join(docText))

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -103,14 +103,19 @@ class GuiDocSplit(QDialog):
         self.hierarchySwitch = QSwitch(width=2*iPx, height=iPx)
         self.hierarchySwitch.setChecked(docHierarchy)
 
+        self.trashLabel = QLabel(self.tr("Move split document to Trash"))
+        self.trashSwitch = QSwitch(width=2*iPx, height=iPx)
+
         self.optBox = QGridLayout()
         self.optBox.addWidget(self.folderLabel,  0, 0)
         self.optBox.addWidget(self.folderSwitch, 0, 1)
         self.optBox.addWidget(self.hierarchyLabel,  1, 0)
         self.optBox.addWidget(self.hierarchySwitch, 1, 1)
+        self.optBox.addWidget(self.trashLabel,  2, 0)
+        self.optBox.addWidget(self.trashSwitch, 2, 1)
         self.optBox.setVerticalSpacing(vSp)
         self.optBox.setHorizontalSpacing(hSp)
-        self.optBox.setColumnStretch(2, 1)
+        self.optBox.setColumnStretch(3, 1)
 
         # Buttons
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -155,11 +160,13 @@ class GuiDocSplit(QDialog):
         spLevel = self.splitLevel.currentData()
         intoFolder = self.folderSwitch.isChecked()
         docHierarchy = self.hierarchySwitch.isChecked()
+        moveToTrash = self.trashSwitch.isChecked()
 
         self._data["spLevel"] = spLevel
         self._data["headerList"] = headerList
         self._data["intoFolder"] = intoFolder
         self._data["docHierarchy"] = docHierarchy
+        self._data["moveToTrash"] = moveToTrash
 
         pOptions = self.theProject.options
         pOptions.setValue("GuiDocSplit", "spLevel", spLevel)

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -254,6 +254,8 @@ class GuiOutlineToolBar(QToolBar):
         self.addWidget(self.tbColumns)
         self.addWidget(stretch)
 
+        self.updateTheme()
+
         logger.debug("GuiOutlineToolBar initialisation complete")
 
         return

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1612,6 +1612,9 @@ class GuiProjectTree(QTreeWidget):
                         self.tr("Could not write document content."), docSplit.getError()
                     ], nwAlert.ERROR)
 
+            if splitData.get("moveToTrash", False):
+                self.moveItemToTrash(tHandle, askFirst=False, flush=True)
+
             self.saveTreeOrder()
 
         else:

--- a/tests/test_core/test_core_doctools.py
+++ b/tests/test_core/test_core_doctools.py
@@ -162,6 +162,8 @@ def testCoreDocTools_DocSplitter(monkeypatch, mockGUI, fncDir, outDir, refDir, m
     docText = "\n\n".join(docData)
     docRaw = docText.splitlines()
     assert NWDoc(theProject, hSplitDoc).writeDocument(docText) is True
+    theProject.tree[hSplitDoc].setStatus(C.sFinished)
+    theProject.tree[hSplitDoc].setImport(C.iMain)
 
     docSplitter = DocSplitter(theProject, hSplitDoc)
     assert docSplitter._srcItem.isFileType()
@@ -241,6 +243,11 @@ def testCoreDocTools_DocSplitter(monkeypatch, mockGUI, fncDir, outDir, refDir, m
         "000000000002d",  # Scene Four is after Scene Three
         "000000000002e",  # Scene Five is after Scene Four
     ]
+
+    # Check that status and importance has been preserved
+    for rHandle in resDocHandle:
+        assert theProject.tree[rHandle].itemStatus == C.sFinished
+        assert theProject.tree[rHandle].itemImport == C.iMain
 
     # Check handling of improper initialisation
     docSplitter = DocSplitter(theProject, C.hInvalid)

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -837,13 +837,16 @@ def testGuiProjTree_SplitDocument(qtbot, monkeypatch, nwGUI, fncDir, mockRnd, ip
         assert tHandle in theProject.tree
         assert os.path.isfile(os.path.join(prjDir, "content", f"{tHandle}.nwd"))
 
-    # Add to a folder
+    # Add to a folder and move source to trash
     splitData["intoFolder"] = True
+    splitData["moveToTrash"] = True
     assert projTree._splitDocument(hSplitDoc) is True
     assert "0000000000029" in theProject.tree  # The folder
     for tHandle in trdSet:
         assert tHandle in theProject.tree
         assert os.path.isfile(os.path.join(prjDir, "content", f"{tHandle}.nwd"))
+
+    assert theProject.tree.isTrash(hSplitDoc) is True
 
     # Cancelled by user
     with monkeypatch.context() as mp:


### PR DESCRIPTION
**Summary:**

This PR adds the move to trash option also for the Split Document dialog,

In addition, the PR fixes the following issues:
* Icons not being initially loaded in the Outline view
* Item importance and status not being preserved when documents are split.

**Related Issue(s):**

Resolves #1179

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
