### PR TITLE
Update closing project procedure, and editor scrolling

### DIFF
--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -130,15 +130,6 @@ class nwAlert(Enum):
 # END Enum nwAlert
 
 
-class nwState(Enum):
-
-    NONE = 0
-    BAD  = 1
-    GOOD = 2
-
-# END Enum nwState
-
-
 class nwView(Enum):
 
     EDITOR  = 0

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -666,12 +666,17 @@ class GuiDocEditor(QTextEdit):
             theCursor.setPosition(minmax(position, 0, nChars-1))
             self.setTextCursor(theCursor)
 
-            # The editor scrolls so the cursor is on the last line, so we must correct
-            vPos = self.verticalScrollBar().value()       # Current scrollbar position
-            cPos = self.cursorRect().topLeft().y()        # Cursor position to scroll to
-            dMrg = int(self.document().documentMargin())  # Document margin to subtract
-            mPos = int(self.viewport().height()*0.1)      # Distance from top to adjust for (10%)
-            self.verticalScrollBar().setValue(max(0, vPos + cPos - dMrg - mPos))
+            # By default, the editor scrolls so the cursor is on the
+            # last line, so we must correct it. The user setting for
+            # auto-scroll is used to determine the scroll distance. This
+            # makes it compatible with the typewriter scrolling feature
+            # when it is enabled. By default, it's 30% of viewport.
+            vPos = self.verticalScrollBar().value()
+            cPos = self.cursorRect().topLeft().y()
+            mPos = int(self.mainConf.autoScrollPos*0.01 * self.viewport().height())
+            if cPos > mPos:
+                # Only scroll if the cursor is past the auto-scroll limit
+                self.verticalScrollBar().setValue(max(0, vPos + cPos - mPos))
 
             self.docFooter.updateLineCount()
 

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -34,7 +34,6 @@ from PyQt5.QtGui import QColor, QPainter
 from PyQt5.QtWidgets import qApp, QStatusBar, QLabel, QAbstractButton
 
 from novelwriter.common import formatTime
-from novelwriter.enum import nwState
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +52,8 @@ class GuiMainStatus(QStatusBar):
         self.userIdle  = False
 
         colNone = QColor(*self.mainTheme.statNone)
-        colTrue = QColor(*self.mainTheme.statUnsaved)
-        colFalse = QColor(*self.mainTheme.statSaved)
+        colSaved = QColor(*self.mainTheme.statSaved)
+        colUnsaved = QColor(*self.mainTheme.statUnsaved)
 
         iPx = self.mainTheme.baseIconSize
 
@@ -72,7 +71,7 @@ class GuiMainStatus(QStatusBar):
         self.addPermanentWidget(self.langText)
 
         # The Editor Status
-        self.docIcon = StatusLED(colNone, colTrue, colFalse, iPx, iPx, self)
+        self.docIcon = StatusLED(colNone, colSaved, colUnsaved, iPx, iPx, self)
         self.docText = QLabel(self.tr("Editor"))
         self.docIcon.setContentsMargins(0, 0, 0, 0)
         self.docText.setContentsMargins(0, 0, xM, 0)
@@ -80,7 +79,7 @@ class GuiMainStatus(QStatusBar):
         self.addPermanentWidget(self.docText)
 
         # The Project Status
-        self.projIcon = StatusLED(colNone, colTrue, colFalse, iPx, iPx, self)
+        self.projIcon = StatusLED(colNone, colSaved, colUnsaved, iPx, iPx, self)
         self.projText = QLabel(self.tr("Project"))
         self.projIcon.setContentsMargins(0, 0, 0, 0)
         self.projText.setContentsMargins(0, 0, xM, 0)
@@ -122,8 +121,8 @@ class GuiMainStatus(QStatusBar):
         self.setRefTime(None)
         self.setLanguage(None, "")
         self.setProjectStats(0, 0)
-        self.setProjectStatus(nwState.NONE)
-        self.setDocumentStatus(nwState.NONE)
+        self.setProjectStatus(StatusLED.S_NONE)
+        self.setDocumentStatus(StatusLED.S_NONE)
         self.updateTime()
         return True
 
@@ -236,20 +235,24 @@ class GuiMainStatus(QStatusBar):
     def doUpdateProjectStatus(self, isChanged):
         """Slot for updating the project status.
         """
-        self.setProjectStatus(nwState.GOOD if isChanged else nwState.BAD)
+        self.setProjectStatus(StatusLED.S_BAD if isChanged else StatusLED.S_GOOD)
         return
 
     @pyqtSlot(bool)
     def doUpdateDocumentStatus(self, isChanged):
         """Slot for updating the document status.
         """
-        self.setDocumentStatus(nwState.GOOD if isChanged else nwState.BAD)
+        self.setDocumentStatus(StatusLED.S_BAD if isChanged else StatusLED.S_GOOD)
         return
 
 # END Class GuiMainStatus
 
 
 class StatusLED(QAbstractButton):
+
+    S_NONE = 0
+    S_BAD  = 1
+    S_GOOD = 2
 
     def __init__(self, colNone, colGood, colBad, sW, sH, parent=None):
         super().__init__(parent=parent)
@@ -271,9 +274,9 @@ class StatusLED(QAbstractButton):
     def setState(self, theState):
         """Set the colour state.
         """
-        if theState == nwState.GOOD:
+        if theState == self.S_GOOD:
             self._theCol = self._colGood
-        elif theState == nwState.BAD:
+        elif theState == self.S_BAD:
             self._theCol = self._colBad
         else:
             self._theCol = self._colNone

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -312,7 +312,7 @@ class GuiMain(QMainWindow):
         # Work Area
         self.docEditor.clearEditor()
         self.docEditor.setDictionaries()
-        self.closeDocViewer()
+        self.closeDocViewer(byUser=False)
         self.outlineView.clearProject()
 
         # General
@@ -1220,14 +1220,19 @@ class GuiMain(QMainWindow):
         self.theProject.data.setLastHandle(None, "editor")
         return
 
-    def closeDocViewer(self):
+    def closeDocViewer(self, byUser=True):
         """Close the document view panel.
         """
         self.docViewer.clearViewer()
-        self.theProject.data.setLastHandle(None, "viewer")
+        if byUser:
+            # Only reset the last handle if the user called this
+            self.theProject.data.setLastHandle(None, "viewer")
+
+        # Hide the panel
         bPos = self.splitMain.sizes()
         self.splitView.setVisible(False)
         self.splitDocs.setSizes([bPos[1], 0])
+
         return not self.splitView.isVisible()
 
     def toggleFocusMode(self):

--- a/tests/test_gui/test_gui_statusbar.py
+++ b/tests/test_gui/test_gui_statusbar.py
@@ -24,7 +24,7 @@ import pytest
 
 from tools import C, buildTestProject
 
-from novelwriter.enum import nwState
+from novelwriter.gui.statusbar import StatusLED
 
 
 @pytest.mark.gui
@@ -44,19 +44,19 @@ def testGuiStatusBar_Main(qtbot, nwGUI, projPath, mockRnd):
     assert nwGUI.mainStatus.refTime == refTime
 
     # Project Status
-    nwGUI.mainStatus.setProjectStatus(nwState.NONE)
+    nwGUI.mainStatus.setProjectStatus(StatusLED.S_NONE)
     assert nwGUI.mainStatus.projIcon._theCol == nwGUI.mainStatus.projIcon._colNone
-    nwGUI.mainStatus.setProjectStatus(nwState.BAD)
+    nwGUI.mainStatus.setProjectStatus(StatusLED.S_BAD)
     assert nwGUI.mainStatus.projIcon._theCol == nwGUI.mainStatus.projIcon._colBad
-    nwGUI.mainStatus.setProjectStatus(nwState.GOOD)
+    nwGUI.mainStatus.setProjectStatus(StatusLED.S_GOOD)
     assert nwGUI.mainStatus.projIcon._theCol == nwGUI.mainStatus.projIcon._colGood
 
     # Document Status
-    nwGUI.mainStatus.setDocumentStatus(nwState.NONE)
+    nwGUI.mainStatus.setDocumentStatus(StatusLED.S_NONE)
     assert nwGUI.mainStatus.docIcon._theCol == nwGUI.mainStatus.docIcon._colNone
-    nwGUI.mainStatus.setDocumentStatus(nwState.BAD)
+    nwGUI.mainStatus.setDocumentStatus(StatusLED.S_BAD)
     assert nwGUI.mainStatus.docIcon._theCol == nwGUI.mainStatus.docIcon._colBad
-    nwGUI.mainStatus.setDocumentStatus(nwState.GOOD)
+    nwGUI.mainStatus.setDocumentStatus(StatusLED.S_GOOD)
     assert nwGUI.mainStatus.docIcon._theCol == nwGUI.mainStatus.docIcon._colGood
 
     # Idle Status


### PR DESCRIPTION
**Summary:**

This PR:
* Makes some changes to how project status saved/unsaved is handled.
* Changes the go to line behaviour of the editor to work similarly to the auto-scrolling feature, and uses the same setting.

**Related Issue(s):**

Closes #1237

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
