### PR TITLE
Add a novel selector class

### DIFF
--- a/novelwriter/gui/components.py
+++ b/novelwriter/gui/components.py
@@ -31,6 +31,7 @@ from PyQt5.QtCore import pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QAbstractButton, QComboBox
 
 from novelwriter.enum import nwItemClass
+from novelwriter.constants import nwLabels
 
 logger = logging.getLogger(__name__)
 
@@ -39,14 +40,12 @@ class NovelSelector(QComboBox):
 
     novelSelectionChanged = pyqtSignal(str)
 
-    def __init__(self, parent, project, icon):
+    def __init__(self, parent, project, theme):
         super().__init__(parent=parent)
 
         self._project = project
-        self._icon = icon
-
+        self._theme = theme
         self._blockSignal = False
-
         self.currentIndexChanged.connect(self._indexChanged)
 
         return
@@ -73,10 +72,13 @@ class NovelSelector(QComboBox):
         """
         self._blockSignal = True
         self.clear()
+        icon = self._theme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
+        handle = self.currentData()
         for tHandle, nwItem in self._project.tree.iterRoots(nwItemClass.NOVEL):
-            self.addItem(self._icon, nwItem.itemName, tHandle)
+            self.addItem(icon, nwItem.itemName, tHandle)
         self.insertSeparator(self.count())
-        self.addItem(self._icon, self.tr("All Novel Folders"), "")
+        self.addItem(icon, self.tr("All Novel Folders"), "")
+        self.setHandle(handle)
         self._blockSignal = False
         return
 

--- a/novelwriter/gui/components.py
+++ b/novelwriter/gui/components.py
@@ -67,19 +67,33 @@ class NovelSelector(QComboBox):
         self._blockSignal = False
         return
 
-    def updateList(self):
+    def updateList(self, includeAll=False, prefix=None):
         """Rebuild the list of novel items.
         """
         self._blockSignal = True
         self.clear()
+
         icon = self._theme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
         handle = self.currentData()
         for tHandle, nwItem in self._project.tree.iterRoots(nwItemClass.NOVEL):
-            self.addItem(icon, nwItem.itemName, tHandle)
-        self.insertSeparator(self.count())
-        self.addItem(icon, self.tr("All Novel Folders"), "")
+            if prefix:
+                name = prefix.format(nwItem.itemName)
+                self.addItem(name, tHandle)
+            else:
+                name = nwItem.itemName
+                self.addItem(icon, nwItem.itemName, tHandle)
+
+        if includeAll:
+            self.insertSeparator(self.count())
+            if prefix:
+                self.addItem(prefix.format(self.tr("All Novel Folders")), "")
+            else:
+                self.addItem(icon, self.tr("All Novel Folders"), "")
+
         self.setHandle(handle)
+        self.setEnabled(self.count() > 1)
         self._blockSignal = False
+
         return
 
     ##

--- a/novelwriter/gui/components.py
+++ b/novelwriter/gui/components.py
@@ -1,0 +1,87 @@
+"""
+novelWriter – GUI Components Module
+===================================
+A module of various small GUI components
+
+File History:
+Created: 2020-05-17 [0.5.1] StatusLED
+
+This file is a part of novelWriter
+Copyright 2018–2022, Veronica Berglyd Olsen
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import logging
+
+from PyQt5.QtGui import QPainter
+from PyQt5.QtWidgets import QAbstractButton
+
+logger = logging.getLogger(__name__)
+
+
+class StatusLED(QAbstractButton):
+
+    S_NONE = 0
+    S_BAD  = 1
+    S_GOOD = 2
+
+    def __init__(self, colNone, colGood, colBad, sW, sH, parent=None):
+        super().__init__(parent=parent)
+
+        self._colNone = colNone
+        self._colGood = colGood
+        self._colBad = colBad
+        self._theCol = colNone
+
+        self.setFixedWidth(sW)
+        self.setFixedHeight(sH)
+
+        return
+
+    ##
+    #  Setters
+    ##
+
+    def setState(self, theState):
+        """Set the colour state.
+        """
+        if theState == self.S_GOOD:
+            self._theCol = self._colGood
+        elif theState == self.S_BAD:
+            self._theCol = self._colBad
+        else:
+            self._theCol = self._colNone
+
+        self.update()
+
+        return
+
+    ##
+    #  Events
+    ##
+
+    def paintEvent(self, _):
+        """Drawing the LED.
+        """
+        qPalette = self.palette()
+        qPaint = QPainter(self)
+        qPaint.setRenderHint(QPainter.Antialiasing, True)
+        qPaint.setPen(qPalette.dark().color())
+        qPaint.setBrush(self._theCol)
+        qPaint.setOpacity(1.0)
+        qPaint.drawEllipse(1, 1, self.width() - 2, self.height() - 2)
+        return
+
+# END Class StatusLED

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -31,11 +31,11 @@ import novelwriter
 from enum import Enum
 from time import time
 
-from PyQt5.QtGui import QPalette
+from PyQt5.QtGui import QFont, QPalette
 from PyQt5.QtCore import Qt, QSize, pyqtSlot, pyqtSignal
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QActionGroup, QFrame, QHBoxLayout, QHeaderView, QLabel,
-    QMenu, QSizePolicy, QToolButton, QToolTip, QTreeWidget, QTreeWidgetItem,
+    QAbstractItemView, QActionGroup, QFrame, QHBoxLayout, QHeaderView, QMenu,
+    QSizePolicy, QToolButton, QToolTip, QTreeWidget, QTreeWidgetItem,
     QVBoxLayout, QWidget
 )
 
@@ -200,17 +200,15 @@ class GuiNovelToolBar(QWidget):
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
 
-        # Widget Label
-        self.viewLabel = QLabel("<b>%s</b>" % self.tr("Novel Outline"))
-        self.viewLabel.setContentsMargins(0, 0, 0, 0)
-        self.viewLabel.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-
         # Novel Selector
         selFont = self.font()
-        selFont.setPointSize(int(0.9 * selFont.pointSize()))
+        selFont.setWeight(QFont.Bold)
+        self.novelPrefix = self.tr("Outline of {0}")
         self.novelValue = NovelSelector(self, self.theProject, self.mainTheme)
-        self.novelValue.setMinimumWidth(self.mainConf.pxInt(150))
         self.novelValue.setFont(selFont)
+        self.novelValue.setMinimumWidth(self.mainConf.pxInt(150))
+        self.novelValue.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.novelValue.setToolTip(self.tr("Click to change root folder"))
         self.novelValue.novelSelectionChanged.connect(self.setCurrentRoot)
 
         # Refresh Button
@@ -238,7 +236,6 @@ class GuiNovelToolBar(QWidget):
 
         # Assemble
         self.outerBox = QHBoxLayout()
-        self.outerBox.addWidget(self.viewLabel)
         self.outerBox.addWidget(self.novelValue)
         self.outerBox.addWidget(self.tbRefresh)
         self.outerBox.addWidget(self.tbMore)
@@ -275,9 +272,14 @@ class GuiNovelToolBar(QWidget):
             "QToolButton:hover {{border: none; background: rgba({1},{2},{3},0.2);}}"
         ).format(self.mainConf.pxInt(2), fadeCol.red(), fadeCol.green(), fadeCol.blue())
 
-        self.novelValue.updateList()
         self.tbRefresh.setStyleSheet(buttonStyle)
         self.tbMore.setStyleSheet(buttonStyle)
+
+        self.novelValue.setStyleSheet(
+            "QComboBox {border-style: none; padding-left: 0;} "
+            "QComboBox::drop-down {border-style: none}"
+        )
+        self.novelValue.updateList(prefix=self.novelPrefix)
 
         return
 
@@ -290,7 +292,7 @@ class GuiNovelToolBar(QWidget):
     def buildNovelRootMenu(self):
         """Build the novel root menu.
         """
-        self.novelValue.updateList()
+        self.novelValue.updateList(prefix=self.novelPrefix)
         return
 
     def setCurrentRoot(self, rootHandle):

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -208,7 +208,6 @@ class GuiNovelToolBar(QWidget):
         self.novelValue.setFont(selFont)
         self.novelValue.setMinimumWidth(self.mainConf.pxInt(150))
         self.novelValue.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.novelValue.setToolTip(self.tr("Click to change root folder"))
         self.novelValue.novelSelectionChanged.connect(self.setCurrentRoot)
 
         # Refresh Button
@@ -280,6 +279,10 @@ class GuiNovelToolBar(QWidget):
             "QComboBox::drop-down {border-style: none}"
         )
         self.novelValue.updateList(prefix=self.novelPrefix)
+        if self.novelValue.count() > 1:
+            self.novelValue.setToolTip(self.tr("Click to change root folder"))
+        else:
+            self.novelValue.setToolTip("")
 
         return
 
@@ -287,12 +290,17 @@ class GuiNovelToolBar(QWidget):
         """Run clearing project tasks.
         """
         self.novelValue.clear()
+        self.novelValue.setToolTip("")
         return
 
     def buildNovelRootMenu(self):
         """Build the novel root menu.
         """
         self.novelValue.updateList(prefix=self.novelPrefix)
+        if self.novelValue.count() > 1:
+            self.novelValue.setToolTip(self.tr("Click to change root folder"))
+        else:
+            self.novelValue.setToolTip("")
         return
 
     def setCurrentRoot(self, rootHandle):

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -234,8 +234,7 @@ class GuiOutlineToolBar(QToolBar):
         self.novelLabel = QLabel(self.tr("Outline of"))
         self.novelLabel.setContentsMargins(0, 0, mPx, 0)
 
-        tIcon = self.mainTheme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
-        self.novelValue = NovelSelector(self, self.theProject, tIcon)
+        self.novelValue = NovelSelector(self, self.theProject, self.mainTheme)
         self.novelValue.setMinimumWidth(self.mainConf.pxInt(200))
         self.novelValue.novelSelectionChanged.connect(self._novelValueChanged)
 
@@ -276,6 +275,7 @@ class GuiOutlineToolBar(QToolBar):
         """
         self.setStyleSheet("QToolBar {border: 0px;}")
 
+        self.novelValue.updateList()
         self.aRefresh.setIcon(self.mainTheme.getIcon("refresh"))
         self.tbColumns.setIcon(self.mainTheme.getIcon("menu"))
 

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -37,9 +37,9 @@ from PyQt5.QtCore import (
     Qt, pyqtSignal, pyqtSlot, QSize, QT_TRANSLATE_NOOP
 )
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QAction, QComboBox, QFrame, QGridLayout, QGroupBox,
-    QHBoxLayout, QLabel, QMenu, QScrollArea, QSizePolicy, QSplitter, QToolBar,
-    QToolButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+    QAbstractItemView, QAction, QFrame, QGridLayout, QGroupBox, QHBoxLayout,
+    QLabel, QMenu, QScrollArea, QSizePolicy, QSplitter, QToolBar, QToolButton,
+    QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
 
 from novelwriter.enum import (
@@ -47,6 +47,7 @@ from novelwriter.enum import (
 )
 from novelwriter.common import checkInt
 from novelwriter.constants import nwHeaders, trConst, nwKeyWords, nwLabels
+from novelwriter.gui.components import NovelSelector
 
 
 logger = logging.getLogger(__name__)
@@ -233,9 +234,10 @@ class GuiOutlineToolBar(QToolBar):
         self.novelLabel = QLabel(self.tr("Outline of"))
         self.novelLabel.setContentsMargins(0, 0, mPx, 0)
 
-        self.novelValue = QComboBox(self)
+        tIcon = self.mainTheme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
+        self.novelValue = NovelSelector(self, self.theProject, tIcon)
         self.novelValue.setMinimumWidth(self.mainConf.pxInt(200))
-        self.novelValue.currentIndexChanged.connect(self._novelValueChanged)
+        self.novelValue.novelSelectionChanged.connect(self._novelValueChanged)
 
         # Actions
         self.aRefresh = QAction(self.tr("Refresh"), self)
@@ -280,25 +282,15 @@ class GuiOutlineToolBar(QToolBar):
         return
 
     def populateNovelList(self):
-        """Fill the novel combo box with a list of all novel folders.
+        """Relaod the content of the novel list.
         """
-        self.novelValue.clear()
-        tIcon = self.mainTheme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
-        for tHandle, nwItem in self.theProject.tree.iterRoots(nwItemClass.NOVEL):
-            self.novelValue.addItem(tIcon, nwItem.itemName, tHandle)
-        self.novelValue.insertSeparator(self.novelValue.count())
-        self.novelValue.addItem(tIcon, self.tr("All Novel Folders"), "")
+        self.novelValue.updateList()
         return
 
     def setCurrentRoot(self, rootHandle):
         """Set the current active root handle.
         """
-        if rootHandle is None:
-            rootIdx = self.novelValue.count() - 1
-        else:
-            rootIdx = self.novelValue.findData(rootHandle)
-        if rootIdx >= 0:
-            self.novelValue.setCurrentIndex(rootIdx)
+        self.novelValue.setHandle(rootHandle)
         return
 
     def setColumnHiddenState(self, hiddenState):
@@ -311,19 +303,18 @@ class GuiOutlineToolBar(QToolBar):
     #  Private Slots
     ##
 
-    @pyqtSlot(int)
-    def _novelValueChanged(self, index):
+    @pyqtSlot(str)
+    def _novelValueChanged(self, tHandle):
         """Emit a signal containing the handle of the selected item.
         """
-        if index >= 0:
-            self.loadNovelRootRequest.emit(self.novelValue.currentData())
+        self.loadNovelRootRequest.emit(tHandle)
         return
 
     @pyqtSlot()
     def _refreshRequested(self):
         """Emit a signal containing the handle of the selected item.
         """
-        self.loadNovelRootRequest.emit(self.novelValue.currentData())
+        self.loadNovelRootRequest.emit(self.novelValue.handle)
         return
 
 # END Class GuiOutlineToolBar
@@ -679,6 +670,7 @@ class GuiOutlineTree(QTreeWidget):
         if they are hidden. This ensures that showing and hiding columns
         is fast and doesn't require a rebuild of the tree.
         """
+        logger.debug("Rebuilding Outline tree")
         self.clear()
 
         if self._firstView:

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -275,7 +275,7 @@ class GuiOutlineToolBar(QToolBar):
         """
         self.setStyleSheet("QToolBar {border: 0px;}")
 
-        self.novelValue.updateList()
+        self.novelValue.updateList(includeAll=True)
         self.aRefresh.setIcon(self.mainTheme.getIcon("refresh"))
         self.tbColumns.setIcon(self.mainTheme.getIcon("menu"))
 
@@ -284,7 +284,7 @@ class GuiOutlineToolBar(QToolBar):
     def populateNovelList(self):
         """Relaod the content of the novel list.
         """
-        self.novelValue.updateList()
+        self.novelValue.updateList(includeAll=True)
         return
 
     def setCurrentRoot(self, rootHandle):

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -30,10 +30,11 @@ import novelwriter
 from time import time
 
 from PyQt5.QtCore import pyqtSlot, QLocale
-from PyQt5.QtGui import QColor, QPainter
-from PyQt5.QtWidgets import qApp, QStatusBar, QLabel, QAbstractButton
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import qApp, QStatusBar, QLabel
 
 from novelwriter.common import formatTime
+from novelwriter.gui.components import StatusLED
 
 logger = logging.getLogger(__name__)
 
@@ -246,59 +247,3 @@ class GuiMainStatus(QStatusBar):
         return
 
 # END Class GuiMainStatus
-
-
-class StatusLED(QAbstractButton):
-
-    S_NONE = 0
-    S_BAD  = 1
-    S_GOOD = 2
-
-    def __init__(self, colNone, colGood, colBad, sW, sH, parent=None):
-        super().__init__(parent=parent)
-
-        self._colNone = colNone
-        self._colGood = colGood
-        self._colBad = colBad
-        self._theCol = colNone
-
-        self.setFixedWidth(sW)
-        self.setFixedHeight(sH)
-
-        return
-
-    ##
-    #  Setters
-    ##
-
-    def setState(self, theState):
-        """Set the colour state.
-        """
-        if theState == self.S_GOOD:
-            self._theCol = self._colGood
-        elif theState == self.S_BAD:
-            self._theCol = self._colBad
-        else:
-            self._theCol = self._colNone
-
-        self.update()
-
-        return
-
-    ##
-    #  Events
-    ##
-
-    def paintEvent(self, _):
-        """Drawing the LED.
-        """
-        qPalette = self.palette()
-        qPaint = QPainter(self)
-        qPaint.setRenderHint(QPainter.Antialiasing, True)
-        qPaint.setPen(qPalette.dark().color())
-        qPaint.setBrush(self._theCol)
-        qPaint.setOpacity(1.0)
-        qPaint.drawEllipse(1, 1, self.width() - 2, self.height() - 2)
-        return
-
-# END Class StatusLED


### PR DESCRIPTION
**Summary:**

This PR adds a NovelSelector class that can be used to select the novel folder to be viewed in the relevant tool. It is added to the Outline View and the Novel View.

In the Novel View it replaces the label at the top of the tree, which becomes a dropdown box if there are more than one novel folder. If there is only one, it acts like a label.

**Related Issue(s):**

Closes #1250

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
