### PR TITLE
Fix escaped markdown not being cleaned up for HTML and ODT

### DIFF
--- a/novelwriter/core/tohtml.py
+++ b/novelwriter/core/tohtml.py
@@ -26,7 +26,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import logging
 
 from novelwriter.constants import nwKeyWords, nwLabels, nwHtmlUnicode
-from novelwriter.core.tokenizer import Tokenizer
+from novelwriter.core.tokenizer import Tokenizer, stripEscape
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ class ToHtml(Tokenizer):
                     parStyle = hStyle
                 for xPos, xLen, xFmt in reversed(tFormat):
                     tTemp = tTemp[:xPos] + htmlTags[xFmt] + tTemp[xPos+xLen:]
-                thisPar.append(tTemp.rstrip())
+                thisPar.append(stripEscape(tTemp.rstrip()))
 
             elif tType == self.T_SYNOPSIS and self._doSynopsis:
                 tmpResult.append(self._formatSynopsis(tText))

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -40,6 +40,17 @@ from novelwriter.constants import nwConst, nwRegEx, nwUnicode
 logger = logging.getLogger(__name__)
 
 
+def stripEscape(text):
+    """Helper function to strip escaped markdown characters from
+    paragraph text.
+    """
+    if "\\" in text:
+        # Checking first is slightly slower when there are escaped
+        # characters in the text, but significantly faster when not
+        return text.replace(r"\*", "*").replace(r"\~", "~").replace(r"\_", "_")
+    return text
+
+
 class Tokenizer(ABC):
 
     # In-Text Format
@@ -338,23 +349,6 @@ class Tokenizer(ABC):
         trDict = {nwUnicode.U_MAPOSS: nwUnicode.U_RSQUO}
         self._theText = self._theText.translate(str.maketrans(trDict))
 
-        return
-
-    def doPostProcessing(self):
-        """Do some postprocessing. Overloaded by subclasses. This just
-        does the standard escaped characters.
-        """
-        escapeDict = {
-            r"\*": "*",
-            r"\~": "~",
-            r"\_": "_",
-        }
-        escReplace = re.compile(
-            "|".join([re.escape(k) for k in escapeDict.keys()]), flags=re.DOTALL
-        )
-        self._theResult = escReplace.sub(
-            lambda x: escapeDict[x.group(0)], self._theResult
-        )
         return
 
     def tokenizeText(self):

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -32,7 +32,7 @@ from zipfile import ZipFile
 from datetime import datetime
 
 from novelwriter.constants import nwKeyWords, nwLabels
-from novelwriter.core.tokenizer import Tokenizer
+from novelwriter.core.tokenizer import Tokenizer, stripEscape
 
 logger = logging.getLogger(__name__)
 
@@ -1356,16 +1356,17 @@ class XMLParagraph:
 
         return
 
-    def appendText(self, tText):
+    def appendText(self, text):
         """Append text to the XML element. We do this one character at
         the time in order to be able to process line breaks, tabs and
         spaces separately. Multiple spaces above one are concatenated
         into a single tag, and must therefore be processed separately.
         """
+        text = stripEscape(text)
         nSpaces = 0
-        self._rawTxt += tText
+        self._rawTxt += text
 
-        for c in tText:
+        for c in text:
             if c == " ":
                 nSpaces += 1
                 continue

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -188,7 +188,6 @@ class GuiDocViewer(QTextBrowser):
             aDoc.doPreProcessing()
             aDoc.tokenizeText()
             aDoc.doConvert()
-            aDoc.doPostProcessing()
         except Exception:
             logger.error("Failed to generate preview for document with handle '%s'", tHandle)
             logException()

--- a/novelwriter/tools/build.py
+++ b/novelwriter/tools/build.py
@@ -771,7 +771,6 @@ class GuiBuildNovel(QDialog):
                     bldObj.doHeaders()
                     if doConvert:
                         bldObj.doConvert()
-                    bldObj.doPostProcessing()
 
             except Exception:
                 logger.error("Failed to build document '%s'", tItem.itemHandle)

--- a/tests/test_core/test_core_tohtml.py
+++ b/tests/test_core/test_core_tohtml.py
@@ -574,10 +574,6 @@ def testCoreToHtml_Methods(mockGUI):
     assert theHtml.theMarkdown[-1] == (
         "Text with <brackets> &amp; short&ndash;dash, long&mdash;dash &hellip;\n\n"
     )
-    theHtml.doPostProcessing()
-    assert theHtml.theMarkdown[-1] == (
-        "Text with <brackets> &amp; short&ndash;dash, long&mdash;dash &hellip;\n\n"
-    )
 
     # Result Size
     assert theHtml.getFullResultSize() == 147

--- a/tests/test_core/test_core_tohtml.py
+++ b/tests/test_core/test_core_tohtml.py
@@ -378,7 +378,7 @@ def testCoreToHtml_ConvertDirect(mockGUI):
 
 @pytest.mark.core
 def testCoreToHtml_SpecialCases(mockGUI):
-    """Test some special cases that has caused errors in the past.
+    """Test some special cases that have caused errors in the past.
     """
     theProject = NWProject(mockGUI)
     theHtml = ToHtml(theProject)
@@ -415,8 +415,8 @@ def testCoreToHtml_SpecialCases(mockGUI):
         "<p>Test &gt; text <em>&lt;<strong>bold</strong>&gt;</em> and more.</p>\n"
     )
 
-    # Test for bug #950
-    # =================
+    # Test for issue #950
+    # ===================
     # See: https://github.com/vkbo/novelWriter/issues/950
 
     theHtml.setComments(True)
@@ -434,6 +434,17 @@ def testCoreToHtml_SpecialCases(mockGUI):
     theHtml.doConvert()
     assert theHtml.theResult == (
         "<h1 style='page-break-before: always;'>Heading &lt;1&gt;</h1>\n"
+    )
+
+    # Test for issue #1412
+    # ====================
+    # See: https://github.com/vkbo/novelWriter/issues/1412
+
+    theHtml._theText = "Test text \\**_bold_** and more.\n"
+    theHtml.tokenizeText()
+    theHtml.doConvert()
+    assert theHtml.theResult == (
+        "<p>Test text **<em>bold</em>** and more.</p>\n"
     )
 
 # END Test testCoreToHtml_SpecialCases

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -24,7 +24,7 @@ import pytest
 from tools import C, buildTestProject, readFile
 
 from novelwriter.core.project import NWProject
-from novelwriter.core.tokenizer import Tokenizer
+from novelwriter.core.tokenizer import Tokenizer, stripEscape
 
 
 class BareTokenizer(Tokenizer):
@@ -203,11 +203,6 @@ def testCoreToken_TextOps(monkeypatch, mockGUI, mockRnd, fncPath):
     theToken.doPreProcessing()
     assert theToken._theText == docTextR
 
-    # Post Processing
-    theToken._theResult = r"This is text with escapes: \** \~~ \__"
-    theToken.doPostProcessing()
-    assert theToken.theResult == "This is text with escapes: ** ~~ __"
-
     # Save File
     savePath = fncPath / "dump.nwd"
     theToken.saveRawMarkdown(savePath)
@@ -221,6 +216,16 @@ def testCoreToken_TextOps(monkeypatch, mockGUI, mockRnd, fncPath):
         theToken.doConvert()
 
 # END Test testCoreToken_TextOps
+
+
+@pytest.mark.core
+def testCoreToken_StripEscape():
+    """Test the stripEscape helper function.
+    """
+    text = r"This is text with escapes: \** \~~ \__"
+    assert stripEscape(text) == "This is text with escapes: ** ~~ __"
+
+    return
 
 
 @pytest.mark.core

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -222,10 +222,12 @@ def testCoreToken_TextOps(monkeypatch, mockGUI, mockRnd, fncPath):
 def testCoreToken_StripEscape():
     """Test the stripEscape helper function.
     """
-    text = r"This is text with escapes: \** \~~ \__"
-    assert stripEscape(text) == "This is text with escapes: ** ~~ __"
+    text1 = "This is text with escapes: \\** \\~~ \\__"
+    text2 = "This is text with escapes: ** ~~ __"
+    assert stripEscape(text1) == "This is text with escapes: ** ~~ __"
+    assert stripEscape(text2) == "This is text with escapes: ** ~~ __"
 
-    return
+# END Test testCoreToken_StripEscape
 
 
 @pytest.mark.core

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -221,7 +221,21 @@ def testCoreToOdt_TextFormatting(mockGUI):
         "</office:text>"
     )
 
-    # Tabs and Breaks
+    # Test for issue #1412
+    # ====================
+    # See: https://github.com/vkbo/novelWriter/issues/1412
+
+    theDoc.initDocument()
+    theTxt = "Test text \\**_bold_** and more."
+    theFmt = "             I    i            "
+    theDoc._addTextPar("Standard", oStyle, theTxt, theFmt=theFmt)
+    assert theDoc.getErrors() == []
+    assert xmlToText(theDoc._xText) == (
+        "<office:text>"
+        "<text:p text:style-name=\"Standard\">Test text **<text:span text:style-name=\"T2\">"
+        "bold</text:span>** and more.</text:p>"
+        "</office:text>"
+    )
 
 # END Test testCoreToOdt_TextFormatting
 


### PR DESCRIPTION
**Summary:**

This PR changes how escaped markdown characters are handled. Previously, they were handled in a post processing step that only actually worked for the document viewer.

The new implementation runs a utility function on each piece of text that goes into an HTML or ODT paragraph during the processing loop. This is now format-dependant and the post processing function itself has been removed.

**Related Issue(s):**

Closes #1412

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
