### PR TITLE
Apply new item rules in project tree

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -38,6 +38,7 @@ from PyQt5.QtWidgets import (
     QMenu, QShortcut, QSizePolicy, QToolButton, QTreeWidget, QTreeWidgetItem,
     QVBoxLayout, QWidget
 )
+from novelwriter.core.item import NWItem
 
 from novelwriter.enum import nwDocMode, nwItemType, nwItemClass, nwItemLayout, nwAlert, nwWidget
 from novelwriter.constants import nwHeaders, nwUnicode, trConst, nwLabels
@@ -107,6 +108,9 @@ class GuiProjectView(QWidget):
         self.keyContext.setKey("Ctrl+.")
         self.keyContext.setContext(Qt.WidgetShortcut)
         self.keyContext.activated.connect(lambda: self.projTree.openContextOnSelected())
+
+        # Signals
+        self.selectedItemChanged.connect(self.projBar._treeSelectionChanged)
 
         # Function Mappings
         self.emptyTrash = self.projTree.emptyTrash
@@ -416,6 +420,23 @@ class GuiProjectToolBar(QWidget):
         addClass(nwItemClass.ENTITY)
         addClass(nwItemClass.CUSTOM)
 
+        return
+
+    ##
+    #  Slots
+    ##
+
+    @pyqtSlot(str)
+    def _treeSelectionChanged(self, tHandle):
+        """Toggle the visibility of the new item enties for novel
+        documents. They should only be visible if novel documents can
+        actually be added.
+        """
+        nwItem = self.theProject.tree[tHandle]
+        allowDoc = isinstance(nwItem, NWItem) and nwItem.documentAllowed()
+        self.aAddEmpty.setVisible(allowDoc)
+        self.aAddChap.setVisible(allowDoc)
+        self.aAddScene.setVisible(allowDoc)
         return
 
 # END Class GuiProjectToolBar


### PR DESCRIPTION
**Summary:**

This PR adds a small check when item selection in the project tree changes whether the selected item can have a document added to it. If it cannot, the corresponding options in the new items menu are hidden.

**Related Issue(s):**

Closes #1404

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
