### PR TITLE
Fix handling of item with missing parent item

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1693,18 +1693,22 @@ class GuiProjectTree(QTreeWidget):
                 del self._treeMap[tHandle]
                 return None
 
-        else:
+        elif pHandle in self._treeMap:
             byIndex = -1
             if nHandle is not None and nHandle in self._treeMap:
-                try:
-                    byIndex = self._treeMap[pHandle].indexOfChild(self._treeMap[nHandle])
-                except Exception:
-                    logger.error("Failed to get index of item with handle '%s'", nHandle)
+                byIndex = self._treeMap[pHandle].indexOfChild(self._treeMap[nHandle])
             if byIndex >= 0:
                 self._treeMap[pHandle].insertChild(byIndex + 1, newItem)
             else:
                 self._treeMap[pHandle].addChild(newItem)
             self.propagateCount(tHandle, nwItem.wordCount, countChildren=True)
+
+        else:
+            self.mainGui.makeAlert(self.tr(
+                "There is nowhere to add item with name '{0}'."
+            ).format(nwItem.itemName), nwAlert.ERROR)
+            del self._treeMap[tHandle]
+            return None
 
         self.setTreeItemValues(tHandle)
         newItem.setExpanded(nwItem.isExpanded)

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -885,6 +885,11 @@ def testGuiProjTree_Other(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     nwGUI.theProject.tree[nHandle].setParent(None)
     assert projTree.revealNewTreeItem(nHandle) is False
 
+    # Try to add an item with unknown parent to the tree
+    nHandle = nwGUI.theProject.newFile("Test", C.hNovelRoot)
+    nwGUI.theProject.tree[nHandle].setParent(C.hInvalid)
+    assert projTree.revealNewTreeItem(nHandle) is False
+
     # Method: undoLastMove
     # ====================
 


### PR DESCRIPTION
**Summary:**

This PR fixes an issue where a project item with a parent that cannot be loaded would crash the app. The parent item would pass the first check during loading, because it does exist, but would not be added to the tree in the app due to having incomplete or wrong data. The subsequent adding of the child item would thus fail in the same function as there was no check that the parent item was there before the child item was added (resulting in a KeyError).

The issue was discovered with #1283, where a project file from an unreleased version of novelWriter triggered this issue. The issue can be triggered by taking the type of a root item and set its type value to an invalid one.

**Related Issue(s):**

Closes #1283

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
