### PR TITLE
Add empty init files to subdirs of main package

### DIFF
--- a/novelwriter/core/__init__.py
+++ b/novelwriter/core/__init__.py
@@ -1,0 +1,3 @@
+"""
+novelWriter – Core Init File
+"""

--- a/novelwriter/dialogs/__init__.py
+++ b/novelwriter/dialogs/__init__.py
@@ -1,0 +1,3 @@
+"""
+novelWriter – Dialogs Init File
+"""

--- a/novelwriter/gui/__init__.py
+++ b/novelwriter/gui/__init__.py
@@ -1,0 +1,3 @@
+"""
+novelWriter – GUI Init File
+"""

--- a/novelwriter/tools/__init__.py
+++ b/novelwriter/tools/__init__.py
@@ -1,0 +1,3 @@
+"""
+novelWriter – Tools Init File
+"""


### PR DESCRIPTION
**Summary:**

The `__init__.py` files were removed in #1262, but empty ones are still needed for the build tool.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
