### PR TITLE
Mention Qt SVG dependency for Arch Linux in the docs (#1319)

### DIFF
--- a/docs/source/int_source.rst
+++ b/docs/source/int_source.rst
@@ -48,6 +48,13 @@ source, dependencies can still be installed from PyPi with:
 
    pip install -r requirements.txt
 
+.. note::
+
+   On Linux distros, the Qt library is usually split up into multiple packages. In some cases,
+   secondary dependencies may not be installed automatically. For novelWriter, the library files
+   for renderring the SVG icons may be left out and needs to be installed manually. This is the
+   case on for instance Arch Linux.
+
 
 .. _a_source_install:
 


### PR DESCRIPTION
**Summary:**

Add a note in the docs about the Qt SVG library sometimes needing to be installed manually.

**Related Issue(s):**

Related to #1319

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
