### PR TITLE
Replace lxml in project XML classes

### DIFF
--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-17 16:28:09">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1453" autoCount="237" editTime="69933">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:43:46">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1457" autoCount="237" editTime="69989">
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
@@ -26,7 +26,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sf12341" count="4" red="100" green="100" blue="100">New</entry>
@@ -46,111 +46,111 @@
   </settings>
   <content items="27" novelWords="954" notesWords="409">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="93" wordCount="19" paraCount="2" cursorPos="119"/>
+      <meta expanded="no" heading="H1" charCount="93" wordCount="19" paraCount="2" cursorPos="119" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277"/>
+      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277" />
       <name status="sf12341" import="ia857f0" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="7031beac91f75" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s90e6c9" import="ia857f0" active="yes">Part One</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="7031beac91f75" root="7031beac91f75" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291"/>
+      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291" />
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="67"/>
+      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="67" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465"/>
+      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465" />
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310"/>
+      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0" />
       <name status="sf24ce6" import="ia857f0" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="7031beac91f75" root="7031beac91f75" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188"/>
+      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="88706ddc78b1b" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0" />
       <name status="s90e6c9" import="ia857f0" active="yes">We Found John!</name>
     </item>
     <item handle="e5e47ebf63b1c" parent="None" root="e5e47ebf63b1c" order="1" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Sequel</name>
     </item>
     <item handle="bacb7059e3083" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100"/>
+      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="a520879ca0b45" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104"/>
+      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="f6622b4617424" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="f6622b4617424" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="sf12341" import="icfb3a5" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="f6622b4617424" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="sf12341" import="i2d7a54" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="15c4492bd5107" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="sf12341" import="i56be10" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="15c4492bd5107" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="sf12341" import="icfb3a5" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="15c4492bd5107" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="sf12341" import="i2d7a54" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="4" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="6827118336ac1" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="6827118336ac1" order="0" type="FILE" class="ARCHIVE" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239"/>
+      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239" />
       <name status="s90e6c9" import="ia857f0" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="5" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="98acd8c76c93a" order="0" type="FILE" class="TRASH" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="sf12341" import="ia857f0" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/files/nwProject-1.5.nwx
+++ b/tests/files/nwProject-1.5.nwx
@@ -26,7 +26,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sf12341" count="4" red="100" green="100" blue="100">New</entry>
@@ -46,111 +46,111 @@
   </settings>
   <content items="27" novelWords="954" notesWords="409">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="93" wordCount="19" paraCount="2" cursorPos="119"/>
+      <meta expanded="no" heading="H1" charCount="93" wordCount="19" paraCount="2" cursorPos="119" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277"/>
+      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277" />
       <name status="sf12341" import="ia857f0" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="7031beac91f75" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s90e6c9" import="ia857f0" active="yes">Part One</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="7031beac91f75" root="7031beac91f75" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291"/>
+      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291" />
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="67"/>
+      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="67" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465"/>
+      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465" />
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310"/>
+      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0" />
       <name status="sf24ce6" import="ia857f0" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="7031beac91f75" root="7031beac91f75" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188"/>
+      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="88706ddc78b1b" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0" />
       <name status="s90e6c9" import="ia857f0" active="yes">We Found John!</name>
     </item>
     <item handle="e5e47ebf63b1c" parent="None" root="e5e47ebf63b1c" order="1" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Sequel</name>
     </item>
     <item handle="bacb7059e3083" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100"/>
+      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="a520879ca0b45" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104"/>
+      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="f6622b4617424" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="f6622b4617424" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="sf12341" import="icfb3a5" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="f6622b4617424" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="sf12341" import="i2d7a54" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="15c4492bd5107" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="sf12341" import="i56be10" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="15c4492bd5107" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="sf12341" import="icfb3a5" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="15c4492bd5107" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="sf12341" import="i2d7a54" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="4" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="6827118336ac1" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="6827118336ac1" order="0" type="FILE" class="ARCHIVE" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239"/>
+      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239" />
       <name status="s90e6c9" import="ia857f0" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="5" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="98acd8c76c93a" order="0" type="FILE" class="TRASH" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="sf12341" import="ia857f0" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/lipsum/nwProject.nwx
+++ b/tests/lipsum/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:00:43">
-  <project id="5ac0df12-8b8b-476b-9905-21d33685687c" saveCount="38" autoCount="24" editTime="1900">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:58:36">
+  <project id="5ac0df12-8b8b-476b-9905-21d33685687c" saveCount="40" autoCount="24" editTime="1903">
     <name>Lorem Ipsum</name>
     <title>Lorem Ipsum</title>
     <author>lipsum.com</author>
@@ -24,7 +24,7 @@
       <entry key="chapter">Chapter %ch%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sbaa94f" count="3" red="100" green="100" blue="100">New</entry>
@@ -41,87 +41,87 @@
   </settings>
   <content items="21" novelWords="3109" notesWords="738">
     <item handle="b3643d0f92e32" parent="None" root="b3643d0f92e32" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">Novel</name>
     </item>
     <item handle="7a992350f3eb6" parent="b3643d0f92e32" root="b3643d0f92e32" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="230" wordCount="40" paraCount="3" cursorPos="148"/>
+      <meta expanded="no" heading="H1" charCount="230" wordCount="40" paraCount="3" cursorPos="148" />
       <name status="sedd043" import="i613591" active="yes">Lorem Ipsum</name>
     </item>
     <item handle="8c58a65414c23" parent="b3643d0f92e32" root="b3643d0f92e32" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="1058" wordCount="176" paraCount="2" cursorPos="43"/>
+      <meta expanded="no" heading="H0" charCount="1058" wordCount="176" paraCount="2" cursorPos="43" />
       <name status="sedd043" import="i613591" active="yes">Front Matter</name>
     </item>
     <item handle="88d59a277361b" parent="b3643d0f92e32" root="b3643d0f92e32" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="584" wordCount="92" paraCount="1" cursorPos="4"/>
+      <meta expanded="no" heading="H2" charCount="584" wordCount="92" paraCount="1" cursorPos="4" />
       <name status="s92a87b" import="i613591" active="yes">Prologue</name>
     </item>
     <item handle="db7e733775d4d" parent="b3643d0f92e32" root="b3643d0f92e32" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="35" wordCount="6" paraCount="1" cursorPos="42"/>
+      <meta expanded="no" heading="H1" charCount="35" wordCount="6" paraCount="1" cursorPos="42" />
       <name status="sbaa94f" import="i613591" active="yes">Act One</name>
     </item>
     <item handle="45e6b01ca35c1" parent="b3643d0f92e32" root="b3643d0f92e32" order="4" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s92a87b" import="i613591">Chapter One</name>
     </item>
     <item handle="fb609cd8319dc" parent="45e6b01ca35c1" root="b3643d0f92e32" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="419" wordCount="67" paraCount="1" cursorPos="56"/>
+      <meta expanded="no" heading="H2" charCount="419" wordCount="67" paraCount="1" cursorPos="56" />
       <name status="s92a87b" import="i613591" active="yes">Chapter One</name>
     </item>
     <item handle="88243afbe5ed8" parent="45e6b01ca35c1" root="b3643d0f92e32" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2758" wordCount="404" paraCount="4" cursorPos="1528"/>
+      <meta expanded="no" heading="H3" charCount="2758" wordCount="404" paraCount="4" cursorPos="1528" />
       <name status="sedd043" import="i613591" active="yes">Scene One</name>
     </item>
     <item handle="f96ec11c6a3da" parent="45e6b01ca35c1" root="b3643d0f92e32" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="4043" wordCount="600" paraCount="6" cursorPos="2335"/>
+      <meta expanded="no" heading="H3" charCount="4043" wordCount="600" paraCount="6" cursorPos="2335" />
       <name status="sedd043" import="i613591" active="yes">Scene Two</name>
     </item>
     <item handle="846352075de7d" parent="b3643d0f92e32" root="b3643d0f92e32" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="631" wordCount="109" paraCount="3" cursorPos="376"/>
+      <meta expanded="no" heading="H2" charCount="631" wordCount="109" paraCount="3" cursorPos="376" />
       <name status="sbaa94f" import="i613591" active="no">Interlude</name>
     </item>
     <item handle="6bd935d2490cd" parent="b3643d0f92e32" root="b3643d0f92e32" order="6" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s92a87b" import="i613591">Chapter Two</name>
     </item>
     <item handle="441420a886d82" parent="6bd935d2490cd" root="b3643d0f92e32" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="477" wordCount="70" paraCount="1" cursorPos="56"/>
+      <meta expanded="no" heading="H2" charCount="477" wordCount="70" paraCount="1" cursorPos="56" />
       <name status="s92a87b" import="i613591" active="yes">Chapter Two</name>
     </item>
     <item handle="eb103bc70c90c" parent="6bd935d2490cd" root="b3643d0f92e32" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3006" wordCount="439" paraCount="4" cursorPos="57"/>
+      <meta expanded="no" heading="H3" charCount="3006" wordCount="439" paraCount="4" cursorPos="57" />
       <name status="sedd043" import="i613591" active="yes">Scene Three</name>
     </item>
     <item handle="f8c0562e50f1b" parent="6bd935d2490cd" root="b3643d0f92e32" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3839" wordCount="563" paraCount="6" cursorPos="56"/>
+      <meta expanded="no" heading="H3" charCount="3839" wordCount="563" paraCount="6" cursorPos="56" />
       <name status="sedd043" import="i613591" active="yes">Scene Four</name>
     </item>
     <item handle="47666c91c7ccf" parent="6bd935d2490cd" root="b3643d0f92e32" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3644" wordCount="543" paraCount="5" cursorPos="351"/>
+      <meta expanded="no" heading="H3" charCount="3644" wordCount="543" paraCount="5" cursorPos="351" />
       <name status="sedd043" import="i613591" active="yes">Scene Five</name>
     </item>
     <item handle="67a8707f2f249" parent="None" root="67a8707f2f249" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">Characters</name>
     </item>
     <item handle="4c4f28287af27" parent="67a8707f2f249" root="67a8707f2f249" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1864" wordCount="284" paraCount="3" cursorPos="1883"/>
+      <meta expanded="no" heading="H1" charCount="1864" wordCount="284" paraCount="3" cursorPos="1883" />
       <name status="sbaa94f" import="i613591" active="yes">Mr. Nobody</name>
     </item>
     <item handle="6c6afb1247750" parent="None" root="6c6afb1247750" order="2" type="ROOT" class="PLOT">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">Plot</name>
     </item>
     <item handle="2426c6f0ca922" parent="6c6afb1247750" root="6c6afb1247750" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1369" wordCount="195" paraCount="2" cursorPos="1387"/>
+      <meta expanded="no" heading="H1" charCount="1369" wordCount="195" paraCount="2" cursorPos="1387" />
       <name status="sbaa94f" import="i613591" active="yes">Main</name>
     </item>
     <item handle="60bdf227455cc" parent="None" root="60bdf227455cc" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">World</name>
     </item>
     <item handle="04468803b92e1" parent="60bdf227455cc" root="60bdf227455cc" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1770" wordCount="259" paraCount="3" cursorPos="1792"/>
+      <meta expanded="no" heading="H1" charCount="1770" wordCount="259" paraCount="3" cursorPos="1792" />
       <name status="sbaa94f" import="i613591" active="yes">Ancient Europe</name>
     </item>
   </content>

--- a/tests/reference/coreProject_NewFileFolder_nwProject.nwx
+++ b/tests/reference/coreProject_NewFileFolder_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:05:22">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:58:03">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="7" red="100" green="100" blue="100">New</entry>
@@ -38,47 +38,47 @@
   </settings>
   <content items="11" novelWords="10" notesWords="3">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">World</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000010" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Stuff</name>
     </item>
     <item handle="0000000000011" parent="0000000000010" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="5" wordCount="1" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="5" wordCount="1" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Hello</name>
     </item>
     <item handle="0000000000012" parent="000000000000a" root="000000000000a" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="11" wordCount="3" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="11" wordCount="3" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Jane</name>
     </item>
   </content>

--- a/tests/reference/coreProject_NewRoot_nwProject.nwx
+++ b/tests/reference/coreProject_NewRoot_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:05:22">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:58:03">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="6" red="100" green="100" blue="100">New</entry>
@@ -38,67 +38,67 @@
   </settings>
   <content items="16" novelWords="9" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">World</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000010" parent="None" root="0000000000010" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000011" parent="None" root="0000000000011" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000012" parent="None" root="0000000000012" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000013" parent="None" root="0000000000013" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="0000000000014" parent="None" root="0000000000014" order="0" type="ROOT" class="TIMELINE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Timeline</name>
     </item>
     <item handle="0000000000015" parent="None" root="0000000000015" order="0" type="ROOT" class="OBJECT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Objects</name>
     </item>
     <item handle="0000000000016" parent="None" root="0000000000016" order="0" type="ROOT" class="CUSTOM">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Custom</name>
     </item>
     <item handle="0000000000017" parent="None" root="0000000000017" order="0" type="ROOT" class="CUSTOM">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Custom</name>
     </item>
   </content>

--- a/tests/reference/coreTools_NewCustomA_nwProject.nwx
+++ b/tests/reference/coreTools_NewCustomA_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:05:22">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:58:03">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Custom</name>
     <title>Test Novel</title>
@@ -16,13 +16,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="15" red="100" green="100" blue="100">New</entry>
@@ -39,91 +39,91 @@
   </settings>
   <content items="22" novelWords="0" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000a" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Chapter 1</name>
     </item>
     <item handle="000000000000b" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1.1</name>
     </item>
     <item handle="000000000000c" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1.2</name>
     </item>
     <item handle="000000000000d" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1.3</name>
     </item>
     <item handle="000000000000e" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Chapter 2</name>
     </item>
     <item handle="000000000000f" parent="000000000000e" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2.1</name>
     </item>
     <item handle="0000000000010" parent="000000000000e" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2.2</name>
     </item>
     <item handle="0000000000011" parent="000000000000e" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2.3</name>
     </item>
     <item handle="0000000000012" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Chapter 3</name>
     </item>
     <item handle="0000000000013" parent="0000000000012" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3.1</name>
     </item>
     <item handle="0000000000014" parent="0000000000012" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3.2</name>
     </item>
     <item handle="0000000000015" parent="0000000000012" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3.3</name>
     </item>
     <item handle="0000000000016" parent="None" root="0000000000016" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000017" parent="0000000000016" root="0000000000016" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Plot</name>
     </item>
     <item handle="0000000000018" parent="None" root="0000000000018" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000019" parent="0000000000018" root="0000000000018" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Protagonist</name>
     </item>
     <item handle="000000000001a" parent="None" root="000000000001a" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="000000000001b" parent="000000000001a" root="000000000001a" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Location</name>
     </item>
     <item handle="000000000001c" parent="None" root="000000000001c" order="0" type="ROOT" class="ARCHIVE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Archive</name>
     </item>
     <item handle="000000000001d" parent="None" root="000000000001d" order="0" type="ROOT" class="TRASH">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Trash</name>
     </item>
   </content>

--- a/tests/reference/coreTools_NewCustomB_nwProject.nwx
+++ b/tests/reference/coreTools_NewCustomB_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:05:22">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:58:03">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Custom</name>
     <title>Test Novel</title>
@@ -16,13 +16,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="9" red="100" green="100" blue="100">New</entry>
@@ -39,67 +39,67 @@
   </settings>
   <content items="16" novelWords="0" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000a" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1</name>
     </item>
     <item handle="000000000000b" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 4</name>
     </item>
     <item handle="000000000000e" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 5</name>
     </item>
     <item handle="000000000000f" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 6</name>
     </item>
     <item handle="0000000000010" parent="None" root="0000000000010" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000011" parent="0000000000010" root="0000000000010" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Plot</name>
     </item>
     <item handle="0000000000012" parent="None" root="0000000000012" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000013" parent="0000000000012" root="0000000000012" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Protagonist</name>
     </item>
     <item handle="0000000000014" parent="None" root="0000000000014" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="0000000000015" parent="0000000000014" root="0000000000014" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Location</name>
     </item>
     <item handle="0000000000016" parent="None" root="0000000000016" order="0" type="ROOT" class="ARCHIVE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Archive</name>
     </item>
     <item handle="0000000000017" parent="None" root="0000000000017" order="0" type="ROOT" class="TRASH">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Trash</name>
     </item>
   </content>

--- a/tests/reference/coreTools_NewMinimal_nwProject.nwx
+++ b/tests/reference/coreTools_NewMinimal_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:05:22">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:58:03">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>New Project</name>
     <title>New Project</title>
@@ -14,13 +14,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="5" red="100" green="100" blue="100">New</entry>
@@ -37,35 +37,35 @@
   </settings>
   <content items="8" novelWords="0" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000a" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000b" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="000000000000c" parent="None" root="000000000000c" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000d" parent="None" root="000000000000d" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000e" parent="None" root="000000000000e" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="000000000000f" parent="None" root="000000000000f" order="0" type="ROOT" class="ARCHIVE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Archive</name>
     </item>
   </content>

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-15 15:14:31">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 22:00:53">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="3">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">0000000000008</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="5" red="100" green="100" blue="100">New</entry>
@@ -38,47 +38,47 @@
   </settings>
   <content items="11" novelWords="136" notesWords="27">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="1" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="781" wordCount="129" paraCount="14" cursorPos="1010"/>
+      <meta expanded="no" heading="H1" charCount="781" wordCount="129" paraCount="14" cursorPos="1010" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="1" type="ROOT" class="PLOT">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000011" parent="0000000000009" root="0000000000009" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="48" wordCount="10" paraCount="1" cursorPos="69"/>
+      <meta expanded="no" heading="H1" charCount="48" wordCount="10" paraCount="1" cursorPos="69" />
       <name status="s000000" import="i000004" active="yes">New Note</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000010" parent="000000000000a" root="000000000000a" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="34" wordCount="8" paraCount="1" cursorPos="51"/>
+      <meta expanded="no" heading="H1" charCount="34" wordCount="8" paraCount="1" cursorPos="51" />
       <name status="s000000" import="i000004" active="yes">New Note</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">World</name>
     </item>
     <item handle="0000000000012" parent="000000000000b" root="000000000000b" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="51" wordCount="9" paraCount="1" cursorPos="68"/>
+      <meta expanded="no" heading="H1" charCount="51" wordCount="9" paraCount="1" cursorPos="68" />
       <name status="s000000" import="i000004" active="yes">New Note</name>
     </item>
   </content>

--- a/tests/reference/guiEditor_Main_Initial_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Initial_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 12:57:21">
+<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-24 21:58:10">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="2" autoCount="1" editTime="0">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="5" red="100" green="100" blue="100">New</entry>
@@ -38,35 +38,35 @@
   </settings>
   <content items="8" novelWords="9" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="1" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="1" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="3" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">World</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy10.nwx
+++ b/tests/reference/projectXML_ReadLegacy10.nwx
@@ -26,7 +26,7 @@
       <entry key="chapter">Chapter %ch%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -46,91 +46,91 @@
   </settings>
   <content items="22" novelWords="0" notesWords="0">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78"/>
+      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="208" wordCount="40" paraCount="2" cursorPos="213"/>
+      <meta expanded="no" heading="H0" charCount="208" wordCount="40" paraCount="2" cursorPos="213" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215"/>
+      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="1199" wordCount="216" paraCount="7" cursorPos="527"/>
+      <meta expanded="no" heading="H0" charCount="1199" wordCount="216" paraCount="7" cursorPos="527" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="551"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="551" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238"/>
+      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238" />
       <name status="s000006" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="3" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy11.nwx
+++ b/tests/reference/projectXML_ReadLegacy11.nwx
@@ -26,7 +26,7 @@
       <entry key="chapter">Chapter %ch%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -46,91 +46,91 @@
   </settings>
   <content items="22" novelWords="0" notesWords="0">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78"/>
+      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="210" wordCount="40" paraCount="2" cursorPos="213"/>
+      <meta expanded="no" heading="H0" charCount="210" wordCount="40" paraCount="2" cursorPos="213" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215"/>
+      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="1483" wordCount="263" paraCount="8" cursorPos="1086"/>
+      <meta expanded="no" heading="H0" charCount="1483" wordCount="263" paraCount="8" cursorPos="1086" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="428"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="428" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238"/>
+      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238" />
       <name status="s000006" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="3" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy12.nwx
+++ b/tests/reference/projectXML_ReadLegacy12.nwx
@@ -26,7 +26,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -46,103 +46,103 @@
   </settings>
   <content items="25" novelWords="840" notesWords="376">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="241" wordCount="42" paraCount="3" cursorPos="252"/>
+      <meta expanded="no" heading="H0" charCount="241" wordCount="42" paraCount="3" cursorPos="252" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="125" wordCount="26" paraCount="2" cursorPos="127"/>
+      <meta expanded="no" heading="H0" charCount="125" wordCount="26" paraCount="2" cursorPos="127" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="30"/>
+      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="30" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279"/>
+      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="61"/>
+      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="61" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="1137"/>
+      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="1137" />
       <name status="s000000" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="3" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Outtakes</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="None" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="315" wordCount="55" paraCount="1" cursorPos="322"/>
+      <meta expanded="no" heading="H0" charCount="315" wordCount="55" paraCount="1" cursorPos="322" />
       <name status="s000003" import="i000007" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="4" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy13.nwx
+++ b/tests/reference/projectXML_ReadLegacy13.nwx
@@ -26,7 +26,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -46,103 +46,103 @@
   </settings>
   <content items="25" novelWords="830" notesWords="376">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="2"/>
+      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="2" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="186" wordCount="39" paraCount="2" cursorPos="212"/>
+      <meta expanded="no" heading="H0" charCount="186" wordCount="39" paraCount="2" cursorPos="212" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="33"/>
+      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="33" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279"/>
+      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="62"/>
+      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="62" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="4"/>
+      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="4" />
       <name status="s000000" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="3" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="None" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="314" wordCount="55" paraCount="1" cursorPos="322"/>
+      <meta expanded="no" heading="H0" charCount="314" wordCount="55" paraCount="1" cursorPos="322" />
       <name status="s000003" import="i000007" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="4" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy14.nwx
+++ b/tests/reference/projectXML_ReadLegacy14.nwx
@@ -26,7 +26,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sf12341" count="4" red="100" green="100" blue="100">New</entry>
@@ -46,111 +46,111 @@
   </settings>
   <content items="27" novelWords="954" notesWords="409">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="119"/>
+      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="119" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277"/>
+      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277" />
       <name status="sf12341" import="ia857f0" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="7031beac91f75" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s90e6c9" import="ia857f0" active="yes">Part One</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="7031beac91f75" root="7031beac91f75" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H0" charCount="95" wordCount="18" paraCount="1" cursorPos="291"/>
+      <meta expanded="yes" heading="H0" charCount="95" wordCount="18" paraCount="1" cursorPos="291" />
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="2687" wordCount="479" paraCount="14" cursorPos="67"/>
+      <meta expanded="no" heading="H0" charCount="2687" wordCount="479" paraCount="14" cursorPos="67" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="548" wordCount="108" paraCount="3" cursorPos="465"/>
+      <meta expanded="no" heading="H0" charCount="548" wordCount="108" paraCount="3" cursorPos="465" />
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="310"/>
+      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="310" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1909" wordCount="346" paraCount="7" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="1909" wordCount="346" paraCount="7" cursorPos="0" />
       <name status="sf24ce6" import="ia857f0" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="7031beac91f75" root="7031beac91f75" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="188"/>
+      <meta expanded="yes" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="188" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="88706ddc78b1b" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="0" />
       <name status="s90e6c9" import="ia857f0" active="yes">We Found John!</name>
     </item>
     <item handle="e5e47ebf63b1c" parent="None" root="e5e47ebf63b1c" order="1" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Sequel</name>
     </item>
     <item handle="bacb7059e3083" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="27" wordCount="5" paraCount="1" cursorPos="100"/>
+      <meta expanded="no" heading="H0" charCount="27" wordCount="5" paraCount="1" cursorPos="100" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="a520879ca0b45" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="299" wordCount="55" paraCount="2" cursorPos="104"/>
+      <meta expanded="no" heading="H0" charCount="299" wordCount="55" paraCount="2" cursorPos="104" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="f6622b4617424" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="f6622b4617424" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="sf12341" import="icfb3a5" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="f6622b4617424" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="sf12341" import="i2d7a54" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="15c4492bd5107" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="sf12341" import="i56be10" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="15c4492bd5107" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="sf12341" import="icfb3a5" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="15c4492bd5107" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="sf12341" import="i2d7a54" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="4" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="6827118336ac1" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="6827118336ac1" order="0" type="FILE" class="ARCHIVE" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="232" wordCount="42" paraCount="1" cursorPos="239"/>
+      <meta expanded="no" heading="H0" charCount="232" wordCount="42" paraCount="1" cursorPos="239" />
       <name status="s90e6c9" import="ia857f0" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="5" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="98acd8c76c93a" order="0" type="FILE" class="TRASH" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="sf12341" import="ia857f0" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -226,7 +226,7 @@ def testCoreProjectXML_ReadCurrent(monkeypatch, tstPaths, fncPath):
 
     # Fail saving
     with monkeypatch.context() as mp:
-        mp.setattr("pathlib.Path.write_bytes", causeOSError)
+        mp.setattr("xml.etree.ElementTree.ElementTree.write", causeOSError)
         assert xmlWriter.write(data, packedContent, timeStamp, 1000) is False
         assert str(xmlWriter.error) == "Mock OSError"
 


### PR DESCRIPTION
**Summary:**

This PR removes the dependency of lxml in the project XML classes.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
