### PR TITLE
Set a max column width for novel tree extra column

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -104,7 +104,7 @@ class NWIndex:
         """
         self.clearIndex()
         for nwItem in self._project.tree:
-            if nwItem is not None and nwItem.isFileType():
+            if nwItem.isFileType():
                 tHandle = nwItem.itemHandle
                 theDoc = self._project.storage.getDocument(tHandle)
                 self.scanText(tHandle, theDoc.readDocument() or "")
@@ -794,8 +794,6 @@ class ItemIndex:
         a given root handle, or for all if root handle is None.
         """
         for tItem in self._project.tree:
-            if tItem is None:
-                continue
             if tItem.isNoteLayout():
                 continue
             if skipExcl and not tItem.isActive:

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -50,7 +50,6 @@ class NWTree:
         self._treeRoots   = {}     # The root items of the tree
         self._trashRoot   = None   # The handle of the trash root folder
         self._archRoot    = None   # The handle of the archive root folder
-        self._theIndex    = 0      # The current iterator index
         self._treeChanged = False  # True if tree structure has changed
 
         return
@@ -62,12 +61,11 @@ class NWTree:
     def clear(self):
         """Clear the item tree entirely.
         """
-        self._projTree  = {}
-        self._treeOrder = []
-        self._treeRoots = {}
-        self._trashRoot = None
-        self._archRoot  = None
-        self._theIndex  = 0
+        self._projTree    = {}
+        self._treeOrder   = []
+        self._treeRoots   = {}
+        self._trashRoot   = None
+        self._archRoot    = None
         self._treeChanged = False
         return
 
@@ -278,7 +276,7 @@ class NWTree:
         """
         for tHandle in self._treeOrder:
             nwItem = self.__getitem__(tHandle)
-            if nwItem is not None and nwItem.isRootType():
+            if isinstance(nwItem, NWItem) and nwItem.isRootType():
                 if itemClass is None or nwItem.itemClass == itemClass:
                     yield tHandle, nwItem
         return
@@ -365,22 +363,18 @@ class NWTree:
         return True
 
     ##
-    #  Meta Methods
+    #  Special Methods
     ##
 
     def __len__(self):
-        """Return the length counter. Does not check that it is correct!
+        """The number of items in the project.
         """
         return len(self._treeOrder)
 
     def __bool__(self):
-        """Returns True if the tree has any entries.
+        """True if there are any items in the project.
         """
-        return len(self._treeOrder) > 0
-
-    ##
-    #  Item Access Methods
-    ##
+        return bool(self._treeOrder)
 
     def __getitem__(self, tHandle):
         """Return a project item based on its handle. Returns None if
@@ -417,25 +411,14 @@ class NWTree:
         """
         return tHandle in self._treeOrder
 
-    ##
-    #  Iterator Methods
-    ##
-
     def __iter__(self):
-        """Initiates the iterator.
+        """Iterate through project items.
         """
-        self._theIndex = 0
-        return self
-
-    def __next__(self):
-        """Returns the item from the next entry in the _treeOrder list.
-        """
-        if self._theIndex < len(self._treeOrder):
-            theItem = self.__getitem__(self._treeOrder[self._theIndex])
-            self._theIndex += 1
-            return theItem
-        else:
-            raise StopIteration
+        for tHandle in self._treeOrder:
+            tItem = self._projTree.get(tHandle)
+            if isinstance(tItem, NWItem):
+                yield tItem
+        return
 
     ##
     #  Internal Functions

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -73,6 +73,7 @@ class GuiOutlineView(QWidget):
         self.splitOutline = QSplitter(Qt.Vertical)
         self.splitOutline.addWidget(self.outlineTree)
         self.splitOutline.addWidget(self.outlineData)
+        self.splitOutline.setOpaqueResize(False)
         self.splitOutline.setSizes(self.mainConf.outlinePanePos)
 
         # Assemble

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -140,12 +140,14 @@ class GuiMain(QMainWindow):
         self.splitView.addWidget(self.docViewer)
         self.splitView.addWidget(self.viewMeta)
         self.splitView.setHandleWidth(hWd)
+        self.splitView.setOpaqueResize(False)
         self.splitView.setSizes(self.mainConf.viewPanePos)
 
         # Splitter : Document Editor / Document Viewer
         self.splitDocs = QSplitter(Qt.Horizontal)
         self.splitDocs.addWidget(self.docEditor)
         self.splitDocs.addWidget(self.splitView)
+        self.splitDocs.setOpaqueResize(False)
         self.splitDocs.setHandleWidth(hWd)
 
         # Splitter : Project Tree / Main Tabs
@@ -153,6 +155,7 @@ class GuiMain(QMainWindow):
         self.splitMain.setContentsMargins(0, 0, 0, 0)
         self.splitMain.addWidget(self.treePane)
         self.splitMain.addWidget(self.splitDocs)
+        self.splitMain.setOpaqueResize(False)
         self.splitMain.setHandleWidth(hWd)
         self.splitMain.setSizes(self.mainConf.mainPanePos)
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -628,7 +628,7 @@ class GuiMain(QMainWindow):
         fHandle = None   # The first file handle we encounter
         foundIt = False  # We've found tHandle, pick the next we see
         for tItem in self.theProject.tree:
-            if tItem is None or not tItem.isFileType():
+            if not tItem.isFileType():
                 continue
             if fHandle is None:
                 fHandle = tItem.itemHandle

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -144,11 +144,11 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     assert novelTree.lastColType == NovelTreeColumn.HIDDEN
     assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == ("", "")
 
-    novelBar.setLastColType(NovelTreeColumn.POV)
+    novelBar.setLastColType(NovelTreeColumn.PLOT)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == NovelTreeColumn.POV
+    assert novelTree.lastColType == NovelTreeColumn.PLOT
     assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
-        "Jane", "Point of View: Jane"
+        "", ""
     )
 
     novelBar.setLastColType(NovelTreeColumn.FOCUS)
@@ -158,15 +158,19 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
         "Jane", "Focus: Jane"
     )
 
-    novelBar.setLastColType(NovelTreeColumn.PLOT)
+    novelBar.setLastColType(NovelTreeColumn.POV)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == NovelTreeColumn.PLOT
+    assert novelTree.lastColType == NovelTreeColumn.POV
     assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
-        "", "Plot: "
+        "Jane", "Point of View: Jane"
     )
 
     novelTree._lastCol = None
     assert novelTree._getLastColumnText("0000000000000", "T0000") == ("", "")
+
+    # This forces the resizeEvent function to process labels
+    spSize = nwGUI.splitMain.sizes()
+    nwGUI.splitMain.setSizes([spSize[0] + 10, spSize[1] - 10])
 
     # Item Meta
     # =========


### PR DESCRIPTION
**Summary:**

This PR makes a few changes to the optional extra column in the novel view:
* The column will now only show the first of the references in the list returned from the index. The full data is still shown in the tooltip.
* The column will still shrink to content, but if the content grows larger than 25% of the width of the widget, the text will be elided using the QFontMetric class.

In addition, this PR improves how project items are iterated through in the project tree class. It now uses yield instead of index, and checks the type before yielding an item. This means a None will never be returned here.

**Related Issue(s):**

Closes #1238

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
