### PR TITLE
Fix GUI bugs and broken reference links

### DIFF
--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -1201,17 +1201,18 @@ class GuiDocViewDetails(QScrollArea):
         return
 
     ##
-    #  Internal Functions
+    #  Private Slots
     ##
 
+    @pyqtSlot(str)
     def _linkClicked(self, theLink):
         """Capture the link-click and forward it to the document viewer
         class for handling.
         """
         logger.debug("Clicked link: '%s'", theLink)
-        if len(theLink) == 21:
+        if len(theLink) >= 13:
             tHandle = theLink[:13]
-            tAnchor = theLink[13:]
+            tAnchor = theLink[13:] or None
             self.mainGui.viewDocument(tHandle, tAnchor)
         return
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1088,7 +1088,6 @@ class GuiProjectTree(QTreeWidget):
         if tItem is None:
             return False
 
-        self.setFocus()
         if tHandle in self._treeMap:
             self.setCurrentItem(self._treeMap[tHandle])
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -39,7 +39,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout, QWidget
 )
 
-from novelwriter.enum import nwDocMode, nwItemType, nwItemClass, nwItemLayout, nwAlert
+from novelwriter.enum import nwDocMode, nwItemType, nwItemClass, nwItemLayout, nwAlert, nwWidget
 from novelwriter.constants import nwHeaders, nwUnicode, trConst, nwLabels
 from novelwriter.core.coretools import DocMerger, DocSplitter
 from novelwriter.dialogs.docmerge import GuiDocMerge
@@ -630,6 +630,7 @@ class GuiProjectTree(QTreeWidget):
 
         # Add the new item to the project tree
         self.revealNewTreeItem(tHandle, nHandle=nHandle, wordCount=True)
+        self.mainGui.switchFocus(nwWidget.TREE)
 
         return True
 

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -171,6 +171,19 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, nwLipsum):
         assert nwGUI.docViewer.loadText("846352075de7d") is False
         assert nwGUI.docViewer.toPlainText() == "An error occurred while generating the preview."
 
+    # Check reference panel (issue #1378)
+    assert nwGUI.viewDocument("4c4f28287af27") is True
+    assert nwGUI.docViewer.toPlainText().startswith("Nobody Owens")
+
+    nwGUI.viewMeta._linkClicked("fb609cd8319dc")
+    assert nwGUI.docViewer.toPlainText().startswith("Chapter One")
+
+    nwGUI.viewMeta._linkClicked("88243afbe5ed8#T0001")
+    assert nwGUI.docViewer.toPlainText().startswith("Scene One")
+
+    nwGUI.viewMeta._linkClicked("88243afbe5ed8#ABCD")
+    assert nwGUI.docViewer.toPlainText().startswith("Scene One")
+
     # qtbot.stop()
 
 # END Test testGuiViewer_Main


### PR DESCRIPTION
**Summary:**

This PR fixes three bugs:

* The Reference Panel link would no longer recognise the new, shorter links after the 2.0 project index change. The explicit check has been made more lenient and will now accept any link that is at least 13 characters long (the length of a document handle).
* Test coverage has been added for handling Reference Panel links.
* When new items are created in the project tree via shortcuts, the project tree receives focus. Since these actions can be accessed when the project tree does not have focus, a user would have to manually switch focus to be able to open new items if they were in the editor when activating them.
* The `setSelectedItem` method of the project tree class had a `setFocus()` call. It should not do this as global focus is handled by the main GUI class, and doing this explicitly in the `setSelectedItem` method is presumptuous.

**Related Issue(s):**

Closes #1378
Closes #1376
Closes #1369

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
