### PR TITLE
Fix convert folders and open from outline

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1251,16 +1251,28 @@ class GuiProjectTree(QTreeWidget):
             isDocFile = isFile and tItem.isDocumentLayout()
             isNoteFile = isFile and tItem.isNoteLayout()
 
-            if (isNoteFile or isFolder) and tItem.documentAllowed():
+            if isNoteFile and tItem.documentAllowed():
                 aConvert1 = mTrans.addAction(self.tr("Convert to {0}").format(trDoc))
                 aConvert1.triggered.connect(
                     lambda: self._changeItemLayout(tHandle, nwItemLayout.DOCUMENT)
                 )
 
-            if isDocFile or isFolder:
+            if isDocFile:
                 aConvert2 = mTrans.addAction(self.tr("Convert to {0}").format(trNote))
                 aConvert2.triggered.connect(
                     lambda: self._changeItemLayout(tHandle, nwItemLayout.NOTE)
+                )
+
+            if isFolder and tItem.documentAllowed():
+                aConvert3 = mTrans.addAction(self.tr("Convert to {0}").format(trDoc))
+                aConvert3.triggered.connect(
+                    lambda: self._covertFolderToFile(tHandle, nwItemLayout.DOCUMENT)
+                )
+
+            if isFolder:
+                aConvert4 = mTrans.addAction(self.tr("Convert to {0}").format(trNote))
+                aConvert4.triggered.connect(
+                    lambda: self._covertFolderToFile(tHandle, nwItemLayout.NOTE)
                 )
 
             if hasChild and isFile:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1512,8 +1512,10 @@ class GuiMain(QMainWindow):
                 hItem = self.theProject.index.getItemHeader(tHandle, sTitle)
                 if hItem is not None:
                     tLine = hItem.line
+                self.mainStack.setCurrentWidget(self.splitMain)
                 self.openDocument(tHandle, tLine=tLine, changeFocus=setFocus)
             elif tMode == nwDocMode.VIEW:
+                self.mainStack.setCurrentWidget(self.splitMain)
                 self.viewDocument(tHandle=tHandle, sTitle=sTitle)
         return
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -610,6 +610,7 @@ class GuiMain(QMainWindow):
             logger.debug("Requested item '%s' is not a document", tHandle)
             return False
 
+        self._changeView(nwView.EDITOR)
         cHandle = self.docEditor.docHandle()
         if cHandle == tHandle:
             self.docEditor.setCursorLine(tLine)
@@ -618,7 +619,6 @@ class GuiMain(QMainWindow):
             return True
 
         self.closeDocument(beforeOpen=True)
-        self._changeView(nwView.EDITOR)
         if self.docEditor.loadText(tHandle, tLine):
             self.theProject.data.setLastHandle(tHandle, "editor")
             self.projView.setSelectedHandle(tHandle, doScroll=doScroll)
@@ -1512,10 +1512,8 @@ class GuiMain(QMainWindow):
                 hItem = self.theProject.index.getItemHeader(tHandle, sTitle)
                 if hItem is not None:
                     tLine = hItem.line
-                self.mainStack.setCurrentWidget(self.splitMain)
                 self.openDocument(tHandle, tLine=tLine, changeFocus=setFocus)
             elif tMode == nwDocMode.VIEW:
-                self.mainStack.setCurrentWidget(self.splitMain)
                 self.viewDocument(tHandle=tHandle, sTitle=sTitle)
         return
 


### PR DESCRIPTION
**Summary:**

This PR fixes two issues:
* The convert to document/note menu entries in the project tree were still trying to convert files even if it was applied to a folder. They now properly call the convert folder function when used on folders.
* Trying to open a document from outline view should switch focus even if the document is already open.

**Related Issue(s):**

Closes #1291
Closes #1305

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
