### PR TITLE
Fix docs URL

### DIFF
--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -872,14 +872,9 @@ class GuiMainMenu(QMenuBar):
         self.helpMenu.addSeparator()
 
         # Help > User Manual (Online)
-        if novelwriter.__version__[-2] == "f":
-            docUrl = f"{novelwriter.__docurl__}/en/stable/"
-        else:
-            docUrl = f"{novelwriter.__docurl__}/en/latest/"
-
         self.aHelpDocs = QAction(self.tr("User Manual (Online)"), self)
         self.aHelpDocs.setShortcut("F1")
-        self.aHelpDocs.triggered.connect(lambda: self._openWebsite(docUrl))
+        self.aHelpDocs.triggered.connect(lambda: self._openWebsite(novelwriter.__docurl__))
         self.helpMenu.addAction(self.aHelpDocs)
 
         # Help > User Manual (PDF)


### PR DESCRIPTION
**Summary:**

This PR fixes the documentation URL in the Help menu. It was pointing to the correct domain, but the wrong path.

**Related Issue(s):**

Closes #1445

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
