### PR TITLE
Add Ctrl+Enter as a shortcut to open doc end switch focus

### DIFF
--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -270,9 +270,17 @@ class GuiMain(QMainWindow):
         keyReturn.setKey(QKeySequence(Qt.Key_Return))
         keyReturn.activated.connect(self._keyPressReturn)
 
+        keyCtrlReturn = QShortcut(self)
+        keyCtrlReturn.setKey(QKeySequence(Qt.ControlModifier | Qt.Key_Return))
+        keyCtrlReturn.activated.connect(self._keyPressCtrlReturn)
+
         keyEnter = QShortcut(self)
         keyEnter.setKey(QKeySequence(Qt.Key_Enter))
         keyEnter.activated.connect(self._keyPressReturn)
+
+        keyCtrlEnter = QShortcut(self)
+        keyCtrlEnter.setKey(QKeySequence(Qt.ControlModifier | Qt.Key_Enter))
+        keyCtrlEnter.activated.connect(self._keyPressCtrlReturn)
 
         keyEscape = QShortcut(self)
         keyEscape.setKey(QKeySequence(Qt.Key_Escape))
@@ -790,7 +798,7 @@ class GuiMain(QMainWindow):
     #  Tree Item Actions
     ##
 
-    def openSelectedItem(self):
+    def openSelectedItem(self, changeFocus=False):
         """Open the selected item from the tree that is currently
         active. It is not checked that the item is actually a document.
         That should be handled by the openDocument function.
@@ -818,7 +826,7 @@ class GuiMain(QMainWindow):
                 tLine = hItem.line
 
         if tHandle is not None:
-            self.openDocument(tHandle, tLine=tLine, changeFocus=False, doScroll=False)
+            self.openDocument(tHandle, tLine=tLine, changeFocus=changeFocus, doScroll=False)
 
         return True
 
@@ -1585,6 +1593,15 @@ class GuiMain(QMainWindow):
         the currently selected item.
         """
         self.openSelectedItem()
+        return
+
+    @pyqtSlot()
+    def _keyPressCtrlReturn(self):
+        """Forward the control + return/enter keypress to the function
+        that opens the currently selected item and switches focus to the
+        editor.
+        """
+        self.openSelectedItem(changeFocus=True)
         return
 
     @pyqtSlot()


### PR DESCRIPTION
**Summary:**

Using the Enter or Return key in the trees do not switch focus to the editor. This allows the user to look through documents without having to switch focus back to the tree for each document. However, sometimes the user just wants to open and edit a document right away. The `Ctrl + Enter` shortcut added here opens the selected document and switches focus in one go.

This is a minor usability update.

**Related Issue(s):**

Resolves #1368

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
