### PR TITLE
Minor GUI Fixes

### DIFF
--- a/i18n/nw_base.ts
+++ b/i18n/nw_base.ts
@@ -3405,7 +3405,7 @@
     </message>
     <message>
       <location filename="../novelwriter/gui/projtree.py" line="1207" />
-      <source>Change Label</source>
+      <source>Rename</source>
       <translation type="unfinished" />
     </message>
     <message>

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -246,6 +246,8 @@ def main(sysArgs=None):
         nwApp.setApplicationName(CONFIG.appName)
         nwApp.setApplicationVersion(__version__)
         nwApp.setOrganizationDomain(__domain__)
+        nwApp.setOrganizationName(__domain__)
+        nwApp.setDesktopFileName(CONFIG.appName)
 
         # Connect the exception handler before making the main GUI
         sys.excepthook = exceptionHandler

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1204,7 +1204,7 @@ class GuiProjectTree(QTreeWidget):
         # Edit Item Settings
         # ==================
 
-        aLabel = ctxMenu.addAction(self.tr("Change Label"))
+        aLabel = ctxMenu.addAction(self.tr("Rename"))
         aLabel.triggered.connect(lambda: self.renameTreeItem(tHandle))
 
         if isFile:


### PR DESCRIPTION
**Summary:**

This PR:
* Fixes an issue with the application name not showing up properly on Gnome 43 (at least) and novelWriter is instead listed as "io.novelwriter.python3". Apparently it has been guessing the name to some extent, but setting the `QApplication.desktopFileName` value to "novelWriter" seems to clear it up.
* Resolve an issue where the context menu entry for renaming a project item says "Change Label" while the main menu entry says "Rename Item". The context menu now says "Rename", which is more consistent and logical.

**Related Issue(s):**

Closes #1403

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
