### PR TITLE
Auto-open first document

### DIFF
--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -220,9 +220,6 @@ class GuiItemDetails(QWidget):
     def updateTheme(self):
         """Update theme elements.
         """
-        iPx = self.mainTheme.baseIconSize
-        self._expCheck = self.mainTheme.getPixmap("check", (iPx, iPx))
-        self._expCross = self.mainTheme.getPixmap("cross", (iPx, iPx))
         self.updateViewBox(self._itemHandle)
         return
 
@@ -255,11 +252,11 @@ class GuiItemDetails(QWidget):
 
         if nwItem.isFileType():
             if nwItem.isActive:
-                self.labelIcon.setPixmap(self._expCheck)
+                self.labelIcon.setPixmap(self.mainTheme.getPixmap("checked", (iPx, iPx)))
             else:
-                self.labelIcon.setPixmap(self._expCross)
+                self.labelIcon.setPixmap(self.mainTheme.getPixmap("unchecked", (iPx, iPx)))
         else:
-            self.labelIcon.setPixmap(QPixmap(1, 1))
+            self.labelIcon.setPixmap(self.mainTheme.getPixmap("noncheckable", (iPx, iPx)))
 
         self.labelData.setText(theLabel)
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -534,7 +534,14 @@ class GuiMain(QMainWindow):
         self._updateStatusWordCount()
 
         # Restore previously open documents, if any
+        # If none was recorded, open the first document found
         lastEdited = self.theProject.data.getLastHandle("editor")
+        if lastEdited is None:
+            for nwItem in self.theProject.tree:
+                if nwItem and nwItem.isFileType():
+                    lastEdited = nwItem.itemHandle
+                    break
+
         if lastEdited is not None:
             self.openDocument(lastEdited, doScroll=True)
 


### PR DESCRIPTION
**Summary:**

If no last document was recorded, or the project is new, open the first available document if any exist.

This PR also fixes the active/inactive icon in the item details panel.

**Related Issue(s):**

Resolves #1219

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
