### PR TITLE
Replace underscores with spaces when running spell checker

### DIFF
--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -224,13 +224,11 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             hReg.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
             self.rxRules.append((hReg, regRules))
 
-        # Build a QRegExp for spell checker
+        # Build a QRegExp for the spell checker
         # Include additional characters that the highlighter should
         # consider to be word separators
-        wordSep  = r"\-_\+/"
-        wordSep += nwUnicode.U_ENDASH
-        wordSep += nwUnicode.U_EMDASH
-        self.spellRx = QRegularExpression(r"\b[^\s"+wordSep+r"]+\b")
+        uCode = nwUnicode.U_ENDASH + nwUnicode.U_EMDASH
+        self.spellRx = QRegularExpression(r"\b[^\s\-\+\/" + uCode + r"]+\b")
         self.spellRx.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
 
         return True
@@ -389,7 +387,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         if not self.spellCheck:
             return
 
-        rxSpell = self.spellRx.globalMatch(theText, 0)
+        rxSpell = self.spellRx.globalMatch(theText.replace("_", " "), 0)
         while rxSpell.hasNext():
             rxMatch = rxSpell.next()
             if not self.spEnchant.checkWord(rxMatch.captured(0)):


### PR DESCRIPTION
**Summary:**

Since underscores are considered word characters in regex, the spell checker has issues dealing with them when they are used for italics markup. This fix is a temporary solution until new spell checking code can be added, but it essentially just replaces all underscores with spaces before processing the word splitter regex used for spell checking.

The solution is simple, but carries a small overhead. Still, it is not an issue on normal sized documents.

**Related Issue(s):**

Closes #1415

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
