### PR TITLE
Add version and build info to AppImage build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -906,7 +906,6 @@ def makeForLaunchpad(doSign=False, isFirst=False, isSnapshot=False):
 def makeAppImage(sysArgs):
     """Build an Appimage
     """
-
     import glob
     import argparse
     import platform
@@ -1089,8 +1088,9 @@ def makeAppImage(sysArgs):
     shutil.copyfile("setup/icons/novelwriter.svg", f"{imageDir}/novelwriter.svg")
     print("Copied: setup/icons/novelwriter.svg")
 
-    shutil.copyfile("setup/data/hicolor/256x256/apps/novelwriter.png",
-                    f"{imageDir}/novelwriter.png")
+    shutil.copyfile(
+        "setup/data/hicolor/256x256/apps/novelwriter.png", f"{imageDir}/novelwriter.png"
+    )
     print("Copied: setup/data/hicolor/256x256/apps/novelwriter.png")
 
     # Build Appimage
@@ -1111,7 +1111,9 @@ def makeAppImage(sysArgs):
         print("")
         sys.exit(1)
 
-    outFile = glob.glob(f"{bldDir}/*.AppImage")[0]
+    bldFile = glob.glob(f"{bldDir}/*.AppImage")[0]
+    outFile = f"{bldDir}/novelWriter-{pkgVers}-py{pythonVer}-{linuxTag}.AppImage"
+    os.rename(bldFile, outFile)
     shaFile = makeCheckSum(os.path.basename(outFile), cwd=bldDir)
 
     toUpload(outFile)
@@ -1119,10 +1121,10 @@ def makeAppImage(sysArgs):
 
     return unparsedArgs
 
+
 ##
 #  Make Windows Setup EXE (build-win-exe)
 ##
-
 
 def makeWindowsEmbedded(sysArgs):
     """Set up a package with embedded Python and dependencies for


### PR DESCRIPTION
**Summary:**

The file name of the AppImage build now contains the version number, the Python version, and info about the build image.

**Related Issue(s):**

Resolves #1182

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
