### PR TITLE
Fix/project details

### DIFF
--- a/i18n/nw_base.ts
+++ b/i18n/nw_base.ts
@@ -4,72 +4,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="333" />
+      <location filename="../novelwriter/common.py" line="306" />
       <source>in the future</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="337" />
+      <location filename="../novelwriter/common.py" line="310" />
       <source>just now</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="341" />
+      <location filename="../novelwriter/common.py" line="314" />
       <source>a minute ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="345" />
+      <location filename="../novelwriter/common.py" line="318" />
       <source>{0} minutes ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="349" />
+      <location filename="../novelwriter/common.py" line="322" />
       <source>an hour ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="353" />
+      <location filename="../novelwriter/common.py" line="326" />
       <source>{0} hours ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="357" />
+      <location filename="../novelwriter/common.py" line="330" />
       <source>a day ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="361" />
+      <location filename="../novelwriter/common.py" line="334" />
       <source>{0} days ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="365" />
+      <location filename="../novelwriter/common.py" line="338" />
       <source>a week ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="369" />
+      <location filename="../novelwriter/common.py" line="342" />
       <source>{0} weeks ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="373" />
+      <location filename="../novelwriter/common.py" line="346" />
       <source>a month ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="377" />
+      <location filename="../novelwriter/common.py" line="350" />
       <source>{0} months ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="381" />
+      <location filename="../novelwriter/common.py" line="354" />
       <source>a year ago</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="385" />
+      <location filename="../novelwriter/common.py" line="358" />
       <source>{0} years ago</source>
       <translation type="unfinished" />
     </message>
@@ -2884,72 +2884,72 @@
   <context>
     <name>GuiProjectDetailsContents</name>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="295" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="297" />
       <source>Table of Contents</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="314" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="316" />
       <source>Title</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="315" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="317" />
       <source>Words</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="316" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="318" />
       <source>Pages</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="317" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="319" />
       <source>Page</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="318" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="320" />
       <source>Progress</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="353" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="355" />
       <source>Typical word count for a 5 by 8 inch book page with 11 pt font is 350.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="356" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="358" />
       <source>Start counting page numbers from this page.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="359" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="361" />
       <source>Assume a new chapter or partition always start on an odd numbered page.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="362" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="364" />
       <source>Words per page</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="373" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="375" />
       <source>Count pages from</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="384" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="386" />
       <source>Clear double pages</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="447" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="449" />
       <source>END</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="501" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="503" />
       <source>Untitled</source>
       <translation type="unfinished" />
     </message>
@@ -2957,43 +2957,43 @@
   <context>
     <name>GuiProjectDetailsMain</name>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="168" />
-      <source>Working Title: {0}</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="177" />
-      <source>By {0}</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="187" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="185" />
       <source>Words</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="190" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="188" />
       <source>Chapters</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="193" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="191" />
       <source>Scenes</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="196" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="194" />
       <source>Revisions</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="199" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="197" />
       <source>Editing Time</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projdetails.py" line="219" />
+      <location filename="../novelwriter/dialogs/projdetails.py" line="217" />
       <source>Path</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/dialogs/projdetails.py" line="253" />
+      <source>Project: {0}</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/dialogs/projdetails.py" line="254" />
+      <source>By {0}</source>
       <translation type="unfinished" />
     </message>
   </context>

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -207,7 +207,7 @@ class NWProjectData:
         """Set a new project name.
         """
         if value != self._name:
-            self._name = simplified(str(value))
+            self._name = simplified(str(value or ""))
             self.theProject.setProjectChanged(True)
         return
 
@@ -215,7 +215,7 @@ class NWProjectData:
         """Set a new novel title.
         """
         if value != self._title:
-            self._title = simplified(str(value))
+            self._title = simplified(str(value or ""))
             self.theProject.setProjectChanged(True)
         return
 
@@ -223,7 +223,7 @@ class NWProjectData:
         """Set the author value.
         """
         if value != self._title:
-            self._author = simplified(str(value))
+            self._author = simplified(str(value or ""))
             self.theProject.setProjectChanged(True)
         return
 

--- a/novelwriter/dialogs/projdetails.py
+++ b/novelwriter/dialogs/projdetails.py
@@ -34,7 +34,7 @@ from PyQt5.QtWidgets import (
     QLineEdit, QSpinBox, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
 
-from novelwriter.common import numberToRoman
+from novelwriter.common import formatTime, numberToRoman
 from novelwriter.custom import PagedDialog, QSwitch
 from novelwriter.constants import nwUnicode
 from novelwriter.gui.components import NovelSelector
@@ -257,7 +257,7 @@ class GuiProjectDetailsMain(QWidget):
         self.chapCountVal.setText(f"{hCounts[2]:n}")
         self.sceneCountVal.setText(f"{hCounts[3]:n}")
         self.revCountVal.setText(f"{self.theProject.data.saveCount:n}")
-        self.editTimeVal.setText(f"{edTime//3600:02d}:{edTime%3600//60:02d}")
+        self.editTimeVal.setText(formatTime(edTime))
 
         self.projPathVal.setText(str(self.theProject.storage.storagePath))
 

--- a/novelwriter/dialogs/projdetails.py
+++ b/novelwriter/dialogs/projdetails.py
@@ -156,7 +156,7 @@ class GuiProjectDetailsMain(QWidget):
         # Header
         # ======
 
-        self.bookTitle = QLabel(self.theProject.data.title)
+        self.bookTitle = QLabel("")
         bookFont = self.bookTitle.font()
         bookFont.setPointSizeF(2.2*fPt)
         bookFont.setWeight(QFont.Bold)
@@ -164,9 +164,7 @@ class GuiProjectDetailsMain(QWidget):
         self.bookTitle.setAlignment(Qt.AlignHCenter)
         self.bookTitle.setWordWrap(True)
 
-        self.projName = QLabel(
-            self.tr("Working Title: {0}").format(self.theProject.data.name)
-        )
+        self.projName = QLabel("")
         workFont = self.projName.font()
         workFont.setPointSizeF(0.8*fPt)
         workFont.setItalic(True)
@@ -174,7 +172,7 @@ class GuiProjectDetailsMain(QWidget):
         self.projName.setAlignment(Qt.AlignHCenter)
         self.projName.setWordWrap(True)
 
-        self.bookAuthors = QLabel(self.tr("By {0}").format(self.theProject.data.author))
+        self.bookAuthors = QLabel("")
         authFont = self.bookAuthors.font()
         authFont.setPointSizeF(1.2*fPt)
         self.bookAuthors.setFont(authFont)
@@ -250,6 +248,10 @@ class GuiProjectDetailsMain(QWidget):
         hCounts = pIndex.getNovelTitleCounts()
         nwCount = pIndex.getNovelWordCount()
         edTime = self.theProject.getCurrentEditTime()
+
+        self.bookTitle.setText(self.theProject.data.title or self.theProject.data.name)
+        self.projName.setText(self.tr("Project: {0}").format(self.theProject.data.name))
+        self.bookAuthors.setText(self.tr("By {0}").format(self.theProject.data.author))
 
         self.wordCountVal.setText(f"{nwCount:n}")
         self.chapCountVal.setText(f"{hCounts[2]:n}")


### PR DESCRIPTION
**Summary:**

This PR fixes the following on the Project Details dialog:
* An issue where the project name, title and author was not updated due to Qt GUI caching when a new project was loaded.
* Loading of project name, title and author where an empty field would be saved again as the string "None" on the second save. This is because an empty or missing value in the XML returns a `None` which is cast to string. The setters now cast the value as `str(value or "")`. The dialog will now show the project name in place of the title if the title is not set.
* The formatting of the editing time label to use the same format function as the clock on the status bar.

**Related Issue(s):**

Closes #1335
Closes #1336

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
