### PR TITLE
Switch docs theme to Sphinx Book Theme

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,3 +1,14 @@
-body article section {
-    margin-top: 1.8em;
+span.guilabel {
+    font-weight: 400;
+}
+
+.nw-sidebar-title {
+    height: unset;
+    max-height: unset;
+    flex-direction: column;
+    justify-content: center;
+    gap: .25rem;
+    font-size: 1.25rem;
+    font-weight: normal;
+    text-align: center;
 }

--- a/docs/source/_templates/sidebar-title.html
+++ b/docs/source/_templates/sidebar-title.html
@@ -1,0 +1,3 @@
+{% if docstitle %}
+<p class="nw-sidebar-title">{{ docstitle }}</p>
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,7 @@
-#
-# Configuration file for the Sphinx documentation builder.
-# Documentation: http://www.sphinx-doc.org/en/master/config
-#
+"""
+Configuration file for the Sphinx documentation builder.
+Documentation: http://www.sphinx-doc.org/en/master/config
+"""
 
 # -- Imports -----------------------------------------------------------------
 
@@ -12,7 +12,7 @@ import datetime
 # -- Project Information -----------------------------------------------------
 
 project = "novelWriter"
-copyright = f"{datetime.date.today().year}, Veronica Berglyd Olsen"
+copyright = f"{datetime.date.today().year}"
 author = "Veronica Berglyd Olsen"
 
 initFile = os.path.join(
@@ -34,7 +34,7 @@ version = release.split("-")[0]
 os.environ["TZ"] = "Europe/Oslo"
 time.tzset()
 
-needs_sphinx = "4.0"
+needs_sphinx = "5.0"
 extensions = []
 templates_path = ["_templates"]
 source_suffix = ".rst"
@@ -45,23 +45,27 @@ exclude_patterns = []
 
 # -- Options for HTML Output -------------------------------------------------
 
-html_theme = "furo"
+html_theme = "sphinx_book_theme"
+html_title = f"Version {release}"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 html_theme_options = {
-    "light_logo": "novelwriter-light.png",
-    "dark_logo": "novelwriter-dark.png",
+    "logo": {
+        "image_light": "_static/novelwriter-light.png",
+        "image_dark": "_static/novelwriter-dark.png",
+    },
+    "show_toc_level": 2,
+    "show_navbar_depth": 1,
+    "repository_url": "https://github.com/vkbo/novelwriter",
     "navigation_with_keys": True,
-    "dark_css_variables": {
-        "admonition-font-size": "92%",
-    },
-    "light_css_variables": {
-        "admonition-font-size": "92%",
-    },
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "pygment_light_style": "tango",
+    "pygment_dark_style": "dracula",
 }
-html_title = f"<div style='text-align: center'>Documentation Version {release}</div>"
-pygments_style = "tango"
-pygments_dark_style = "native"
+html_sidebars = {
+    "**": ["navbar-logo", "sidebar-title", "sbt-sidebar-nav"],
+}
 
 # -- Options for HTMLHelp Output ---------------------------------------------
 
@@ -110,13 +114,6 @@ texinfo_documents = [(
 
 # Bibliographic Dublin Core info.
 epub_title = project
-
-# The unique identifier of the text. This can be a ISBN number
-# or the project homepage.
-# epub_identifier = ""
-
-# A unique identification for the text.
-# epub_uid = ""
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ["search.html"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,9 @@ Documentation for novelWriter
 #############################
 
 .. image:: images/novelwriter_logo.png
+   :class: dark-light
    :align: right
-   :width: 48
+   :width: 64
 
 | **For Release:** |release|
 | **Last Updated:** |today|
@@ -17,6 +18,7 @@ editor that allows for easy organisation of text and notes, using human readable
 storage for robustness.
 
 .. figure:: images/screenshot_multi.png
+   :class: dark-light
    :align: center
    :width: 500
 
@@ -31,7 +33,7 @@ as well. novelWriter can also be run directly from the Python source, or install
 the pip tool. See :ref:`a_started` for more details.
 
 .. note::
-   Version 1.5 introduced a few changes that will require you to make some minor modifications to
+   Release 1.5 introduced a few changes that will require you to make some minor modifications to
    some of the headings in your project. It should be fairly quick and straightforward. Please see
    the :ref:`a_prjfmt_1_3` section for more details.
 

--- a/docs/source/int_introduction.rst
+++ b/docs/source/int_introduction.rst
@@ -68,12 +68,12 @@ Below are some key features of novelWriter.
 Screenshots
 ===========
 
-**novelWriter with default theme:**
+.. figure:: images/screenshot_default.png
+   :class: dark-light
 
-.. image:: images/screenshot_default.png
-   :width: 800
+   novelWriter with default theme
 
-**novelWriter with dark theme:**
+.. figure:: images/screenshot_dark.png
+   :class: dark-light
 
-.. image:: images/screenshot_dark.png
-   :width: 800
+   novelWriter with dark theme

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,4 +1,5 @@
-furo
-sphinx>=4.0
+sphinx-book-theme
+sphinx>=5.0
+sphinx-favicon
 pygments>=2.7
 docutils>=0.17.1


### PR DESCRIPTION
**Summary:**

This PR switches the main docs theme to use Sphinx Book Theme instead. It is a child theme of the PyData theme that the website now uses, so the source is compatible with the website where the docs are also included.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
