### PR TITLE
Change resize behaviour of main splitter

### DIFF
--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -161,7 +161,7 @@ class GuiMain(QMainWindow):
         self.splitDocs.setOpaqueResize(False)
         self.splitDocs.setHandleWidth(hWd)
 
-        # Splitter : Project Tree / Main Tabs
+        # Splitter : Project Tree / Document Area
         self.splitMain = QSplitter(Qt.Horizontal)
         self.splitMain.setContentsMargins(0, 0, 0, 0)
         self.splitMain.addWidget(self.treePane)
@@ -184,7 +184,7 @@ class GuiMain(QMainWindow):
         self.idxViewDoc  = self.splitView.indexOf(self.docViewer)
         self.idxViewMeta = self.splitView.indexOf(self.viewMeta)
 
-        # Indices of Tab Widgets
+        # Indices of Stack Widgets
         self.idxEditorView  = self.mainStack.indexOf(self.splitMain)
         self.idxOutlineView = self.mainStack.indexOf(self.outlineView)
         self.idxProjView    = self.projStack.indexOf(self.projView)
@@ -197,6 +197,9 @@ class GuiMain(QMainWindow):
         self.splitDocs.setCollapsible(self.idxViewer, False)
         self.splitView.setCollapsible(self.idxViewDoc, False)
         self.splitView.setCollapsible(self.idxViewMeta, False)
+
+        self.splitMain.setStretchFactor(self.idxTree, 0)
+        self.splitMain.setStretchFactor(self.idxMain, 1)
 
         # Editor / Viewer Default State
         self.splitView.setVisible(False)


### PR DESCRIPTION
**Summary:**

This is a small change that modifies the behaviour of the main splitter, between the project tree are and the document area, so that when the window resizes, the project tree area remains fixed.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
