### PR TITLE
Novel view meta

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -154,11 +154,11 @@ def isHandle(value):
 
 
 def isTitleTag(value):
-    """Check if a string is a valid title string.
+    """Check if a string is a valid title tag string.
     """
     if not isinstance(value, str):
         return False
-    if len(value) != 7:
+    if len(value) != 5:
         return False
     if not value.startswith("T"):
         return False

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -61,7 +61,6 @@ class nwHeaders:
 
     H_VALID = ("H0", "H1", "H2", "H3", "H4")
     H_LEVEL = {"H0": 0, "H1": 1, "H2": 2, "H3": 3, "H4": 4}
-    TT_NONE = "T000000"
 
 # END Class nwHeaders
 

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -520,14 +520,6 @@ class NWIndex:
             hCount[iLevel] += 1
         return hCount
 
-    def getHandleWordCounts(self, tHandle):
-        """Get all header word counts for a specific handle.
-        """
-        return [
-            (f"{tHandle}:{sTitle}", hItem.wordCount)
-            for sTitle, hItem in self._itemIndex.iterItemHeaders(tHandle)
-        ]
-
     def getHandleHeaderCount(self, tHandle):
         """Get the number of headers in an item.
         """

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -528,13 +528,13 @@ class NWIndex:
             for sTitle, hItem in self._itemIndex.iterItemHeaders(tHandle)
         ]
 
-    def getHandleHeaders(self, tHandle):
-        """Get all headers for a specific handle.
+    def getHandleHeaderCount(self, tHandle):
+        """Get the number of headers in an item.
         """
-        return [
-            (sTitle, hItem.level, hItem.title)
-            for sTitle, hItem in self._itemIndex.iterItemHeaders(tHandle)
-        ]
+        tItem = self._itemIndex[tHandle]
+        if isinstance(tItem, IndexItem):
+            return len(tItem)
+        return 0
 
     def getTableOfContents(self, rootHandle, maxDepth, skipExcl=True):
         """Generate a table of contents up to a maximum depth.
@@ -645,6 +645,16 @@ class TagsIndex:
         self._tags = {}
         return
 
+    def __contains__(self, tagKey):
+        return tagKey in self._tags
+
+    def __delitem__(self, tagKey):
+        self._tags.pop(tagKey, None)
+        return
+
+    def __getitem__(self, tagKey):
+        return self._tags.get(tagKey, None)
+
     ##
     #  Methods
     ##
@@ -654,22 +664,6 @@ class TagsIndex:
         """
         self._tags = {}
         return
-
-    def __contains__(self, tagKey):
-        """Check if a tag exists in the index,
-        """
-        return tagKey in self._tags
-
-    def __delitem__(self, tagKey):
-        """Delete an entry in the index.
-        """
-        self._tags.pop(tagKey, None)
-        return
-
-    def __getitem__(self, tagKey):
-        """Return a tag, or return None if it isn't found.
-        """
-        return self._tags.get(tagKey, None)
 
     def add(self, tagKey, tHandle, sTitle, itemClass):
         """Add a key to the index and set all values.
@@ -753,6 +747,16 @@ class ItemIndex:
         self._items = {}
         return
 
+    def __contains__(self, tHandle):
+        return tHandle in self._items
+
+    def __delitem__(self, tHandle):
+        self._items.pop(tHandle, None)
+        return
+
+    def __getitem__(self, tHandle):
+        return self._items.get(tHandle, None)
+
     ##
     #  Methods
     ##
@@ -762,22 +766,6 @@ class ItemIndex:
         """
         self._items = {}
         return
-
-    def __contains__(self, tHandle):
-        """Check if an item exists in the index,
-        """
-        return tHandle in self._items
-
-    def __delitem__(self, tHandle):
-        """Delete an entry in the index.
-        """
-        self._items.pop(tHandle, None)
-        return
-
-    def __getitem__(self, tHandle):
-        """Return an item, or return None if it isn't found.
-        """
-        return self._items.get(tHandle, None)
 
     def add(self, tHandle, tItem):
         """Add a new item to the index. This will overwrite the item if
@@ -933,6 +921,15 @@ class IndexItem:
     def __repr__(self):
         return f"<IndexItem handle='{self._handle}'>"
 
+    def __len__(self):
+        return len(self._headings)
+
+    def __getitem__(self, sTitle):
+        return self._headings.get(sTitle, None)
+
+    def __contains__(self, sTitle):
+        return sTitle in self._headings
+
     ##
     # Properties
     ##
@@ -986,12 +983,6 @@ class IndexItem:
     ##
     #  Data Methods
     ##
-
-    def __getitem__(self, sTitle):
-        return self._headings.get(sTitle, None)
-
-    def __contains__(self, sTitle):
-        return sTitle in self._headings
 
     def items(self):
         return self._headings.items()

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -501,6 +501,11 @@ class NWIndex:
             yield f"{tHandle}:{sTitle}", tHandle, sTitle, hItem
         return
 
+    def getItemData(self, tHandle):
+        """Get the index data for a given item.
+        """
+        return self._itemIndex[tHandle]
+
     def getNovelWordCount(self, skipExcl=True):
         """Count the number of words in the novel project.
         """

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -480,16 +480,6 @@ class NWIndex:
     #  Extract Data
     ##
 
-    def novelStructure(self, rootHandle=None, skipExcl=True):
-        """Iterate over all titles in the novel, in the correct order as
-        they appear in the tree view and in the respective document
-        files, but skipping all note files.
-        """
-        novStruct = self._itemIndex.iterNovelStructure(rootHandle=rootHandle, skipExcl=skipExcl)
-        for tHandle, sTitle, hItem in novStruct:
-            yield f"{tHandle}:{sTitle}", tHandle, sTitle, hItem
-        return
-
     def getItemData(self, tHandle):
         """Get the index data for a given item.
         """
@@ -502,6 +492,16 @@ class NWIndex:
         if isinstance(tItem, IndexItem):
             return tItem[sTitle]
         return None
+
+    def novelStructure(self, rootHandle=None, skipExcl=True):
+        """Iterate over all titles in the novel, in the correct order as
+        they appear in the tree view and in the respective document
+        files, but skipping all note files.
+        """
+        novStruct = self._itemIndex.iterNovelStructure(rootHandle=rootHandle, skipExcl=skipExcl)
+        for tHandle, sTitle, hItem in novStruct:
+            yield f"{tHandle}:{sTitle}", tHandle, sTitle, hItem
+        return
 
     def getNovelWordCount(self, skipExcl=True):
         """Count the number of words in the novel project.
@@ -599,13 +599,6 @@ class NWIndex:
                             theRefs[refType].append(aTag)
 
         return theRefs
-
-    def getNovelData(self, tHandle, sTitle):
-        """Return the novel data of a given handle and title.
-        """
-        if tHandle in self._itemIndex:
-            return self._itemIndex[tHandle][sTitle]
-        return None
 
     def getBackReferenceList(self, tHandle):
         """Build a list of files referring back to our file, specified

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -51,7 +51,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter.core import NWSpellEnchant, countWords
-from novelwriter.enum import nwAlert, nwDocAction, nwDocInsert, nwDocMode
+from novelwriter.enum import nwAlert, nwDocAction, nwDocInsert, nwDocMode, nwItemClass
 from novelwriter.common import transferCase
 from novelwriter.constants import nwConst, nwFiles, nwKeyWords, nwUnicode
 from novelwriter.gui.dochighlight import GuiDocHighlighter
@@ -71,6 +71,8 @@ class GuiDocEditor(QTextEdit):
     docEditedStatusChanged = pyqtSignal(bool)
     docCountsChanged = pyqtSignal(str, int, int, int)
     loadDocumentTagRequest = pyqtSignal(str, Enum)
+    novelStructureChanged = pyqtSignal()
+    novelItemMetaChanged = pyqtSignal(str)
 
     def __init__(self, mainGui):
         super().__init__(parent=mainGui)
@@ -534,11 +536,11 @@ class GuiDocEditor(QTextEdit):
         self.theProject.index.scanText(tHandle, docText)
         newHeader = self._nwItem.mainHeading
 
-        # ToDo: This should be a signal
-        if self._updateHeaders():
-            self.mainGui.requestNovelTreeRefresh()
-        else:
-            self.mainGui.novelView.updateWordCounts(tHandle)
+        if self._nwItem.itemClass == nwItemClass.NOVEL:
+            if self._updateHeaders():
+                self.novelStructureChanged.emit()
+            else:
+                self.novelItemMetaChanged.emit(tHandle)
 
         # ToDo: This should be a signal
         if oldHeader != newHeader:

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -729,7 +729,7 @@ class GuiNovelTree(QTreeWidget):
         logger.debug("Generating meta data tooltip for '%s:%s'", tHandle, sTitle)
 
         pIndex = self.theProject.index
-        novIdx = pIndex.getNovelData(tHandle, sTitle)
+        novIdx = pIndex.getItemHeader(tHandle, sTitle)
         refTags = pIndex.getReferences(tHandle, sTitle)
 
         synopText = novIdx.synopsis

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -40,7 +40,6 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter.enum import nwDocMode, nwItemClass, nwOutline
-from novelwriter.common import checkInt
 from novelwriter.constants import nwHeaders, nwKeyWords, nwLabels, trConst
 
 logger = logging.getLogger(__name__)
@@ -60,7 +59,7 @@ class GuiNovelView(QWidget):
 
     # Signals for user interaction with the novel tree
     selectedItemChanged = pyqtSignal(str)
-    openDocumentRequest = pyqtSignal(str, Enum, int, str)
+    openDocumentRequest = pyqtSignal(str, Enum, str)
 
     def __init__(self, mainGui):
         super().__init__(parent=mainGui)
@@ -543,14 +542,11 @@ class GuiNovelTree(QTreeWidget):
         selected, return the first.
         """
         selItem = self.selectedItems()
-        tHandle = None
-        tLine = 0
         if selItem:
             tHandle = selItem[0].data(self.C_TITLE, self.D_HANDLE)
             sTitle = selItem[0].data(self.C_TITLE, self.D_TITLE)
-            tLine = checkInt(sTitle[1:], 1) - 1
-
-        return tHandle, tLine
+            return tHandle, sTitle
+        return None, None
 
     def setLastColType(self, colType, doRefresh=True):
         """Change the content type of the last column and rebuild.
@@ -609,11 +605,11 @@ class GuiNovelTree(QTreeWidget):
             if not isinstance(selItem, QTreeWidgetItem):
                 return
 
-            tHandle, _ = self.getSelectedHandle()
+            tHandle, sTitle = self.getSelectedHandle()
             if tHandle is None:
                 return
 
-            self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, -1, "")
+            self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, sTitle or "")
 
         return
 
@@ -655,8 +651,8 @@ class GuiNovelTree(QTreeWidget):
         clicked, and send it to the main gui class for opening in the
         document editor.
         """
-        tHandle, tLine = self.getSelectedHandle()
-        self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, tLine, "")
+        tHandle, sTitle = self.getSelectedHandle()
+        self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, sTitle or "")
         return
 
     ##

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -1049,7 +1049,7 @@ class GuiOutlineDetails(QScrollArea):
         """
         pIndex = self.theProject.index
         nwItem = self.theProject.tree[tHandle]
-        novIdx = pIndex.getNovelData(tHandle, sTitle)
+        novIdx = pIndex.getItemHeader(tHandle, sTitle)
         theRefs = pIndex.getReferences(tHandle, sTitle)
         if nwItem is None or novIdx is None:
             return False

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -60,7 +60,7 @@ class GuiProjectView(QWidget):
 
     # Signals for user interaction with the project tree
     selectedItemChanged = pyqtSignal(str)
-    openDocumentRequest = pyqtSignal(str, Enum, int, str)
+    openDocumentRequest = pyqtSignal(str, Enum, str)
 
     # Requests for the main GUI
     projectSettingsRequest = pyqtSignal(int)
@@ -1144,7 +1144,7 @@ class GuiProjectTree(QTreeWidget):
             return
 
         if tItem.isFileType():
-            self.projView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, -1, "")
+            self.projView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, "")
         else:
             trItem.setExpanded(not trItem.isExpanded())
 
@@ -1190,11 +1190,11 @@ class GuiProjectTree(QTreeWidget):
         if isFile:
             aOpenDoc = ctxMenu.addAction(self.tr("Open Document"))
             aOpenDoc.triggered.connect(
-                lambda: self.projView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, -1, "")
+                lambda: self.projView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, "")
             )
             aViewDoc = ctxMenu.addAction(self.tr("View Document"))
             aViewDoc.triggered.connect(
-                lambda: self.projView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, -1, "")
+                lambda: self.projView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, "")
             )
             ctxMenu.addSeparator()
 
@@ -1324,7 +1324,7 @@ class GuiProjectTree(QTreeWidget):
                 return
 
             if tItem.isFileType():
-                self.projView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, -1, "")
+                self.projView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, "")
 
         return
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -224,6 +224,8 @@ class GuiMain(QMainWindow):
         self.docEditor.docCountsChanged.connect(self.itemDetails.updateCounts)
         self.docEditor.docCountsChanged.connect(self.projView.updateCounts)
         self.docEditor.loadDocumentTagRequest.connect(self._followTag)
+        self.docEditor.novelStructureChanged.connect(self.novelView.refreshTree)
+        self.docEditor.novelItemMetaChanged.connect(self.novelView.updateNovelItemMeta)
 
         self.docViewer.loadDocumentTagRequest.connect(self._followTag)
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -818,16 +818,7 @@ class GuiMain(QMainWindow):
         """Rebuild the project tree.
         """
         self.projView.populateTree()
-        # self.novelView.refreshTree()
         return
-
-    def requestNovelTreeRefresh(self):
-        """Update the novel tree, but only if it is visible.
-        """
-        if self.projStack.currentIndex() == self.idxNovelView and self.hasProject:
-            self.novelView.refreshTree()
-            return True
-        return False
 
     def rebuildIndex(self, beQuiet=False):
         """Rebuild the entire index.
@@ -843,6 +834,7 @@ class GuiMain(QMainWindow):
         self.projView.saveProjectTasks()
         self.theProject.index.rebuildIndex()
         self.projView.populateTree()
+        self.novelView.refreshTree()
 
         tEnd = time()
         self.setStatus(
@@ -1578,7 +1570,6 @@ class GuiMain(QMainWindow):
             self.docEditor.closeSearch()
         elif self.isFocusMode:
             self.toggleFocusMode()
-
         return
 
     @pyqtSlot(int)
@@ -1595,17 +1586,11 @@ class GuiMain(QMainWindow):
         """Activated when the project view tab is changed.
         """
         sHandle = None
-
         if stIndex == self.idxProjView:
             sHandle = self.projView.getSelectedHandle()
-
         elif stIndex == self.idxNovelView:
-            if self.hasProject:
-                self.novelView.refreshTree()
-                sHandle, _ = self.novelView.getSelectedHandle()
-
+            sHandle, _ = self.novelView.getSelectedHandle()
         self.itemDetails.updateViewBox(sHandle)
-
         return
 
 # END Class GuiMain

--- a/tests/reference/coreIndex_LoadSave_tagsIndex.json
+++ b/tests/reference/coreIndex_LoadSave_tagsIndex.json
@@ -1,109 +1,109 @@
 {
   "tagsIndex": {
-    "Bod": {"handle": "4c4f28287af27", "heading": "T000001", "class": "CHARACTER"},
-    "Main": {"handle": "2426c6f0ca922", "heading": "T000001", "class": "PLOT"},
-    "Europe": {"handle": "04468803b92e1", "heading": "T000001", "class": "WORLD"}
+    "Bod": {"handle": "4c4f28287af27", "heading": "T0001", "class": "CHARACTER"},
+    "Main": {"handle": "2426c6f0ca922", "heading": "T0001", "class": "PLOT"},
+    "Europe": {"handle": "04468803b92e1", "heading": "T0001", "class": "WORLD"}
   },
   "itemIndex": {
     "7a992350f3eb6": {
       "headings": {
-        "T000001": {"level": "H1", "title": "Lorem Ipsum", "tag": "", "cCount": 230, "wCount": 40, "pCount": 3, "synopsis": ""}
+        "T0001": {"level": "H1", "title": "Lorem Ipsum", "line": 1, "tag": "", "cCount": 230, "wCount": 40, "pCount": 3, "synopsis": ""}
       }
     },
     "8c58a65414c23": {
       "headings": {
-        "T000000": {"level": "H0", "title": "", "tag": "", "cCount": 1058, "wCount": 176, "pCount": 2, "synopsis": ""}
+        "T0000": {"level": "H0", "title": "", "line": 0, "tag": "", "cCount": 1058, "wCount": 176, "pCount": 2, "synopsis": ""}
       }
     },
     "88d59a277361b": {
       "headings": {
-        "T000001": {"level": "H2", "title": "Prologue", "tag": "", "cCount": 584, "wCount": 92, "pCount": 1, "synopsis": "Explanation from the lipsum.com website."}
+        "T0001": {"level": "H2", "title": "Prologue", "line": 1, "tag": "", "cCount": 584, "wCount": 92, "pCount": 1, "synopsis": "Explanation from the lipsum.com website."}
       }
     },
     "db7e733775d4d": {
       "headings": {
-        "T000001": {"level": "H1", "title": "Act One", "tag": "", "cCount": 35, "wCount": 6, "pCount": 1, "synopsis": ""}
+        "T0001": {"level": "H1", "title": "Act One", "line": 1, "tag": "", "cCount": 35, "wCount": 6, "pCount": 1, "synopsis": ""}
       }
     },
     "fb609cd8319dc": {
       "headings": {
-        "T000001": {"level": "H2", "title": "Chapter One", "tag": "", "cCount": 419, "wCount": 67, "pCount": 1, "synopsis": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at aliquam quam."}
+        "T0001": {"level": "H2", "title": "Chapter One", "line": 1, "tag": "", "cCount": 419, "wCount": 67, "pCount": 1, "synopsis": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at aliquam quam."}
       },
       "references": {
-        "T000001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
+        "T0001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
       }
     },
     "88243afbe5ed8": {
       "headings": {
-        "T000001": {"level": "H3", "title": "Scene One", "tag": "", "cCount": 1197, "wCount": 174, "pCount": 2, "synopsis": "Aenean ut placerat velit. Etiam laoreet ullamcorper risus, eget lobortis enim scelerisque non. Suspendisse id maximus nunc, et mollis sapien. Curabitur vel semper sapien, non pulvinar dolor. Etiam finibus nisi vel mi molestie consectetur."},
-        "T000013": {"level": "H4", "title": "Scene One, Section Two", "tag": "", "cCount": 1561, "wCount": 230, "pCount": 2, "synopsis": ""}
+        "T0001": {"level": "H3", "title": "Scene One", "line": 1, "tag": "", "cCount": 1197, "wCount": 174, "pCount": 2, "synopsis": "Aenean ut placerat velit. Etiam laoreet ullamcorper risus, eget lobortis enim scelerisque non. Suspendisse id maximus nunc, et mollis sapien. Curabitur vel semper sapien, non pulvinar dolor. Etiam finibus nisi vel mi molestie consectetur."},
+        "T0002": {"level": "H4", "title": "Scene One, Section Two", "line": 13, "tag": "", "cCount": 1561, "wCount": 230, "pCount": 2, "synopsis": ""}
       },
       "references": {
-        "T000001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
+        "T0001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
       }
     },
     "f96ec11c6a3da": {
       "headings": {
-        "T000001": {"level": "H3", "title": "Scene Two", "tag": "", "cCount": 2034, "wCount": 299, "pCount": 3, "synopsis": "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Integer sapien nulla, dictum at lacus a, dignissim consectetur dolor. Nunc vel eleifend lacus, eu dapibus orci."},
-        "T000015": {"level": "H4", "title": "Scene Two, Section Two", "tag": "", "cCount": 2009, "wCount": 301, "pCount": 3, "synopsis": ""}
+        "T0001": {"level": "H3", "title": "Scene Two", "line": 1, "tag": "", "cCount": 2034, "wCount": 299, "pCount": 3, "synopsis": "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Integer sapien nulla, dictum at lacus a, dignissim consectetur dolor. Nunc vel eleifend lacus, eu dapibus orci."},
+        "T0002": {"level": "H4", "title": "Scene Two, Section Two", "line": 15, "tag": "", "cCount": 2009, "wCount": 301, "pCount": 3, "synopsis": ""}
       },
       "references": {
-        "T000001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
+        "T0001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
       }
     },
     "846352075de7d": {
       "headings": {
-        "T000001": {"level": "H2", "title": "Why do we use it?", "tag": "", "cCount": 631, "wCount": 109, "pCount": 3, "synopsis": ""}
+        "T0001": {"level": "H2", "title": "Why do we use it?", "line": 1, "tag": "", "cCount": 631, "wCount": 109, "pCount": 3, "synopsis": ""}
       }
     },
     "441420a886d82": {
       "headings": {
-        "T000001": {"level": "H2", "title": "Chapter Two", "tag": "", "cCount": 477, "wCount": 70, "pCount": 1, "synopsis": "Curabitur a elit posuere, varius ex et, convallis neque. Phasellus sagittis pharetra sem vitae dapibus. Curabitur varius lorem non pulvinar congue."}
+        "T0001": {"level": "H2", "title": "Chapter Two", "line": 1, "tag": "", "cCount": 477, "wCount": 70, "pCount": 1, "synopsis": "Curabitur a elit posuere, varius ex et, convallis neque. Phasellus sagittis pharetra sem vitae dapibus. Curabitur varius lorem non pulvinar congue."}
       },
       "references": {
-        "T000001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
+        "T0001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
       }
     },
     "eb103bc70c90c": {
       "headings": {
-        "T000001": {"level": "H3", "title": "Scene Three", "tag": "", "cCount": 3006, "wCount": 439, "pCount": 4, "synopsis": "Aenean ut libero ut lectus porttitor rhoncus vel et massa. Nam pretium, nibh et varius vehicula, urna metus blandit eros, euismod pharetra diam diam et libero. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos."}
+        "T0001": {"level": "H3", "title": "Scene Three", "line": 1, "tag": "", "cCount": 3006, "wCount": 439, "pCount": 4, "synopsis": "Aenean ut libero ut lectus porttitor rhoncus vel et massa. Nam pretium, nibh et varius vehicula, urna metus blandit eros, euismod pharetra diam diam et libero. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos."}
       },
       "references": {
-        "T000001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
+        "T0001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
       }
     },
     "f8c0562e50f1b": {
       "headings": {
-        "T000001": {"level": "H3", "title": "Scene Four", "tag": "", "cCount": 3839, "wCount": 563, "pCount": 6, "synopsis": "Nam tempor blandit magna laoreet aliquet. Vestibulum auctor posuere leo, ac gravida nisi rhoncus varius. Aenean posuere dolor vitae condimentum volutpat. Donec egestas volutpat risus, quis luctus justo."}
+        "T0001": {"level": "H3", "title": "Scene Four", "line": 1, "tag": "", "cCount": 3839, "wCount": 563, "pCount": 6, "synopsis": "Nam tempor blandit magna laoreet aliquet. Vestibulum auctor posuere leo, ac gravida nisi rhoncus varius. Aenean posuere dolor vitae condimentum volutpat. Donec egestas volutpat risus, quis luctus justo."}
       },
       "references": {
-        "T000001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
+        "T0001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
       }
     },
     "47666c91c7ccf": {
       "headings": {
-        "T000001": {"level": "H3", "title": "Scene Five", "tag": "", "cCount": 3644, "wCount": 543, "pCount": 5, "synopsis": "Praesent eget est porta, dictum ante in, egestas risus. Mauris risus mauris, consequat aliquam mauris et, feugiat iaculis ipsum. Aliquam arcu ipsum, fermentum ut arcu sed, lobortis euismod sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus."}
+        "T0001": {"level": "H3", "title": "Scene Five", "line": 1, "tag": "", "cCount": 3644, "wCount": 543, "pCount": 5, "synopsis": "Praesent eget est porta, dictum ante in, egestas risus. Mauris risus mauris, consequat aliquam mauris et, feugiat iaculis ipsum. Aliquam arcu ipsum, fermentum ut arcu sed, lobortis euismod sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus."}
       },
       "references": {
-        "T000001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
+        "T0001": {"Bod": "@pov", "Main": "@plot", "Europe": "@location"}
       }
     },
     "4c4f28287af27": {
       "headings": {
-        "T000001": {"level": "H1", "title": "Nobody Owens", "tag": "Bod", "cCount": 1864, "wCount": 284, "pCount": 3, "synopsis": ""}
+        "T0001": {"level": "H1", "title": "Nobody Owens", "line": 1, "tag": "Bod", "cCount": 1864, "wCount": 284, "pCount": 3, "synopsis": ""}
       },
       "references": {
-        "T000001": {"Main": "@plot"}
+        "T0001": {"Main": "@plot"}
       }
     },
     "2426c6f0ca922": {
       "headings": {
-        "T000001": {"level": "H1", "title": "Main Plot", "tag": "Main", "cCount": 1369, "wCount": 195, "pCount": 2, "synopsis": ""}
+        "T0001": {"level": "H1", "title": "Main Plot", "line": 1, "tag": "Main", "cCount": 1369, "wCount": 195, "pCount": 2, "synopsis": ""}
       }
     },
     "04468803b92e1": {
       "headings": {
-        "T000001": {"level": "H1", "title": "Ancient Europe", "tag": "Europe", "cCount": 1770, "wCount": 259, "pCount": 3, "synopsis": ""}
+        "T0001": {"level": "H1", "title": "Ancient Europe", "line": 1, "tag": "Europe", "cCount": 1770, "wCount": 259, "pCount": 3, "synopsis": ""}
       }
     }
   }

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -208,12 +208,12 @@ def testBaseCommon_IsHandle():
 def testBaseCommon_IsTitleTag():
     """Test the isItemClass function.
     """
-    assert isTitleTag("T123456") is True
+    assert isTitleTag("T1234") is True
 
-    assert isTitleTag("t123456") is False
-    assert isTitleTag("S123456") is False
-    assert isTitleTag("T12345A") is False
-    assert isTitleTag("T1234567") is False
+    assert isTitleTag("t1234") is False
+    assert isTitleTag("S1234") is False
+    assert isTitleTag("T123A") is False
+    assert isTitleTag("T12345") is False
 
     assert isTitleTag("None") is False
     assert isTitleTag(None) is False

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -580,12 +580,13 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     assert wC == 12  # Words in text and title only
     assert pC == 2   # Paragraphs in text only
 
-    # getItemData
-    # ===========
+    # getItemData + getHandleHeaderCount
+    # ==================================
 
     theItem = theIndex.getItemData(nHandle)
     assert isinstance(theItem, IndexItem)
     assert theItem.headings() == ["T0001"]
+    assert theIndex.getHandleHeaderCount(nHandle) == 1
 
     # getReferences
     # =============
@@ -786,17 +787,6 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
 
     assert theIndex.saveIndex() is True
     assert theProject.saveProject() is True
-
-    # Header Record
-    bHandle = "0000000000000"
-    assert theIndex.getHandleHeaders(bHandle) == []
-    assert theIndex.getHandleHeaders(hHandle) == [("T0001", "H2", "Chapter One")]
-    assert theIndex.getHandleHeaders(sHandle) == [("T0001", "H3", "Scene One")]
-    assert theIndex.getHandleHeaders(tHandle) == [("T0001", "H3", "Scene Two")]
-    assert theIndex.getHandleHeaders(nHandle) == [
-        ("T0001", "H1", "Hello World!"), ("T0002", "H1", "Hello World!")
-    ]
-
     assert theProject.closeProject() is True
 
 # END Test testCoreIndex_ExtractData

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -775,16 +775,6 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
         (f"{nHandle}:T0002", 1, "Hello World!", 22),
     ]
 
-    # Header Word Counts
-    bHandle = "0000000000000"
-    assert theIndex.getHandleWordCounts(bHandle) == []
-    assert theIndex.getHandleWordCounts(hHandle) == [("%s:T0001" % hHandle, 2)]
-    assert theIndex.getHandleWordCounts(sHandle) == [("%s:T0001" % sHandle, 2)]
-    assert theIndex.getHandleWordCounts(tHandle) == [("%s:T0001" % tHandle, 2)]
-    assert theIndex.getHandleWordCounts(nHandle) == [
-        (f"{nHandle}:T0001", 12), (f"{nHandle}:T0002", 16)
-    ]
-
     assert theIndex.saveIndex() is True
     assert theProject.saveProject() is True
     assert theProject.closeProject() is True

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -29,7 +29,7 @@ from tools import C, buildTestProject, cmpFiles, writeFile
 
 from novelwriter.enum import nwItemClass, nwItemLayout
 from novelwriter.constants import nwFiles
-from novelwriter.core.index import NWIndex, countWords, TagsIndex
+from novelwriter.core.index import IndexItem, NWIndex, countWords, TagsIndex
 from novelwriter.core.project import NWProject
 
 
@@ -231,10 +231,10 @@ def testCoreIndex_CheckThese(mockGUI, fncPath, mockRnd):
         "@invalid: John\n"  # Checks for issue #688
     ))
     assert theIndex._tagsIndex.tagHandle("Jane") == cHandle
-    assert theIndex._tagsIndex.tagHeading("Jane") == "T000001"
+    assert theIndex._tagsIndex.tagHeading("Jane") == "T0001"
     assert theIndex._tagsIndex.tagClass("Jane") == "CHARACTER"
-    assert theIndex.getNovelData(nHandle, "T000001").title == "Hello World!"
-    assert theIndex.getReferences(nHandle, "T000001") == {
+    assert theIndex.getItemHeader(nHandle, "T0001").title == "Hello World!"
+    assert theIndex.getReferences(nHandle, "T0001") == {
         "@char": [],
         "@custom": [],
         "@entity": [],
@@ -345,9 +345,9 @@ def testCoreIndex_ScanText(mockGUI, fncPath, mockRnd):
         "Well, not really.\n"
     ))
     assert theIndex._tagsIndex.tagHandle("Jane") == cHandle
-    assert theIndex._tagsIndex.tagHeading("Jane") == "T000001"
+    assert theIndex._tagsIndex.tagHeading("Jane") == "T0001"
     assert theIndex._tagsIndex.tagClass("Jane") == "CHARACTER"
-    assert theIndex.getNovelData(nHandle, "T000001").title == "Hello World!"
+    assert theIndex.getItemHeader(nHandle, "T0001").title == "Hello World!"
 
     # Title Indexing
     # ==============
@@ -369,40 +369,45 @@ def testCoreIndex_ScanText(mockGUI, fncPath, mockRnd):
         "##### Title Five\n\n"  # Not interpreted as a title, the hashes are counted as a word
         "Paragraph Five.\n\n"
     ))
-    assert theIndex._itemIndex[nHandle]["T000001"].references == {}
-    assert theIndex._itemIndex[nHandle]["T000007"].references == {}
-    assert theIndex._itemIndex[nHandle]["T000013"].references == {}
-    assert theIndex._itemIndex[nHandle]["T000019"].references == {}
+    assert theIndex._itemIndex[nHandle]["T0001"].references == {}
+    assert theIndex._itemIndex[nHandle]["T0002"].references == {}
+    assert theIndex._itemIndex[nHandle]["T0003"].references == {}
+    assert theIndex._itemIndex[nHandle]["T0004"].references == {}
 
-    assert theIndex._itemIndex[nHandle]["T000001"].level == "H1"
-    assert theIndex._itemIndex[nHandle]["T000007"].level == "H2"
-    assert theIndex._itemIndex[nHandle]["T000013"].level == "H3"
-    assert theIndex._itemIndex[nHandle]["T000019"].level == "H4"
+    assert theIndex._itemIndex[nHandle]["T0001"].level == "H1"
+    assert theIndex._itemIndex[nHandle]["T0002"].level == "H2"
+    assert theIndex._itemIndex[nHandle]["T0003"].level == "H3"
+    assert theIndex._itemIndex[nHandle]["T0004"].level == "H4"
 
-    assert theIndex._itemIndex[nHandle]["T000001"].title == "Title One"
-    assert theIndex._itemIndex[nHandle]["T000007"].title == "Title Two"
-    assert theIndex._itemIndex[nHandle]["T000013"].title == "Title Three"
-    assert theIndex._itemIndex[nHandle]["T000019"].title == "Title Four"
+    assert theIndex._itemIndex[nHandle]["T0001"].line == 1
+    assert theIndex._itemIndex[nHandle]["T0002"].line == 7
+    assert theIndex._itemIndex[nHandle]["T0003"].line == 13
+    assert theIndex._itemIndex[nHandle]["T0004"].line == 19
 
-    assert theIndex._itemIndex[nHandle]["T000001"].charCount == 23
-    assert theIndex._itemIndex[nHandle]["T000007"].charCount == 23
-    assert theIndex._itemIndex[nHandle]["T000013"].charCount == 27
-    assert theIndex._itemIndex[nHandle]["T000019"].charCount == 56
+    assert theIndex._itemIndex[nHandle]["T0001"].title == "Title One"
+    assert theIndex._itemIndex[nHandle]["T0002"].title == "Title Two"
+    assert theIndex._itemIndex[nHandle]["T0003"].title == "Title Three"
+    assert theIndex._itemIndex[nHandle]["T0004"].title == "Title Four"
 
-    assert theIndex._itemIndex[nHandle]["T000001"].wordCount == 4
-    assert theIndex._itemIndex[nHandle]["T000007"].wordCount == 4
-    assert theIndex._itemIndex[nHandle]["T000013"].wordCount == 4
-    assert theIndex._itemIndex[nHandle]["T000019"].wordCount == 9
+    assert theIndex._itemIndex[nHandle]["T0001"].charCount == 23
+    assert theIndex._itemIndex[nHandle]["T0002"].charCount == 23
+    assert theIndex._itemIndex[nHandle]["T0003"].charCount == 27
+    assert theIndex._itemIndex[nHandle]["T0004"].charCount == 56
 
-    assert theIndex._itemIndex[nHandle]["T000001"].paraCount == 1
-    assert theIndex._itemIndex[nHandle]["T000007"].paraCount == 1
-    assert theIndex._itemIndex[nHandle]["T000013"].paraCount == 1
-    assert theIndex._itemIndex[nHandle]["T000019"].paraCount == 3
+    assert theIndex._itemIndex[nHandle]["T0001"].wordCount == 4
+    assert theIndex._itemIndex[nHandle]["T0002"].wordCount == 4
+    assert theIndex._itemIndex[nHandle]["T0003"].wordCount == 4
+    assert theIndex._itemIndex[nHandle]["T0004"].wordCount == 9
 
-    assert theIndex._itemIndex[nHandle]["T000001"].synopsis == "Synopsis One."
-    assert theIndex._itemIndex[nHandle]["T000007"].synopsis == "Synopsis Two."
-    assert theIndex._itemIndex[nHandle]["T000013"].synopsis == "Synopsis Three."
-    assert theIndex._itemIndex[nHandle]["T000019"].synopsis == "Synopsis Four."
+    assert theIndex._itemIndex[nHandle]["T0001"].paraCount == 1
+    assert theIndex._itemIndex[nHandle]["T0002"].paraCount == 1
+    assert theIndex._itemIndex[nHandle]["T0003"].paraCount == 1
+    assert theIndex._itemIndex[nHandle]["T0004"].paraCount == 3
+
+    assert theIndex._itemIndex[nHandle]["T0001"].synopsis == "Synopsis One."
+    assert theIndex._itemIndex[nHandle]["T0002"].synopsis == "Synopsis Two."
+    assert theIndex._itemIndex[nHandle]["T0003"].synopsis == "Synopsis Three."
+    assert theIndex._itemIndex[nHandle]["T0004"].synopsis == "Synopsis Four."
 
     # Note File
     assert theIndex.scanText(cHandle, (
@@ -411,13 +416,14 @@ def testCoreIndex_ScanText(mockGUI, fncPath, mockRnd):
         "% synopsis: Synopsis One.\n\n"
         "Paragraph One.\n\n"
     ))
-    assert theIndex._itemIndex[cHandle]["T000001"].references == {}
-    assert theIndex._itemIndex[cHandle]["T000001"].level == "H1"
-    assert theIndex._itemIndex[cHandle]["T000001"].title == "Title One"
-    assert theIndex._itemIndex[cHandle]["T000001"].charCount == 23
-    assert theIndex._itemIndex[cHandle]["T000001"].wordCount == 4
-    assert theIndex._itemIndex[cHandle]["T000001"].paraCount == 1
-    assert theIndex._itemIndex[cHandle]["T000001"].synopsis == "Synopsis One."
+    assert theIndex._itemIndex[cHandle]["T0001"].references == {}
+    assert theIndex._itemIndex[cHandle]["T0001"].level == "H1"
+    assert theIndex._itemIndex[cHandle]["T0001"].line == 1
+    assert theIndex._itemIndex[cHandle]["T0001"].title == "Title One"
+    assert theIndex._itemIndex[cHandle]["T0001"].charCount == 23
+    assert theIndex._itemIndex[cHandle]["T0001"].wordCount == 4
+    assert theIndex._itemIndex[cHandle]["T0001"].paraCount == 1
+    assert theIndex._itemIndex[cHandle]["T0001"].synopsis == "Synopsis One."
 
     # Valid and Invalid References
     assert theIndex.scanText(sHandle, (
@@ -428,7 +434,7 @@ def testCoreIndex_ScanText(mockGUI, fncPath, mockRnd):
         "% synopsis: Synopsis One.\n\n"
         "Paragraph One.\n\n"
     ))
-    assert theIndex._itemIndex[sHandle]["T000001"].references == {
+    assert theIndex._itemIndex[sHandle]["T0001"].references == {
         "One": {"@pov"}, "Two": {"@char"}
     }
 
@@ -439,25 +445,27 @@ def testCoreIndex_ScanText(mockGUI, fncPath, mockRnd):
         "#! My Project\n\n"
         ">> By Jane Doe <<\n\n"
     ))
-    assert theIndex._itemIndex[cHandle]["T000001"].references == {}
-    assert theIndex._itemIndex[tHandle]["T000001"].level == "H1"
-    assert theIndex._itemIndex[tHandle]["T000001"].title == "My Project"
-    assert theIndex._itemIndex[tHandle]["T000001"].charCount == 21
-    assert theIndex._itemIndex[tHandle]["T000001"].wordCount == 5
-    assert theIndex._itemIndex[tHandle]["T000001"].paraCount == 1
-    assert theIndex._itemIndex[tHandle]["T000001"].synopsis == ""
+    assert theIndex._itemIndex[cHandle]["T0001"].references == {}
+    assert theIndex._itemIndex[tHandle]["T0001"].level == "H1"
+    assert theIndex._itemIndex[tHandle]["T0001"].line == 1
+    assert theIndex._itemIndex[tHandle]["T0001"].title == "My Project"
+    assert theIndex._itemIndex[tHandle]["T0001"].charCount == 21
+    assert theIndex._itemIndex[tHandle]["T0001"].wordCount == 5
+    assert theIndex._itemIndex[tHandle]["T0001"].paraCount == 1
+    assert theIndex._itemIndex[tHandle]["T0001"].synopsis == ""
 
     assert theIndex.scanText(tHandle, (
         "##! Prologue\n\n"
         "In the beginning there was time ...\n\n"
     ))
-    assert theIndex._itemIndex[cHandle]["T000001"].references == {}
-    assert theIndex._itemIndex[tHandle]["T000001"].level == "H2"
-    assert theIndex._itemIndex[tHandle]["T000001"].title == "Prologue"
-    assert theIndex._itemIndex[tHandle]["T000001"].charCount == 43
-    assert theIndex._itemIndex[tHandle]["T000001"].wordCount == 8
-    assert theIndex._itemIndex[tHandle]["T000001"].paraCount == 1
-    assert theIndex._itemIndex[tHandle]["T000001"].synopsis == ""
+    assert theIndex._itemIndex[cHandle]["T0001"].references == {}
+    assert theIndex._itemIndex[tHandle]["T0001"].level == "H2"
+    assert theIndex._itemIndex[tHandle]["T0001"].line == 1
+    assert theIndex._itemIndex[tHandle]["T0001"].title == "Prologue"
+    assert theIndex._itemIndex[tHandle]["T0001"].charCount == 43
+    assert theIndex._itemIndex[tHandle]["T0001"].wordCount == 8
+    assert theIndex._itemIndex[tHandle]["T0001"].paraCount == 1
+    assert theIndex._itemIndex[tHandle]["T0001"].synopsis == ""
 
     # Page wo/Title
     # =============
@@ -466,25 +474,27 @@ def testCoreIndex_ScanText(mockGUI, fncPath, mockRnd):
     assert theIndex.scanText(pHandle, (
         "This is a page with some text on it.\n\n"
     ))
-    assert theIndex._itemIndex[pHandle]["T000000"].references == {}
-    assert theIndex._itemIndex[pHandle]["T000000"].level == "H0"
-    assert theIndex._itemIndex[pHandle]["T000000"].title == ""
-    assert theIndex._itemIndex[pHandle]["T000000"].charCount == 36
-    assert theIndex._itemIndex[pHandle]["T000000"].wordCount == 9
-    assert theIndex._itemIndex[pHandle]["T000000"].paraCount == 1
-    assert theIndex._itemIndex[pHandle]["T000000"].synopsis == ""
+    assert theIndex._itemIndex[pHandle]["T0000"].references == {}
+    assert theIndex._itemIndex[pHandle]["T0000"].level == "H0"
+    assert theIndex._itemIndex[pHandle]["T0000"].line == 0
+    assert theIndex._itemIndex[pHandle]["T0000"].title == ""
+    assert theIndex._itemIndex[pHandle]["T0000"].charCount == 36
+    assert theIndex._itemIndex[pHandle]["T0000"].wordCount == 9
+    assert theIndex._itemIndex[pHandle]["T0000"].paraCount == 1
+    assert theIndex._itemIndex[pHandle]["T0000"].synopsis == ""
 
     theProject.tree[pHandle]._layout = nwItemLayout.NOTE
     assert theIndex.scanText(pHandle, (
         "This is a page with some text on it.\n\n"
     ))
-    assert theIndex._itemIndex[pHandle]["T000000"].references == {}
-    assert theIndex._itemIndex[pHandle]["T000000"].level == "H0"
-    assert theIndex._itemIndex[pHandle]["T000000"].title == ""
-    assert theIndex._itemIndex[pHandle]["T000000"].charCount == 36
-    assert theIndex._itemIndex[pHandle]["T000000"].wordCount == 9
-    assert theIndex._itemIndex[pHandle]["T000000"].paraCount == 1
-    assert theIndex._itemIndex[pHandle]["T000000"].synopsis == ""
+    assert theIndex._itemIndex[pHandle]["T0000"].references == {}
+    assert theIndex._itemIndex[pHandle]["T0000"].level == "H0"
+    assert theIndex._itemIndex[pHandle]["T0000"].line == 0
+    assert theIndex._itemIndex[pHandle]["T0000"].title == ""
+    assert theIndex._itemIndex[pHandle]["T0000"].charCount == 36
+    assert theIndex._itemIndex[pHandle]["T0000"].wordCount == 9
+    assert theIndex._itemIndex[pHandle]["T0000"].paraCount == 1
+    assert theIndex._itemIndex[pHandle]["T0000"].synopsis == ""
 
     assert theProject.closeProject() is True
 
@@ -512,8 +522,8 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     nHandle = theProject.newFile("Hello", C.hNovelRoot)
     cHandle = theProject.newFile("Jane",  C.hCharRoot)
 
-    assert theIndex.getNovelData("", "") is None
-    assert theIndex.getNovelData(C.hNovelRoot, "") is None
+    assert theIndex.getItemHeader("", "") is None
+    assert theIndex.getItemHeader(C.hNovelRoot, "") is None
 
     assert theIndex.scanText(cHandle, (
         "# Jane Smith\n"
@@ -534,10 +544,10 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
         theKeys.append(aKey)
 
     assert theKeys == [
-        f"{C.hTitlePage}:T000001",
-        f"{C.hChapterDoc}:T000001",
-        f"{C.hSceneDoc}:T000001",
-        f"{nHandle}:T000001",
+        f"{C.hTitlePage}:T0001",
+        f"{C.hChapterDoc}:T0001",
+        f"{C.hSceneDoc}:T0001",
+        f"{nHandle}:T0001",
     ]
 
     # Check that excluded files can be skipped
@@ -548,10 +558,10 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
         theKeys.append(aKey)
 
     assert theKeys == [
-        f"{C.hTitlePage}:T000001",
-        f"{C.hChapterDoc}:T000001",
-        f"{C.hSceneDoc}:T000001",
-        f"{nHandle}:T000001",
+        f"{C.hTitlePage}:T0001",
+        f"{C.hChapterDoc}:T0001",
+        f"{C.hSceneDoc}:T0001",
+        f"{nHandle}:T0001",
     ]
 
     theKeys = []
@@ -559,9 +569,9 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
         theKeys.append(aKey)
 
     assert theKeys == [
-        f"{C.hTitlePage}:T000001",
-        f"{C.hChapterDoc}:T000001",
-        f"{C.hSceneDoc}:T000001",
+        f"{C.hTitlePage}:T0001",
+        f"{C.hChapterDoc}:T0001",
+        f"{C.hSceneDoc}:T0001",
     ]
 
     # The novel file should have the correct counts
@@ -569,6 +579,13 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     assert cC == 62  # Characters in text and title only
     assert wC == 12  # Words in text and title only
     assert pC == 2   # Paragraphs in text only
+
+    # getItemData
+    # ===========
+
+    theItem = theIndex.getItemData(nHandle)
+    assert isinstance(theItem, IndexItem)
+    assert theItem.headings() == ["T0001"]
 
     # getReferences
     # =============
@@ -594,13 +611,13 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
 
     # The character file should have a record of the reference from the novel file
     theRefs = theIndex.getBackReferenceList(cHandle)
-    assert theRefs == {nHandle: "T000001"}
+    assert theRefs == {nHandle: "T0001"}
 
     # getTagSource
     # ============
 
-    assert theIndex.getTagSource("Jane") == (cHandle, "T000001")
-    assert theIndex.getTagSource("John") == (None, "T000000")
+    assert theIndex.getTagSource("Jane") == (cHandle, "T0001")
+    assert theIndex.getTagSource("John") == (None, "T0000")
 
     # getCounts
     # =========
@@ -632,13 +649,13 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     assert pC == 4
 
     # First part
-    cC, wC, pC = theIndex.getCounts(nHandle, "T000001")
+    cC, wC, pC = theIndex.getCounts(nHandle, "T0001")
     assert cC == 62
     assert wC == 12
     assert pC == 2
 
     # Second part
-    cC, wC, pC = theIndex.getCounts(nHandle, "T000011")
+    cC, wC, pC = theIndex.getCounts(nHandle, "T0002")
     assert cC == 90
     assert wC == 16
     assert pC == 2
@@ -665,13 +682,13 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     assert pC == 4
 
     # First part
-    cC, wC, pC = theIndex.getCounts(cHandle, "T000001")
+    cC, wC, pC = theIndex.getCounts(cHandle, "T0001")
     assert cC == 62
     assert wC == 12
     assert pC == 2
 
     # Second part
-    cC, wC, pC = theIndex.getCounts(cHandle, "T000011")
+    cC, wC, pC = theIndex.getCounts(cHandle, "T0002")
     assert cC == 90
     assert wC == 16
     assert pC == 2
@@ -692,36 +709,36 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     assert theIndex.scanText(tHandle, "### Scene Two\n\n")
 
     assert [(h, t) for h, t, _ in theIndex._itemIndex.iterNovelStructure(skipExcl=False)] == [
-        (C.hTitlePage, "T000001"),
-        (C.hChapterDoc, "T000001"),
-        (C.hSceneDoc, "T000001"),
-        (nHandle, "T000001"),
-        (nHandle, "T000011"),
-        (hHandle, "T000001"),
-        (sHandle, "T000001"),
-        (tHandle, "T000001"),
+        (C.hTitlePage, "T0001"),
+        (C.hChapterDoc, "T0001"),
+        (C.hSceneDoc, "T0001"),
+        (nHandle, "T0001"),
+        (nHandle, "T0002"),
+        (hHandle, "T0001"),
+        (sHandle, "T0001"),
+        (tHandle, "T0001"),
     ]
 
     assert [(h, t) for h, t, _ in theIndex._itemIndex.iterNovelStructure(skipExcl=True)] == [
-        (C.hTitlePage, "T000001"),
-        (C.hChapterDoc, "T000001"),
-        (C.hSceneDoc, "T000001"),
-        (hHandle, "T000001"),
-        (sHandle, "T000001"),
-        (tHandle, "T000001"),
+        (C.hTitlePage, "T0001"),
+        (C.hChapterDoc, "T0001"),
+        (C.hSceneDoc, "T0001"),
+        (hHandle, "T0001"),
+        (sHandle, "T0001"),
+        (tHandle, "T0001"),
     ]
 
     # Add a fake handle to the tree and check that it's ignored
     theProject.tree._treeOrder.append("0000000000000")
     assert [(h, t) for h, t, _ in theIndex._itemIndex.iterNovelStructure(skipExcl=False)] == [
-        (C.hTitlePage, "T000001"),
-        (C.hChapterDoc, "T000001"),
-        (C.hSceneDoc, "T000001"),
-        (nHandle, "T000001"),
-        (nHandle, "T000011"),
-        (hHandle, "T000001"),
-        (sHandle, "T000001"),
-        (tHandle, "T000001"),
+        (C.hTitlePage, "T0001"),
+        (C.hChapterDoc, "T0001"),
+        (C.hSceneDoc, "T0001"),
+        (nHandle, "T0001"),
+        (nHandle, "T0002"),
+        (hHandle, "T0001"),
+        (sHandle, "T0001"),
+        (tHandle, "T0001"),
     ]
     theProject.tree._treeOrder.remove("0000000000000")
 
@@ -734,37 +751,37 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     # Table of Contents
     assert theIndex.getTableOfContents(C.hNovelRoot, 0, skipExcl=True) == []
     assert theIndex.getTableOfContents(C.hNovelRoot, 1, skipExcl=True) == [
-        (f"{C.hTitlePage}:T000001", 1, "New Novel", 15),
+        (f"{C.hTitlePage}:T0001", 1, "New Novel", 15),
     ]
     assert theIndex.getTableOfContents(C.hNovelRoot, 2, skipExcl=True) == [
-        (f"{C.hTitlePage}:T000001", 1, "New Novel", 5),
-        (f"{C.hChapterDoc}:T000001", 2, "New Chapter", 4),
-        (f"{hHandle}:T000001", 2, "Chapter One", 6),
+        (f"{C.hTitlePage}:T0001", 1, "New Novel", 5),
+        (f"{C.hChapterDoc}:T0001", 2, "New Chapter", 4),
+        (f"{hHandle}:T0001", 2, "Chapter One", 6),
     ]
     assert theIndex.getTableOfContents(C.hNovelRoot, 3, skipExcl=True) == [
-        (f"{C.hTitlePage}:T000001", 1, "New Novel", 5),
-        (f"{C.hChapterDoc}:T000001", 2, "New Chapter", 2),
-        (f"{C.hSceneDoc}:T000001", 3, "New Scene", 2),
-        (f"{hHandle}:T000001", 2, "Chapter One", 2),
-        (f"{sHandle}:T000001", 3, "Scene One", 2),
-        (f"{tHandle}:T000001", 3, "Scene Two", 2),
+        (f"{C.hTitlePage}:T0001", 1, "New Novel", 5),
+        (f"{C.hChapterDoc}:T0001", 2, "New Chapter", 2),
+        (f"{C.hSceneDoc}:T0001", 3, "New Scene", 2),
+        (f"{hHandle}:T0001", 2, "Chapter One", 2),
+        (f"{sHandle}:T0001", 3, "Scene One", 2),
+        (f"{tHandle}:T0001", 3, "Scene Two", 2),
     ]
 
     assert theIndex.getTableOfContents(C.hNovelRoot, 0, skipExcl=False) == []
     assert theIndex.getTableOfContents(C.hNovelRoot, 1, skipExcl=False) == [
-        (f"{C.hTitlePage}:T000001", 1, "New Novel", 9),
-        (f"{nHandle}:T000001", 1, "Hello World!", 12),
-        (f"{nHandle}:T000011", 1, "Hello World!", 22),
+        (f"{C.hTitlePage}:T0001", 1, "New Novel", 9),
+        (f"{nHandle}:T0001", 1, "Hello World!", 12),
+        (f"{nHandle}:T0002", 1, "Hello World!", 22),
     ]
 
     # Header Word Counts
     bHandle = "0000000000000"
     assert theIndex.getHandleWordCounts(bHandle) == []
-    assert theIndex.getHandleWordCounts(hHandle) == [("%s:T000001" % hHandle, 2)]
-    assert theIndex.getHandleWordCounts(sHandle) == [("%s:T000001" % sHandle, 2)]
-    assert theIndex.getHandleWordCounts(tHandle) == [("%s:T000001" % tHandle, 2)]
+    assert theIndex.getHandleWordCounts(hHandle) == [("%s:T0001" % hHandle, 2)]
+    assert theIndex.getHandleWordCounts(sHandle) == [("%s:T0001" % sHandle, 2)]
+    assert theIndex.getHandleWordCounts(tHandle) == [("%s:T0001" % tHandle, 2)]
     assert theIndex.getHandleWordCounts(nHandle) == [
-        (f"{nHandle}:T000001", 12), (f"{nHandle}:T000011", 16)
+        (f"{nHandle}:T0001", 12), (f"{nHandle}:T0002", 16)
     ]
 
     assert theIndex.saveIndex() is True
@@ -773,11 +790,11 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     # Header Record
     bHandle = "0000000000000"
     assert theIndex.getHandleHeaders(bHandle) == []
-    assert theIndex.getHandleHeaders(hHandle) == [("T000001", "H2", "Chapter One")]
-    assert theIndex.getHandleHeaders(sHandle) == [("T000001", "H3", "Scene One")]
-    assert theIndex.getHandleHeaders(tHandle) == [("T000001", "H3", "Scene Two")]
+    assert theIndex.getHandleHeaders(hHandle) == [("T0001", "H2", "Chapter One")]
+    assert theIndex.getHandleHeaders(sHandle) == [("T0001", "H3", "Scene One")]
+    assert theIndex.getHandleHeaders(tHandle) == [("T0001", "H3", "Scene Two")]
     assert theIndex.getHandleHeaders(nHandle) == [
-        ("T000001", "H1", "Hello World!"), ("T000011", "H1", "Hello World!")
+        ("T0001", "H1", "Hello World!"), ("T0002", "H1", "Hello World!")
     ]
 
     assert theProject.closeProject() is True
@@ -796,25 +813,25 @@ def testCoreIndex_TagsIndex():
     content = {
         "Tag1": {
             "handle": "0000000000001",
-            "heading": "T000001",
+            "heading": "T0001",
             "class": nwItemClass.NOVEL.name,
         },
         "Tag2": {
             "handle": "0000000000002",
-            "heading": "T000002",
+            "heading": "T0002",
             "class": nwItemClass.CHARACTER.name,
         },
         "Tag3": {
             "handle": "0000000000003",
-            "heading": "T000003",
+            "heading": "T0003",
             "class": nwItemClass.PLOT.name,
         },
     }
 
     # Add data
-    tagsIndex.add("Tag1", "0000000000001", "T000001", nwItemClass.NOVEL)
-    tagsIndex.add("Tag2", "0000000000002", "T000002", nwItemClass.CHARACTER)
-    tagsIndex.add("Tag3", "0000000000003", "T000003", nwItemClass.PLOT)
+    tagsIndex.add("Tag1", "0000000000001", "T0001", nwItemClass.NOVEL)
+    tagsIndex.add("Tag2", "0000000000002", "T0002", nwItemClass.CHARACTER)
+    tagsIndex.add("Tag3", "0000000000003", "T0003", nwItemClass.PLOT)
     assert tagsIndex._tags == content
 
     # Get items
@@ -836,10 +853,10 @@ def testCoreIndex_TagsIndex():
     assert tagsIndex.tagHandle("Tag4") is None
 
     # Read back headings
-    assert tagsIndex.tagHeading("Tag1") == "T000001"
-    assert tagsIndex.tagHeading("Tag2") == "T000002"
-    assert tagsIndex.tagHeading("Tag3") == "T000003"
-    assert tagsIndex.tagHeading("Tag4") == "T000000"
+    assert tagsIndex.tagHeading("Tag1") == "T0001"
+    assert tagsIndex.tagHeading("Tag2") == "T0002"
+    assert tagsIndex.tagHeading("Tag3") == "T0003"
+    assert tagsIndex.tagHeading("Tag4") == "T0000"
 
     # Read back classes
     assert tagsIndex.tagClass("Tag1") == nwItemClass.NOVEL.name
@@ -880,7 +897,7 @@ def testCoreIndex_TagsIndex():
         tagsIndex.unpackData({
             1234: {
                 "handle": "0000000000001",
-                "heading": "T000001",
+                "heading": "T0001",
                 "class": "NOVEL",
             }
         })
@@ -889,7 +906,7 @@ def testCoreIndex_TagsIndex():
     with pytest.raises(KeyError):
         tagsIndex.unpackData({
             "Tag1": {
-                "heading": "T000001",
+                "heading": "T0001",
                 "class": "NOVEL",
             }
         })
@@ -908,7 +925,7 @@ def testCoreIndex_TagsIndex():
         tagsIndex.unpackData({
             "Tag1": {
                 "handle": "0000000000001",
-                "heading": "T000001",
+                "heading": "T0001",
             }
         })
 
@@ -917,7 +934,7 @@ def testCoreIndex_TagsIndex():
         tagsIndex.unpackData({
             "Tag1": {
                 "handle": "blablabla",
-                "heading": "T000001",
+                "heading": "T0001",
                 "class": "NOVEL",
             }
         })
@@ -937,7 +954,7 @@ def testCoreIndex_TagsIndex():
         tagsIndex.unpackData({
             "Tag1": {
                 "handle": "0000000000001",
-                "heading": "T000001",
+                "heading": "T0001",
                 "class": "blabla",
             }
         })
@@ -975,66 +992,70 @@ def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
     assert cHandle in itemIndex
     assert itemIndex[cHandle].item == theProject.tree[cHandle]
     assert itemIndex.allItemTags(cHandle) == []
-    assert list(itemIndex.iterItemHeaders(cHandle))[0][0] == "T000000"
+    assert list(itemIndex.iterItemHeaders(cHandle))[0][0] == "T0000"
 
     # Add a heading to the item, which should replace the T000000 heading
-    itemIndex.addItemHeading(cHandle, "T000001", "H2", "Chapter One")
-    assert list(itemIndex.iterItemHeaders(cHandle))[0][0] == "T000001"
+    assert itemIndex.addItemHeading(cHandle, 1, "H2", "Chapter One") == "T0001"
+    assert list(itemIndex.iterItemHeaders(cHandle))[0][0] == "T0001"
+
+    # Add a heading to an invalid item
+    assert itemIndex.addItemHeading(C.hInvalid, 1, "H1", "Stuff") == "T0000"
 
     # Set the remainig data values
-    itemIndex.setHeadingCounts(cHandle, "T000001", 60, 10, 2)
-    itemIndex.setHeadingSynopsis(cHandle, "T000001", "In the beginning ...")
-    itemIndex.setHeadingTag(cHandle, "T000001", "One")
-    itemIndex.addHeadingReferences(cHandle, "T000001", ["Jane"], "@pov")
-    itemIndex.addHeadingReferences(cHandle, "T000001", ["Jane"], "@focus")
-    itemIndex.addHeadingReferences(cHandle, "T000001", ["Jane", "John"], "@char")
+    itemIndex.setHeadingCounts(cHandle, "T0001", 60, 10, 2)
+    itemIndex.setHeadingSynopsis(cHandle, "T0001", "In the beginning ...")
+    itemIndex.setHeadingTag(cHandle, "T0001", "One")
+    itemIndex.addHeadingReferences(cHandle, "T0001", ["Jane"], "@pov")
+    itemIndex.addHeadingReferences(cHandle, "T0001", ["Jane"], "@focus")
+    itemIndex.addHeadingReferences(cHandle, "T0001", ["Jane", "John"], "@char")
     idxData = itemIndex.packData()
 
-    assert idxData[cHandle]["headings"]["T000001"] == {
-        "level": "H2", "title": "Chapter One", "tag": "One",
+    assert idxData[cHandle]["headings"]["T0001"] == {
+        "level": "H2", "line": 1, "title": "Chapter One", "tag": "One",
         "cCount": 60, "wCount": 10, "pCount": 2, "synopsis": "In the beginning ...",
     }
-    assert "@pov" in idxData[cHandle]["references"]["T000001"]["Jane"]
-    assert "@focus" in idxData[cHandle]["references"]["T000001"]["Jane"]
-    assert "@char" in idxData[cHandle]["references"]["T000001"]["Jane"]
-    assert "@char" in idxData[cHandle]["references"]["T000001"]["John"]
+    assert "@pov" in idxData[cHandle]["references"]["T0001"]["Jane"]
+    assert "@focus" in idxData[cHandle]["references"]["T0001"]["Jane"]
+    assert "@char" in idxData[cHandle]["references"]["T0001"]["Jane"]
+    assert "@char" in idxData[cHandle]["references"]["T0001"]["John"]
 
     # Add the other two files
     itemIndex.add(nHandle, theProject.tree[nHandle])
     itemIndex.add(sHandle, theProject.tree[sHandle])
-    itemIndex.addItemHeading(nHandle, "T000001", "H1", "Novel")
-    itemIndex.addItemHeading(sHandle, "T000001", "H3", "Scene One")
+    itemIndex.addItemHeading(nHandle, 1, "H1", "Novel")
+    itemIndex.addItemHeading(sHandle, 1, "H3", "Scene One")
 
     # Check Item and Heading Direct Access
     # ====================================
 
     # Check repr strings
     assert repr(itemIndex[nHandle]) == f"<IndexItem handle='{nHandle}'>"
-    assert repr(itemIndex[nHandle]["T000001"]) == "<IndexHeading key='T000001'>"
+    assert repr(itemIndex[nHandle]["T0001"]) == "<IndexHeading key='T0001'>"
 
     # Check content of a single item
-    assert "T000001" in itemIndex[nHandle]
+    assert "T0001" in itemIndex[nHandle]
     assert itemIndex[cHandle].allTags() == ["One"]
 
     # Check the content of a single heading
-    assert itemIndex[cHandle]["T000001"].key == "T000001"
-    assert itemIndex[cHandle]["T000001"].level == "H2"
-    assert itemIndex[cHandle]["T000001"].title == "Chapter One"
-    assert itemIndex[cHandle]["T000001"].tag == "One"
-    assert itemIndex[cHandle]["T000001"].charCount == 60
-    assert itemIndex[cHandle]["T000001"].wordCount == 10
-    assert itemIndex[cHandle]["T000001"].paraCount == 2
-    assert itemIndex[cHandle]["T000001"].synopsis == "In the beginning ..."
-    assert "Jane" in itemIndex[cHandle]["T000001"].references
-    assert "John" in itemIndex[cHandle]["T000001"].references
+    assert itemIndex[cHandle]["T0001"].key == "T0001"
+    assert itemIndex[cHandle]["T0001"].level == "H2"
+    assert itemIndex[cHandle]["T0001"].line == 1
+    assert itemIndex[cHandle]["T0001"].title == "Chapter One"
+    assert itemIndex[cHandle]["T0001"].tag == "One"
+    assert itemIndex[cHandle]["T0001"].charCount == 60
+    assert itemIndex[cHandle]["T0001"].wordCount == 10
+    assert itemIndex[cHandle]["T0001"].paraCount == 2
+    assert itemIndex[cHandle]["T0001"].synopsis == "In the beginning ..."
+    assert "Jane" in itemIndex[cHandle]["T0001"].references
+    assert "John" in itemIndex[cHandle]["T0001"].references
 
     # Check heading level setter
-    itemIndex[cHandle]["T000001"].setLevel("H3")  # Change it
-    assert itemIndex[cHandle]["T000001"].level == "H3"
-    itemIndex[cHandle]["T000001"].setLevel("H2")  # Set it back
-    assert itemIndex[cHandle]["T000001"].level == "H2"
-    itemIndex[cHandle]["T000001"].setLevel("H5")  # Invalid level
-    assert itemIndex[cHandle]["T000001"].level == "H2"
+    itemIndex[cHandle]["T0001"].setLevel("H3")  # Change it
+    assert itemIndex[cHandle]["T0001"].level == "H3"
+    itemIndex[cHandle]["T0001"].setLevel("H2")  # Set it back
+    assert itemIndex[cHandle]["T0001"].level == "H2"
+    itemIndex[cHandle]["T0001"].setLevel("H5")  # Invalid level
+    assert itemIndex[cHandle]["T0001"].level == "H2"
 
     # Data Extraction
     # ===============
@@ -1044,9 +1065,9 @@ def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
     assert allHeads[0][0] == cHandle
     assert allHeads[1][0] == nHandle
     assert allHeads[2][0] == sHandle
-    assert allHeads[0][1] == "T000001"
-    assert allHeads[1][1] == "T000001"
-    assert allHeads[2][1] == "T000001"
+    assert allHeads[0][1] == "T0001"
+    assert allHeads[1][1] == "T0001"
+    assert allHeads[2][1] == "T0001"
 
     # Ask for stuff that doesn't exist
     assert itemIndex.allItemTags("blablabla") == []
@@ -1058,7 +1079,7 @@ def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
     mHandle = theProject.newRoot(nwItemClass.NOVEL)
     uHandle = theProject.newFile("Title Page", mHandle)
     itemIndex.add(uHandle, theProject.tree[uHandle])
-    itemIndex.addItemHeading(uHandle, "T000001", "H1", "Novel 2")
+    itemIndex.addItemHeading(uHandle, "T0001", "H1", "Novel 2")
     assert uHandle in itemIndex
 
     # Structure of all novels
@@ -1134,20 +1155,20 @@ def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
     # Reference without a heading should be rejected
     itemIndex.unpackData({
         cHandle: {
-            "headings": {"T000001": {}},
-            "references": {"T000001": {}, "T000002": {}},
+            "headings": {"T0001": {}},
+            "references": {"T0001": {}, "T0002": {}},
         }
     })
-    assert "T000001" in itemIndex[cHandle]
-    assert "T000002" not in itemIndex[cHandle]
+    assert "T0001" in itemIndex[cHandle]
+    assert "T0002" not in itemIndex[cHandle]
     itemIndex.clear()
 
     # Tag keys must be strings
     with pytest.raises(ValueError):
         itemIndex.unpackData({
             cHandle: {
-                "headings": {"T000001": {}},
-                "references": {"T000001": {1234: "@pov"}},
+                "headings": {"T0001": {}},
+                "references": {"T0001": {1234: "@pov"}},
             }
         })
 
@@ -1155,8 +1176,8 @@ def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
     with pytest.raises(ValueError):
         itemIndex.unpackData({
             cHandle: {
-                "headings": {"T000001": {}},
-                "references": {"T000001": {"John": []}},
+                "headings": {"T0001": {}},
+                "references": {"T0001": {"John": []}},
             }
         })
 
@@ -1164,16 +1185,16 @@ def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
     with pytest.raises(ValueError):
         itemIndex.unpackData({
             cHandle: {
-                "headings": {"T000001": {}},
-                "references": {"T000001": {"John": "@pov,@char,@stuff"}},
+                "headings": {"T0001": {}},
+                "references": {"T0001": {"John": "@pov,@char,@stuff"}},
             }
         })
 
     # This should pass
     itemIndex.unpackData({
         cHandle: {
-            "headings": {"T000001": {}},
-            "references": {"T000001": {"John": "@pov,@char"}},
+            "headings": {"T0001": {}},
+            "references": {"T0001": {"John": "@pov,@char"}},
         }
     })
 

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -118,10 +118,10 @@ def testGuiEditor_LoadText(qtbot, monkeypatch, caplog, nwGUI, projPath, ipsumTex
     assert nwGUI.docEditor.loadText(C.hSceneDoc) is True
     assert nwGUI.docEditor._bigDoc is True
 
-    # Regular open, with line number
+    # Regular open, with line number (1 indexed)
     assert nwGUI.docEditor.loadText(C.hSceneDoc, tLine=4) is True
     cursPos = nwGUI.docEditor.getCursorPosition()
-    assert nwGUI.docEditor.document().findBlock(cursPos).blockNumber() == 4
+    assert nwGUI.docEditor.document().findBlock(cursPos).blockNumber() == 3
 
     # Load empty document
     nwGUI.docEditor.replaceText("")

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -57,7 +57,6 @@ def testGuiMain_ProjectBlocker(nwGUI):
     assert nwGUI.importDocument() is False
     assert nwGUI.openSelectedItem() is False
     assert nwGUI.editItemLabel() is False
-    assert nwGUI.requestNovelTreeRefresh() is False
     assert nwGUI.rebuildIndex() is False
     assert nwGUI.showProjectSettingsDialog() is False
     assert nwGUI.showProjectDetailsDialog() is False

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -92,7 +92,7 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     assert not topItem.isSelected()
     topItem.setSelected(True)
     assert novelTree.selectedItems()[0] == topItem
-    assert novelView.getSelectedHandle() == (C.hTitlePage, 0)
+    assert novelView.getSelectedHandle() == (C.hTitlePage, "T0001")
 
     # Refresh using the slot for the butoom
     novelBar._refreshNovelTree()
@@ -142,31 +142,31 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     novelBar.setLastColType(NovelTreeColumn.HIDDEN)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is True
     assert novelTree.lastColType == NovelTreeColumn.HIDDEN
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == ("", "")
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == ("", "")
 
     novelBar.setLastColType(NovelTreeColumn.POV)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
     assert novelTree.lastColType == NovelTreeColumn.POV
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == (
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
         "Jane", "Point of View: Jane"
     )
 
     novelBar.setLastColType(NovelTreeColumn.FOCUS)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
     assert novelTree.lastColType == NovelTreeColumn.FOCUS
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == (
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
         "Jane", "Focus: Jane"
     )
 
     novelBar.setLastColType(NovelTreeColumn.PLOT)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
     assert novelTree.lastColType == NovelTreeColumn.PLOT
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T000001") == (
+    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
         "", "Plot: "
     )
 
     novelTree._lastCol = None
-    assert novelTree._getLastColumnText("0000000000000", "T000000") == ("", "")
+    assert novelTree._getLastColumnText("0000000000000", "T0000") == ("", "")
 
     # Item Meta
     # =========

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -225,9 +225,9 @@ def testGuiOutline_Content(qtbot, nwGUI, nwLipsum):
     selItem = outlineTree.topLevelItem(4)
 
     outlineTree.setCurrentItem(selItem)
-    tHandle, tLine = outlineTree.getSelectedHandle()
+    tHandle, sTitle = outlineTree.getSelectedHandle()
     assert tHandle == "88243afbe5ed8"
-    assert tLine == 0
+    assert sTitle == "T0001"
 
     assert outlineData.titleLabel.text() == "<b>Scene</b>"
     assert outlineData.titleValue.text() == "Scene One"
@@ -243,9 +243,9 @@ def testGuiOutline_Content(qtbot, nwGUI, nwLipsum):
     selItem = outlineTree.topLevelItem(5)
 
     outlineTree.setCurrentItem(selItem)
-    tHandle, tLine = outlineTree.getSelectedHandle()
+    tHandle, sTitle = outlineTree.getSelectedHandle()
     assert tHandle == "88243afbe5ed8"
-    assert tLine == 12
+    assert sTitle == "T0002"
 
     assert outlineData.titleLabel.text() == "<b>Section</b>"
     assert outlineData.titleValue.text() == "Scene One, Section Two"


### PR DESCRIPTION
**Summary:**

This PR redesigns how the novel tree is updated. As long as the number of headings in a document don't change, the meta data for a document is refreshed each time the document is saved. Previously, this required a full rebuild of the tree, which is somewhat expensive. The tree is now rebuilt only when there are headings added or removed.

In order to better detect this, the index handling of headers has been changed. Each heading is now saved with a key that simply corresponds to its order in the document. Previously, the key represented the line number, which means it changed much more often. The line number is rarely needed, but is now recorded as a separate value in the heading index for those cases.

This change also simplified a number of different pieces of code tracking the status of a documents meta data.

**Related Issue(s):**

Closes #1240

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
