### PR TITLE
Add project content path check

### DIFF
--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -79,8 +79,16 @@ class NWStorage:
 
     @property
     def contentPath(self):
+        """Return the path used for project content. The folder must
+        already exist, otherwise this property is None.
+        """
         if self._runtimePath is not None:
-            return self._runtimePath / "content"
+            contentPath = self._runtimePath / "content"
+            if contentPath.is_dir():
+                return contentPath
+            else:
+                logger.error("Path not found: %s", contentPath)
+                return None
         return None
 
     ##

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -469,6 +469,7 @@ def testCoreTree_ToCFile(monkeypatch, mockGUI, mockItems, tmpPath):
         assert theTree.writeToCFile() is False
 
     theProject._storage._runtimePath = tmpPath
+    (tmpPath / "content").mkdir()
     assert theTree.writeToCFile() is True
 
     pathA = str(Path("content") / "c000000000001.nwd")


### PR DESCRIPTION
**Summary:**

This adds a check to the storage class that verifies that the storage path for project content still exists when saving a document. It solves #1317 for now, but the process needs to be handled better in general in a proper feature change not suitable for a patch.

**Related Issue(s):**

Closes #1317

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
