### PR TITLE
Block toolbars when there is no project

### DIFF
--- a/novelwriter/dialogs/projload.py
+++ b/novelwriter/dialogs/projload.py
@@ -77,7 +77,6 @@ class GuiProjectLoad(QDialog):
         self.setWindowTitle(self.tr("Open Project"))
         self.setMinimumWidth(self.mainConf.pxInt(650))
         self.setMinimumHeight(self.mainConf.pxInt(400))
-        self.setModal(True)
 
         self.nwIcon = QLabel()
         self.nwIcon.setPixmap(self.mainGui.mainTheme.getPixmap("novelwriter", (nPx, nPx)))

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -69,8 +69,9 @@ class GuiNovelView(QWidget):
         self.theProject = mainGui.theProject
 
         # Build GUI
-        self.novelBar = GuiNovelToolBar(self)
         self.novelTree = GuiNovelTree(self)
+        self.novelBar = GuiNovelToolBar(self)
+        self.novelBar.setEnabled(False)
 
         # Assemble
         self.outerBox = QVBoxLayout()
@@ -117,6 +118,7 @@ class GuiNovelView(QWidget):
         """
         self.novelTree.clearContent()
         self.novelBar.clearContent()
+        self.novelBar.setEnabled(False)
         return
 
     def openProjectTasks(self):
@@ -136,6 +138,7 @@ class GuiNovelView(QWidget):
         self.novelBar.buildNovelRootMenu()
         self.novelBar.setLastColType(lastCol, doRefresh=False)
         self.novelBar.setCurrentRoot(lastNovel)
+        self.novelBar.setEnabled(True)
 
         return
 

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -64,9 +64,10 @@ class GuiOutlineView(QWidget):
         self.theProject = mainGui.theProject
 
         # Build GUI
-        self.outlineBar  = GuiOutlineToolBar(self)
         self.outlineTree = GuiOutlineTree(self)
         self.outlineData = GuiOutlineDetails(self)
+        self.outlineBar = GuiOutlineToolBar(self)
+        self.outlineBar.setEnabled(False)
 
         self.splitOutline = QSplitter(Qt.Vertical)
         self.splitOutline.addWidget(self.outlineTree)
@@ -121,6 +122,7 @@ class GuiOutlineView(QWidget):
         """Clear project-related GUI content.
         """
         self.outlineData.clearDetails()
+        self.outlineBar.setEnabled(False)
         return
 
     def openProjectTasks(self):
@@ -135,6 +137,7 @@ class GuiOutlineView(QWidget):
         self.clearProject()
         self.outlineBar.populateNovelList()
         self.outlineBar.setCurrentRoot(lastOutline)
+        self.outlineBar.setEnabled(True)
 
         return
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -73,6 +73,7 @@ class GuiProjectView(QWidget):
         # Build GUI
         self.projTree = GuiProjectTree(self)
         self.projBar = GuiProjectToolBar(self)
+        self.projBar.setEnabled(False)
 
         # Assemble
         self.outerBox = QVBoxLayout()
@@ -136,6 +137,7 @@ class GuiProjectView(QWidget):
         """Clear project-related GUI content.
         """
         self.projBar.clearContent()
+        self.projBar.setEnabled(False)
         self.projTree.clearTree()
         return
 
@@ -143,6 +145,7 @@ class GuiProjectView(QWidget):
         """Run open project tasks.
         """
         self.projBar.buildQuickLinkMenu()
+        self.projBar.setEnabled(True)
         return
 
     def saveProjectTasks(self):

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -872,6 +872,7 @@ class GuiMain(QMainWindow):
         """
         dlgProj = GuiProjectLoad(self)
         dlgProj.exec_()
+
         if dlgProj.result() == QDialog.Accepted:
             if dlgProj.openState == GuiProjectLoad.OPEN_STATE:
                 self.openProject(dlgProj.openPath)


### PR DESCRIPTION
**Summary:**

Block the toolbars when there are no projects open.

**Related Issue(s):**

Resolves #1220

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
