### PR TITLE
Fix PyQt5 version check

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -179,12 +179,12 @@ def main(sysArgs=None):
             "At least Python 3.7 is required, found %s" % CONFIG.verPyString
         )
         errorCode |= 0x04
-    if CONFIG.verQtValue < 51000:
+    if CONFIG.verQtValue < 0x050a00:
         errorData.append(
             "At least Qt5 version 5.10 is required, found %s" % CONFIG.verQtString
         )
         errorCode |= 0x08
-    if CONFIG.verPyQtValue < 51000:
+    if CONFIG.verPyQtValue < 0x050a00:
         errorData.append(
             "At least PyQt5 version 5.10 is required, found %s" % CONFIG.verPyQtString
         )

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -277,33 +277,6 @@ def yesNo(value):
     return "yes" if value else "no"
 
 
-def splitVersionNumber(value):
-    """Split a version string on the form aa.bb.cc into major, minor
-    and patch, and computes an integer value aabbcc.
-    """
-    if not isinstance(value, str):
-        return 0, 0, 0, 0
-
-    vMajor = 0
-    vMinor = 0
-    vPatch = 0
-    vInt = 0
-
-    vBits = value.split(".")
-    nBits = len(vBits)
-
-    if nBits > 0:
-        vMajor = checkInt(vBits[0], 0)
-    if nBits > 1:
-        vMinor = checkInt(vBits[1], 0)
-    if nBits > 2:
-        vPatch = checkInt(vBits[2], 0)
-
-    vInt = vMajor*10000 + vMinor*100 + vPatch
-
-    return vMajor, vMinor, vPatch, vInt
-
-
 def transferCase(source, target):
     """Transfers the case of the source word to the target word. This
     will consider all upper or lower, and first char capitalisation.

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -30,14 +30,13 @@ import logging
 from time import time
 from pathlib import Path
 
-from PyQt5.Qt import PYQT_VERSION_STR
 from PyQt5.QtCore import (
-    QT_VERSION_STR, QStandardPaths, QSysInfo, QLocale, QLibraryInfo,
-    QTranslator
+    QT_VERSION, QT_VERSION_STR, PYQT_VERSION, PYQT_VERSION_STR, QStandardPaths,
+    QSysInfo, QLocale, QLibraryInfo, QTranslator
 )
 
 from novelwriter.error import logException, formatException
-from novelwriter.common import checkPath, splitVersionNumber, formatTimeStamp, NWConfigParser
+from novelwriter.common import checkPath, formatTimeStamp, NWConfigParser
 from novelwriter.constants import nwFiles, nwUnicode
 
 logger = logging.getLogger(__name__)
@@ -190,25 +189,13 @@ class Config:
         # ==========================
 
         # Check Qt5 Versions
-        verQt = splitVersionNumber(QT_VERSION_STR)
-        self.verQtString = QT_VERSION_STR
-        self.verQtMajor  = verQt[0]
-        self.verQtMinor  = verQt[1]
-        self.verQtPatch  = verQt[2]
-        self.verQtValue  = verQt[3]
-
-        verQt = splitVersionNumber(PYQT_VERSION_STR)
+        self.verQtString   = QT_VERSION_STR
+        self.verQtValue    = QT_VERSION
         self.verPyQtString = PYQT_VERSION_STR
-        self.verPyQtMajor  = verQt[0]
-        self.verPyQtMinor  = verQt[1]
-        self.verPyQtPatch  = verQt[2]
-        self.verPyQtValue  = verQt[3]
+        self.verPyQtValue  = PYQT_VERSION
 
         # Check Python Version
         self.verPyString = sys.version.split()[0]
-        self.verPyMajor  = sys.version_info[0]
-        self.verPyMinor  = sys.version_info[1]
-        self.verPyPatch  = sys.version_info[2]
         self.verPyHexVal = sys.hexversion
 
         # Check OS Type

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -112,8 +112,7 @@ class NWErrorMessage(QDialog):
         """
         from traceback import format_tb
         from novelwriter import __issuesurl__, __version__
-        from PyQt5.Qt import PYQT_VERSION_STR
-        from PyQt5.QtCore import QT_VERSION_STR, QSysInfo
+        from PyQt5.QtCore import QT_VERSION_STR, PYQT_VERSION_STR, QSysInfo
 
         self.msgHead.setText((
             "<p>An unhandled error has been encountered.</p>"

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -2512,7 +2512,7 @@ class GuiDocEditSearch(QFrame):
             # Using the Unicode-capable QRegularExpression class was
             # only added in Qt 5.13. Otherwise, 5.3 and up supports
             # only the QRegExp class.
-            if self.mainConf.verQtValue >= 51300:
+            if self.mainConf.verQtValue >= 0x050d00:
                 rxOpt = QRegularExpression.UseUnicodePropertiesOption
                 if not self.isCaseSense:
                     rxOpt |= QRegularExpression.CaseInsensitiveOption

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -87,9 +87,9 @@ class GuiMain(QMainWindow):
         logger.info("OS: %s", self.mainConf.osType)
         logger.info("Kernel: %s", self.mainConf.kernelVer)
         logger.info("Host: %s", self.mainConf.hostName)
-        logger.info("Qt5: %s (%d)", self.mainConf.verQtString, self.mainConf.verQtValue)
-        logger.info("PyQt5: %s (%d)", self.mainConf.verPyQtString, self.mainConf.verPyQtValue)
-        logger.info("Python: %s (0x%x)", self.mainConf.verPyString, self.mainConf.verPyHexVal)
+        logger.info("Qt5: %s (0x%06x)", self.mainConf.verQtString, self.mainConf.verQtValue)
+        logger.info("PyQt5: %s (0x%06x)", self.mainConf.verPyQtString, self.mainConf.verPyQtValue)
+        logger.info("Python: %s (0x%08x)", self.mainConf.verPyString, self.mainConf.verPyHexVal)
         logger.info("GUI Language: %s", self.mainConf.guiLocale)
 
         # Core Classes

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -33,9 +33,9 @@ from novelwriter.common import (
     checkStringNone, checkString, checkInt, checkFloat, checkBool, checkHandle,
     checkUuid, checkPath, isHandle, isTitleTag, isItemClass, isItemType,
     isItemLayout, hexToInt, minmax, checkIntTuple, formatInt, formatTimeStamp,
-    formatTime, simplified, yesNo, splitVersionNumber, transferCase, fuzzyTime,
-    numberToRoman, jsonEncode, readTextFile, makeFileNameSafe, sha256sum,
-    getGuiItem, NWConfigParser
+    formatTime, simplified, yesNo, transferCase, fuzzyTime, numberToRoman,
+    jsonEncode, readTextFile, makeFileNameSafe, sha256sum, getGuiItem,
+    NWConfigParser
 )
 
 
@@ -396,25 +396,6 @@ def testBaseCommon_YesNo():
     assert yesNo(2.0) == "yes"
 
 # END Test testBaseCommon_YesNo
-
-
-@pytest.mark.base
-def testBaseCommon_SplitVersionNumber():
-    """Test the splitVersionNumber function.
-    """
-    # OK Values
-    assert splitVersionNumber("1") == (1, 0, 0, 10000)
-    assert splitVersionNumber("1.2") == (1, 2, 0, 10200)
-    assert splitVersionNumber("1.2.3") == (1, 2, 3, 10203)
-    assert splitVersionNumber("1.2.3.4") == (1, 2, 3, 10203)
-    assert splitVersionNumber("99.99.99") == (99, 99, 99, 999999)
-
-    # Failed Values
-    assert splitVersionNumber(None) == (0, 0, 0, 0)
-    assert splitVersionNumber(1234) == (0, 0, 0, 0)
-    assert splitVersionNumber("1.2abc") == (1, 0, 0, 10000)
-
-# END Test testBaseCommon_SplitVersionNumber
 
 
 @pytest.mark.base

--- a/tests/test_base/test_base_init.py
+++ b/tests/test_base/test_base_init.py
@@ -155,8 +155,8 @@ def testBaseInit_Imports(caplog, monkeypatch, tmpPath):
     monkeypatch.setattr("PyQt5.QtWidgets.QErrorMessage.showMessage", lambda *a: None)
     monkeypatch.setitem(sys.modules, "lxml", None)
     monkeypatch.setattr("sys.hexversion", 0x0)
-    monkeypatch.setattr("novelwriter.CONFIG.verQtValue", 50000)
-    monkeypatch.setattr("novelwriter.CONFIG.verPyQtValue", 50000)
+    monkeypatch.setattr("novelwriter.CONFIG.verQtValue", 0x050000)
+    monkeypatch.setattr("novelwriter.CONFIG.verPyQtValue", 0x050000)
 
     with pytest.raises(SystemExit) as ex:
         _ = novelwriter.main(


### PR DESCRIPTION
**Summary:**

Seems `QT_VERSION_STR` has been imported from a different location than what's listed in the PyQt5 documentation. It may have moved at some point, or the import from `PyQt5.Qt` may have been a bleed through that is no longer there.

This PR imports it from `PyQt5.QtCore` instead, as the PyQt5 docs state. The PR also replaces the 10 base integer version with the hex version provided by PyQt5. There is only one version check left in the main code anyway.

**Related Issue(s):**

Resolves #1324

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
