### PR TITLE
Rewrite config mocking

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -64,12 +64,6 @@ __hexversion__ = "0x020007f0"
 __date__       = "2023-04-16"
 __status__     = "Stable"
 __domain__     = "novelwriter.io"
-__url__        = "https://novelwriter.io"
-__docurl__     = "https://docs.novelwriter.io/"
-__sourceurl__  = "https://github.com/vkbo/novelWriter"
-__issuesurl__  = "https://github.com/vkbo/novelWriter/issues"
-__helpurl__    = "https://github.com/vkbo/novelWriter/discussions"
-__releaseurl__ = "https://github.com/vkbo/novelWriter/releases/latest"
 
 logger = logging.getLogger(__name__)
 

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -430,10 +430,10 @@ class Config:
         """
         logger.debug("Initialising Config ...")
         if isinstance(confPath, (str, Path)):
-            logger.info("Setting config from alternative path: %s", confPath)
+            logger.info("Setting alternative config path: %s", confPath)
             self._confPath = Path(confPath)
         if isinstance(dataPath, (str, Path)):
-            logger.info("Setting data path from alternative path: %s", dataPath)
+            logger.info("Setting alternative data path: %s", dataPath)
             self._dataPath = Path(dataPath)
 
         logger.debug("Config Path: %s", self._confPath)

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -776,8 +776,8 @@ class Config:
 
 class RecentProjects:
 
-    def __init__(self, mainConf):
-        self.mainConf = mainConf
+    def __init__(self, config):
+        self._conf = config
         self._data = {}
         return
 
@@ -786,7 +786,7 @@ class RecentProjects:
         """
         self._data = {}
 
-        cacheFile = self.mainConf.dataPath(nwFiles.RECENT_FILE)
+        cacheFile = self._conf.dataPath(nwFiles.RECENT_FILE)
         if not cacheFile.is_file():
             return True
 
@@ -809,7 +809,7 @@ class RecentProjects:
     def saveCache(self):
         """Save the cache dictionary of recent projects.
         """
-        cacheFile = self.mainConf.dataPath(nwFiles.RECENT_FILE)
+        cacheFile = self._conf.dataPath(nwFiles.RECENT_FILE)
         cacheTemp = cacheFile.with_suffix(".tmp")
         try:
             with open(cacheTemp, mode="w+", encoding="utf-8") as outFile:

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -45,6 +45,14 @@ class nwConst:
     MAX_DOCSIZE   = 5000000   # Maxium size of a single document
     MAX_BUILDSIZE = 10000000  # Maxium size of a project build
 
+    # URLs
+    URL_WEB     = "https://novelwriter.io"
+    URL_DOCS    = "https://docs.novelwriter.io"
+    URL_CODE    = "https://github.com/vkbo/novelWriter"
+    URL_REPORT  = "https://github.com/vkbo/novelWriter/issues"
+    URL_HELP    = "https://github.com/vkbo/novelWriter/discussions"
+    URL_RELEASE = "https://github.com/vkbo/novelWriter/releases/latest"
+
 # END Class nwConst
 
 

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -27,13 +27,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import shutil
 import logging
-import novelwriter
 
 from time import time
 from functools import partial
 
 from PyQt5.QtCore import QCoreApplication
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwAlert
 from novelwriter.common import minmax, simplified
 from novelwriter.constants import nwItemClass
@@ -268,12 +268,8 @@ class ProjectBuilder:
     """
 
     def __init__(self, mainGui):
-
         self.mainGui = mainGui
-        self.mainConf = novelwriter.CONFIG
-
         self.tr = partial(QCoreApplication.translate, "NWProject")
-
         return
 
     ##
@@ -431,7 +427,7 @@ class ProjectBuilder:
             logger.error("No project path set for the example project")
             return False
 
-        pkgSample = self.mainConf.assetPath("sample.zip")
+        pkgSample = CONFIG.assetPath("sample.zip")
         if pkgSample.is_file():
             try:
                 shutil.unpack_archive(pkgSample, projPath)

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import json
 import logging
-import novelwriter
 
 from time import time
 from pathlib import Path
@@ -33,6 +32,7 @@ from functools import partial
 
 from PyQt5.QtCore import QCoreApplication, QObject, pyqtSignal
 
+from novelwriter import CONFIG, __version__, __hexversion__
 from novelwriter.enum import nwItemType, nwItemClass, nwItemLayout, nwAlert
 from novelwriter.error import logException
 from novelwriter.constants import trConst, nwFiles, nwLabels
@@ -58,8 +58,7 @@ class NWProject(QObject):
         super().__init__(parent=mainGui)
 
         # Internal
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
+        self.mainGui = mainGui
 
         # Core Elements
         self._options = OptionState(self)    # Project-specific GUI options
@@ -328,7 +327,7 @@ class NWProject(QObject):
         # Check novelWriter Version
         # =========================
 
-        if xmlReader.hexVersion > hexToInt(novelwriter.__hexversion__):
+        if xmlReader.hexVersion > hexToInt(__hexversion__):
             msgYes = self.mainGui.askQuestion(
                 self.tr("Version Conflict"),
                 self.tr(
@@ -337,7 +336,7 @@ class NWProject(QObject):
                     "continue to open the project, some attributes and "
                     "settings may not be preserved, but the overall project "
                     "should be fine. Continue opening the project?"
-                ).format(appVersion, novelwriter.__version__)
+                ).format(appVersion, __version__)
             )
             if not msgYes:
                 self.clearProject()
@@ -351,7 +350,7 @@ class NWProject(QObject):
         self._loadProjectLocalisation()
 
         # Update recent projects
-        self.mainConf.recentProjects.update(
+        CONFIG.recentProjects.update(
             self._storage.storagePath, self._data.name, sum(self._data.initCounts), time()
         )
 
@@ -422,7 +421,7 @@ class NWProject(QObject):
         self._storage.runPostSaveTasks(autoSave=autoSave)
 
         # Update recent projects
-        self.mainConf.recentProjects.update(
+        CONFIG.recentProjects.update(
             self._storage.storagePath, self._data.name, sum(self._data.currCounts), saveTime
         )
 
@@ -455,7 +454,7 @@ class NWProject(QObject):
         logger.info("Backing up project")
         self.mainGui.setStatus(self.tr("Backing up project ..."))
 
-        backupPath = self.mainConf.backupPath()
+        backupPath = CONFIG.backupPath()
         if not isinstance(backupPath, Path):
             self.mainGui.makeAlert(self.tr(
                 "Cannot backup project because no valid backup path is set. "
@@ -677,13 +676,13 @@ class NWProject(QObject):
     def _loadProjectLocalisation(self):
         """Load the language data for the current project language.
         """
-        if self._data.language is None or self.mainConf._nwLangPath is None:
+        if self._data.language is None or CONFIG._nwLangPath is None:
             self._langData = {}
             return False
 
-        langFile = Path(self.mainConf._nwLangPath) / f"project_{self._data.language}.json"
+        langFile = Path(CONFIG._nwLangPath) / f"project_{self._data.language}.json"
         if not langFile.is_file():
-            langFile = Path(self.mainConf._nwLangPath) / "project_en_GB.json"
+            langFile = Path(CONFIG._nwLangPath) / "project_en_GB.json"
 
         try:
             with open(langFile, mode="r", encoding="utf-8") as inFile:

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -26,13 +26,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from enum import Enum
 from lxml import etree
 from time import time
 from pathlib import Path
 
+from novelwriter import __version__, __hexversion__
 from novelwriter.common import (
     checkBool, checkInt, checkString, checkStringNone, formatTimeStamp,
     hexToInt, simplified, yesNo
@@ -501,8 +501,8 @@ class ProjectXMLWriter:
         logger.debug("Writing project XML")
 
         xRoot = etree.Element("novelWriterXML", attrib={
-            "appVersion":  str(novelwriter.__version__),
-            "hexVersion":  str(novelwriter.__hexversion__),
+            "appVersion":  str(__version__),
+            "hexVersion":  str(__hexversion__),
             "fileVersion": FILE_VERSION,
             "timeStamp":   formatTimeStamp(saveTime),
         })

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -26,11 +26,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import random
 import logging
-import novelwriter
 
 from PyQt5.QtGui import QIcon, QPainter, QPainterPath, QPixmap, QColor
 from PyQt5.QtCore import QRectF, Qt
 
+from novelwriter import CONFIG
 from novelwriter.common import minmax, simplified
 
 logger = logging.getLogger(__name__)
@@ -47,11 +47,11 @@ class NWStatus:
         self._store = {}
         self._default = None
 
-        self._iPX = novelwriter.CONFIG.pxInt(24)
+        self._iPX = CONFIG.pxInt(24)
 
-        pA = novelwriter.CONFIG.pxInt(2)
-        pB = novelwriter.CONFIG.pxInt(20)
-        pR = float(novelwriter.CONFIG.pxInt(4))
+        pA = CONFIG.pxInt(2)
+        pB = CONFIG.pxInt(20)
+        pR = float(CONFIG.pxInt(4))
         self._iconPath = QPainterPath()
         self._iconPath.addRoundedRect(QRectF(pA, pA, pB, pB), pR, pR)
 

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -24,12 +24,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from time import time
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 
+from novelwriter import CONFIG
 from novelwriter.error import logException
 from novelwriter.common import minmax
 from novelwriter.constants import nwFiles
@@ -47,7 +47,6 @@ class NWStorage:
 
     def __init__(self, theProject):
 
-        self.mainConf = novelwriter.CONFIG
         self.theProject = theProject
 
         self._storagePath = None
@@ -220,8 +219,8 @@ class NWStorage:
             return False
 
         data = [
-            self.mainConf.hostName, self.mainConf.osType,
-            self.mainConf.kernelVer, str(int(time()))
+            CONFIG.hostName, CONFIG.osType,
+            CONFIG.kernelVer, str(int(time()))
         ]
         try:
             self._lockFilePath.write_text(";".join(data), encoding="utf-8")

--- a/novelwriter/core/tohtml.py
+++ b/novelwriter/core/tohtml.py
@@ -25,6 +25,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
 
+from novelwriter import CONFIG
 from novelwriter.constants import nwKeyWords, nwLabels, nwHtmlUnicode
 from novelwriter.core.tokenizer import Tokenizer, stripEscape
 
@@ -204,9 +205,9 @@ class ToHtml(Tokenizer):
                     aStyle.append("margin-top: 0;")
 
                 if tStyle & self.A_IND_L:
-                    aStyle.append(f"margin-left: {self.mainConf.tabWidth:d}px;")
+                    aStyle.append(f"margin-left: {CONFIG.tabWidth:d}px;")
                 if tStyle & self.A_IND_R:
-                    aStyle.append(f"margin-right: {self.mainConf.tabWidth:d}px;")
+                    aStyle.append(f"margin-right: {CONFIG.tabWidth:d}px;")
 
             if len(aStyle) > 0:
                 stVals = " ".join(aStyle)

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import re
 import logging
-import novelwriter
 
 from abc import ABC, abstractmethod
 from operator import itemgetter
@@ -92,7 +91,6 @@ class Tokenizer(ABC):
     def __init__(self, theProject):
 
         self.theProject = theProject
-        self.mainConf   = novelwriter.CONFIG
 
         # Data Variables
         self._theText   = ""    # The raw text to be tokenized

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -24,13 +24,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from lxml import etree
 from hashlib import sha256
 from zipfile import ZipFile
 from datetime import datetime
 
+from novelwriter import __version__
 from novelwriter.constants import nwKeyWords, nwLabels
 from novelwriter.core.tokenizer import Tokenizer, stripEscape
 
@@ -336,7 +336,7 @@ class ToOdt(Tokenizer):
         xMeta.text = timeStamp
 
         xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "generator"))
-        xMeta.text = f"novelWriter/{novelwriter.__version__}"
+        xMeta.text = f"novelWriter/{__version__}"
 
         xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "initial-creator"))
         xMeta.text = self.theProject.data.author

--- a/novelwriter/custom.py
+++ b/novelwriter/custom.py
@@ -26,7 +26,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtGui import QColor, QPalette, QPainter
 from PyQt5.QtCore import (
@@ -38,6 +37,7 @@ from PyQt5.QtWidgets import (
     QStyleOptionTab, QLineEdit
 )
 
+from novelwriter import CONFIG
 from novelwriter.constants import nwUnicode
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class QConfigLayout(QGridLayout):
 
         self._itemMap = {}
 
-        wSp = novelwriter.CONFIG.pxInt(8)
+        wSp = CONFIG.pxInt(8)
         self.setHorizontalSpacing(wSp)
         self.setVerticalSpacing(wSp)
         self.setColumnStretch(0, 1)
@@ -108,7 +108,7 @@ class QConfigLayout(QGridLayout):
             qLabel = None
             raise ValueError("theLabel must be a QLabel")
 
-        hM = novelwriter.CONFIG.pxInt(4)
+        hM = CONFIG.pxInt(4)
         qLabel.setContentsMargins(0, hM, 0, hM)
         self.addWidget(qLabel, self._nextRow, 0, 1, 2, Qt.AlignLeft)
 
@@ -142,7 +142,7 @@ class QConfigLayout(QGridLayout):
             qWidget = None
             raise ValueError("theWidget must be a QWidget")
 
-        wSp = novelwriter.CONFIG.pxInt(8)
+        wSp = CONFIG.pxInt(8)
         qLabel.setIndent(wSp)
         if helpText is not None:
             qHelp = QHelpLabel(str(helpText), self._helpCol, self._fontScale)
@@ -235,18 +235,18 @@ class QSwitch(QAbstractButton):
         super().__init__(parent=parent)
 
         if width is None:
-            self._xW = novelwriter.CONFIG.pxInt(40)
+            self._xW = CONFIG.pxInt(40)
         else:
             self._xW = width
 
         if height is None:
-            self._xH = novelwriter.CONFIG.pxInt(20)
+            self._xH = CONFIG.pxInt(20)
         else:
             self._xH = height
 
         self._xR = int(self._xH*0.5)
         self._xT = int(self._xH*0.6)
-        self._rB = int(novelwriter.CONFIG.guiScale*2)
+        self._rB = int(CONFIG.guiScale*2)
         self._rH = self._xH - 2*self._rB
         self._rR = self._xR - self._rB
 
@@ -434,7 +434,7 @@ class VerticalTabBar(QTabBar):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self._mW = novelwriter.CONFIG.pxInt(150)
+        self._mW = CONFIG.pxInt(150)
         return
 
     def tabSizeHint(self, index):

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -37,6 +37,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG
 from novelwriter.common import readTextFile
+from novelwriter.constants import nwConst
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +151,7 @@ class GuiAbout(QDialog):
             title1=self.tr("About novelWriter"),
             copy=novelwriter.__copyright__,
             link=self.tr("Website: {0}").format(
-                f"<a href='{novelwriter.__url__}'>{novelwriter.__domain__}</a>"
+                f"<a href='{nwConst.URL_WEB}'>{novelwriter.__domain__}</a>"
             ),
             intro=self.tr(
                 "novelWriter is a markdown-like text editor designed for organising and "

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -35,6 +35,7 @@ from PyQt5.QtWidgets import (
     QTextBrowser, QLabel
 )
 
+from novelwriter import CONFIG
 from novelwriter.common import readTextFile
 
 logger = logging.getLogger(__name__)
@@ -48,19 +49,18 @@ class GuiAbout(QDialog):
         logger.debug("Initialising GuiAbout ...")
         self.setObjectName("GuiAbout")
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
         self.mainTheme = mainGui.mainTheme
 
         self.outerBox = QVBoxLayout()
         self.innerBox = QHBoxLayout()
-        self.innerBox.setSpacing(self.mainConf.pxInt(16))
+        self.innerBox.setSpacing(CONFIG.pxInt(16))
 
         self.setWindowTitle(self.tr("About novelWriter"))
-        self.setMinimumWidth(self.mainConf.pxInt(650))
-        self.setMinimumHeight(self.mainConf.pxInt(600))
+        self.setMinimumWidth(CONFIG.pxInt(650))
+        self.setMinimumHeight(CONFIG.pxInt(600))
 
-        nPx = self.mainConf.pxInt(96)
+        nPx = CONFIG.pxInt(96)
         self.nwIcon = QLabel()
         self.nwIcon.setPixmap(self.mainGui.mainTheme.getPixmap("novelwriter", (nPx, nPx)))
         self.lblName = QLabel("<b>novelWriter</b>")
@@ -68,7 +68,7 @@ class GuiAbout(QDialog):
         self.lblDate = QLabel(datetime.strptime(novelwriter.__date__, "%Y-%m-%d").strftime("%x"))
 
         self.leftBox = QVBoxLayout()
-        self.leftBox.setSpacing(self.mainConf.pxInt(4))
+        self.leftBox.setSpacing(CONFIG.pxInt(4))
         self.leftBox.addWidget(self.nwIcon,  0, Qt.AlignCenter)
         self.leftBox.addWidget(self.lblName, 0, Qt.AlignCenter)
         self.leftBox.addWidget(self.lblVers, 0, Qt.AlignCenter)
@@ -79,19 +79,19 @@ class GuiAbout(QDialog):
         # Pages
         self.pageAbout = QTextBrowser()
         self.pageAbout.setOpenExternalLinks(True)
-        self.pageAbout.document().setDocumentMargin(self.mainConf.pxInt(16))
+        self.pageAbout.document().setDocumentMargin(CONFIG.pxInt(16))
 
         self.pageNotes = QTextBrowser()
         self.pageNotes.setOpenExternalLinks(True)
-        self.pageNotes.document().setDocumentMargin(self.mainConf.pxInt(16))
+        self.pageNotes.document().setDocumentMargin(CONFIG.pxInt(16))
 
         self.pageCredits = QTextBrowser()
         self.pageCredits.setOpenExternalLinks(True)
-        self.pageCredits.document().setDocumentMargin(self.mainConf.pxInt(16))
+        self.pageCredits.document().setDocumentMargin(CONFIG.pxInt(16))
 
         self.pageLicense = QTextBrowser()
         self.pageLicense.setOpenExternalLinks(True)
-        self.pageLicense.document().setDocumentMargin(self.mainConf.pxInt(16))
+        self.pageLicense.document().setDocumentMargin(CONFIG.pxInt(16))
 
         # Main Tab Area
         self.tabBox = QTabWidget()
@@ -182,7 +182,7 @@ class GuiAbout(QDialog):
     def _fillNotesPage(self):
         """Load the content for the Release Notes page.
         """
-        docPath = self.mainConf.assetPath("text") / "release_notes.htm"
+        docPath = CONFIG.assetPath("text") / "release_notes.htm"
         docText = readTextFile(docPath)
         if docText:
             self.pageNotes.setHtml(docText)
@@ -193,7 +193,7 @@ class GuiAbout(QDialog):
     def _fillCreditsPage(self):
         """Load the content for the Credits page.
         """
-        docPath = self.mainConf.assetPath("text") / "credits_en.htm"
+        docPath = CONFIG.assetPath("text") / "credits_en.htm"
         docText = readTextFile(docPath)
         if docText:
             self.pageCredits.setHtml(docText)
@@ -204,7 +204,7 @@ class GuiAbout(QDialog):
     def _fillLicensePage(self):
         """Load the content for the Licence page.
         """
-        docPath = self.mainConf.assetPath("text") / "gplv3_en.htm"
+        docPath = CONFIG.assetPath("text") / "gplv3_en.htm"
         docText = readTextFile(docPath)
         if docText:
             self.pageLicense.setHtml(docText)

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtWidgets import (
@@ -33,6 +32,7 @@ from PyQt5.QtWidgets import (
     QListWidget, QListWidgetItem, QVBoxLayout,
 )
 
+from novelwriter import CONFIG
 from novelwriter.custom import QHelpLabel, QSwitch
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,6 @@ class GuiDocMerge(QDialog):
         logger.debug("Initialising GuiDocMerge ...")
         self.setObjectName("GuiDocMerge")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
@@ -61,14 +60,14 @@ class GuiDocMerge(QDialog):
         ), self.mainTheme.helpText)
 
         iPx = self.mainTheme.baseIconSize
-        hSp = self.mainConf.pxInt(12)
-        vSp = self.mainConf.pxInt(8)
-        bSp = self.mainConf.pxInt(12)
+        hSp = CONFIG.pxInt(12)
+        vSp = CONFIG.pxInt(8)
+        bSp = CONFIG.pxInt(12)
 
         self.listBox = QListWidget()
         self.listBox.setIconSize(QSize(iPx, iPx))
-        self.listBox.setMinimumWidth(self.mainConf.pxInt(400))
-        self.listBox.setMinimumHeight(self.mainConf.pxInt(180))
+        self.listBox.setMinimumWidth(CONFIG.pxInt(400))
+        self.listBox.setMinimumHeight(CONFIG.pxInt(180))
         self.listBox.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.listBox.setSelectionMode(QAbstractItemView.SingleSelection)
         self.listBox.setDragDropMode(QAbstractItemView.InternalMove)

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
@@ -33,6 +32,7 @@ from PyQt5.QtWidgets import (
     QListWidgetItem, QDialogButtonBox, QLabel, QGridLayout
 )
 
+from novelwriter import CONFIG
 from novelwriter.custom import QHelpLabel, QSwitch
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,6 @@ class GuiDocSplit(QDialog):
         logger.debug("Initialising GuiDocSplit ...")
         self.setObjectName("GuiDocSplit")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
@@ -68,9 +67,9 @@ class GuiDocSplit(QDialog):
 
         # Values
         iPx = self.mainTheme.baseIconSize
-        hSp = self.mainConf.pxInt(12)
-        vSp = self.mainConf.pxInt(8)
-        bSp = self.mainConf.pxInt(12)
+        hSp = CONFIG.pxInt(12)
+        vSp = CONFIG.pxInt(8)
+        bSp = CONFIG.pxInt(12)
 
         pOptions = self.theProject.options
         spLevel = pOptions.getInt("GuiDocSplit", "spLevel", 3)
@@ -80,8 +79,8 @@ class GuiDocSplit(QDialog):
         # Header Selection
         self.listBox = QListWidget()
         self.listBox.setDragDropMode(QAbstractItemView.NoDragDrop)
-        self.listBox.setMinimumWidth(self.mainConf.pxInt(400))
-        self.listBox.setMinimumHeight(self.mainConf.pxInt(180))
+        self.listBox.setMinimumWidth(CONFIG.pxInt(400))
+        self.listBox.setMinimumHeight(CONFIG.pxInt(180))
 
         self.splitLevel = QComboBox(self)
         self.splitLevel.addItem(self.tr("Split on Header Level 1 (Title)"),      1)

--- a/novelwriter/dialogs/editlabel.py
+++ b/novelwriter/dialogs/editlabel.py
@@ -24,11 +24,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QLineEdit, QLabel, QDialogButtonBox, QHBoxLayout
 )
+
+from novelwriter import CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +42,8 @@ class GuiEditLabel(QDialog):
         self.setObjectName("GuiEditLabel")
         self.setWindowTitle(self.tr("Item Label"))
 
-        mVd = novelwriter.CONFIG.pxInt(220)
-        mSp = novelwriter.CONFIG.pxInt(12)
+        mVd = CONFIG.pxInt(220)
+        mSp = CONFIG.pxInt(12)
 
         # Item Label
         self.labelValue = QLineEdit()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -24,7 +24,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtGui import QFont
 from PyQt5.QtCore import Qt, QLocale
@@ -33,6 +32,7 @@ from PyQt5.QtWidgets import (
     QLineEdit, QFileDialog, QFontDialog, QDoubleSpinBox
 )
 
+from novelwriter import CONFIG
 from novelwriter.custom import QSwitch, QConfigLayout, PagedDialog
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 
@@ -47,7 +47,6 @@ class GuiPreferences(PagedDialog):
         logger.debug("Initialising GuiPreferences ...")
         self.setObjectName("GuiPreferences")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
 
@@ -74,7 +73,7 @@ class GuiPreferences(PagedDialog):
         self.buttonBox.rejected.connect(self._doClose)
         self.addControls(self.buttonBox)
 
-        self.resize(*self.mainConf.preferencesWinSize)
+        self.resize(*CONFIG.preferencesWinSize)
 
         # Settings
         self._updateTheme = False
@@ -125,7 +124,7 @@ class GuiPreferences(PagedDialog):
         self.tabQuote.saveValues()
 
         self._saveWindowSize()
-        self.mainConf.saveConfig()
+        CONFIG.saveConfig()
         self.accept()
 
         return
@@ -144,7 +143,7 @@ class GuiPreferences(PagedDialog):
     def _saveWindowSize(self):
         """Save the dialog window size.
         """
-        self.mainConf.setPreferencesWinSize(self.width(), self.height())
+        CONFIG.setPreferencesWinSize(self.width(), self.height())
         return
 
 # END Class GuiPreferences
@@ -155,7 +154,6 @@ class GuiPreferencesGeneral(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainConf  = novelwriter.CONFIG
         self.prefsGui  = prefsGui
         self.mainGui   = prefsGui.mainGui
         self.mainTheme = prefsGui.mainGui.mainTheme
@@ -168,15 +166,15 @@ class GuiPreferencesGeneral(QWidget):
         # Look and Feel
         # =============
         self.mainForm.addGroupLabel(self.tr("Look and Feel"))
-        minWidth = self.mainConf.pxInt(200)
+        minWidth = CONFIG.pxInt(200)
 
         # Select Locale
         self.guiLocale = QComboBox()
         self.guiLocale.setMinimumWidth(minWidth)
-        theLangs = self.mainConf.listLanguages(self.mainConf.LANG_NW)
+        theLangs = CONFIG.listLanguages(CONFIG.LANG_NW)
         for lang, langName in theLangs:
             self.guiLocale.addItem(langName, lang)
-        langIdx = self.guiLocale.findData(self.mainConf.guiLocale)
+        langIdx = self.guiLocale.findData(CONFIG.guiLocale)
         if langIdx != -1:
             self.guiLocale.setCurrentIndex(langIdx)
 
@@ -192,7 +190,7 @@ class GuiPreferencesGeneral(QWidget):
         self.theThemes = self.mainTheme.listThemes()
         for themeDir, themeName in self.theThemes:
             self.guiTheme.addItem(themeName, themeDir)
-        themeIdx = self.guiTheme.findData(self.mainConf.guiTheme)
+        themeIdx = self.guiTheme.findData(CONFIG.guiTheme)
         if themeIdx != -1:
             self.guiTheme.setCurrentIndex(themeIdx)
 
@@ -204,11 +202,11 @@ class GuiPreferencesGeneral(QWidget):
 
         # Editor Theme
         self.guiSyntax = QComboBox()
-        self.guiSyntax.setMinimumWidth(self.mainConf.pxInt(200))
+        self.guiSyntax.setMinimumWidth(CONFIG.pxInt(200))
         self.theSyntaxes = self.mainTheme.listSyntax()
         for syntaxFile, syntaxName in self.theSyntaxes:
             self.guiSyntax.addItem(syntaxName, syntaxFile)
-        syntaxIdx = self.guiSyntax.findData(self.mainConf.guiSyntax)
+        syntaxIdx = self.guiSyntax.findData(CONFIG.guiSyntax)
         if syntaxIdx != -1:
             self.guiSyntax.setCurrentIndex(syntaxIdx)
 
@@ -221,8 +219,8 @@ class GuiPreferencesGeneral(QWidget):
         # Font Family
         self.guiFont = QLineEdit()
         self.guiFont.setReadOnly(True)
-        self.guiFont.setFixedWidth(self.mainConf.pxInt(162))
-        self.guiFont.setText(self.mainConf.guiFont)
+        self.guiFont.setFixedWidth(CONFIG.pxInt(162))
+        self.guiFont.setText(CONFIG.guiFont)
         self.fontButton = QPushButton("...")
         self.fontButton.setMaximumWidth(int(2.5*self.mainTheme.getTextWidth("...")))
         self.fontButton.clicked.connect(self._selectFont)
@@ -238,7 +236,7 @@ class GuiPreferencesGeneral(QWidget):
         self.guiFontSize.setMinimum(8)
         self.guiFontSize.setMaximum(60)
         self.guiFontSize.setSingleStep(1)
-        self.guiFontSize.setValue(self.mainConf.guiFontSize)
+        self.guiFontSize.setValue(CONFIG.guiFontSize)
         self.mainForm.addRow(
             self.tr("Font size"),
             self.guiFontSize,
@@ -251,7 +249,7 @@ class GuiPreferencesGeneral(QWidget):
         self.mainForm.addGroupLabel(self.tr("GUI Settings"))
 
         self.emphLabels = QSwitch()
-        self.emphLabels.setChecked(self.mainConf.emphLabels)
+        self.emphLabels.setChecked(CONFIG.emphLabels)
         self.mainForm.addRow(
             self.tr("Emphasise partition and chapter labels"),
             self.emphLabels,
@@ -259,7 +257,7 @@ class GuiPreferencesGeneral(QWidget):
         )
 
         self.showFullPath = QSwitch()
-        self.showFullPath.setChecked(self.mainConf.showFullPath)
+        self.showFullPath.setChecked(CONFIG.showFullPath)
         self.mainForm.addRow(
             self.tr("Show full path in document header"),
             self.showFullPath,
@@ -267,7 +265,7 @@ class GuiPreferencesGeneral(QWidget):
         )
 
         self.hideVScroll = QSwitch()
-        self.hideVScroll.setChecked(self.mainConf.hideVScroll)
+        self.hideVScroll.setChecked(CONFIG.hideVScroll)
         self.mainForm.addRow(
             self.tr("Hide vertical scroll bars in main windows"),
             self.hideVScroll,
@@ -275,7 +273,7 @@ class GuiPreferencesGeneral(QWidget):
         )
 
         self.hideHScroll = QSwitch()
-        self.hideHScroll.setChecked(self.mainConf.hideHScroll)
+        self.hideHScroll.setChecked(CONFIG.hideHScroll)
         self.mainForm.addRow(
             self.tr("Hide horizontal scroll bars in main windows"),
             self.hideHScroll,
@@ -295,22 +293,22 @@ class GuiPreferencesGeneral(QWidget):
         emphLabels  = self.emphLabels.isChecked()
 
         # Update Flags
-        self.prefsGui._updateTheme |= self.mainConf.guiTheme != guiTheme
-        self.prefsGui._updateSyntax |= self.mainConf.guiSyntax != guiSyntax
-        self.prefsGui._needsRestart |= self.mainConf.guiLocale != guiLocale
-        self.prefsGui._needsRestart |= self.mainConf.guiFont != guiFont
-        self.prefsGui._needsRestart |= self.mainConf.guiFontSize != guiFontSize
-        self.prefsGui._refreshTree |= self.mainConf.emphLabels != emphLabels
+        self.prefsGui._updateTheme |= CONFIG.guiTheme != guiTheme
+        self.prefsGui._updateSyntax |= CONFIG.guiSyntax != guiSyntax
+        self.prefsGui._needsRestart |= CONFIG.guiLocale != guiLocale
+        self.prefsGui._needsRestart |= CONFIG.guiFont != guiFont
+        self.prefsGui._needsRestart |= CONFIG.guiFontSize != guiFontSize
+        self.prefsGui._refreshTree |= CONFIG.emphLabels != emphLabels
 
-        self.mainConf.guiLocale    = guiLocale
-        self.mainConf.guiTheme     = guiTheme
-        self.mainConf.guiSyntax    = guiSyntax
-        self.mainConf.guiFont      = guiFont
-        self.mainConf.guiFontSize  = guiFontSize
-        self.mainConf.emphLabels   = emphLabels
-        self.mainConf.showFullPath = self.showFullPath.isChecked()
-        self.mainConf.hideVScroll  = self.hideVScroll.isChecked()
-        self.mainConf.hideHScroll  = self.hideHScroll.isChecked()
+        CONFIG.guiLocale    = guiLocale
+        CONFIG.guiTheme     = guiTheme
+        CONFIG.guiSyntax    = guiSyntax
+        CONFIG.guiFont      = guiFont
+        CONFIG.guiFontSize  = guiFontSize
+        CONFIG.emphLabels   = emphLabels
+        CONFIG.showFullPath = self.showFullPath.isChecked()
+        CONFIG.hideVScroll  = self.hideVScroll.isChecked()
+        CONFIG.hideHScroll  = self.hideHScroll.isChecked()
 
         return
 
@@ -322,8 +320,8 @@ class GuiPreferencesGeneral(QWidget):
         """Open the QFontDialog and set a font for the font style.
         """
         currFont = QFont()
-        currFont.setFamily(self.mainConf.guiFont)
-        currFont.setPointSize(self.mainConf.guiFontSize)
+        currFont.setFamily(CONFIG.guiFont)
+        currFont.setPointSize(CONFIG.guiFontSize)
         theFont, theStatus = QFontDialog.getFont(currFont, self)
         if theStatus:
             self.guiFont.setText(theFont.family())
@@ -338,7 +336,6 @@ class GuiPreferencesProjects(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = prefsGui.mainGui
         self.mainTheme = prefsGui.mainGui.mainTheme
 
@@ -356,7 +353,7 @@ class GuiPreferencesProjects(QWidget):
         self.autoSaveDoc.setMinimum(5)
         self.autoSaveDoc.setMaximum(600)
         self.autoSaveDoc.setSingleStep(1)
-        self.autoSaveDoc.setValue(self.mainConf.autoSaveDoc)
+        self.autoSaveDoc.setValue(CONFIG.autoSaveDoc)
         self.mainForm.addRow(
             self.tr("Save document interval"),
             self.autoSaveDoc,
@@ -369,7 +366,7 @@ class GuiPreferencesProjects(QWidget):
         self.autoSaveProj.setMinimum(5)
         self.autoSaveProj.setMaximum(600)
         self.autoSaveProj.setSingleStep(1)
-        self.autoSaveProj.setValue(self.mainConf.autoSaveProj)
+        self.autoSaveProj.setValue(CONFIG.autoSaveProj)
         self.mainForm.addRow(
             self.tr("Save project interval"),
             self.autoSaveProj,
@@ -382,7 +379,7 @@ class GuiPreferencesProjects(QWidget):
         self.mainForm.addGroupLabel(self.tr("Project Backup"))
 
         # Backup Path
-        self.backupPath = self.mainConf.backupPath()
+        self.backupPath = CONFIG.backupPath()
         self.backupGetPath = QPushButton(self.tr("Browse"))
         self.backupGetPath.clicked.connect(self._backupFolder)
         self.backupPathRow = self.mainForm.addRow(
@@ -393,7 +390,7 @@ class GuiPreferencesProjects(QWidget):
 
         # Run when closing
         self.backupOnClose = QSwitch()
-        self.backupOnClose.setChecked(self.mainConf.backupOnClose)
+        self.backupOnClose.setChecked(CONFIG.backupOnClose)
         self.backupOnClose.toggled.connect(self._toggledBackupOnClose)
         self.mainForm.addRow(
             self.tr("Run backup when the project is closed"),
@@ -404,8 +401,8 @@ class GuiPreferencesProjects(QWidget):
         # Ask before backup
         # Only enabled when "Run when closing" is checked
         self.askBeforeBackup = QSwitch()
-        self.askBeforeBackup.setChecked(self.mainConf.askBeforeBackup)
-        self.askBeforeBackup.setEnabled(self.mainConf.backupOnClose)
+        self.askBeforeBackup.setChecked(CONFIG.askBeforeBackup)
+        self.askBeforeBackup.setEnabled(CONFIG.backupOnClose)
         self.mainForm.addRow(
             self.tr("Ask before running backup"),
             self.askBeforeBackup,
@@ -418,7 +415,7 @@ class GuiPreferencesProjects(QWidget):
 
         # Pause when idle
         self.stopWhenIdle = QSwitch()
-        self.stopWhenIdle.setChecked(self.mainConf.stopWhenIdle)
+        self.stopWhenIdle.setChecked(CONFIG.stopWhenIdle)
         self.mainForm.addRow(
             self.tr("Pause the session timer when not writing"),
             self.stopWhenIdle,
@@ -431,7 +428,7 @@ class GuiPreferencesProjects(QWidget):
         self.userIdleTime.setMaximum(600.0)
         self.userIdleTime.setSingleStep(0.5)
         self.userIdleTime.setDecimals(1)
-        self.userIdleTime.setValue(self.mainConf.userIdleTime/60.0)
+        self.userIdleTime.setValue(CONFIG.userIdleTime/60.0)
         self.mainForm.addRow(
             self.tr("Editor inactive time before pausing timer"),
             self.userIdleTime,
@@ -445,17 +442,17 @@ class GuiPreferencesProjects(QWidget):
         """Save the values set for this tab.
         """
         # Automatic Save
-        self.mainConf.autoSaveDoc  = self.autoSaveDoc.value()
-        self.mainConf.autoSaveProj = self.autoSaveProj.value()
+        CONFIG.autoSaveDoc  = self.autoSaveDoc.value()
+        CONFIG.autoSaveProj = self.autoSaveProj.value()
 
         # Project Backup
-        self.mainConf.setBackupPath(self.backupPath)
-        self.mainConf.backupOnClose   = self.backupOnClose.isChecked()
-        self.mainConf.askBeforeBackup = self.askBeforeBackup.isChecked()
+        CONFIG.setBackupPath(self.backupPath)
+        CONFIG.backupOnClose   = self.backupOnClose.isChecked()
+        CONFIG.askBeforeBackup = self.askBeforeBackup.isChecked()
 
         # Session Timer
-        self.mainConf.stopWhenIdle = self.stopWhenIdle.isChecked()
-        self.mainConf.userIdleTime = round(self.userIdleTime.value() * 60)
+        CONFIG.stopWhenIdle = self.stopWhenIdle.isChecked()
+        CONFIG.userIdleTime = round(self.userIdleTime.value() * 60)
 
         return
 
@@ -494,7 +491,6 @@ class GuiPreferencesDocuments(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = prefsGui.mainGui
         self.mainTheme = prefsGui.mainGui.mainTheme
 
@@ -510,8 +506,8 @@ class GuiPreferencesDocuments(QWidget):
         # Font Family
         self.textFont = QLineEdit()
         self.textFont.setReadOnly(True)
-        self.textFont.setFixedWidth(self.mainConf.pxInt(162))
-        self.textFont.setText(self.mainConf.textFont)
+        self.textFont.setFixedWidth(CONFIG.pxInt(162))
+        self.textFont.setText(CONFIG.textFont)
         self.fontButton = QPushButton("...")
         self.fontButton.setMaximumWidth(int(2.5*self.mainTheme.getTextWidth("...")))
         self.fontButton.clicked.connect(self._selectFont)
@@ -527,7 +523,7 @@ class GuiPreferencesDocuments(QWidget):
         self.textSize.setMinimum(8)
         self.textSize.setMaximum(60)
         self.textSize.setSingleStep(1)
-        self.textSize.setValue(self.mainConf.textSize)
+        self.textSize.setValue(CONFIG.textSize)
         self.mainForm.addRow(
             self.tr("Font size"),
             self.textSize,
@@ -544,7 +540,7 @@ class GuiPreferencesDocuments(QWidget):
         self.textWidth.setMinimum(0)
         self.textWidth.setMaximum(10000)
         self.textWidth.setSingleStep(10)
-        self.textWidth.setValue(self.mainConf.textWidth)
+        self.textWidth.setValue(CONFIG.textWidth)
         self.mainForm.addRow(
             self.tr("Maximum text width in \"Normal Mode\""),
             self.textWidth,
@@ -557,7 +553,7 @@ class GuiPreferencesDocuments(QWidget):
         self.focusWidth.setMinimum(200)
         self.focusWidth.setMaximum(10000)
         self.focusWidth.setSingleStep(10)
-        self.focusWidth.setValue(self.mainConf.focusWidth)
+        self.focusWidth.setValue(CONFIG.focusWidth)
         self.mainForm.addRow(
             self.tr("Maximum text width in \"Focus Mode\""),
             self.focusWidth,
@@ -567,7 +563,7 @@ class GuiPreferencesDocuments(QWidget):
 
         # Focus Mode Footer
         self.hideFocusFooter = QSwitch()
-        self.hideFocusFooter.setChecked(self.mainConf.hideFocusFooter)
+        self.hideFocusFooter.setChecked(CONFIG.hideFocusFooter)
         self.mainForm.addRow(
             self.tr("Hide document footer in \"Focus Mode\""),
             self.hideFocusFooter,
@@ -576,7 +572,7 @@ class GuiPreferencesDocuments(QWidget):
 
         # Justify Text
         self.doJustify = QSwitch()
-        self.doJustify.setChecked(self.mainConf.doJustify)
+        self.doJustify.setChecked(CONFIG.doJustify)
         self.mainForm.addRow(
             self.tr("Justify the text margins"),
             self.doJustify,
@@ -588,7 +584,7 @@ class GuiPreferencesDocuments(QWidget):
         self.textMargin.setMinimum(0)
         self.textMargin.setMaximum(900)
         self.textMargin.setSingleStep(1)
-        self.textMargin.setValue(self.mainConf.textMargin)
+        self.textMargin.setValue(CONFIG.textMargin)
         self.mainForm.addRow(
             self.tr("Minimum text margin"),
             self.textMargin,
@@ -601,7 +597,7 @@ class GuiPreferencesDocuments(QWidget):
         self.tabWidth.setMinimum(0)
         self.tabWidth.setMaximum(200)
         self.tabWidth.setSingleStep(1)
-        self.tabWidth.setValue(self.mainConf.tabWidth)
+        self.tabWidth.setValue(CONFIG.tabWidth)
         self.mainForm.addRow(
             self.tr("Tab width"),
             self.tabWidth,
@@ -615,16 +611,16 @@ class GuiPreferencesDocuments(QWidget):
         """Save the values set for this tab.
         """
         # Text Style
-        self.mainConf.textFont = self.textFont.text()
-        self.mainConf.textSize = self.textSize.value()
+        CONFIG.textFont = self.textFont.text()
+        CONFIG.textSize = self.textSize.value()
 
         # Text Flow
-        self.mainConf.textWidth       = self.textWidth.value()
-        self.mainConf.focusWidth      = self.focusWidth.value()
-        self.mainConf.hideFocusFooter = self.hideFocusFooter.isChecked()
-        self.mainConf.doJustify       = self.doJustify.isChecked()
-        self.mainConf.textMargin      = self.textMargin.value()
-        self.mainConf.tabWidth        = self.tabWidth.value()
+        CONFIG.textWidth       = self.textWidth.value()
+        CONFIG.focusWidth      = self.focusWidth.value()
+        CONFIG.hideFocusFooter = self.hideFocusFooter.isChecked()
+        CONFIG.doJustify       = self.doJustify.isChecked()
+        CONFIG.textMargin      = self.textMargin.value()
+        CONFIG.tabWidth        = self.tabWidth.value()
 
         return
 
@@ -636,8 +632,8 @@ class GuiPreferencesDocuments(QWidget):
         """Open the QFontDialog and set a font for the font style.
         """
         currFont = QFont()
-        currFont.setFamily(self.mainConf.textFont)
-        currFont.setPointSize(self.mainConf.textSize)
+        currFont.setFamily(CONFIG.textFont)
+        currFont.setPointSize(CONFIG.textSize)
         theFont, theStatus = QFontDialog.getFont(currFont, self)
         if theStatus:
             self.textFont.setText(theFont.family())
@@ -653,7 +649,6 @@ class GuiPreferencesEditor(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = prefsGui.mainGui
         self.mainTheme = prefsGui.mainGui.mainTheme
 
@@ -662,7 +657,7 @@ class GuiPreferencesEditor(QWidget):
         self.mainForm.setHelpTextStyle(self.mainTheme.helpText)
         self.setLayout(self.mainForm)
 
-        mW = self.mainConf.pxInt(250)
+        mW = CONFIG.pxInt(250)
 
         # Spell Checking
         # ==============
@@ -673,7 +668,7 @@ class GuiPreferencesEditor(QWidget):
         self.spellLanguage.setMaximumWidth(mW)
 
         langAvail = self.mainGui.docEditor.spEnchant.listDictionaries()
-        if self.mainConf.hasEnchant:
+        if CONFIG.hasEnchant:
             if langAvail:
                 for spTag, spProv in langAvail:
                     qLocal = QLocale(spTag)
@@ -686,7 +681,7 @@ class GuiPreferencesEditor(QWidget):
             self.spellLanguage.addItem(self.tr("Not installed"), "")
             self.spellLanguage.setEnabled(False)
 
-        spellIdx = self.spellLanguage.findData(self.mainConf.spellLanguage)
+        spellIdx = self.spellLanguage.findData(CONFIG.spellLanguage)
         if spellIdx != -1:
             self.spellLanguage.setCurrentIndex(spellIdx)
 
@@ -701,7 +696,7 @@ class GuiPreferencesEditor(QWidget):
         self.bigDocLimit.setMinimum(10)
         self.bigDocLimit.setMaximum(10000)
         self.bigDocLimit.setSingleStep(10)
-        self.bigDocLimit.setValue(self.mainConf.bigDocLimit)
+        self.bigDocLimit.setValue(CONFIG.bigDocLimit)
         self.mainForm.addRow(
             self.tr("Big document limit"),
             self.bigDocLimit,
@@ -719,7 +714,7 @@ class GuiPreferencesEditor(QWidget):
         self.wordCountTimer.setMinimum(2.0)
         self.wordCountTimer.setMaximum(600.0)
         self.wordCountTimer.setSingleStep(0.1)
-        self.wordCountTimer.setValue(self.mainConf.wordCountTimer)
+        self.wordCountTimer.setValue(CONFIG.wordCountTimer)
         self.mainForm.addRow(
             self.tr("Word count interval"),
             self.wordCountTimer,
@@ -728,7 +723,7 @@ class GuiPreferencesEditor(QWidget):
 
         # Include Notes in Word Count
         self.incNotesWCount = QSwitch()
-        self.incNotesWCount.setChecked(self.mainConf.incNotesWCount)
+        self.incNotesWCount.setChecked(CONFIG.incNotesWCount)
         self.mainForm.addRow(
             self.tr("Include project notes in status bar word count"),
             self.incNotesWCount
@@ -740,7 +735,7 @@ class GuiPreferencesEditor(QWidget):
 
         # Show Tabs and Spaces
         self.showTabsNSpaces = QSwitch()
-        self.showTabsNSpaces.setChecked(self.mainConf.showTabsNSpaces)
+        self.showTabsNSpaces.setChecked(CONFIG.showTabsNSpaces)
         self.mainForm.addRow(
             self.tr("Show tabs and spaces"),
             self.showTabsNSpaces
@@ -748,7 +743,7 @@ class GuiPreferencesEditor(QWidget):
 
         # Show Line Endings
         self.showLineEndings = QSwitch()
-        self.showLineEndings.setChecked(self.mainConf.showLineEndings)
+        self.showLineEndings.setChecked(CONFIG.showLineEndings)
         self.mainForm.addRow(
             self.tr("Show line endings"),
             self.showLineEndings
@@ -763,7 +758,7 @@ class GuiPreferencesEditor(QWidget):
         self.scrollPastEnd.setMinimum(0)
         self.scrollPastEnd.setMaximum(100)
         self.scrollPastEnd.setSingleStep(1)
-        self.scrollPastEnd.setValue(int(self.mainConf.scrollPastEnd))
+        self.scrollPastEnd.setValue(int(CONFIG.scrollPastEnd))
         self.mainForm.addRow(
             self.tr("Scroll past end of the document"),
             self.scrollPastEnd,
@@ -773,7 +768,7 @@ class GuiPreferencesEditor(QWidget):
 
         # Typewriter Scrolling
         self.autoScroll = QSwitch()
-        self.autoScroll.setChecked(self.mainConf.autoScroll)
+        self.autoScroll.setChecked(CONFIG.autoScroll)
         self.mainForm.addRow(
             self.tr("Typewriter style scrolling when you type"),
             self.autoScroll,
@@ -785,7 +780,7 @@ class GuiPreferencesEditor(QWidget):
         self.autoScrollPos.setMinimum(10)
         self.autoScrollPos.setMaximum(90)
         self.autoScrollPos.setSingleStep(1)
-        self.autoScrollPos.setValue(int(self.mainConf.autoScrollPos))
+        self.autoScrollPos.setValue(int(CONFIG.autoScrollPos))
         self.mainForm.addRow(
             self.tr("Minimum position for Typewriter scrolling"),
             self.autoScrollPos,
@@ -799,21 +794,21 @@ class GuiPreferencesEditor(QWidget):
         """Save the values set for this tab.
         """
         # Spell Checking
-        self.mainConf.spellLanguage = self.spellLanguage.currentData()
-        self.mainConf.bigDocLimit   = self.bigDocLimit.value()
+        CONFIG.spellLanguage = self.spellLanguage.currentData()
+        CONFIG.bigDocLimit   = self.bigDocLimit.value()
 
         # Word Count
-        self.mainConf.wordCountTimer = self.wordCountTimer.value()
-        self.mainConf.incNotesWCount = self.incNotesWCount.isChecked()
+        CONFIG.wordCountTimer = self.wordCountTimer.value()
+        CONFIG.incNotesWCount = self.incNotesWCount.isChecked()
 
         # Writing Guides
-        self.mainConf.showTabsNSpaces = self.showTabsNSpaces.isChecked()
-        self.mainConf.showLineEndings = self.showLineEndings.isChecked()
+        CONFIG.showTabsNSpaces = self.showTabsNSpaces.isChecked()
+        CONFIG.showLineEndings = self.showLineEndings.isChecked()
 
         # Scroll Behaviour
-        self.mainConf.scrollPastEnd = self.scrollPastEnd.value()
-        self.mainConf.autoScroll    = self.autoScroll.isChecked()
-        self.mainConf.autoScrollPos = self.autoScrollPos.value()
+        CONFIG.scrollPastEnd = self.scrollPastEnd.value()
+        CONFIG.autoScroll    = self.autoScroll.isChecked()
+        CONFIG.autoScrollPos = self.autoScrollPos.value()
 
         return
 
@@ -825,7 +820,6 @@ class GuiPreferencesSyntax(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainConf  = novelwriter.CONFIG
         self.prefsGui  = prefsGui
         self.mainGui   = prefsGui.mainGui
         self.mainTheme = prefsGui.mainGui.mainTheme
@@ -840,7 +834,7 @@ class GuiPreferencesSyntax(QWidget):
         self.mainForm.addGroupLabel(self.tr("Quotes & Dialogue"))
 
         self.highlightQuotes = QSwitch()
-        self.highlightQuotes.setChecked(self.mainConf.highlightQuotes)
+        self.highlightQuotes.setChecked(CONFIG.highlightQuotes)
         self.highlightQuotes.toggled.connect(self._toggleHighlightQuotes)
         self.mainForm.addRow(
             self.tr("Highlight text wrapped in quotes"),
@@ -849,7 +843,7 @@ class GuiPreferencesSyntax(QWidget):
         )
 
         self.allowOpenSQuote = QSwitch()
-        self.allowOpenSQuote.setChecked(self.mainConf.allowOpenSQuote)
+        self.allowOpenSQuote.setChecked(CONFIG.allowOpenSQuote)
         self.mainForm.addRow(
             self.tr("Allow open-ended single quotes"),
             self.allowOpenSQuote,
@@ -857,7 +851,7 @@ class GuiPreferencesSyntax(QWidget):
         )
 
         self.allowOpenDQuote = QSwitch()
-        self.allowOpenDQuote.setChecked(self.mainConf.allowOpenDQuote)
+        self.allowOpenDQuote.setChecked(CONFIG.allowOpenDQuote)
         self.mainForm.addRow(
             self.tr("Allow open-ended double quotes"),
             self.allowOpenDQuote,
@@ -869,7 +863,7 @@ class GuiPreferencesSyntax(QWidget):
         self.mainForm.addGroupLabel(self.tr("Text Emphasis"))
 
         self.highlightEmph = QSwitch()
-        self.highlightEmph.setChecked(self.mainConf.highlightEmph)
+        self.highlightEmph.setChecked(CONFIG.highlightEmph)
         self.mainForm.addRow(
             self.tr("Add highlight colour to emphasised text"),
             self.highlightEmph,
@@ -882,7 +876,7 @@ class GuiPreferencesSyntax(QWidget):
         self.mainForm.addGroupLabel(self.tr("Text Errors"))
 
         self.showMultiSpaces = QSwitch()
-        self.showMultiSpaces.setChecked(self.mainConf.showMultiSpaces)
+        self.showMultiSpaces.setChecked(CONFIG.showMultiSpaces)
         self.mainForm.addRow(
             self.tr("Highlight multiple or trailing spaces"),
             self.showMultiSpaces,
@@ -900,15 +894,15 @@ class GuiPreferencesSyntax(QWidget):
         highlightEmph   = self.highlightEmph.isChecked()
         showMultiSpaces = self.showMultiSpaces.isChecked()
 
-        self.prefsGui._updateSyntax |= self.mainConf.highlightQuotes != highlightQuotes
-        self.prefsGui._updateSyntax |= self.mainConf.highlightEmph != highlightEmph
-        self.prefsGui._updateSyntax |= self.mainConf.showMultiSpaces != showMultiSpaces
+        self.prefsGui._updateSyntax |= CONFIG.highlightQuotes != highlightQuotes
+        self.prefsGui._updateSyntax |= CONFIG.highlightEmph != highlightEmph
+        self.prefsGui._updateSyntax |= CONFIG.showMultiSpaces != showMultiSpaces
 
-        self.mainConf.highlightQuotes = highlightQuotes
-        self.mainConf.allowOpenSQuote = allowOpenSQuote
-        self.mainConf.allowOpenDQuote = allowOpenDQuote
-        self.mainConf.highlightEmph   = highlightEmph
-        self.mainConf.showMultiSpaces = showMultiSpaces
+        CONFIG.highlightQuotes = highlightQuotes
+        CONFIG.allowOpenSQuote = allowOpenSQuote
+        CONFIG.allowOpenDQuote = allowOpenDQuote
+        CONFIG.highlightEmph   = highlightEmph
+        CONFIG.showMultiSpaces = showMultiSpaces
 
         return
 
@@ -932,7 +926,6 @@ class GuiPreferencesAutomation(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = prefsGui.mainGui
         self.mainTheme = prefsGui.mainGui.mainTheme
 
@@ -947,7 +940,7 @@ class GuiPreferencesAutomation(QWidget):
 
         # Auto-Select Word Under Cursor
         self.autoSelect = QSwitch()
-        self.autoSelect.setChecked(self.mainConf.autoSelect)
+        self.autoSelect.setChecked(CONFIG.autoSelect)
         self.mainForm.addRow(
             self.tr("Auto-select word under cursor"),
             self.autoSelect,
@@ -956,7 +949,7 @@ class GuiPreferencesAutomation(QWidget):
 
         # Auto-Replace as You Type Main Switch
         self.doReplace = QSwitch()
-        self.doReplace.setChecked(self.mainConf.doReplace)
+        self.doReplace.setChecked(CONFIG.doReplace)
         self.doReplace.toggled.connect(self._toggleAutoReplaceMain)
         self.mainForm.addRow(
             self.tr("Auto-replace text as you type"),
@@ -970,8 +963,8 @@ class GuiPreferencesAutomation(QWidget):
 
         # Auto-Replace Single Quotes
         self.doReplaceSQuote = QSwitch()
-        self.doReplaceSQuote.setChecked(self.mainConf.doReplaceSQuote)
-        self.doReplaceSQuote.setEnabled(self.mainConf.doReplace)
+        self.doReplaceSQuote.setChecked(CONFIG.doReplaceSQuote)
+        self.doReplaceSQuote.setEnabled(CONFIG.doReplace)
         self.mainForm.addRow(
             self.tr("Auto-replace single quotes"),
             self.doReplaceSQuote,
@@ -980,8 +973,8 @@ class GuiPreferencesAutomation(QWidget):
 
         # Auto-Replace Double Quotes
         self.doReplaceDQuote = QSwitch()
-        self.doReplaceDQuote.setChecked(self.mainConf.doReplaceDQuote)
-        self.doReplaceDQuote.setEnabled(self.mainConf.doReplace)
+        self.doReplaceDQuote.setChecked(CONFIG.doReplaceDQuote)
+        self.doReplaceDQuote.setEnabled(CONFIG.doReplace)
         self.mainForm.addRow(
             self.tr("Auto-replace double quotes"),
             self.doReplaceDQuote,
@@ -990,8 +983,8 @@ class GuiPreferencesAutomation(QWidget):
 
         # Auto-Replace Hyphens
         self.doReplaceDash = QSwitch()
-        self.doReplaceDash.setChecked(self.mainConf.doReplaceDash)
-        self.doReplaceDash.setEnabled(self.mainConf.doReplace)
+        self.doReplaceDash.setChecked(CONFIG.doReplaceDash)
+        self.doReplaceDash.setEnabled(CONFIG.doReplace)
         self.mainForm.addRow(
             self.tr("Auto-replace dashes"),
             self.doReplaceDash,
@@ -1000,8 +993,8 @@ class GuiPreferencesAutomation(QWidget):
 
         # Auto-Replace Dots
         self.doReplaceDots = QSwitch()
-        self.doReplaceDots.setChecked(self.mainConf.doReplaceDots)
-        self.doReplaceDots.setEnabled(self.mainConf.doReplace)
+        self.doReplaceDots.setChecked(CONFIG.doReplaceDots)
+        self.doReplaceDots.setEnabled(CONFIG.doReplace)
         self.mainForm.addRow(
             self.tr("Auto-replace dots"),
             self.doReplaceDots,
@@ -1015,7 +1008,7 @@ class GuiPreferencesAutomation(QWidget):
         # Pad Before
         self.fmtPadBefore = QLineEdit()
         self.fmtPadBefore.setMaxLength(32)
-        self.fmtPadBefore.setText(self.mainConf.fmtPadBefore)
+        self.fmtPadBefore.setText(CONFIG.fmtPadBefore)
         self.mainForm.addRow(
             self.tr("Insert non-breaking space before"),
             self.fmtPadBefore,
@@ -1025,7 +1018,7 @@ class GuiPreferencesAutomation(QWidget):
         # Pad After
         self.fmtPadAfter = QLineEdit()
         self.fmtPadAfter.setMaxLength(32)
-        self.fmtPadAfter.setText(self.mainConf.fmtPadAfter)
+        self.fmtPadAfter.setText(CONFIG.fmtPadAfter)
         self.mainForm.addRow(
             self.tr("Insert non-breaking space after"),
             self.fmtPadAfter,
@@ -1034,8 +1027,8 @@ class GuiPreferencesAutomation(QWidget):
 
         # Use Thin Space
         self.fmtPadThin = QSwitch()
-        self.fmtPadThin.setChecked(self.mainConf.fmtPadThin)
-        self.fmtPadThin.setEnabled(self.mainConf.doReplace)
+        self.fmtPadThin.setChecked(CONFIG.fmtPadThin)
+        self.fmtPadThin.setEnabled(CONFIG.doReplace)
         self.mainForm.addRow(
             self.tr("Use thin space instead"),
             self.fmtPadThin,
@@ -1048,19 +1041,19 @@ class GuiPreferencesAutomation(QWidget):
         """Save the values set for this tab.
         """
         # Automatic Features
-        self.mainConf.autoSelect = self.autoSelect.isChecked()
-        self.mainConf.doReplace  = self.doReplace.isChecked()
+        CONFIG.autoSelect = self.autoSelect.isChecked()
+        CONFIG.doReplace  = self.doReplace.isChecked()
 
         # Replace as You Type
-        self.mainConf.doReplaceSQuote = self.doReplaceSQuote.isChecked()
-        self.mainConf.doReplaceDQuote = self.doReplaceDQuote.isChecked()
-        self.mainConf.doReplaceDash   = self.doReplaceDash.isChecked()
-        self.mainConf.doReplaceDots   = self.doReplaceDots.isChecked()
+        CONFIG.doReplaceSQuote = self.doReplaceSQuote.isChecked()
+        CONFIG.doReplaceDQuote = self.doReplaceDQuote.isChecked()
+        CONFIG.doReplaceDash   = self.doReplaceDash.isChecked()
+        CONFIG.doReplaceDots   = self.doReplaceDots.isChecked()
 
         # Automatic Padding
-        self.mainConf.fmtPadBefore = self.fmtPadBefore.text().strip()
-        self.mainConf.fmtPadAfter  = self.fmtPadAfter.text().strip()
-        self.mainConf.fmtPadThin   = self.fmtPadThin.isChecked()
+        CONFIG.fmtPadBefore = self.fmtPadBefore.text().strip()
+        CONFIG.fmtPadAfter  = self.fmtPadAfter.text().strip()
+        CONFIG.fmtPadThin   = self.fmtPadThin.isChecked()
 
         return
 
@@ -1087,7 +1080,6 @@ class GuiPreferencesQuotes(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = prefsGui.mainGui
         self.mainTheme = prefsGui.mainGui.mainTheme
 
@@ -1100,7 +1092,7 @@ class GuiPreferencesQuotes(QWidget):
         # ===============
         self.mainForm.addGroupLabel(self.tr("Quotation Style"))
 
-        qWidth = self.mainConf.pxInt(40)
+        qWidth = CONFIG.pxInt(40)
         bWidth = int(2.5*self.mainTheme.getTextWidth("..."))
         self.quoteSym = {}
 
@@ -1110,7 +1102,7 @@ class GuiPreferencesQuotes(QWidget):
         self.quoteSym["SO"].setReadOnly(True)
         self.quoteSym["SO"].setFixedWidth(qWidth)
         self.quoteSym["SO"].setAlignment(Qt.AlignCenter)
-        self.quoteSym["SO"].setText(self.mainConf.fmtSQuoteOpen)
+        self.quoteSym["SO"].setText(CONFIG.fmtSQuoteOpen)
         self.btnSingleStyleO = QPushButton("...")
         self.btnSingleStyleO.setMaximumWidth(bWidth)
         self.btnSingleStyleO.clicked.connect(lambda: self._getQuote("SO"))
@@ -1126,7 +1118,7 @@ class GuiPreferencesQuotes(QWidget):
         self.quoteSym["SC"].setReadOnly(True)
         self.quoteSym["SC"].setFixedWidth(qWidth)
         self.quoteSym["SC"].setAlignment(Qt.AlignCenter)
-        self.quoteSym["SC"].setText(self.mainConf.fmtSQuoteClose)
+        self.quoteSym["SC"].setText(CONFIG.fmtSQuoteClose)
         self.btnSingleStyleC = QPushButton("...")
         self.btnSingleStyleC.setMaximumWidth(bWidth)
         self.btnSingleStyleC.clicked.connect(lambda: self._getQuote("SC"))
@@ -1143,7 +1135,7 @@ class GuiPreferencesQuotes(QWidget):
         self.quoteSym["DO"].setReadOnly(True)
         self.quoteSym["DO"].setFixedWidth(qWidth)
         self.quoteSym["DO"].setAlignment(Qt.AlignCenter)
-        self.quoteSym["DO"].setText(self.mainConf.fmtDQuoteOpen)
+        self.quoteSym["DO"].setText(CONFIG.fmtDQuoteOpen)
         self.btnDoubleStyleO = QPushButton("...")
         self.btnDoubleStyleO.setMaximumWidth(bWidth)
         self.btnDoubleStyleO.clicked.connect(lambda: self._getQuote("DO"))
@@ -1159,7 +1151,7 @@ class GuiPreferencesQuotes(QWidget):
         self.quoteSym["DC"].setReadOnly(True)
         self.quoteSym["DC"].setFixedWidth(qWidth)
         self.quoteSym["DC"].setAlignment(Qt.AlignCenter)
-        self.quoteSym["DC"].setText(self.mainConf.fmtDQuoteClose)
+        self.quoteSym["DC"].setText(CONFIG.fmtDQuoteClose)
         self.btnDoubleStyleC = QPushButton("...")
         self.btnDoubleStyleC.setMaximumWidth(bWidth)
         self.btnDoubleStyleC.clicked.connect(lambda: self._getQuote("DC"))
@@ -1176,10 +1168,10 @@ class GuiPreferencesQuotes(QWidget):
         """Save the values set for this tab.
         """
         # Quotation Style
-        self.mainConf.fmtSQuoteOpen = self.quoteSym["SO"].text()
-        self.mainConf.fmtSQuoteClose = self.quoteSym["SC"].text()
-        self.mainConf.fmtDQuoteOpen = self.quoteSym["DO"].text()
-        self.mainConf.fmtDQuoteClose = self.quoteSym["DC"].text()
+        CONFIG.fmtSQuoteOpen = self.quoteSym["SO"].text()
+        CONFIG.fmtSQuoteClose = self.quoteSym["SC"].text()
+        CONFIG.fmtDQuoteOpen = self.quoteSym["DO"].text()
+        CONFIG.fmtDQuoteClose = self.quoteSym["DC"].text()
         return
 
     ##

--- a/novelwriter/dialogs/projdetails.py
+++ b/novelwriter/dialogs/projdetails.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import math
 import logging
-import novelwriter
 
 from PyQt5.QtCore import Qt, QSize, pyqtSlot
 from PyQt5.QtGui import QFont
@@ -34,6 +33,7 @@ from PyQt5.QtWidgets import (
     QLineEdit, QSpinBox, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
 
+from novelwriter import CONFIG
 from novelwriter.common import formatTime, numberToRoman
 from novelwriter.custom import PagedDialog, QSwitch
 from novelwriter.constants import nwUnicode
@@ -50,21 +50,20 @@ class GuiProjectDetails(PagedDialog):
         logger.debug("Initialising GuiProjectDetails ...")
         self.setObjectName("GuiProjectDetails")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
 
         self.setWindowTitle(self.tr("Project Details"))
 
-        wW = self.mainConf.pxInt(600)
-        wH = self.mainConf.pxInt(400)
+        wW = CONFIG.pxInt(600)
+        wH = CONFIG.pxInt(400)
         pOptions = self.theProject.options
 
         self.setMinimumWidth(wW)
         self.setMinimumHeight(wH)
         self.resize(
-            self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "winWidth",  wW)),
-            self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "winHeight", wH))
+            CONFIG.pxInt(pOptions.getInt("GuiProjectDetails", "winWidth",  wW)),
+            CONFIG.pxInt(pOptions.getInt("GuiProjectDetails", "winHeight", wH))
         )
 
         self.tabMain = GuiProjectDetailsMain(self.mainGui, self.theProject)
@@ -107,15 +106,15 @@ class GuiProjectDetails(PagedDialog):
     def _saveGuiSettings(self):
         """Save GUI settings.
         """
-        winWidth  = self.mainConf.rpxInt(self.width())
-        winHeight = self.mainConf.rpxInt(self.height())
+        winWidth  = CONFIG.rpxInt(self.width())
+        winHeight = CONFIG.rpxInt(self.height())
 
         cColWidth = self.tabContents.getColumnSizes()
-        widthCol0 = self.mainConf.rpxInt(cColWidth[0])
-        widthCol1 = self.mainConf.rpxInt(cColWidth[1])
-        widthCol2 = self.mainConf.rpxInt(cColWidth[2])
-        widthCol3 = self.mainConf.rpxInt(cColWidth[3])
-        widthCol4 = self.mainConf.rpxInt(cColWidth[4])
+        widthCol0 = CONFIG.rpxInt(cColWidth[0])
+        widthCol1 = CONFIG.rpxInt(cColWidth[1])
+        widthCol2 = CONFIG.rpxInt(cColWidth[2])
+        widthCol3 = CONFIG.rpxInt(cColWidth[3])
+        widthCol4 = CONFIG.rpxInt(cColWidth[4])
 
         wordsPerPage = self.tabContents.wpValue.value()
         countFrom    = self.tabContents.poValue.value()
@@ -143,15 +142,14 @@ class GuiProjectDetailsMain(QWidget):
     def __init__(self, mainGui, theProject):
         super().__init__(parent=mainGui)
 
-        self.mainConf   = novelwriter.CONFIG
         self.theProject = theProject
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
 
         fPx = self.mainTheme.fontPixelSize
         fPt = self.mainTheme.fontPointSize
-        vPx = self.mainConf.pxInt(4)
-        hPx = self.mainConf.pxInt(12)
+        vPx = CONFIG.pxInt(4)
+        hPx = CONFIG.pxInt(12)
 
         # Header
         # ======
@@ -277,7 +275,6 @@ class GuiProjectDetailsContents(QWidget):
     def __init__(self, mainGui, theProject):
         super().__init__(parent=mainGui)
 
-        self.mainConf   = novelwriter.CONFIG
         self.theProject = theProject
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
@@ -287,8 +284,8 @@ class GuiProjectDetailsContents(QWidget):
         self._currentRoot = None
 
         iPx = self.mainTheme.baseIconSize
-        hPx = self.mainConf.pxInt(12)
-        vPx = self.mainConf.pxInt(4)
+        hPx = CONFIG.pxInt(12)
+        vPx = CONFIG.pxInt(4)
         pOptions = self.theProject.options
 
         # Header
@@ -297,7 +294,7 @@ class GuiProjectDetailsContents(QWidget):
         self.tocLabel = QLabel("<b>%s</b>" % self.tr("Table of Contents"))
 
         self.novelValue = NovelSelector(self, self.theProject, self.mainGui)
-        self.novelValue.setMinimumWidth(self.mainConf.pxInt(200))
+        self.novelValue.setMinimumWidth(CONFIG.pxInt(200))
         self.novelValue.novelSelectionChanged.connect(self._novelValueChanged)
 
         self.headBox = QHBoxLayout()
@@ -331,11 +328,11 @@ class GuiProjectDetailsContents(QWidget):
         treeHeader.setStretchLastSection(True)
         treeHeader.setMinimumSectionSize(hPx)
 
-        wCol0 = self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol0", 200))
-        wCol1 = self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol1", 60))
-        wCol2 = self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol2", 60))
-        wCol3 = self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol3", 60))
-        wCol4 = self.mainConf.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol4", 90))
+        wCol0 = CONFIG.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol0", 200))
+        wCol1 = CONFIG.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol1", 60))
+        wCol2 = CONFIG.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol2", 60))
+        wCol3 = CONFIG.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol3", 60))
+        wCol4 = CONFIG.pxInt(pOptions.getInt("GuiProjectDetails", "widthCol4", 90))
 
         self.tocTree.setColumnWidth(0, wCol0)
         self.tocTree.setColumnWidth(1, wCol1)

--- a/novelwriter/dialogs/projload.py
+++ b/novelwriter/dialogs/projload.py
@@ -24,7 +24,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from pathlib import Path
 from datetime import datetime
@@ -37,6 +36,7 @@ from PyQt5.QtWidgets import (
     QFileDialog, QLineEdit
 )
 
+from novelwriter import CONFIG
 from novelwriter.common import formatInt
 from novelwriter.constants import nwFiles
 
@@ -59,14 +59,13 @@ class GuiProjectLoad(QDialog):
         logger.debug("Initialising GuiProjectLoad ...")
         self.setObjectName("GuiProjectLoad")
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
         self.mainTheme = mainGui.mainTheme
         self.openState = self.NONE_STATE
         self.openPath  = None
 
-        sPx = self.mainConf.pxInt(16)
-        nPx = self.mainConf.pxInt(96)
+        sPx = CONFIG.pxInt(16)
+        nPx = CONFIG.pxInt(96)
         iPx = self.mainTheme.baseIconSize
 
         self.outerBox = QVBoxLayout()
@@ -75,8 +74,8 @@ class GuiProjectLoad(QDialog):
         self.innerBox.setSpacing(sPx)
 
         self.setWindowTitle(self.tr("Open Project"))
-        self.setMinimumWidth(self.mainConf.pxInt(650))
-        self.setMinimumHeight(self.mainConf.pxInt(400))
+        self.setMinimumWidth(CONFIG.pxInt(650))
+        self.setMinimumHeight(CONFIG.pxInt(400))
 
         self.nwIcon = QLabel()
         self.nwIcon.setPixmap(self.mainGui.mainTheme.getPixmap("novelwriter", (nPx, nPx)))
@@ -120,8 +119,8 @@ class GuiProjectLoad(QDialog):
         self.projectForm.setColumnStretch(0, 0)
         self.projectForm.setColumnStretch(1, 1)
         self.projectForm.setColumnStretch(2, 0)
-        self.projectForm.setVerticalSpacing(self.mainConf.pxInt(4))
-        self.projectForm.setHorizontalSpacing(self.mainConf.pxInt(8))
+        self.projectForm.setVerticalSpacing(CONFIG.pxInt(4))
+        self.projectForm.setHorizontalSpacing(CONFIG.pxInt(8))
 
         self.innerBox.addLayout(self.projectForm)
 
@@ -228,7 +227,7 @@ class GuiProjectLoad(QDialog):
                 ).format(projName)
             )
             if msgYes:
-                self.mainConf.recentProjects.remove(
+                CONFIG.recentProjects.remove(
                     selList[0].data(self.C_NAME, Qt.UserRole)
                 )
                 self._populateList()
@@ -257,14 +256,14 @@ class GuiProjectLoad(QDialog):
         colWidths[self.C_NAME]  = self.listBox.columnWidth(self.C_NAME)
         colWidths[self.C_COUNT] = self.listBox.columnWidth(self.C_COUNT)
         colWidths[self.C_TIME]  = self.listBox.columnWidth(self.C_TIME)
-        self.mainConf.setProjLoadColWidths(colWidths)
+        CONFIG.setProjLoadColWidths(colWidths)
         return
 
     def _populateList(self):
         """Populate the list box with recent project data.
         """
         self.listBox.clear()
-        dataList = self.mainConf.recentProjects.listEntries()
+        dataList = CONFIG.recentProjects.listEntries()
         sortList = sorted(dataList, key=lambda x: x[3], reverse=True)
         nwxIcon = self.mainGui.mainTheme.getIcon("proj_nwx")
         for path, title, words, time in sortList:
@@ -283,7 +282,7 @@ class GuiProjectLoad(QDialog):
         if self.listBox.topLevelItemCount() > 0:
             self.listBox.topLevelItem(0).setSelected(True)
 
-        projColWidth = self.mainConf.projLoadColWidths
+        projColWidth = CONFIG.projLoadColWidths
         if len(projColWidth) == 3:
             self.listBox.setColumnWidth(self.C_NAME,  projColWidth[self.C_NAME])
             self.listBox.setColumnWidth(self.C_COUNT, projColWidth[self.C_COUNT])

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -24,7 +24,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtGui import QIcon, QPixmap, QColor
 from PyQt5.QtCore import Qt, QLocale, pyqtSlot
@@ -33,6 +32,7 @@ from PyQt5.QtWidgets import (
     QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwAlert
 from novelwriter.common import simplified
 from novelwriter.custom import QSwitch, PagedDialog, QConfigLayout
@@ -53,22 +53,21 @@ class GuiProjectSettings(PagedDialog):
         logger.debug("Initialising GuiProjectSettings ...")
         self.setObjectName("GuiProjectSettings")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
 
         self.theProject.countStatus()
         self.setWindowTitle(self.tr("Project Settings"))
 
-        wW = self.mainConf.pxInt(570)
-        wH = self.mainConf.pxInt(375)
+        wW = CONFIG.pxInt(570)
+        wH = CONFIG.pxInt(375)
         pOptions = self.theProject.options
 
         self.setMinimumWidth(wW)
         self.setMinimumHeight(wH)
         self.resize(
-            self.mainConf.pxInt(pOptions.getInt("GuiProjectSettings", "winWidth",  wW)),
-            self.mainConf.pxInt(pOptions.getInt("GuiProjectSettings", "winHeight", wH))
+            CONFIG.pxInt(pOptions.getInt("GuiProjectSettings", "winWidth",  wW)),
+            CONFIG.pxInt(pOptions.getInt("GuiProjectSettings", "winHeight", wH))
         )
 
         self.tabMain    = GuiProjectEditMain(self)
@@ -168,11 +167,11 @@ class GuiProjectSettings(PagedDialog):
     def _saveGuiSettings(self):
         """Save GUI settings.
         """
-        winWidth    = self.mainConf.rpxInt(self.width())
-        winHeight   = self.mainConf.rpxInt(self.height())
-        replaceColW = self.mainConf.rpxInt(self.tabReplace.listBox.columnWidth(0))
-        statusColW  = self.mainConf.rpxInt(self.tabStatus.listBox.columnWidth(0))
-        importColW  = self.mainConf.rpxInt(self.tabImport.listBox.columnWidth(0))
+        winWidth    = CONFIG.rpxInt(self.width())
+        winHeight   = CONFIG.rpxInt(self.height())
+        replaceColW = CONFIG.rpxInt(self.tabReplace.listBox.columnWidth(0))
+        statusColW  = CONFIG.rpxInt(self.tabStatus.listBox.columnWidth(0))
+        importColW  = CONFIG.rpxInt(self.tabImport.listBox.columnWidth(0))
 
         pOptions = self.theProject.options
         pOptions.setValue("GuiProjectSettings", "winWidth",    winWidth)
@@ -191,7 +190,6 @@ class GuiProjectEditMain(QWidget):
     def __init__(self, projGui):
         super().__init__(parent=projGui)
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = projGui.mainGui
         self.theProject = projGui.theProject
 
@@ -202,7 +200,7 @@ class GuiProjectEditMain(QWidget):
 
         self.mainForm.addGroupLabel(self.tr("Project Settings"))
 
-        xW = self.mainConf.pxInt(250)
+        xW = CONFIG.pxInt(250)
 
         self.editName = QLineEdit()
         self.editName.setMaxLength(200)
@@ -280,7 +278,6 @@ class GuiProjectEditStatus(QWidget):
     def __init__(self, projGui, isStatus):
         super().__init__(parent=projGui)
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = projGui.mainGui
         self.theProject = projGui.theProject
         self.mainTheme  = projGui.mainGui.mainTheme
@@ -294,7 +291,7 @@ class GuiProjectEditStatus(QWidget):
             pageLabel = self.tr("Note File Importance Levels")
             colSetting = "importColW"
 
-        wCol0 = self.mainConf.pxInt(
+        wCol0 = CONFIG.pxInt(
             self.theProject.options.getInt("GuiProjectSettings", colSetting, 130)
         )
 
@@ -569,13 +566,12 @@ class GuiProjectEditReplace(QWidget):
     def __init__(self, projGui):
         super().__init__(parent=projGui)
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = projGui.mainGui
         self.mainTheme  = projGui.mainGui.mainTheme
         self.theProject = projGui.theProject
         self.arChanged  = False
 
-        wCol0 = self.mainConf.pxInt(
+        wCol0 = CONFIG.pxInt(
             self.theProject.options.getInt("GuiProjectSettings", "replaceColW", 130)
         )
         pageLabel = self.tr("Text Replace List for Preview and Export")

--- a/novelwriter/dialogs/quotes.py
+++ b/novelwriter/dialogs/quotes.py
@@ -24,7 +24,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtCore import Qt, QSize
@@ -33,6 +32,7 @@ from PyQt5.QtWidgets import (
     QListWidget, QListWidgetItem, QFrame
 )
 
+from novelwriter import CONFIG
 from novelwriter.constants import trConst, nwQuotes
 
 logger = logging.getLogger(__name__)
@@ -44,8 +44,6 @@ class GuiQuoteSelect(QDialog):
 
     def __init__(self, parent=None, currentQuote='"'):
         super().__init__(parent=parent)
-
-        self.mainConf = novelwriter.CONFIG
 
         self.outerBox = QVBoxLayout()
         self.innerBox = QHBoxLayout()
@@ -82,8 +80,8 @@ class GuiQuoteSelect(QDialog):
             if sKey == currentQuote:
                 self.listBox.setCurrentItem(qtItem)
 
-        self.listBox.setMinimumWidth(minSize + self.mainConf.pxInt(40))
-        self.listBox.setMinimumHeight(self.mainConf.pxInt(150))
+        self.listBox.setMinimumWidth(minSize + CONFIG.pxInt(40))
+        self.listBox.setMinimumHeight(CONFIG.pxInt(150))
 
         # Buttons
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)

--- a/novelwriter/dialogs/updates.py
+++ b/novelwriter/dialogs/updates.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import json
 import logging
-import novelwriter
 
 from datetime import datetime
 from urllib.request import Request, urlopen
@@ -36,6 +35,7 @@ from PyQt5.QtWidgets import (
     qApp, QDialog, QHBoxLayout, QVBoxLayout, QDialogButtonBox, QLabel
 )
 
+from novelwriter import CONFIG, __version__, __date__, __url__
 from novelwriter.common import logException
 
 logger = logging.getLogger(__name__)
@@ -49,15 +49,14 @@ class GuiUpdates(QDialog):
         logger.debug("Initialising GuiUpdates ...")
         self.setObjectName("GuiUpdates")
 
-        self.mainConf = novelwriter.CONFIG
-        self.mainGui  = mainGui
+        self.mainGui = mainGui
 
         self.setWindowTitle(self.tr("Check for Updates"))
 
-        nPx = self.mainConf.pxInt(96)
-        sPx = self.mainConf.pxInt(16)
-        tPx = self.mainConf.pxInt(8)
-        mPx = self.mainConf.pxInt(4)
+        nPx = CONFIG.pxInt(96)
+        sPx = CONFIG.pxInt(16)
+        tPx = CONFIG.pxInt(8)
+        mPx = CONFIG.pxInt(4)
 
         # Left Box
         self.nwIcon = QLabel()
@@ -72,8 +71,8 @@ class GuiUpdates(QDialog):
         self.currentValue = QLabel(self.tr(
             "novelWriter {0} released on {1}"
         ).format(
-            "v%s" % novelwriter.__version__,
-            datetime.strptime(novelwriter.__date__, "%Y-%m-%d").strftime("%x"))
+            "v%s" % __version__,
+            datetime.strptime(__date__, "%Y-%m-%d").strftime("%x"))
         )
 
         self.latestLabel = QLabel(self.tr("Latest Release"))
@@ -152,7 +151,7 @@ class GuiUpdates(QDialog):
         self.latestLink.setText(self.tr(
             "Download: {0}"
         ).format(
-            f'<a href="{novelwriter.__url__}">{novelwriter.__url__}</a>'
+            f'<a href="{__url__}">{__url__}</a>'
         ))
 
         qApp.restoreOverrideCursor()

--- a/novelwriter/dialogs/updates.py
+++ b/novelwriter/dialogs/updates.py
@@ -35,8 +35,9 @@ from PyQt5.QtWidgets import (
     qApp, QDialog, QHBoxLayout, QVBoxLayout, QDialogButtonBox, QLabel
 )
 
-from novelwriter import CONFIG, __version__, __date__, __url__
+from novelwriter import CONFIG, __version__, __date__
 from novelwriter.common import logException
+from novelwriter.constants import nwConst
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +152,7 @@ class GuiUpdates(QDialog):
         self.latestLink.setText(self.tr(
             "Download: {0}"
         ).format(
-            f'<a href="{__url__}">{__url__}</a>'
+            f'<a href="{nwConst.URL_WEB}">{nwConst.URL_WEB}</a>'
         ))
 
         qApp.restoreOverrideCursor()

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -24,7 +24,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from pathlib import Path
 
@@ -34,6 +33,7 @@ from PyQt5.QtWidgets import (
     QAbstractItemView, QPushButton, QLineEdit, QLabel
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwAlert
 from novelwriter.error import logException
 from novelwriter.constants import nwFiles
@@ -49,23 +49,22 @@ class GuiWordList(QDialog):
         logger.debug("Initialising GuiWordList ...")
         self.setObjectName("GuiWordList")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
 
         self.setWindowTitle(self.tr("Project Word List"))
 
-        mS = self.mainConf.pxInt(250)
-        wW = self.mainConf.pxInt(320)
-        wH = self.mainConf.pxInt(340)
+        mS = CONFIG.pxInt(250)
+        wW = CONFIG.pxInt(320)
+        wH = CONFIG.pxInt(340)
         pOptions = self.theProject.options
 
         self.setMinimumWidth(mS)
         self.setMinimumHeight(mS)
         self.resize(
-            self.mainConf.pxInt(pOptions.getInt("GuiWordList", "winWidth",  wW)),
-            self.mainConf.pxInt(pOptions.getInt("GuiWordList", "winHeight", wH))
+            CONFIG.pxInt(pOptions.getInt("GuiWordList", "winWidth",  wW)),
+            CONFIG.pxInt(pOptions.getInt("GuiWordList", "winHeight", wH))
         )
 
         # Main Widgets
@@ -99,10 +98,10 @@ class GuiWordList(QDialog):
 
         self.outerBox = QVBoxLayout()
         self.outerBox.addWidget(self.headLabel)
-        self.outerBox.addSpacing(self.mainConf.pxInt(8))
+        self.outerBox.addSpacing(CONFIG.pxInt(8))
         self.outerBox.addWidget(self.listBox, 1)
         self.outerBox.addLayout(self.editBox, 0)
-        self.outerBox.addSpacing(self.mainConf.pxInt(12))
+        self.outerBox.addSpacing(CONFIG.pxInt(12))
         self.outerBox.addWidget(self.buttonBox, 0)
 
         self.setLayout(self.outerBox)
@@ -210,8 +209,8 @@ class GuiWordList(QDialog):
     def _saveGuiSettings(self):
         """Save GUI settings.
         """
-        winWidth  = self.mainConf.rpxInt(self.width())
-        winHeight = self.mainConf.rpxInt(self.height())
+        winWidth  = CONFIG.rpxInt(self.width())
+        winHeight = CONFIG.rpxInt(self.height())
 
         pOptions = self.theProject.options
         pOptions.setValue("GuiWordList", "winWidth",  winWidth)

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -111,18 +111,17 @@ class NWErrorMessage(QDialog):
         error traceback.
         """
         from traceback import format_tb
-        from novelwriter import __issuesurl__, __version__
+        from novelwriter import __version__
+        from novelwriter.constants import nwConst
         from PyQt5.QtCore import QT_VERSION_STR, PYQT_VERSION_STR, QSysInfo
 
-        self.msgHead.setText((
+        self.msgHead.setText(
             "<p>An unhandled error has been encountered.</p>"
             "<p>Please report this error by submitting an issue report on "
             "GitHub, providing a description and including the error "
             "message and traceback shown below.</p>"
-            "<p>URL: <a href='{issueUrl}'>{issueUrl}</a></p>"
-        ).format(
-            issueUrl=__issuesurl__,
-        ))
+            f"<p>URL: <a href='{nwConst.URL_REPORT}'>{nwConst.URL_REPORT}</a></p>"
+        )
 
         try:
             kernelVersion = QSysInfo.kernelVersion()

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -24,7 +24,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from time import time
 
@@ -33,6 +32,7 @@ from PyQt5.QtGui import (
     QColor, QTextCharFormat, QFont, QSyntaxHighlighter, QBrush
 )
 
+from novelwriter import CONFIG
 from novelwriter.common import checkInt
 from novelwriter.constants import nwRegEx, nwUnicode
 
@@ -50,7 +50,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         super().__init__(theDoc)
 
         logger.debug("Initialising GuiDocHighlighter ...")
-        self.mainConf   = novelwriter.CONFIG
         self.theDoc     = theDoc
         self.spEnchant  = spEnchant
         self.mainGui    = mainGui
@@ -103,7 +102,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self.colBreak.setAlpha(64)
 
         self.colEmph = None
-        if self.mainConf.highlightEmph:
+        if CONFIG.highlightEmph:
             self.colEmph = QColor(*self.mainTheme.colEmph)
 
         self.hStyles = {
@@ -135,7 +134,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self.hRules = []
 
         # Multiple or Trailing Spaces
-        if self.mainConf.showMultiSpaces:
+        if CONFIG.showMultiSpaces:
             self.hRules.append((
                 r"[ ]{2,}|[ ]*$", {
                     0: self.hStyles["mspaces"],
@@ -150,11 +149,11 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         ))
 
         # Quoted Strings
-        if self.mainConf.highlightQuotes:
-            fmtDblO = self.mainConf.fmtDQuoteOpen
-            fmtDblC = self.mainConf.fmtDQuoteClose
-            fmtSngO = self.mainConf.fmtSQuoteOpen
-            fmtSngC = self.mainConf.fmtSQuoteClose
+        if CONFIG.highlightQuotes:
+            fmtDblO = CONFIG.fmtDQuoteOpen
+            fmtDblC = CONFIG.fmtDQuoteClose
+            fmtSngO = CONFIG.fmtSQuoteOpen
+            fmtSngC = CONFIG.fmtSQuoteClose
 
             # Straight Quotes
             if not (fmtDblO == fmtDblC == "\""):
@@ -165,7 +164,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 ))
 
             # Double Quotes
-            dblEnd = "|$" if self.mainConf.allowOpenDQuote else ""
+            dblEnd = "|$" if CONFIG.allowOpenDQuote else ""
             self.hRules.append((
                 f"(\\B{fmtDblO})(.*?)({fmtDblC}\\B{dblEnd})", {
                     0: self.hStyles["dialogue2"],
@@ -173,7 +172,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             ))
 
             # Single Quotes
-            sngEnd = "|$" if self.mainConf.allowOpenSQuote else ""
+            sngEnd = "|$" if CONFIG.allowOpenSQuote else ""
             self.hRules.append((
                 f"(\\B{fmtSngO})(.*?)({fmtSngC}\\B{sngEnd})", {
                     0: self.hStyles["dialogue3"],
@@ -432,7 +431,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 theFormat.setBackground(QBrush(fmtCol, Qt.SolidPattern))
 
         if fmtSize is not None:
-            theFormat.setFontPointSize(int(round(fmtSize*self.mainConf.textSize)))
+            theFormat.setFontPointSize(int(round(fmtSize*CONFIG.textSize)))
 
         return theFormat
 

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -28,7 +28,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from enum import Enum
 
@@ -41,6 +40,7 @@ from PyQt5.QtWidgets import (
     QAction, QMenu, QFrame
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwItemType, nwDocAction, nwDocMode
 from novelwriter.error import logException
 from novelwriter.constants import nwUnicode
@@ -59,7 +59,6 @@ class GuiDocViewer(QTextBrowser):
         logger.debug("Initialising GuiDocViewer ...")
 
         # Class Variables
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
@@ -68,7 +67,7 @@ class GuiDocViewer(QTextBrowser):
         self._docHandle = None
 
         # Settings
-        self.setMinimumWidth(self.mainConf.pxInt(300))
+        self.setMinimumWidth(CONFIG.pxInt(300))
         self.setAutoFillBackground(True)
         self.setOpenExternalLinks(False)
         self.setFocusPolicy(Qt.StrongFocus)
@@ -116,11 +115,11 @@ class GuiDocViewer(QTextBrowser):
 
         # Set Font
         theFont = QFont()
-        if self.mainConf.textFont is None:
+        if CONFIG.textFont is None:
             # If none is defined, set the default back to config
-            self.mainConf.textFont = self.document().defaultFont().family()
-        theFont.setFamily(self.mainConf.textFont)
-        theFont.setPointSize(self.mainConf.textSize)
+            CONFIG.textFont = self.document().defaultFont().family()
+        theFont.setFamily(CONFIG.textFont)
+        theFont.setPointSize(CONFIG.textSize)
         self.setFont(theFont)
 
         # Set the widget colours to match syntax theme
@@ -141,23 +140,23 @@ class GuiDocViewer(QTextBrowser):
         # Set default text margins
         self.document().setDocumentMargin(0)
         theOpt = QTextOption()
-        if self.mainConf.doJustify:
+        if CONFIG.doJustify:
             theOpt.setAlignment(Qt.AlignJustify)
         self.document().setDefaultTextOption(theOpt)
 
         # Scroll bars
-        if self.mainConf.hideVScroll:
+        if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
-        if self.mainConf.hideHScroll:
+        if CONFIG.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         # Refresh the tab stops
-        self.setTabStopDistance(self.mainConf.getTabWidth())
+        self.setTabStopDistance(CONFIG.getTabWidth())
 
         # If we have a document open, we should reload it in case the font changed
         if self._docHandle is not None:
@@ -177,7 +176,7 @@ class GuiDocViewer(QTextBrowser):
 
         sPos = self.verticalScrollBar().value()
         aDoc = ToHtml(self.theProject)
-        aDoc.setPreview(self.mainConf.viewComments, self.mainConf.viewSynopsis)
+        aDoc.setPreview(CONFIG.viewComments, CONFIG.viewSynopsis)
         aDoc.setLinkHeaders(True)
 
         # Be extra careful here to prevent crashes when first opening a
@@ -196,7 +195,7 @@ class GuiDocViewer(QTextBrowser):
             return False
 
         # Refresh the tab stops
-        self.setTabStopDistance(self.mainConf.getTabWidth())
+        self.setTabStopDistance(CONFIG.getTabWidth())
 
         # Must be before setHtml
         if updateHistory:
@@ -297,7 +296,7 @@ class GuiDocViewer(QTextBrowser):
         """
         wW = self.width()
         wH = self.height()
-        cM = self.mainConf.getTextMargin()
+        cM = CONFIG.getTextMargin()
 
         vBar = self.verticalScrollBar()
         sW = vBar.width() if vBar.isVisible() else 0
@@ -306,8 +305,8 @@ class GuiDocViewer(QTextBrowser):
         sH = hBar.height() if hBar.isVisible() else 0
 
         tM = cM
-        if self.mainConf.textWidth > 0:
-            tW = self.mainConf.getTextWidth()
+        if CONFIG.textWidth > 0:
+            tW = CONFIG.getTextWidth()
             tM = max((wW - sW - tW)//2, cM)
 
         tB = self.frameWidth()
@@ -685,7 +684,6 @@ class GuiDocViewHeader(QWidget):
 
         logger.debug("Initialising GuiDocViewHeader ...")
 
-        self.mainConf   = novelwriter.CONFIG
         self.docViewer  = docViewer
         self.mainGui    = docViewer.mainGui
         self.theProject = docViewer.theProject
@@ -695,7 +693,7 @@ class GuiDocViewHeader(QWidget):
         self._docHandle = None
 
         fPx = int(0.9*self.mainTheme.fontPixelSize)
-        hSp = self.mainConf.pxInt(6)
+        hSp = CONFIG.pxInt(6)
 
         # Main Widget Settings
         self.setAutoFillBackground(True)
@@ -763,7 +761,7 @@ class GuiDocViewHeader(QWidget):
 
         # Fix Margins and Size
         # This is needed for high DPI systems. See issue #499.
-        cM = self.mainConf.pxInt(8)
+        cM = CONFIG.pxInt(8)
         self.setContentsMargins(0, 0, 0, 0)
         self.outerBox.setContentsMargins(cM, cM, cM, cM)
         self.setMinimumHeight(fPx + 2*cM)
@@ -828,7 +826,7 @@ class GuiDocViewHeader(QWidget):
             self.refreshButton.setVisible(False)
             return True
 
-        if self.mainConf.showFullPath:
+        if CONFIG.showFullPath:
             tTitle = []
             tTree = self.theProject.tree.getItemPath(tHandle)
             for aHandle in reversed(tTree):
@@ -903,7 +901,6 @@ class GuiDocViewFooter(QWidget):
 
         logger.debug("Initialising GuiDocViewFooter ...")
 
-        self.mainConf  = novelwriter.CONFIG
         self.docViewer = docViewer
         self.mainGui   = docViewer.mainGui
         self.mainTheme = docViewer.mainTheme
@@ -913,8 +910,8 @@ class GuiDocViewFooter(QWidget):
         self._docHandle = None
 
         fPx = int(0.9*self.mainTheme.fontPixelSize)
-        bSp = self.mainConf.pxInt(2)
-        hSp = self.mainConf.pxInt(8)
+        bSp = CONFIG.pxInt(2)
+        hSp = CONFIG.pxInt(8)
 
         # Main Widget Settings
         self.setContentsMargins(0, 0, 0, 0)
@@ -942,7 +939,7 @@ class GuiDocViewFooter(QWidget):
         # Show Comments
         self.showComments = QToolButton(self)
         self.showComments.setCheckable(True)
-        self.showComments.setChecked(self.mainConf.viewComments)
+        self.showComments.setChecked(CONFIG.viewComments)
         self.showComments.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.showComments.setIconSize(QSize(fPx, fPx))
         self.showComments.setFixedSize(QSize(fPx, fPx))
@@ -952,7 +949,7 @@ class GuiDocViewFooter(QWidget):
         # Show Synopsis
         self.showSynopsis = QToolButton(self)
         self.showSynopsis.setCheckable(True)
-        self.showSynopsis.setChecked(self.mainConf.viewSynopsis)
+        self.showSynopsis.setChecked(CONFIG.viewSynopsis)
         self.showSynopsis.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.showSynopsis.setIconSize(QSize(fPx, fPx))
         self.showSynopsis.setFixedSize(QSize(fPx, fPx))
@@ -1021,7 +1018,7 @@ class GuiDocViewFooter(QWidget):
 
         # Fix Margins and Size
         # This is needed for high DPI systems. See issue #499.
-        cM = self.mainConf.pxInt(8)
+        cM = CONFIG.pxInt(8)
         self.setContentsMargins(0, 0, 0, 0)
         self.outerBox.setContentsMargins(cM, cM, cM, cM)
         self.setMinimumHeight(fPx + 2*cM)
@@ -1120,7 +1117,7 @@ class GuiDocViewFooter(QWidget):
     def _doToggleComments(self, theState):
         """Toggle the view comment button and reload the document.
         """
-        self.mainConf.viewComments = theState
+        CONFIG.viewComments = theState
         self.docViewer.reloadText()
         return
 
@@ -1128,7 +1125,7 @@ class GuiDocViewFooter(QWidget):
     def _doToggleSynopsis(self, theState):
         """Toggle the view synopsis button and reload the document.
         """
-        self.mainConf.viewSynopsis = theState
+        CONFIG.viewSynopsis = theState
         self.docViewer.reloadText()
         return
 
@@ -1146,7 +1143,6 @@ class GuiDocViewDetails(QScrollArea):
         super().__init__(parent=mainGui)
 
         logger.debug("Initialising GuiDocViewDetails ...")
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
         self.mainTheme  = mainGui.mainTheme
@@ -1172,7 +1168,7 @@ class GuiDocViewDetails(QScrollArea):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.setWidgetResizable(True)
-        self.setMinimumHeight(self.mainConf.pxInt(50))
+        self.setMinimumHeight(CONFIG.pxInt(50))
         self.setFrameStyle(QFrame.NoFrame)
 
         logger.debug("GuiDocViewDetails initialisation complete")

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -24,12 +24,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtGui import QFont, QPixmap
 from PyQt5.QtWidgets import QWidget, QGridLayout, QLabel
 
+from novelwriter import CONFIG
 from novelwriter.constants import trConst, nwLabels
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,6 @@ class GuiItemDetails(QWidget):
         super().__init__(parent=mainGui)
 
         logger.debug("Initialising GuiItemDetails ...")
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
         self.mainTheme  = mainGui.mainTheme
@@ -50,9 +49,9 @@ class GuiItemDetails(QWidget):
         self._itemHandle  = None
 
         # Sizes
-        hSp = self.mainConf.pxInt(6)
-        vSp = self.mainConf.pxInt(1)
-        mPx = self.mainConf.pxInt(6)
+        hSp = CONFIG.pxInt(6)
+        vSp = CONFIG.pxInt(1)
+        mPx = CONFIG.pxInt(6)
         fPt = self.mainTheme.fontPointSize
 
         fntLabel = QFont()

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -34,6 +34,7 @@ from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import QMenuBar, QAction
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwDocAction, nwDocInsert, nwWidget
 from novelwriter.constants import trConst, nwKeyWords, nwLabels, nwUnicode
 
@@ -50,7 +51,6 @@ class GuiMainMenu(QMenuBar):
         super().__init__(parent=mainGui)
 
         logger.debug("Initialising GuiMainMenu ...")
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
 
@@ -105,9 +105,9 @@ class GuiMainMenu(QMenuBar):
     def _openUserManualFile(self):
         """Open the documentation in PDF format.
         """
-        if isinstance(self.mainConf.pdfDocs, Path):
+        if isinstance(CONFIG.pdfDocs, Path):
             QDesktopServices.openUrl(
-                QUrl(urljoin("file:", pathname2url(str(self.mainConf.pdfDocs))))
+                QUrl(urljoin("file:", pathname2url(str(CONFIG.pdfDocs))))
             )
         return
 
@@ -310,7 +310,7 @@ class GuiMainMenu(QMenuBar):
 
         # View > TreeView
         self.aFocusTree = QAction(self.tr("Go to Project Tree"), self)
-        if self.mainConf.osWindows:
+        if CONFIG.osWindows:
             self.aFocusTree.setShortcut("Ctrl+Alt+1")
         else:
             self.aFocusTree.setShortcut("Alt+1")
@@ -319,7 +319,7 @@ class GuiMainMenu(QMenuBar):
 
         # View > Document Pane 1
         self.aFocusEditor = QAction(self.tr("Go to Document Editor"), self)
-        if self.mainConf.osWindows:
+        if CONFIG.osWindows:
             self.aFocusEditor.setShortcut("Ctrl+Alt+2")
         else:
             self.aFocusEditor.setShortcut("Alt+2")
@@ -328,7 +328,7 @@ class GuiMainMenu(QMenuBar):
 
         # View > Document Pane 2
         self.aFocusView = QAction(self.tr("Go to Document Viewer"), self)
-        if self.mainConf.osWindows:
+        if CONFIG.osWindows:
             self.aFocusView.setShortcut("Ctrl+Alt+3")
         else:
             self.aFocusView.setShortcut("Alt+3")
@@ -337,7 +337,7 @@ class GuiMainMenu(QMenuBar):
 
         # View > Outline
         self.aFocusOutline = QAction(self.tr("Go to Outline"), self)
-        if self.mainConf.osWindows:
+        if CONFIG.osWindows:
             self.aFocusOutline.setShortcut("Ctrl+Alt+4")
         else:
             self.aFocusOutline.setShortcut("Alt+4")
@@ -754,7 +754,7 @@ class GuiMainMenu(QMenuBar):
 
         # Search > Replace
         self.aReplace = QAction(self.tr("Replace"), self)
-        if self.mainConf.osDarwin:
+        if CONFIG.osDarwin:
             self.aReplace.setShortcut("Ctrl+=")
         else:
             self.aReplace.setShortcut("Ctrl+H")
@@ -763,7 +763,7 @@ class GuiMainMenu(QMenuBar):
 
         # Search > Find Next
         self.aFindNext = QAction(self.tr("Find Next"), self)
-        if self.mainConf.osDarwin:
+        if CONFIG.osDarwin:
             self.aFindNext.setShortcuts(["Ctrl+G", "F3"])
         else:
             self.aFindNext.setShortcuts(["F3", "Ctrl+G"])
@@ -772,7 +772,7 @@ class GuiMainMenu(QMenuBar):
 
         # Search > Find Prev
         self.aFindPrev = QAction(self.tr("Find Previous"), self)
-        if self.mainConf.osDarwin:
+        if CONFIG.osDarwin:
             self.aFindPrev.setShortcuts(["Ctrl+Shift+G", "Shift+F3"])
         else:
             self.aFindPrev.setShortcuts(["Shift+F3", "Ctrl+Shift+G"])
@@ -883,7 +883,7 @@ class GuiMainMenu(QMenuBar):
         self.helpMenu.addAction(self.aHelpDocs)
 
         # Help > User Manual (PDF)
-        if isinstance(self.mainConf.pdfDocs, Path):
+        if isinstance(CONFIG.pdfDocs, Path):
             self.aPdfDocs = QAction(self.tr("User Manual (PDF)"), self)
             self.aPdfDocs.setShortcut("Shift+F1")
             self.aPdfDocs.triggered.connect(self._openUserManualFile)

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -24,7 +24,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from pathlib import Path
 from urllib.parse import urljoin
@@ -36,7 +35,7 @@ from PyQt5.QtWidgets import QMenuBar, QAction
 
 from novelwriter import CONFIG
 from novelwriter.enum import nwDocAction, nwDocInsert, nwWidget
-from novelwriter.constants import trConst, nwKeyWords, nwLabels, nwUnicode
+from novelwriter.constants import nwConst, trConst, nwKeyWords, nwLabels, nwUnicode
 
 logger = logging.getLogger(__name__)
 
@@ -872,14 +871,9 @@ class GuiMainMenu(QMenuBar):
         self.helpMenu.addSeparator()
 
         # Help > User Manual (Online)
-        if novelwriter.__version__[-2] == "f":
-            docUrl = f"{novelwriter.__docurl__}/en/stable/"
-        else:
-            docUrl = f"{novelwriter.__docurl__}/en/latest/"
-
         self.aHelpDocs = QAction(self.tr("User Manual (Online)"), self)
         self.aHelpDocs.setShortcut("F1")
-        self.aHelpDocs.triggered.connect(lambda: self._openWebsite(docUrl))
+        self.aHelpDocs.triggered.connect(lambda: self._openWebsite(nwConst.URL_DOCS))
         self.helpMenu.addAction(self.aHelpDocs)
 
         # Help > User Manual (PDF)
@@ -894,17 +888,17 @@ class GuiMainMenu(QMenuBar):
 
         # Document > Report an Issue
         self.aIssue = QAction(self.tr("Report an Issue (GitHub)"), self)
-        self.aIssue.triggered.connect(lambda: self._openWebsite(novelwriter.__issuesurl__))
+        self.aIssue.triggered.connect(lambda: self._openWebsite(nwConst.URL_REPORT))
         self.helpMenu.addAction(self.aIssue)
 
         # Document > Ask a Question
         self.aQuestion = QAction(self.tr("Ask a Question (GitHub)"), self)
-        self.aQuestion.triggered.connect(lambda: self._openWebsite(novelwriter.__helpurl__))
+        self.aQuestion.triggered.connect(lambda: self._openWebsite(nwConst.URL_HELP))
         self.helpMenu.addAction(self.aQuestion)
 
         # Document > Main Website
         self.aWebsite = QAction(self.tr("The novelWriter Website"), self)
-        self.aWebsite.triggered.connect(lambda: self._openWebsite(novelwriter.__url__))
+        self.aWebsite.triggered.connect(lambda: self._openWebsite(nwConst.URL_WEB))
         self.helpMenu.addAction(self.aWebsite)
 
         # Help > Separator

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -26,7 +26,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from enum import Enum
 from time import time
@@ -39,6 +38,7 @@ from PyQt5.QtWidgets import (
     QTreeWidgetItem, QVBoxLayout, QWidget
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwDocMode, nwItemClass, nwOutline
 from novelwriter.common import minmax
 from novelwriter.constants import nwHeaders, nwKeyWords, nwLabels, trConst
@@ -198,14 +198,13 @@ class GuiNovelToolBar(QWidget):
 
         logger.debug("Initialising GuiNovelToolBar ...")
 
-        self.mainConf   = novelwriter.CONFIG
         self.novelView  = novelView
         self.mainGui    = novelView.mainGui
         self.theProject = novelView.mainGui.theProject
         self.mainTheme  = novelView.mainGui.mainTheme
 
         iPx = self.mainTheme.baseIconSize
-        mPx = self.mainConf.pxInt(2)
+        mPx = CONFIG.pxInt(2)
 
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
@@ -216,7 +215,7 @@ class GuiNovelToolBar(QWidget):
         self.novelPrefix = self.tr("Outline of {0}")
         self.novelValue = NovelSelector(self, self.theProject, self.mainGui)
         self.novelValue.setFont(selFont)
-        self.novelValue.setMinimumWidth(self.mainConf.pxInt(150))
+        self.novelValue.setMinimumWidth(CONFIG.pxInt(150))
         self.novelValue.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.novelValue.novelSelectionChanged.connect(self.setCurrentRoot)
 
@@ -290,7 +289,7 @@ class GuiNovelToolBar(QWidget):
         buttonStyle = (
             "QToolButton {{padding: {0}px; border: none; background: transparent;}} "
             "QToolButton:hover {{border: none; background: rgba({1},{2},{3},0.2);}}"
-        ).format(self.mainConf.pxInt(2), fadeCol.red(), fadeCol.green(), fadeCol.blue())
+        ).format(CONFIG.pxInt(2), fadeCol.red(), fadeCol.green(), fadeCol.blue())
 
         self.tbNovel.setStyleSheet(buttonStyle)
         self.tbRefresh.setStyleSheet(buttonStyle)
@@ -398,7 +397,6 @@ class GuiNovelTree(QTreeWidget):
 
         logger.debug("Initialising GuiNovelTree ...")
 
-        self.mainConf   = novelwriter.CONFIG
         self.novelView  = novelView
         self.mainGui    = novelView.mainGui
         self.mainTheme  = novelView.mainGui.mainTheme
@@ -420,7 +418,7 @@ class GuiNovelTree(QTreeWidget):
         # =========
 
         iPx = self.mainTheme.baseIconSize
-        cMg = self.mainConf.pxInt(6)
+        cMg = CONFIG.pxInt(6)
 
         self.setIconSize(QSize(iPx, iPx))
         self.setFrameStyle(QFrame.NoFrame)
@@ -470,12 +468,12 @@ class GuiNovelTree(QTreeWidget):
         """Set or update tree widget settings.
         """
         # Scroll bars
-        if self.mainConf.hideVScroll:
+        if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
-        if self.mainConf.hideHScroll:
+        if CONFIG.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -28,7 +28,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from time import time
 from enum import Enum
@@ -42,6 +41,7 @@ from PyQt5.QtWidgets import (
     QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import (
     nwDocMode, nwItemClass, nwItemLayout, nwItemType, nwOutline
 )
@@ -61,7 +61,6 @@ class GuiOutlineView(QWidget):
     def __init__(self, mainGui):
         super().__init__(parent=mainGui)
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.theProject = mainGui.theProject
 
@@ -75,7 +74,7 @@ class GuiOutlineView(QWidget):
         self.splitOutline.addWidget(self.outlineTree)
         self.splitOutline.addWidget(self.outlineData)
         self.splitOutline.setOpaqueResize(False)
-        self.splitOutline.setSizes(self.mainConf.outlinePanePos)
+        self.splitOutline.setSizes(CONFIG.outlinePanePos)
 
         # Assemble
         self.outerBox = QVBoxLayout()
@@ -215,13 +214,12 @@ class GuiOutlineToolBar(QToolBar):
 
         logger.debug("Initialising GuiOutlineToolBar ...")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = theOutline.mainGui
         self.theProject = theOutline.mainGui.theProject
         self.mainTheme  = theOutline.mainGui.mainTheme
 
-        iPx = self.mainConf.pxInt(22)
-        mPx = self.mainConf.pxInt(12)
+        iPx = CONFIG.pxInt(22)
+        mPx = CONFIG.pxInt(12)
 
         self.setMovable(False)
         self.setIconSize(QSize(iPx, iPx))
@@ -235,7 +233,7 @@ class GuiOutlineToolBar(QToolBar):
         self.novelLabel.setContentsMargins(0, 0, mPx, 0)
 
         self.novelValue = NovelSelector(self, self.theProject, self.mainGui)
-        self.novelValue.setMinimumWidth(self.mainConf.pxInt(200))
+        self.novelValue.setMinimumWidth(CONFIG.pxInt(200))
         self.novelValue.novelSelectionChanged.connect(self._novelValueChanged)
 
         # Actions
@@ -373,7 +371,6 @@ class GuiOutlineTree(QTreeWidget):
 
         logger.debug("Initialising GuiOutlineTree ...")
 
-        self.mainConf    = novelwriter.CONFIG
         self.outlineView = outlineView
         self.mainGui     = outlineView.mainGui
         self.theProject  = outlineView.mainGui.theProject
@@ -446,12 +443,12 @@ class GuiOutlineTree(QTreeWidget):
         """Set or update outline settings.
         """
         # Scroll bars
-        if self.mainConf.hideVScroll:
+        if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
-        if self.mainConf.hideHScroll:
+        if CONFIG.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
@@ -610,7 +607,7 @@ class GuiOutlineTree(QTreeWidget):
         tmpWidth = pOptions.getValue("GuiOutline", "columnWidth", {})
         for hName in tmpWidth:
             try:
-                self._colWidth[nwOutline[hName]] = self.mainConf.pxInt(tmpWidth[hName])
+                self._colWidth[nwOutline[hName]] = CONFIG.pxInt(tmpWidth[hName])
             except Exception:
                 logger.warning("Ignored unknown outline column '%s'", str(hName))
 
@@ -640,7 +637,7 @@ class GuiOutlineTree(QTreeWidget):
         colHidden = {}
 
         for hItem in nwOutline:
-            colWidth[hItem.name] = self.mainConf.rpxInt(self._colWidth[hItem])
+            colWidth[hItem.name] = CONFIG.rpxInt(self._colWidth[hItem])
             colHidden[hItem.name] = self._colHidden[hItem]
 
         for iCol in range(self.columnCount()):
@@ -648,7 +645,7 @@ class GuiOutlineTree(QTreeWidget):
             treeOrder.append(hName)
 
             iLog = self.treeHead.logicalIndex(iCol)
-            logWidth = self.mainConf.rpxInt(self.columnWidth(iLog))
+            logWidth = CONFIG.rpxInt(self.columnWidth(iLog))
             logHidden = self.isColumnHidden(iLog)
 
             colHidden[hName] = logHidden
@@ -801,7 +798,6 @@ class GuiOutlineDetails(QScrollArea):
 
         logger.debug("Initialising GuiOutlineDetails ...")
 
-        self.mainConf   = novelwriter.CONFIG
         self.theOutline = theOutline
         self.mainGui    = theOutline.mainGui
         self.theProject = theOutline.mainGui.theProject
@@ -811,8 +807,8 @@ class GuiOutlineDetails(QScrollArea):
         minTitle = 30*self.mainTheme.textNWidth
         maxTitle = 40*self.mainTheme.textNWidth
         wCount = self.mainTheme.getTextWidth("999,999")
-        hSpace = int(self.mainConf.pxInt(10))
-        vSpace = int(self.mainConf.pxInt(4))
+        hSpace = int(CONFIG.pxInt(10))
+        vSpace = int(CONFIG.pxInt(4))
 
         # Details Area
         self.titleLabel = QLabel("<b>%s</b>" % self.tr("Title"))
@@ -994,12 +990,12 @@ class GuiOutlineDetails(QScrollArea):
         """Set or update outline settings.
         """
         # Scroll bars
-        if self.mainConf.hideVScroll:
+        if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
-        if self.mainConf.hideHScroll:
+        if CONFIG.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -26,7 +26,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from enum import Enum
 from time import time
@@ -38,10 +37,11 @@ from PyQt5.QtWidgets import (
     QMenu, QShortcut, QSizePolicy, QToolButton, QTreeWidget, QTreeWidgetItem,
     QVBoxLayout, QWidget
 )
-from novelwriter.core.item import NWItem
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwDocMode, nwItemType, nwItemClass, nwItemLayout, nwAlert, nwWidget
 from novelwriter.constants import nwHeaders, nwUnicode, trConst, nwLabels
+from novelwriter.core.item import NWItem
 from novelwriter.core.coretools import DocMerger, DocSplitter
 from novelwriter.dialogs.docmerge import GuiDocMerge
 from novelwriter.dialogs.docsplit import GuiDocSplit
@@ -217,7 +217,6 @@ class GuiProjectToolBar(QWidget):
 
         logger.debug("Initialising GuiProjectToolBar ...")
 
-        self.mainConf   = novelwriter.CONFIG
         self.projView   = projView
         self.projTree   = projView.projTree
         self.mainGui    = projView.mainGui
@@ -225,7 +224,7 @@ class GuiProjectToolBar(QWidget):
         self.mainTheme  = projView.mainGui.mainTheme
 
         iPx = self.mainTheme.baseIconSize
-        mPx = self.mainConf.pxInt(2)
+        mPx = CONFIG.pxInt(2)
 
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
@@ -348,7 +347,7 @@ class GuiProjectToolBar(QWidget):
         buttonStyle = (
             "QToolButton {{padding: {0}px; border: none; background: transparent;}} "
             "QToolButton:hover {{border: none; background: rgba({1},{2},{3},0.2);}}"
-        ).format(self.mainConf.pxInt(2), fadeCol.red(), fadeCol.green(), fadeCol.blue())
+        ).format(CONFIG.pxInt(2), fadeCol.red(), fadeCol.green(), fadeCol.blue())
 
         self.tbQuick.setStyleSheet(buttonStyle)
         self.tbMoveU.setStyleSheet(buttonStyle)
@@ -458,7 +457,6 @@ class GuiProjectTree(QTreeWidget):
 
         logger.debug("Initialising GuiProjectTree ...")
 
-        self.mainConf   = novelwriter.CONFIG
         self.projView   = projView
         self.mainGui    = projView.mainGui
         self.mainTheme  = projView.mainGui.mainTheme
@@ -478,7 +476,7 @@ class GuiProjectTree(QTreeWidget):
 
         # Tree Settings
         iPx = self.mainTheme.baseIconSize
-        cMg = self.mainConf.pxInt(6)
+        cMg = CONFIG.pxInt(6)
 
         self.setIconSize(QSize(iPx, iPx))
         self.setFrameStyle(QFrame.NoFrame)
@@ -532,12 +530,12 @@ class GuiProjectTree(QTreeWidget):
         """Set or update tree widget settings.
         """
         # Scroll bars
-        if self.mainConf.hideVScroll:
+        if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
-        if self.mainConf.hideHScroll:
+        if CONFIG.hideHScroll:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         else:
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
@@ -987,7 +985,7 @@ class GuiProjectTree(QTreeWidget):
 
         trItem.setIcon(self.C_ACTIVE, self.mainTheme.getIcon(iconName))
 
-        if self.mainConf.emphLabels and nwItem.isDocumentLayout():
+        if CONFIG.emphLabels and nwItem.isDocumentLayout():
             trFont = trItem.font(self.C_NAME)
             trFont.setBold(hLevel == "H1" or hLevel == "H2")
             trFont.setUnderline(hLevel == "H1")

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -24,13 +24,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from PyQt5.QtCore import Qt, QSize, pyqtSignal
 from PyQt5.QtWidgets import (
     QToolBar, QWidget, QSizePolicy, QAction, QMenu, QToolButton
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwView
 
 logger = logging.getLogger(__name__)
@@ -45,13 +45,12 @@ class GuiSideBar(QToolBar):
 
         logger.debug("Initialising GuiSideBar ...")
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
         self.mainTheme = mainGui.mainTheme
 
         # Style
-        iPx = self.mainConf.pxInt(22)
-        mPx = self.mainConf.pxInt(60)
+        iPx = CONFIG.pxInt(22)
+        mPx = CONFIG.pxInt(60)
 
         lblFont = self.mainTheme.guiFont
         lblFont.setPointSizeF(0.65*self.mainTheme.fontPointSize)

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from time import time
 
@@ -33,6 +32,7 @@ from PyQt5.QtCore import pyqtSlot, QLocale
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import qApp, QStatusBar, QLabel
 
+from novelwriter import CONFIG
 from novelwriter.common import formatTime
 from novelwriter.gui.components import StatusLED
 
@@ -46,7 +46,6 @@ class GuiMainStatus(QStatusBar):
 
         logger.debug("Initialising GuiMainStatus ...")
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
         self.mainTheme = mainGui.mainTheme
         self.refTime   = None
@@ -61,7 +60,7 @@ class GuiMainStatus(QStatusBar):
         # Permanent Widgets
         # =================
 
-        xM = self.mainConf.pxInt(8)
+        xM = CONFIG.pxInt(8)
 
         # The Spell Checker Language
         self.langIcon = QLabel("")
@@ -174,7 +173,7 @@ class GuiMainStatus(QStatusBar):
     def setUserIdle(self, userIdle):
         """Change the idle status icon.
         """
-        if not self.mainConf.stopWhenIdle:
+        if not CONFIG.stopWhenIdle:
             userIdle = False
 
         if self.userIdle != userIdle:
@@ -191,7 +190,7 @@ class GuiMainStatus(QStatusBar):
         """Update the current project statistics.
         """
         self.statsText.setText(self.tr("Words: {0} ({1})").format(f"{pWC:n}", f"{sWC:+n}"))
-        if self.mainConf.incNotesWCount:
+        if CONFIG.incNotesWCount:
             self.statsText.setToolTip(self.tr("Project word count (session change)"))
         else:
             self.statsText.setToolTip(self.tr("Novel word count (session change)"))
@@ -203,7 +202,7 @@ class GuiMainStatus(QStatusBar):
         if self.refTime is None:
             self.timeText.setText("00:00:00")
         else:
-            if self.mainConf.stopWhenIdle:
+            if CONFIG.stopWhenIdle:
                 sessTime = round(time() - self.refTime - idleTime)
             else:
                 sessTime = round(time() - self.refTime)

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
-import novelwriter
 
 from math import ceil
 
@@ -35,6 +34,7 @@ from PyQt5.QtGui import (
     QPalette, QColor, QIcon, QFont, QFontMetrics, QFontDatabase, QPixmap
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwItemLayout, nwItemType
 from novelwriter.error import logException
 from novelwriter.common import NWConfigParser, minmax
@@ -52,7 +52,6 @@ class GuiTheme:
 
     def __init__(self):
 
-        self.mainConf = novelwriter.CONFIG
         self.iconCache = GuiIcons(self)
 
         # Loaded Theme Settings
@@ -118,10 +117,10 @@ class GuiTheme:
         self._availThemes = {}
         self._availSyntax = {}
 
-        self._listConf(self._availSyntax, self.mainConf.assetPath("syntax"))
-        self._listConf(self._availThemes, self.mainConf.assetPath("themes"))
-        self._listConf(self._availSyntax, self.mainConf.dataPath("syntax"))
-        self._listConf(self._availThemes, self.mainConf.dataPath("themes"))
+        self._listConf(self._availSyntax, CONFIG.assetPath("syntax"))
+        self._listConf(self._availThemes, CONFIG.assetPath("themes"))
+        self._listConf(self._availSyntax, CONFIG.dataPath("syntax"))
+        self._listConf(self._availThemes, CONFIG.dataPath("themes"))
 
         self.loadTheme()
         self.loadSyntax()
@@ -136,7 +135,7 @@ class GuiTheme:
         # Extract Other Info
         self.guiDPI = qApp.primaryScreen().logicalDotsPerInchX()
         self.guiScale = qApp.primaryScreen().logicalDotsPerInchX()/96.0
-        self.mainConf.guiScale = self.guiScale
+        CONFIG.guiScale = self.guiScale
         logger.debug("GUI DPI: %.1f", self.guiDPI)
         logger.debug("GUI Scale: %.2f", self.guiScale)
 
@@ -184,11 +183,11 @@ class GuiTheme:
     def loadTheme(self):
         """Load the currently specified GUI theme.
         """
-        guiTheme = self.mainConf.guiTheme
+        guiTheme = CONFIG.guiTheme
         if guiTheme not in self._availThemes:
             logger.error("Could not find GUI theme '%s'", guiTheme)
             guiTheme = "default"
-            self.mainConf.guiTheme = guiTheme
+            CONFIG.guiTheme = guiTheme
 
         themeFile = self._availThemes.get(guiTheme, None)
         if themeFile is None:
@@ -270,11 +269,11 @@ class GuiTheme:
     def loadSyntax(self):
         """Load the currently specified syntax highlighter theme.
         """
-        guiSyntax = self.mainConf.guiSyntax
+        guiSyntax = CONFIG.guiSyntax
         if guiSyntax not in self._availSyntax:
             logger.error("Could not find syntax theme '%s'", guiSyntax)
             guiSyntax = "default_light"
-            self.mainConf.guiSyntax = guiSyntax
+            CONFIG.guiSyntax = guiSyntax
 
         syntaxFile = self._availSyntax.get(guiSyntax, None)
         if syntaxFile is None:
@@ -367,18 +366,18 @@ class GuiTheme:
         """Update the GUI's font style from settings.
         """
         theFont = QFont()
-        if self.mainConf.guiFont not in self.guiFontDB.families():
-            if self.mainConf.osWindows and "Arial" in self.guiFontDB.families():
+        if CONFIG.guiFont not in self.guiFontDB.families():
+            if CONFIG.osWindows and "Arial" in self.guiFontDB.families():
                 # On Windows we default to Arial if possible
                 theFont.setFamily("Arial")
                 theFont.setPointSize(10)
             else:
                 theFont = self.guiFontDB.systemFont(QFontDatabase.GeneralFont)
-            self.mainConf.guiFont = theFont.family()
-            self.mainConf.guiFontSize = theFont.pointSize()
+            CONFIG.guiFont = theFont.family()
+            CONFIG.guiFontSize = theFont.pointSize()
         else:
-            theFont.setFamily(self.mainConf.guiFont)
-            theFont.setPointSize(self.mainConf.guiFontSize)
+            theFont.setFamily(CONFIG.guiFont)
+            theFont.setPointSize(CONFIG.guiFontSize)
 
         qApp.setFont(theFont)
 
@@ -472,7 +471,6 @@ class GuiIcons:
 
     def __init__(self, mainTheme):
 
-        self.mainConf = novelwriter.CONFIG
         self.mainTheme = mainTheme
 
         # Storage
@@ -482,7 +480,7 @@ class GuiIcons:
         self._confName  = "icons.conf"
 
         # Icon Theme Path
-        self._iconPath = self.mainConf.assetPath("icons")
+        self._iconPath = CONFIG.assetPath("icons")
 
         # Icon Theme Meta
         self.themeName        = ""
@@ -507,7 +505,7 @@ class GuiIcons:
         self._themeMap = {}
         themePath = self._iconPath / iconTheme
         if not themePath.is_dir():
-            themePath = self.mainConf.dataPath("icons") / iconTheme
+            themePath = CONFIG.dataPath("icons") / iconTheme
             if not themePath.is_dir():
                 logger.warning("No icons loaded for '%s'", iconTheme)
                 return False
@@ -580,7 +578,7 @@ class GuiIcons:
         if decoKey in self._themeMap:
             imgPath = self._themeMap[decoKey]
         elif decoKey in self.IMAGE_MAP:
-            imgPath = self.mainConf.assetPath("images") / self.IMAGE_MAP[decoKey]
+            imgPath = CONFIG.assetPath("images") / self.IMAGE_MAP[decoKey]
         else:
             logger.error("Decoration with name '%s' does not exist", decoKey)
             return QPixmap()

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import random
 import logging
-import novelwriter
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
@@ -33,6 +32,7 @@ from PyQt5.QtWidgets import (
     QSpinBox
 )
 
+from novelwriter import CONFIG
 from novelwriter.common import readTextFile
 from novelwriter.custom import QSwitch
 
@@ -47,18 +47,17 @@ class GuiLipsum(QDialog):
         logger.debug("Initialising GuiLipsum ...")
         self.setObjectName("GuiLipsum")
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
         self.mainTheme = mainGui.mainTheme
 
         self.setWindowTitle(self.tr("Insert Placeholder Text"))
 
         self.innerBox = QHBoxLayout()
-        self.innerBox.setSpacing(self.mainConf.pxInt(16))
+        self.innerBox.setSpacing(CONFIG.pxInt(16))
 
         # Icon
-        nPx = self.mainConf.pxInt(64)
-        vSp = self.mainConf.pxInt(4)
+        nPx = CONFIG.pxInt(64)
+        vSp = CONFIG.pxInt(4)
         self.docIcon = QLabel()
         self.docIcon.setPixmap(self.mainTheme.getPixmap("proj_document", (nPx, nPx)))
 
@@ -105,7 +104,7 @@ class GuiLipsum(QDialog):
         self.outerBox = QVBoxLayout()
         self.outerBox.addLayout(self.innerBox)
         self.outerBox.addWidget(self.buttonBox)
-        self.outerBox.setSpacing(self.mainConf.pxInt(16))
+        self.outerBox.setSpacing(CONFIG.pxInt(16))
         self.setLayout(self.outerBox)
 
         logger.debug("GuiLipsum initialisation complete")
@@ -119,7 +118,7 @@ class GuiLipsum(QDialog):
     def _doInsert(self):
         """Load the text and insert it in the open document.
         """
-        lipsumFile = self.mainConf.assetPath("text") / "lipsum.txt"
+        lipsumFile = CONFIG.assetPath("text") / "lipsum.txt"
         lipsumText = readTextFile(lipsumFile).splitlines()
 
         if self.randSwitch.isChecked():

--- a/novelwriter/tools/projwizard.py
+++ b/novelwriter/tools/projwizard.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import os
 import logging
-import novelwriter
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
@@ -33,6 +32,7 @@ from PyQt5.QtWidgets import (
     QPushButton, QRadioButton, QSpinBox, QVBoxLayout, QWizard, QWizardPage
 )
 
+from novelwriter import CONFIG
 from novelwriter.common import makeFileNameSafe
 from novelwriter.custom import QSwitch
 
@@ -53,12 +53,11 @@ class GuiProjectWizard(QWizard):
         logger.debug("Initialising GuiProjectWizard ...")
         self.setObjectName("GuiProjectWizard")
 
-        self.mainConf  = novelwriter.CONFIG
         self.mainGui   = mainGui
         self.mainTheme = mainGui.mainTheme
 
         self.sideImage = self.mainTheme.loadDecoration(
-            "wiz-back", None, self.mainConf.pxInt(370)
+            "wiz-back", None, CONFIG.pxInt(370)
         )
         self.setWizardStyle(QWizard.ModernStyle)
         self.setPixmap(QWizard.WatermarkPixmap, self.sideImage)
@@ -89,7 +88,6 @@ class ProjWizardIntroPage(QWizardPage):
     def __init__(self, theWizard):
         super().__init__()
 
-        self.mainConf  = novelwriter.CONFIG
         self.theWizard = theWizard
         self.mainTheme = theWizard.mainTheme
 
@@ -109,9 +107,9 @@ class ProjWizardIntroPage(QWizardPage):
         lblFont.setPointSizeF(0.6*self.mainTheme.fontPointSize)
         self.imgCredit.setFont(lblFont)
 
-        xW = self.mainConf.pxInt(300)
-        vS = self.mainConf.pxInt(12)
-        fS = self.mainConf.pxInt(4)
+        xW = CONFIG.pxInt(300)
+        vS = CONFIG.pxInt(12)
+        fS = CONFIG.pxInt(4)
 
         # The Page Form
         self.projName = QLineEdit()
@@ -158,7 +156,6 @@ class ProjWizardFolderPage(QWizardPage):
     def __init__(self, theWizard):
         super().__init__()
 
-        self.mainConf  = novelwriter.CONFIG
         self.theWizard = theWizard
         self.mainTheme = theWizard.mainTheme
 
@@ -169,9 +166,9 @@ class ProjWizardFolderPage(QWizardPage):
         ))
         self.theText.setWordWrap(True)
 
-        xW = self.mainConf.pxInt(300)
-        vS = self.mainConf.pxInt(12)
-        fS = self.mainConf.pxInt(8)
+        xW = CONFIG.pxInt(300)
+        vS = CONFIG.pxInt(12)
+        fS = CONFIG.pxInt(8)
 
         self.projPath = QLineEdit("")
         self.projPath.setFixedWidth(xW)
@@ -234,7 +231,7 @@ class ProjWizardFolderPage(QWizardPage):
     def _doBrowse(self):
         """Select a project folder.
         """
-        lastPath = self.mainConf.lastPath()
+        lastPath = CONFIG.lastPath()
         projDir = QFileDialog.getExistingDirectory(
             self, self.tr("Select Project Folder"), str(lastPath), options=QFileDialog.ShowDirsOnly
         )
@@ -256,7 +253,6 @@ class ProjWizardPopulatePage(QWizardPage):
     def __init__(self, theWizard):
         super().__init__()
 
-        self.mainConf  = novelwriter.CONFIG
         self.theWizard = theWizard
 
         self.setTitle(self.tr("Populate Project"))
@@ -267,8 +263,8 @@ class ProjWizardPopulatePage(QWizardPage):
         ))
         self.theText.setWordWrap(True)
 
-        vS = self.mainConf.pxInt(12)
-        fS = self.mainConf.pxInt(4)
+        vS = CONFIG.pxInt(12)
+        fS = CONFIG.pxInt(4)
 
         self.popMinimal = QRadioButton(self.tr("Fill the project with a minimal set of items"))
         self.popSample = QRadioButton(self.tr("Fill the project with example files"))
@@ -312,7 +308,6 @@ class ProjWizardCustomPage(QWizardPage):
     def __init__(self, theWizard):
         super().__init__()
 
-        self.mainConf  = novelwriter.CONFIG
         self.theWizard = theWizard
 
         self.setTitle(self.tr("Custom Project Options"))
@@ -323,9 +318,9 @@ class ProjWizardCustomPage(QWizardPage):
         ))
         self.theText.setWordWrap(True)
 
-        cM = self.mainConf.pxInt(12)
-        mH = self.mainConf.pxInt(26)
-        fS = self.mainConf.pxInt(4)
+        cM = CONFIG.pxInt(12)
+        mH = CONFIG.pxInt(26)
+        fS = CONFIG.pxInt(4)
 
         # Root Folders
         self.addPlot = QSwitch()
@@ -413,7 +408,6 @@ class ProjWizardFinalPage(QWizardPage):
     def __init__(self, theWizard):
         super().__init__()
 
-        self.mainConf  = novelwriter.CONFIG
         self.theWizard = theWizard
 
         self.setTitle(self.tr("Summary"))
@@ -422,7 +416,7 @@ class ProjWizardFinalPage(QWizardPage):
 
         # Assemble
         self.outerBox = QVBoxLayout()
-        self.outerBox.setSpacing(self.mainConf.pxInt(12))
+        self.outerBox.setSpacing(CONFIG.pxInt(12))
         self.outerBox.addWidget(self.theText)
         self.outerBox.addStretch(1)
         self.setLayout(self.outerBox)
@@ -470,7 +464,7 @@ class ProjWizardFinalPage(QWizardPage):
                 self.tr("You have selected the following:"),
                 "<br>&nbsp;&bull;&nbsp;".join(sumList),
                 self.tr("Press '{0}' to create the new project.").format(
-                    self.tr("Done") if self.mainConf.osDarwin else self.tr("Finish")
+                    self.tr("Done") if CONFIG.osDarwin else self.tr("Finish")
                 )
             )
         )

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -25,7 +25,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import json
 import logging
-import novelwriter
 
 from pathlib import Path
 from datetime import datetime
@@ -37,6 +36,7 @@ from PyQt5.QtWidgets import (
     QLabel, QGroupBox, QMenu, QAction, QFileDialog, QSpinBox, QHBoxLayout
 )
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwAlert
 from novelwriter.error import formatException
 from novelwriter.common import formatTime, checkInt, checkIntTuple, minmax
@@ -63,7 +63,6 @@ class GuiWritingStats(QDialog):
         logger.debug("Initialising GuiWritingStats ...")
         self.setObjectName("GuiWritingStats")
 
-        self.mainConf   = novelwriter.CONFIG
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
@@ -76,24 +75,24 @@ class GuiWritingStats(QDialog):
         pOptions = self.theProject.options
 
         self.setWindowTitle(self.tr("Writing Statistics"))
-        self.setMinimumWidth(self.mainConf.pxInt(420))
-        self.setMinimumHeight(self.mainConf.pxInt(400))
+        self.setMinimumWidth(CONFIG.pxInt(420))
+        self.setMinimumHeight(CONFIG.pxInt(400))
         self.resize(
-            self.mainConf.pxInt(pOptions.getInt("GuiWritingStats", "winWidth",  550)),
-            self.mainConf.pxInt(pOptions.getInt("GuiWritingStats", "winHeight", 500))
+            CONFIG.pxInt(pOptions.getInt("GuiWritingStats", "winWidth",  550)),
+            CONFIG.pxInt(pOptions.getInt("GuiWritingStats", "winHeight", 500))
         )
 
         # List Box
-        wCol0 = self.mainConf.pxInt(
+        wCol0 = CONFIG.pxInt(
             pOptions.getInt("GuiWritingStats", "widthCol0", 180)
         )
-        wCol1 = self.mainConf.pxInt(
+        wCol1 = CONFIG.pxInt(
             pOptions.getInt("GuiWritingStats", "widthCol1", 80)
         )
-        wCol2 = self.mainConf.pxInt(
+        wCol2 = CONFIG.pxInt(
             pOptions.getInt("GuiWritingStats", "widthCol2", 80)
         )
-        wCol3 = self.mainConf.pxInt(
+        wCol3 = CONFIG.pxInt(
             pOptions.getInt("GuiWritingStats", "widthCol3", 80)
         )
 
@@ -127,7 +126,7 @@ class GuiWritingStats(QDialog):
 
         # Word Bar
         self.barHeight = int(round(0.5*self.mainTheme.fontPixelSize))
-        self.barWidth = self.mainConf.pxInt(200)
+        self.barWidth = CONFIG.pxInt(200)
         self.barImage = QPixmap(self.barHeight, self.barHeight)
         self.barImage.fill(self.palette().highlight().color())
 
@@ -309,12 +308,12 @@ class GuiWritingStats(QDialog):
         """
         self.logData = []
 
-        winWidth     = self.mainConf.rpxInt(self.width())
-        winHeight    = self.mainConf.rpxInt(self.height())
-        widthCol0    = self.mainConf.rpxInt(self.listBox.columnWidth(0))
-        widthCol1    = self.mainConf.rpxInt(self.listBox.columnWidth(1))
-        widthCol2    = self.mainConf.rpxInt(self.listBox.columnWidth(2))
-        widthCol3    = self.mainConf.rpxInt(self.listBox.columnWidth(3))
+        winWidth     = CONFIG.rpxInt(self.width())
+        winHeight    = CONFIG.rpxInt(self.height())
+        widthCol0    = CONFIG.rpxInt(self.listBox.columnWidth(0))
+        widthCol1    = CONFIG.rpxInt(self.listBox.columnWidth(1))
+        widthCol2    = CONFIG.rpxInt(self.listBox.columnWidth(2))
+        widthCol3    = CONFIG.rpxInt(self.listBox.columnWidth(3))
         sortCol      = self.listBox.sortColumn()
         sortOrder    = self.listBox.header().sortIndicatorOrder()
         incNovel     = self.incNovel.isChecked()
@@ -362,14 +361,14 @@ class GuiWritingStats(QDialog):
             return False
 
         # Generate the file name
-        savePath = self.mainConf.lastPath() / f"sessionStats.{fileExt}"
+        savePath = CONFIG.lastPath() / f"sessionStats.{fileExt}"
         savePath, _ = QFileDialog.getSaveFileName(
             self, self.tr("Save Data As"), str(savePath), "%s (*.%s)" % (textFmt, fileExt)
         )
         if not savePath:
             return False
 
-        self.mainConf.setLastPath(savePath)
+        CONFIG.setLastPath(savePath)
 
         # Do the actual writing
         wSuccess = False

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -31,7 +31,6 @@ class MockGuiMain(QObject):
     def __init__(self):
         super().__init__()
 
-        self.mainConf = None
         self.hasProject = True
         self.theProject = None
         self.mainStatus = MockStatusBar()

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from mock import causeOSError, MockApp
 from tools import cmpFiles, writeFile
 
+from novelwriter import CONFIG
 from novelwriter.config import Config, RecentProjects
 from novelwriter.constants import nwFiles
 
@@ -196,197 +197,206 @@ def testBaseConfig_Localisation(fncPath, tstPaths):
 
 
 @pytest.mark.base
-def testBaseConfig_Methods(tmpConf, tmpPath):
+def testBaseConfig_Methods(fncPath):
     """Check class methods.
     """
+    tstConf = Config()
+    tstConf.initConfig(confPath=fncPath, dataPath=fncPath)
+
     # Data Path
-    assert tmpConf.dataPath() == tmpPath
-    assert tmpConf.dataPath("stuff") == tmpPath / "stuff"
+    assert tstConf.dataPath() == fncPath
+    assert tstConf.dataPath("stuff") == fncPath / "stuff"
 
     # Assets Path
-    appPath = tmpConf._appPath
-    assert tmpConf.assetPath() == appPath / "assets"
-    assert tmpConf.assetPath("stuff") == appPath / "assets" / "stuff"
+    appPath = tstConf._appPath
+    assert tstConf.assetPath() == appPath / "assets"
+    assert tstConf.assetPath("stuff") == appPath / "assets" / "stuff"
 
     # Last Path
-    assert tmpConf.lastPath() == tmpPath
+    assert tstConf.lastPath() == Path.home().absolute()
 
-    tmpStuff = tmpPath / "stuff"
+    tmpStuff = fncPath / "stuff"
     tmpStuff.mkdir()
-    tmpConf.setLastPath(tmpStuff)
-    assert tmpConf.lastPath() == tmpStuff
+    tstConf.setLastPath(tmpStuff)
+    assert tstConf.lastPath() == tmpStuff
 
     fileStuff = tmpStuff / "more_stuff.txt"
     fileStuff.write_text("Stuff")
-    tmpConf.setLastPath(fileStuff)
-    assert tmpConf.lastPath() == tmpStuff
+    tstConf.setLastPath(fileStuff)
+    assert tstConf.lastPath() == tmpStuff
 
     fileStuff.unlink()
     tmpStuff.rmdir()
-    assert tmpConf.lastPath() == Path.home().absolute()
+    assert tstConf.lastPath() == Path.home().absolute()
 
     # Recent Projects
-    assert isinstance(tmpConf.recentProjects, RecentProjects)
+    assert isinstance(tstConf.recentProjects, RecentProjects)
 
 # END Test testBaseConfig_Methods
 
 
 @pytest.mark.base
-def testBaseConfig_SettersGetters(tmpConf):
+def testBaseConfig_SettersGetters(fncPath):
     """Set various sizes and positions
     """
+    tstConf = Config()
+    tstConf.initConfig(confPath=fncPath, dataPath=fncPath)
+
     # GUI Scaling
     # ===========
 
-    tmpConf.guiScale = 1.0
-    assert tmpConf.pxInt(10) == 10
-    assert tmpConf.pxInt(13) == 13
-    assert tmpConf.rpxInt(10) == 10
-    assert tmpConf.rpxInt(13) == 13
+    tstConf.guiScale = 1.0
+    assert tstConf.pxInt(10) == 10
+    assert tstConf.pxInt(13) == 13
+    assert tstConf.rpxInt(10) == 10
+    assert tstConf.rpxInt(13) == 13
 
-    tmpConf.guiScale = 2.0
-    assert tmpConf.pxInt(10) == 20
-    assert tmpConf.pxInt(13) == 26
-    assert tmpConf.rpxInt(10) == 5
-    assert tmpConf.rpxInt(13) == 6
+    tstConf.guiScale = 2.0
+    assert tstConf.pxInt(10) == 20
+    assert tstConf.pxInt(13) == 26
+    assert tstConf.rpxInt(10) == 5
+    assert tstConf.rpxInt(13) == 6
 
     # Setter + Getter Combos
     # ======================
 
     # Window Size
-    tmpConf.guiScale = 1.0
-    tmpConf.setMainWinSize(1205, 655)
-    assert tmpConf.mainWinSize == [1200, 650]
+    tstConf.guiScale = 1.0
+    tstConf.setMainWinSize(1205, 655)
+    assert tstConf.mainWinSize == [1200, 650]
 
-    tmpConf.guiScale = 2.0
-    tmpConf.setMainWinSize(70, 70)
-    assert tmpConf.mainWinSize == [70, 70]
-    assert tmpConf._mainWinSize == [35, 35]
+    tstConf.guiScale = 2.0
+    tstConf.setMainWinSize(70, 70)
+    assert tstConf.mainWinSize == [70, 70]
+    assert tstConf._mainWinSize == [35, 35]
 
-    tmpConf.guiScale = 1.0
-    tmpConf.setMainWinSize(70, 70)
-    assert tmpConf.mainWinSize == [70, 70]
-    assert tmpConf._mainWinSize == [70, 70]
+    tstConf.guiScale = 1.0
+    tstConf.setMainWinSize(70, 70)
+    assert tstConf.mainWinSize == [70, 70]
+    assert tstConf._mainWinSize == [70, 70]
 
-    tmpConf.setMainWinSize(1200, 650)
+    tstConf.setMainWinSize(1200, 650)
 
     # Preferences Size
-    tmpConf.guiScale = 2.0
-    tmpConf.setPreferencesWinSize(70, 70)
-    assert tmpConf.preferencesWinSize == [70, 70]
-    assert tmpConf._prefsWinSize == [35, 35]
+    tstConf.guiScale = 2.0
+    tstConf.setPreferencesWinSize(70, 70)
+    assert tstConf.preferencesWinSize == [70, 70]
+    assert tstConf._prefsWinSize == [35, 35]
 
-    tmpConf.guiScale = 1.0
-    tmpConf.setPreferencesWinSize(70, 70)
-    assert tmpConf.preferencesWinSize == [70, 70]
-    assert tmpConf._prefsWinSize == [70, 70]
+    tstConf.guiScale = 1.0
+    tstConf.setPreferencesWinSize(70, 70)
+    assert tstConf.preferencesWinSize == [70, 70]
+    assert tstConf._prefsWinSize == [70, 70]
 
-    tmpConf.setPreferencesWinSize(700, 615)
+    tstConf.setPreferencesWinSize(700, 615)
 
     # Project Settings Tree Columns
-    tmpConf.guiScale = 2.0
-    tmpConf.setProjLoadColWidths([10, 20, 30])
-    assert tmpConf.projLoadColWidths == [10, 20, 30]
-    assert tmpConf._projLoadCols == [5, 10, 15]
+    tstConf.guiScale = 2.0
+    tstConf.setProjLoadColWidths([10, 20, 30])
+    assert tstConf.projLoadColWidths == [10, 20, 30]
+    assert tstConf._projLoadCols == [5, 10, 15]
 
-    tmpConf.guiScale = 1.0
-    tmpConf.setProjLoadColWidths([10, 20, 30])
-    assert tmpConf.projLoadColWidths == [10, 20, 30]
-    assert tmpConf._projLoadCols == [10, 20, 30]
+    tstConf.guiScale = 1.0
+    tstConf.setProjLoadColWidths([10, 20, 30])
+    assert tstConf.projLoadColWidths == [10, 20, 30]
+    assert tstConf._projLoadCols == [10, 20, 30]
 
-    tmpConf.setProjLoadColWidths([200, 60, 140])
+    tstConf.setProjLoadColWidths([200, 60, 140])
 
     # Main Pane Splitter
-    tmpConf.guiScale = 2.0
-    tmpConf.setMainPanePos([200, 700])
-    assert tmpConf.mainPanePos == [200, 700]
-    assert tmpConf._mainPanePos == [100, 350]
+    tstConf.guiScale = 2.0
+    tstConf.setMainPanePos([200, 700])
+    assert tstConf.mainPanePos == [200, 700]
+    assert tstConf._mainPanePos == [100, 350]
 
-    tmpConf.guiScale = 1.0
-    tmpConf.setMainPanePos([200, 700])
-    assert tmpConf.mainPanePos == [200, 700]
-    assert tmpConf._mainPanePos == [200, 700]
+    tstConf.guiScale = 1.0
+    tstConf.setMainPanePos([200, 700])
+    assert tstConf.mainPanePos == [200, 700]
+    assert tstConf._mainPanePos == [200, 700]
 
-    tmpConf.setMainPanePos([300, 800])
+    tstConf.setMainPanePos([300, 800])
 
     # View Pane Splitter
-    tmpConf.guiScale = 2.0
-    tmpConf.setViewPanePos([400, 250])
-    assert tmpConf.viewPanePos == [400, 250]
-    assert tmpConf._viewPanePos == [200, 125]
+    tstConf.guiScale = 2.0
+    tstConf.setViewPanePos([400, 250])
+    assert tstConf.viewPanePos == [400, 250]
+    assert tstConf._viewPanePos == [200, 125]
 
-    tmpConf.guiScale = 1.0
-    tmpConf.setViewPanePos([400, 250])
-    assert tmpConf.viewPanePos == [400, 250]
-    assert tmpConf._viewPanePos == [400, 250]
+    tstConf.guiScale = 1.0
+    tstConf.setViewPanePos([400, 250])
+    assert tstConf.viewPanePos == [400, 250]
+    assert tstConf._viewPanePos == [400, 250]
 
-    tmpConf.setViewPanePos([500, 150])
+    tstConf.setViewPanePos([500, 150])
 
     # Outline Pane Splitter
-    tmpConf.guiScale = 2.0
-    tmpConf.setOutlinePanePos([400, 250])
-    assert tmpConf.outlinePanePos == [400, 250]
-    assert tmpConf._outlnPanePos == [200, 125]
+    tstConf.guiScale = 2.0
+    tstConf.setOutlinePanePos([400, 250])
+    assert tstConf.outlinePanePos == [400, 250]
+    assert tstConf._outlnPanePos == [200, 125]
 
-    tmpConf.guiScale = 1.0
-    tmpConf.setOutlinePanePos([400, 250])
-    assert tmpConf.outlinePanePos == [400, 250]
-    assert tmpConf._outlnPanePos == [400, 250]
+    tstConf.guiScale = 1.0
+    tstConf.setOutlinePanePos([400, 250])
+    assert tstConf.outlinePanePos == [400, 250]
+    assert tstConf._outlnPanePos == [400, 250]
 
-    tmpConf.setOutlinePanePos([500, 150])
+    tstConf.setOutlinePanePos([500, 150])
 
     # Getters Only
     # ============
 
-    tmpConf.guiScale = 1.0
-    assert tmpConf.getTextWidth(False) == 700
-    assert tmpConf.getTextWidth(True) == 800
-    assert tmpConf.getTextMargin() == 40
-    assert tmpConf.getTabWidth() == 40
+    tstConf.guiScale = 1.0
+    assert tstConf.getTextWidth(False) == 700
+    assert tstConf.getTextWidth(True) == 800
+    assert tstConf.getTextMargin() == 40
+    assert tstConf.getTabWidth() == 40
 
-    tmpConf.guiScale = 2.0
-    assert tmpConf.getTextWidth(False) == 1400
-    assert tmpConf.getTextWidth(True) == 1600
-    assert tmpConf.getTextMargin() == 80
-    assert tmpConf.getTabWidth() == 80
+    tstConf.guiScale = 2.0
+    assert tstConf.getTextWidth(False) == 1400
+    assert tstConf.getTextWidth(True) == 1600
+    assert tstConf.getTextMargin() == 80
+    assert tstConf.getTabWidth() == 80
 
 # END Test testBaseConfig_SettersGetters
 
 
 @pytest.mark.base
-def testBaseConfig_Internal(monkeypatch, tmpConf):
+def testBaseConfig_Internal(monkeypatch, fncPath):
     """Check internal functions.
     """
+    tstConf = Config()
+    tstConf.initConfig(confPath=fncPath, dataPath=fncPath)
+
     # Function _packList
-    assert tmpConf._packList(["A", 1, 2.0, None, False]) == "A, 1, 2.0, None, False"
+    assert tstConf._packList(["A", 1, 2.0, None, False]) == "A, 1, 2.0, None, False"
 
     # Function _checkNone
-    assert tmpConf._checkNone(None) is None
-    assert tmpConf._checkNone("None") is None
-    assert tmpConf._checkNone("none") is None
-    assert tmpConf._checkNone("NONE") is None
-    assert tmpConf._checkNone("NoNe") is None
-    assert tmpConf._checkNone(123456) == 123456
+    assert tstConf._checkNone(None) is None
+    assert tstConf._checkNone("None") is None
+    assert tstConf._checkNone("none") is None
+    assert tstConf._checkNone("NONE") is None
+    assert tstConf._checkNone("NoNe") is None
+    assert tstConf._checkNone(123456) == 123456
 
     # Function _checkOptionalPackages
     # (Assumes enchant package exists and is importable)
-    tmpConf._checkOptionalPackages()
-    assert tmpConf.hasEnchant is True
+    tstConf._checkOptionalPackages()
+    assert tstConf.hasEnchant is True
 
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "enchant", None)
-        tmpConf._checkOptionalPackages()
-        assert tmpConf.hasEnchant is False
+        tstConf._checkOptionalPackages()
+        assert tstConf.hasEnchant is False
 
 # END Test testBaseConfig_Internal
 
 
 @pytest.mark.base
-def testBaseConfig_RecentCache(monkeypatch, fncConf, fncPath):
+def testBaseConfig_RecentCache(monkeypatch, tstPaths):
     """Test recent cache file.
     """
-    cacheFile = fncPath / nwFiles.RECENT_FILE
-    recent = RecentProjects(fncConf)
+    cacheFile = tstPaths.cnfDir / nwFiles.RECENT_FILE
+    recent = RecentProjects(CONFIG)
 
     # Load when there is no file should pass, but load nothing
     assert not cacheFile.exists()
@@ -394,8 +404,8 @@ def testBaseConfig_RecentCache(monkeypatch, fncConf, fncPath):
     assert recent.listEntries() == []
 
     # Add a couple of values
-    pathOne = fncPath / "projPathOne" / nwFiles.PROJ_FILE
-    pathTwo = fncPath / "projPathTwo" / nwFiles.PROJ_FILE
+    pathOne = tstPaths.cnfDir / "projPathOne" / nwFiles.PROJ_FILE
+    pathTwo = tstPaths.cnfDir / "projPathTwo" / nwFiles.PROJ_FILE
 
     recent.update(pathOne, "Proj One", 100, 1600002000)
     recent.update(pathTwo, "Proj Two", 200, 1600005600)

--- a/tests/test_base/test_base_init.py
+++ b/tests/test_base/test_base_init.py
@@ -22,9 +22,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import sys
 import pytest
 import logging
-import novelwriter
 
 from mock import MockGuiMain
+
+from novelwriter import CONFIG, main, logger
 
 
 @pytest.mark.base
@@ -34,34 +35,34 @@ def testBaseInit_Launch(caplog, monkeypatch, fncPath):
     monkeypatch.setattr("novelwriter.guimain.GuiMain", MockGuiMain)
 
     # TestMode Launch
-    nwGUI = novelwriter.main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
+    nwGUI = main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
     assert isinstance(nwGUI, MockGuiMain)
 
     # Darwin Launch
     caplog.clear()
-    osDarwin = novelwriter.CONFIG.osDarwin
-    novelwriter.CONFIG.osDarwin = True
+    osDarwin = CONFIG.osDarwin
+    CONFIG.osDarwin = True
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "Foundation", None)
-        nwGUI = novelwriter.main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
+        nwGUI = main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
         assert isinstance(nwGUI, MockGuiMain)
         assert "Failed" in caplog.text
 
-    novelwriter.CONFIG.osDarwin = osDarwin
+    CONFIG.osDarwin = osDarwin
 
     # Windows Launch
     caplog.clear()
-    osWindows = novelwriter.CONFIG.osWindows
-    novelwriter.CONFIG.osWindows = True
+    osWindows = CONFIG.osWindows
+    CONFIG.osWindows = True
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "ctypes", None)
-        nwGUI = novelwriter.main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
+        nwGUI = main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
         assert isinstance(nwGUI, MockGuiMain)
         if not sys.platform.startswith("darwin"):
             # For some reason, the test doesn't work on macOS
             assert "Failed" in caplog.text
 
-    novelwriter.CONFIG.osWindows = osWindows
+    CONFIG.osWindows = osWindows
 
     # Normal Launch
     monkeypatch.setattr("PyQt5.QtWidgets.QApplication.__init__", lambda *a: None)
@@ -71,7 +72,7 @@ def testBaseInit_Launch(caplog, monkeypatch, fncPath):
     monkeypatch.setattr("PyQt5.QtWidgets.QApplication.setOrganizationDomain", lambda *a: None)
     monkeypatch.setattr("PyQt5.QtWidgets.QApplication.exec_", lambda *a: 0)
     with pytest.raises(SystemExit) as ex:
-        novelwriter.main([f"--config={fncPath}", f"--data={fncPath}"])
+        main([f"--config={fncPath}", f"--data={fncPath}"])
         assert ex.value.code == 0
 
 # END Test testBaseInit_Launch
@@ -87,40 +88,40 @@ def testBaseInit_Options(monkeypatch, fncPath):
     ])
 
     # Defaults w/None Args
-    nwGUI = novelwriter.main()
-    assert novelwriter.logger.getEffectiveLevel() == logging.WARNING
+    nwGUI = main()
+    assert logger.getEffectiveLevel() == logging.WARNING
     assert nwGUI.closeMain() == "closeMain"
 
     # Defaults
-    nwGUI = novelwriter.main(
+    nwGUI = main(
         ["--testmode", f"--config={fncPath}", f"--data={fncPath}", "--style=Fusion"]
     )
-    assert novelwriter.logger.getEffectiveLevel() == logging.WARNING
+    assert logger.getEffectiveLevel() == logging.WARNING
     assert nwGUI.closeMain() == "closeMain"
 
     # Log Levels
-    nwGUI = novelwriter.main(
+    nwGUI = main(
         ["--testmode", "--info", f"--config={fncPath}", f"--data={fncPath}"]
     )
-    assert novelwriter.logger.getEffectiveLevel() == logging.INFO
+    assert logger.getEffectiveLevel() == logging.INFO
     assert nwGUI.closeMain() == "closeMain"
 
-    nwGUI = novelwriter.main(
+    nwGUI = main(
         ["--testmode", "--debug", f"--config={fncPath}", f"--data={fncPath}"]
     )
-    assert novelwriter.logger.getEffectiveLevel() == logging.DEBUG
+    assert logger.getEffectiveLevel() == logging.DEBUG
     assert nwGUI.closeMain() == "closeMain"
 
     # Help and Version
     with pytest.raises(SystemExit) as ex:
-        nwGUI = novelwriter.main(
+        nwGUI = main(
             ["--testmode", "--help", f"--config={fncPath}", f"--data={fncPath}"]
         )
     assert nwGUI.closeMain() == "closeMain"
     assert ex.value.code == 0
 
     with pytest.raises(SystemExit) as ex:
-        nwGUI = novelwriter.main(
+        nwGUI = main(
             ["--testmode", "--version", f"--config={fncPath}", f"--data={fncPath}"]
         )
     assert nwGUI.closeMain() == "closeMain"
@@ -128,14 +129,14 @@ def testBaseInit_Options(monkeypatch, fncPath):
 
     # Invalid options
     with pytest.raises(SystemExit) as ex:
-        nwGUI = novelwriter.main(
+        nwGUI = main(
             ["--testmode", "--invalid", f"--config={fncPath}", f"--data={fncPath}"]
         )
     assert nwGUI.closeMain() == "closeMain"
     assert ex.value.code == 2
 
     # Project Path
-    nwGUI = novelwriter.main(
+    nwGUI = main(
         ["--testmode", f"--config={fncPath}", f"--data={fncPath}", "sample/"]
     )
     assert nwGUI.closeMain() == "closeMain"
@@ -159,7 +160,7 @@ def testBaseInit_Imports(caplog, monkeypatch, fncPath):
     monkeypatch.setattr("novelwriter.CONFIG.verPyQtValue", 0x050000)
 
     with pytest.raises(SystemExit) as ex:
-        _ = novelwriter.main(
+        _ = main(
             ["--testmode", f"--config={fncPath}", f"--data={fncPath}"]
         )
 

--- a/tests/test_base/test_base_init.py
+++ b/tests/test_base/test_base_init.py
@@ -28,13 +28,13 @@ from mock import MockGuiMain
 
 
 @pytest.mark.base
-def testBaseInit_Launch(caplog, monkeypatch, tmpPath):
+def testBaseInit_Launch(caplog, monkeypatch, fncPath):
     """Check launching the main GUI.
     """
     monkeypatch.setattr("novelwriter.guimain.GuiMain", MockGuiMain)
 
     # TestMode Launch
-    nwGUI = novelwriter.main(["--testmode", f"--config={tmpPath}", f"--data={tmpPath}"])
+    nwGUI = novelwriter.main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
     assert isinstance(nwGUI, MockGuiMain)
 
     # Darwin Launch
@@ -43,7 +43,7 @@ def testBaseInit_Launch(caplog, monkeypatch, tmpPath):
     novelwriter.CONFIG.osDarwin = True
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "Foundation", None)
-        nwGUI = novelwriter.main(["--testmode", f"--config={tmpPath}", f"--data={tmpPath}"])
+        nwGUI = novelwriter.main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
         assert isinstance(nwGUI, MockGuiMain)
         assert "Failed" in caplog.text
 
@@ -55,7 +55,7 @@ def testBaseInit_Launch(caplog, monkeypatch, tmpPath):
     novelwriter.CONFIG.osWindows = True
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "ctypes", None)
-        nwGUI = novelwriter.main(["--testmode", f"--config={tmpPath}", f"--data={tmpPath}"])
+        nwGUI = novelwriter.main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
         assert isinstance(nwGUI, MockGuiMain)
         if not sys.platform.startswith("darwin"):
             # For some reason, the test doesn't work on macOS
@@ -71,19 +71,19 @@ def testBaseInit_Launch(caplog, monkeypatch, tmpPath):
     monkeypatch.setattr("PyQt5.QtWidgets.QApplication.setOrganizationDomain", lambda *a: None)
     monkeypatch.setattr("PyQt5.QtWidgets.QApplication.exec_", lambda *a: 0)
     with pytest.raises(SystemExit) as ex:
-        novelwriter.main([f"--config={tmpPath}", f"--data={tmpPath}"])
+        novelwriter.main([f"--config={fncPath}", f"--data={fncPath}"])
         assert ex.value.code == 0
 
 # END Test testBaseInit_Launch
 
 
 @pytest.mark.base
-def testBaseInit_Options(monkeypatch, tmpPath):
+def testBaseInit_Options(monkeypatch, fncPath):
     """Test command line options for logging level.
     """
     monkeypatch.setattr("novelwriter.guimain.GuiMain", MockGuiMain)
     monkeypatch.setattr(sys, "argv", [
-        "novelWriter.py", "--testmode", f"--config={tmpPath}", f"--data={tmpPath}"
+        "novelWriter.py", "--testmode", f"--config={fncPath}", f"--data={fncPath}"
     ])
 
     # Defaults w/None Args
@@ -93,20 +93,20 @@ def testBaseInit_Options(monkeypatch, tmpPath):
 
     # Defaults
     nwGUI = novelwriter.main(
-        ["--testmode", f"--config={tmpPath}", f"--data={tmpPath}", "--style=Fusion"]
+        ["--testmode", f"--config={fncPath}", f"--data={fncPath}", "--style=Fusion"]
     )
     assert novelwriter.logger.getEffectiveLevel() == logging.WARNING
     assert nwGUI.closeMain() == "closeMain"
 
     # Log Levels
     nwGUI = novelwriter.main(
-        ["--testmode", "--info", f"--config={tmpPath}", f"--data={tmpPath}"]
+        ["--testmode", "--info", f"--config={fncPath}", f"--data={fncPath}"]
     )
     assert novelwriter.logger.getEffectiveLevel() == logging.INFO
     assert nwGUI.closeMain() == "closeMain"
 
     nwGUI = novelwriter.main(
-        ["--testmode", "--debug", f"--config={tmpPath}", f"--data={tmpPath}"]
+        ["--testmode", "--debug", f"--config={fncPath}", f"--data={fncPath}"]
     )
     assert novelwriter.logger.getEffectiveLevel() == logging.DEBUG
     assert nwGUI.closeMain() == "closeMain"
@@ -114,14 +114,14 @@ def testBaseInit_Options(monkeypatch, tmpPath):
     # Help and Version
     with pytest.raises(SystemExit) as ex:
         nwGUI = novelwriter.main(
-            ["--testmode", "--help", f"--config={tmpPath}", f"--data={tmpPath}"]
+            ["--testmode", "--help", f"--config={fncPath}", f"--data={fncPath}"]
         )
     assert nwGUI.closeMain() == "closeMain"
     assert ex.value.code == 0
 
     with pytest.raises(SystemExit) as ex:
         nwGUI = novelwriter.main(
-            ["--testmode", "--version", f"--config={tmpPath}", f"--data={tmpPath}"]
+            ["--testmode", "--version", f"--config={fncPath}", f"--data={fncPath}"]
         )
     assert nwGUI.closeMain() == "closeMain"
     assert ex.value.code == 0
@@ -129,14 +129,14 @@ def testBaseInit_Options(monkeypatch, tmpPath):
     # Invalid options
     with pytest.raises(SystemExit) as ex:
         nwGUI = novelwriter.main(
-            ["--testmode", "--invalid", f"--config={tmpPath}", f"--data={tmpPath}"]
+            ["--testmode", "--invalid", f"--config={fncPath}", f"--data={fncPath}"]
         )
     assert nwGUI.closeMain() == "closeMain"
     assert ex.value.code == 2
 
     # Project Path
     nwGUI = novelwriter.main(
-        ["--testmode", f"--config={tmpPath}", f"--data={tmpPath}", "sample/"]
+        ["--testmode", f"--config={fncPath}", f"--data={fncPath}", "sample/"]
     )
     assert nwGUI.closeMain() == "closeMain"
 
@@ -144,7 +144,7 @@ def testBaseInit_Options(monkeypatch, tmpPath):
 
 
 @pytest.mark.base
-def testBaseInit_Imports(caplog, monkeypatch, tmpPath):
+def testBaseInit_Imports(caplog, monkeypatch, fncPath):
     """Check import error handling.
     """
     monkeypatch.setattr("novelwriter.guimain.GuiMain", MockGuiMain)
@@ -160,7 +160,7 @@ def testBaseInit_Imports(caplog, monkeypatch, tmpPath):
 
     with pytest.raises(SystemExit) as ex:
         _ = novelwriter.main(
-            ["--testmode", f"--config={tmpPath}", f"--data={tmpPath}"]
+            ["--testmode", f"--config={fncPath}", f"--data={fncPath}"]
         )
 
     assert ex.value.code & 4 == 4    # Python version not satisfied

--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -28,6 +28,7 @@ from zipfile import ZipFile
 from mock import causeOSError
 from tools import C, buildTestProject, cmpFiles, XML_IGNORE
 
+from novelwriter import CONFIG
 from novelwriter.constants import nwItemClass
 from novelwriter.core.project import NWProject
 from novelwriter.core.coretools import DocMerger, DocSplitter, ProjectBuilder
@@ -371,7 +372,7 @@ def testCoreTools_NewCustomB(monkeypatch, fncPath, tstPaths, mockGUI, mockRnd):
 
 
 @pytest.mark.core
-def testCoreTools_NewSample(monkeypatch, fncPath, tmpConf, tmpPath, mockGUI):
+def testCoreTools_NewSample(monkeypatch, fncPath, tstPaths, mockGUI):
     """Check that we can create a new project can be created from the
     provided sample project via a zip file.
     """
@@ -391,10 +392,10 @@ def testCoreTools_NewSample(monkeypatch, fncPath, tmpConf, tmpPath, mockGUI):
     assert projBuild.buildProject({"popSample": True}) is False
 
     # Force the lookup path for assets to our temp folder
-    srcSample = tmpConf._appRoot / "sample"
-    dstSample = tmpPath / "sample.zip"
+    srcSample = CONFIG._appRoot / "sample"
+    dstSample = tstPaths.tmpDir / "sample.zip"
     monkeypatch.setattr(
-        "novelwriter.config.Config.assetPath", lambda *a: tmpPath / "sample.zip"
+        "novelwriter.config.Config.assetPath", lambda *a: tstPaths.tmpDir / "sample.zip"
     )
 
     # Cannot extract when the zip does not exist

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -704,7 +704,7 @@ def testCoreProject_OrphanedFiles(mockGUI, prjLipsum):
 
 
 @pytest.mark.core
-def testCoreProject_Backup(monkeypatch, mockGUI, fncPath, tmpPath):
+def testCoreProject_Backup(monkeypatch, mockGUI, fncPath, tstPaths):
     """Test the automated backup feature of the project class. The test
     creates a backup of the Minimal test project, and then unzips the
     backupd file and checks that the project XML file is identical to
@@ -720,23 +720,18 @@ def testCoreProject_Backup(monkeypatch, mockGUI, fncPath, tmpPath):
     # Invalid Settings
     # ================
 
-    # No project
-    mockGUI.hasProject = False
-    assert theProject.backupProject(doNotify=False) is False
-    mockGUI.hasProject = True
-
     # Invalid path
     theProject.mainConf._backupPath = None
     assert theProject.backupProject(doNotify=False) is False
 
     # Missing project name
-    theProject.mainConf._backupPath = tmpPath
+    theProject.mainConf._backupPath = tstPaths.tmpDir
     theProject.data.setName("")
     assert theProject.backupProject(doNotify=False) is False
 
     # Valid Settings
     # ==============
-    theProject.mainConf._backupPath = tmpPath
+    theProject.mainConf._backupPath = tstPaths.tmpDir
     theProject.data.setName("Test Minimal")
 
     # Can't make folder
@@ -752,7 +747,7 @@ def testCoreProject_Backup(monkeypatch, mockGUI, fncPath, tmpPath):
     # Test correct settings
     assert theProject.backupProject(doNotify=True) is True
 
-    theFiles = list((tmpPath / "Test Minimal").iterdir())
+    theFiles = list((tstPaths.tmpDir / "Test Minimal").iterdir())
     assert len(theFiles) == 1
 
     theZip = theFiles[0].name
@@ -760,13 +755,13 @@ def testCoreProject_Backup(monkeypatch, mockGUI, fncPath, tmpPath):
     assert theZip[-4:] == ".zip"
 
     # Extract the archive
-    with ZipFile(tmpPath / "Test Minimal" / theZip, mode="r") as inZip:
-        inZip.extractall(tmpPath / "extract")
+    with ZipFile(tstPaths.tmpDir / "Test Minimal" / theZip, mode="r") as inZip:
+        inZip.extractall(tstPaths.tmpDir / "extract")
 
     # Check that the main project file was restored
     assert cmpFiles(
         fncPath / "nwProject.nwx",
-        tmpPath / "extract" / "nwProject.nwx"
+        tstPaths.tmpDir / "extract" / "nwProject.nwx"
     )
 
 # END Test testCoreProject_Backup

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -29,6 +29,7 @@ from zipfile import ZipFile
 from mock import causeOSError
 from tools import C, cmpFiles, writeFile, buildTestProject, XML_IGNORE
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwItemClass, nwItemType, nwItemLayout
 from novelwriter.common import formatTimeStamp
 from novelwriter.constants import nwFiles
@@ -721,17 +722,17 @@ def testCoreProject_Backup(monkeypatch, mockGUI, fncPath, tstPaths):
     # ================
 
     # Invalid path
-    theProject.mainConf._backupPath = None
+    CONFIG._backupPath = None
     assert theProject.backupProject(doNotify=False) is False
 
     # Missing project name
-    theProject.mainConf._backupPath = tstPaths.tmpDir
+    CONFIG._backupPath = tstPaths.tmpDir
     theProject.data.setName("")
     assert theProject.backupProject(doNotify=False) is False
 
     # Valid Settings
     # ==============
-    theProject.mainConf._backupPath = tstPaths.tmpDir
+    CONFIG._backupPath = tstPaths.tmpDir
     theProject.data.setName("Test Minimal")
 
     # Can't make folder

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -40,8 +40,8 @@ class MockProject:
 
 @pytest.fixture(scope="function", autouse=True)
 def mockVersion(monkeypatch):
-    monkeypatch.setattr("novelwriter.__version__", "2.0-rc1")
-    monkeypatch.setattr("novelwriter.__hexversion__", "0x020000c1")
+    monkeypatch.setattr("novelwriter.core.projectxml.__version__", "2.0-rc1")
+    monkeypatch.setattr("novelwriter.core.projectxml.__hexversion__", "0x020000c1")
     return
 
 

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -25,6 +25,7 @@ import pytest
 from mock import causeOSError
 from tools import C, buildTestProject, writeFile
 
+from novelwriter import CONFIG
 from novelwriter.constants import nwFiles
 from novelwriter.core.project import NWProject
 from novelwriter.core.storage import NWStorage
@@ -148,9 +149,9 @@ def testCoreStorage_LockFile(monkeypatch, fncPath):
 
     # Successful read
     assert storage.readLockFile() == [
-        storage.mainConf.hostName,
-        storage.mainConf.osType,
-        storage.mainConf.kernelVer,
+        CONFIG.hostName,
+        CONFIG.osType,
+        CONFIG.kernelVer,
         "1000",
     ]
 

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -299,10 +299,10 @@ def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
 
 
 @pytest.mark.core
-def testCoreStorage_ZipIt(monkeypatch, mockGUI, fncPath, tmpPath, mockRnd):
+def testCoreStorage_ZipIt(monkeypatch, mockGUI, fncPath, tstPaths, mockRnd):
     """Test making a zip archive of a project.
     """
-    zipFile = tmpPath / "project.zip"
+    zipFile = tstPaths.tmpDir / "project.zip"
 
     theProject = NWProject(mockGUI)
     storage = theProject.storage

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -437,7 +437,7 @@ def testCoreTree_Reorder(caplog, mockGUI, mockItems):
 
 
 @pytest.mark.core
-def testCoreTree_ToCFile(monkeypatch, mockGUI, mockItems, tmpPath):
+def testCoreTree_ToCFile(monkeypatch, tstPaths, mockGUI, mockItems):
     """Test writing the ToC.txt file.
     """
     theProject = NWProject(mockGUI)
@@ -463,20 +463,20 @@ def testCoreTree_ToCFile(monkeypatch, mockGUI, mockItems, tmpPath):
     theProject._storage._runtimePath = None
     assert theTree.writeToCFile() is False
 
-    theProject._storage._runtimePath = tmpPath
+    theProject._storage._runtimePath = tstPaths.tmpDir
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", causeOSError)
         assert theTree.writeToCFile() is False
 
-    theProject._storage._runtimePath = tmpPath
-    (tmpPath / "content").mkdir()
+    theProject._storage._runtimePath = tstPaths.tmpDir
+    (tstPaths.tmpDir / "content").mkdir()
     assert theTree.writeToCFile() is True
 
     pathA = str(Path("content") / "c000000000001.nwd")
     pathB = str(Path("content") / "c000000000002.nwd")
     pathC = str(Path("content") / "b000000000002.nwd")
 
-    assert readFile(tmpPath / nwFiles.TOC_TXT) == (
+    assert readFile(tstPaths.tmpDir / nwFiles.TOC_TXT) == (
         "\n"
         "Table of Contents\n"
         "=================\n"

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -30,6 +30,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox, QDialog, QAction, QFileDialog, QFontDialog
 )
 
+from novelwriter import CONFIG
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 from novelwriter.dialogs.preferences import GuiPreferences
 
@@ -211,7 +212,7 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     qtbot.mouseClick(nwPrefs.buttonBox.button(QDialogButtonBox.Ok), Qt.LeftButton)
     nwPrefs._doClose()
 
-    assert nwGUI.mainConf.saveConfig()
+    assert CONFIG.saveConfig()
     projFile = tstPaths.cnfDir / "novelwriter.conf"
     testFile = tstPaths.outDir / "guiPreferences_novelwriter.conf"
     compFile = tstPaths.refDir / "guiPreferences_novelwriter.conf"

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -37,12 +37,9 @@ KEY_DELAY = 1
 
 
 @pytest.mark.gui
-def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
+def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     """Test the load project wizard.
     """
-    theConf = nwGUI.mainConf
-    assert theConf._confPath == fncPath
-
     monkeypatch.setattr(GuiPreferences, "exec_", lambda *a: None)
     monkeypatch.setattr(GuiPreferences, "result", lambda *a: QDialog.Accepted)
     monkeypatch.setattr(nwGUI.docEditor.spEnchant, "listDictionaries", lambda: [("en", "none")])
@@ -58,7 +55,6 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     nwPrefs = getGuiItem("GuiPreferences")
     assert isinstance(nwPrefs, GuiPreferences)
     nwPrefs.show()
-    assert nwPrefs.mainConf._confPath == fncPath
 
     assert nwPrefs.updateTheme is False
     assert nwPrefs.updateSyntax is False
@@ -216,7 +212,7 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     nwPrefs._doClose()
 
     assert nwGUI.mainConf.saveConfig()
-    projFile = fncPath / "novelwriter.conf"
+    projFile = tstPaths.cnfDir / "novelwriter.conf"
     testFile = tstPaths.outDir / "guiPreferences_novelwriter.conf"
     compFile = tstPaths.refDir / "guiPreferences_novelwriter.conf"
     copyfile(projFile, testFile)

--- a/tests/test_dialogs/test_dlg_projsettings.py
+++ b/tests/test_dialogs/test_dlg_projsettings.py
@@ -91,7 +91,7 @@ def testDlgProjSettings_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockR
     # Create new project
     buildTestProject(nwGUI, projPath)
     mockRnd.reset()
-    nwGUI.mainConf.backupPath = fncPath
+    nwGUI.mainConf.setBackupPath(fncPath)
 
     # Set some values
     theProject = nwGUI.theProject
@@ -156,7 +156,7 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, fncPath, projPat
     # Create new project
     mockRnd.reset()
     buildTestProject(nwGUI, projPath)
-    nwGUI.mainConf.backupPath = fncPath
+    nwGUI.mainConf.setBackupPath(fncPath)
 
     # Set some values
     theProject = nwGUI.theProject
@@ -357,7 +357,7 @@ def testDlgProjSettings_Replace(qtbot, monkeypatch, nwGUI, fncPath, projPath, mo
     # Create new project
     mockRnd.reset()
     buildTestProject(nwGUI, projPath)
-    nwGUI.mainConf.backupPath = fncPath
+    nwGUI.mainConf.setBackupPath(fncPath)
 
     # Set some values
     theProject = nwGUI.theProject

--- a/tests/test_dialogs/test_dlg_projsettings.py
+++ b/tests/test_dialogs/test_dlg_projsettings.py
@@ -21,13 +21,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 
-from novelwriter.enum import nwItemType
 from tools import C, getGuiItem, buildTestProject
 
 from PyQt5.QtGui import QColor
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QDialog, QAction, QColorDialog
 
+from novelwriter import CONFIG
+from novelwriter.enum import nwItemType
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projsettings import GuiProjectSettings
 
@@ -91,7 +92,7 @@ def testDlgProjSettings_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockR
     # Create new project
     buildTestProject(nwGUI, projPath)
     mockRnd.reset()
-    nwGUI.mainConf.setBackupPath(fncPath)
+    CONFIG.setBackupPath(fncPath)
 
     # Set some values
     theProject = nwGUI.theProject
@@ -156,7 +157,7 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, fncPath, projPat
     # Create new project
     mockRnd.reset()
     buildTestProject(nwGUI, projPath)
-    nwGUI.mainConf.setBackupPath(fncPath)
+    CONFIG.setBackupPath(fncPath)
 
     # Set some values
     theProject = nwGUI.theProject
@@ -357,7 +358,7 @@ def testDlgProjSettings_Replace(qtbot, monkeypatch, nwGUI, fncPath, projPath, mo
     # Create new project
     mockRnd.reset()
     buildTestProject(nwGUI, projPath)
-    nwGUI.mainConf.setBackupPath(fncPath)
+    CONFIG.setBackupPath(fncPath)
 
     # Set some values
     theProject = nwGUI.theProject

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -28,6 +28,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QTextBlock, QTextCursor, QTextOption
 from PyQt5.QtWidgets import QAction, qApp
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwDocAction, nwDocInsert, nwItemLayout
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.core.index import countWords
@@ -55,18 +56,18 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.docEditor._typPadChar == nwUnicode.U_NBSP
 
     # Check that editor handles settings
-    nwGUI.mainConf.textFont = None
-    nwGUI.mainConf.doJustify = True
-    nwGUI.mainConf.showTabsNSpaces = True
-    nwGUI.mainConf.showLineEndings = True
-    nwGUI.mainConf.hideVScroll = True
-    nwGUI.mainConf.hideHScroll = True
-    nwGUI.mainConf.fmtPadThin = True
+    CONFIG.textFont = None
+    CONFIG.doJustify = True
+    CONFIG.showTabsNSpaces = True
+    CONFIG.showLineEndings = True
+    CONFIG.hideVScroll = True
+    CONFIG.hideHScroll = True
+    CONFIG.fmtPadThin = True
 
     assert nwGUI.docEditor.initEditor()
 
     qDoc = nwGUI.docEditor.document()
-    assert nwGUI.mainConf.textFont == qDoc.defaultFont().family()
+    assert CONFIG.textFont == qDoc.defaultFont().family()
     assert qDoc.defaultTextOption().alignment() == Qt.AlignJustify
     assert qDoc.defaultTextOption().flags() & QTextOption.ShowTabsAndSpaces
     assert qDoc.defaultTextOption().flags() & QTextOption.ShowLineAndParagraphSeparators
@@ -114,7 +115,7 @@ def testGuiEditor_LoadText(qtbot, monkeypatch, caplog, nwGUI, projPath, ipsumTex
         assert "The document you are trying to open is too big." in caplog.text
 
     # Big doc handling
-    nwGUI.mainConf.bigDocLimit = 50
+    CONFIG.bigDocLimit = 50
     assert nwGUI.docEditor.loadText(C.hSceneDoc) is True
     assert nwGUI.docEditor._bigDoc is True
 

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -21,11 +21,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 
+from mock import causeException
+
 from PyQt5.QtCore import Qt, QUrl
 from PyQt5.QtGui import QTextCursor
 from PyQt5.QtWidgets import qApp, QAction
-from mock import causeException
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwDocAction
 from novelwriter.core.tohtml import ToHtml
 
@@ -134,10 +136,10 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, nwLipsum):
     assert nwGUI.docViewer.docHeader.theTitle.text() == "Characters  ›  Test Title"
 
     # Ttile without full path
-    nwGUI.mainConf.showFullPath = False
+    CONFIG.showFullPath = False
     nwGUI.docViewer.updateDocInfo("4c4f28287af27")
     assert nwGUI.docViewer.docHeader.theTitle.text() == "Test Title"
-    nwGUI.mainConf.showFullPath = True
+    CONFIG.showFullPath = True
 
     # Document footer show/hide references
     viewState = nwGUI.viewMeta.isVisible()

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -30,6 +30,7 @@ from tools import (
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QDialog, QMessageBox, QInputDialog
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwItemType, nwView, nwWidget
 from novelwriter.constants import nwFiles
 from novelwriter.gui.outline import GuiOutlineView
@@ -75,7 +76,7 @@ def testGuiMain_Launch(qtbot, monkeypatch, nwGUI, prjLipsum):
     """
     monkeypatch.setattr(GuiProjectLoad, "exec_", lambda *a: None)
     monkeypatch.setattr(GuiProjectLoad, "result", lambda *a: QDialog.Accepted)
-    nwGUI.mainConf.lastNotes = "0x0"
+    CONFIG.lastNotes = "0x0"
 
     # Open Lipsum project
     nwGUI.postLaunchTasks(prjLipsum)
@@ -244,10 +245,10 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     assert nwGUI.mainMenu._toggleSpellCheck()
 
     # Change some settings
-    nwGUI.mainConf.hideHScroll = True
-    nwGUI.mainConf.hideVScroll = True
-    nwGUI.mainConf.autoScrollPos = 80
-    nwGUI.mainConf.autoScroll = True
+    CONFIG.hideHScroll = True
+    CONFIG.hideVScroll = True
+    CONFIG.autoScrollPos = 80
+    CONFIG.autoScroll = True
 
     # Add a Character File
     nwGUI.switchFocus(nwWidget.TREE)
@@ -589,11 +590,11 @@ def testGuiMain_FocusFullMode(qtbot, nwGUI, projPath, mockRnd):
     # Full Screen Mode
     # ================
 
-    assert nwGUI.mainConf.isFullScreen is False
+    assert CONFIG.isFullScreen is False
     nwGUI.toggleFullScreenMode()
-    assert nwGUI.mainConf.isFullScreen is True
+    assert CONFIG.isFullScreen is True
     nwGUI.toggleFullScreenMode()
-    assert nwGUI.mainConf.isFullScreen is False
+    assert CONFIG.isFullScreen is False
 
     # qtbot.stop()
 

--- a/tests/test_gui/test_gui_i18n.py
+++ b/tests/test_gui/test_gui_i18n.py
@@ -20,20 +20,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import sys
-import novelwriter
-
 import pytest
 
 from PyQt5.QtWidgets import qApp, QMessageBox
 
-LANG_DATA = novelwriter.CONFIG.listLanguages(novelwriter.CONFIG.LANG_NW)
+from novelwriter import CONFIG, main
+
+LANG_DATA = CONFIG.listLanguages(CONFIG.LANG_NW)
 
 
 @pytest.mark.gui
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux Only")
 @pytest.mark.skipif(not LANG_DATA, reason="No i18n Data")
 @pytest.mark.parametrize("language", [a for a, b in LANG_DATA])
-def testI18n_Localisation(qtbot, monkeypatch, language, fncPath, fncConf):
+def testI18n_Localisation(qtbot, monkeypatch, language, fncPath):
     """test loading the gui with a specific language.
     """
     monkeypatch.setattr(QMessageBox, "warning", lambda *a: QMessageBox.Ok)
@@ -42,18 +42,13 @@ def testI18n_Localisation(qtbot, monkeypatch, language, fncPath, fncConf):
     monkeypatch.setattr(QMessageBox, "question", lambda *a: QMessageBox.Yes)
 
     # Set the test langauge
-    monkeypatch.setattr("novelwriter.CONFIG", fncConf)
-    fncConf.guiLocale = language
-    fncConf.initLocalisation(qApp)
+    CONFIG.guiLocale = language
+    CONFIG.initLocalisation(qApp)
 
-    nwGUI = novelwriter.main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
+    nwGUI = main(["--testmode", f"--config={fncPath}", f"--data={fncPath}"])
     qtbot.addWidget(nwGUI)
     nwGUI.show()
     qtbot.wait(20)
     nwGUI.closeMain()
-
-    # Reset the app language
-    fncConf.guiLocale = "en_GB"
-    fncConf.initLocalisation(qApp)
 
 # END Test testI18n_Localisation

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -27,6 +27,7 @@ from PyQt5.QtWidgets import QAction, QFileDialog, QMessageBox
 
 from tools import C, writeFile, buildTestProject
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwDocAction, nwDocInsert
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.gui.doceditor import GuiDocEditor
@@ -461,19 +462,19 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
     nwGUI.docEditor.clear()
 
     nwGUI.mainMenu.aInsQuoteLS.activate(QAction.Trigger)
-    assert nwGUI.docEditor.getText() == nwGUI.mainConf.fmtSQuoteOpen
+    assert nwGUI.docEditor.getText() == CONFIG.fmtSQuoteOpen
     nwGUI.docEditor.clear()
 
     nwGUI.mainMenu.aInsQuoteRS.activate(QAction.Trigger)
-    assert nwGUI.docEditor.getText() == nwGUI.mainConf.fmtSQuoteClose
+    assert nwGUI.docEditor.getText() == CONFIG.fmtSQuoteClose
     nwGUI.docEditor.clear()
 
     nwGUI.mainMenu.aInsQuoteLD.activate(QAction.Trigger)
-    assert nwGUI.docEditor.getText() == nwGUI.mainConf.fmtDQuoteOpen
+    assert nwGUI.docEditor.getText() == CONFIG.fmtDQuoteOpen
     nwGUI.docEditor.clear()
 
     nwGUI.mainMenu.aInsQuoteRD.activate(QAction.Trigger)
-    assert nwGUI.docEditor.getText() == nwGUI.mainConf.fmtDQuoteClose
+    assert nwGUI.docEditor.getText() == CONFIG.fmtDQuoteClose
     nwGUI.docEditor.clear()
 
     nwGUI.mainMenu.aInsMSApos.activate(QAction.Trigger)

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -29,6 +29,7 @@ from PyQt5.QtGui import QFocusEvent
 from PyQt5.QtCore import Qt, QEvent
 from PyQt5.QtWidgets import QInputDialog, QToolTip
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwWidget, nwItemType
 from novelwriter.gui.noveltree import NovelTreeColumn
 from novelwriter.dialogs.editlabel import GuiEditLabel
@@ -67,14 +68,14 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     # Show/Hide Scrollbars
     # ====================
 
-    nwGUI.mainConf.hideVScroll = True
-    nwGUI.mainConf.hideHScroll = True
+    CONFIG.hideVScroll = True
+    CONFIG.hideHScroll = True
     novelView.initSettings()
     assert not novelTree.verticalScrollBar().isVisible()
     assert not novelTree.horizontalScrollBar().isVisible()
 
-    nwGUI.mainConf.hideVScroll = False
-    nwGUI.mainConf.hideHScroll = False
+    CONFIG.hideVScroll = False
+    CONFIG.hideHScroll = False
     novelView.initSettings()
     assert novelTree.verticalScrollBar().isEnabled()
     assert novelTree.horizontalScrollBar().isEnabled()

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -28,6 +28,7 @@ from tools import buildTestProject, writeFile
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QAction
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwItemClass, nwOutline, nwView
 
 
@@ -47,16 +48,16 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, projPath):
     outlineMenu = outlineView.outlineBar.mColumns
 
     # Toggle scrollbars
-    nwGUI.mainConf.hideVScroll = True
-    nwGUI.mainConf.hideHScroll = True
+    CONFIG.hideVScroll = True
+    CONFIG.hideHScroll = True
     outlineView.initSettings()
     assert outlineTree.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert outlineTree.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert outlineData.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert outlineData.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
 
-    nwGUI.mainConf.hideVScroll = False
-    nwGUI.mainConf.hideHScroll = False
+    CONFIG.hideVScroll = False
+    CONFIG.hideHScroll = False
     outlineView.initSettings()
     assert outlineTree.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
     assert outlineTree.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -27,6 +27,7 @@ from tools import C, buildTestProject
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMessageBox, QMenu, QTreeWidgetItem, QDialog
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwItemLayout, nwItemType, nwItemClass
 from novelwriter.gui.projtree import GuiProjectTree
 from novelwriter.dialogs.docmerge import GuiDocMerge
@@ -862,14 +863,14 @@ def testGuiProjTree_Other(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     # ====================
 
     # Test that the scrollbar setting works
-    nwGUI.mainConf.hideVScroll = True
-    nwGUI.mainConf.hideHScroll = True
+    CONFIG.hideVScroll = True
+    CONFIG.hideHScroll = True
     projView.initSettings()
     assert projTree.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
     assert projTree.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
 
-    nwGUI.mainConf.hideVScroll = False
-    nwGUI.mainConf.hideHScroll = False
+    CONFIG.hideVScroll = False
+    CONFIG.hideHScroll = False
     projView.initSettings()
     assert projTree.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
     assert projTree.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded

--- a/tests/test_gui/test_gui_statusbar.py
+++ b/tests/test_gui/test_gui_statusbar.py
@@ -24,6 +24,7 @@ import pytest
 
 from tools import C, buildTestProject
 
+from novelwriter import CONFIG
 from novelwriter.gui.statusbar import StatusLED
 
 
@@ -60,13 +61,13 @@ def testGuiStatusBar_Main(qtbot, nwGUI, projPath, mockRnd):
     assert nwGUI.mainStatus.docIcon._theCol == nwGUI.mainStatus.docIcon._colGood
 
     # Idle Status
-    nwGUI.mainStatus.mainConf.stopWhenIdle = False
+    CONFIG.stopWhenIdle = False
     nwGUI.mainStatus.setUserIdle(True)
     nwGUI.mainStatus.updateTime()
     assert nwGUI.mainStatus.userIdle is False
     assert nwGUI.mainStatus.timeText.text() == "00:00:00"
 
-    nwGUI.mainStatus.mainConf.stopWhenIdle = True
+    CONFIG.stopWhenIdle = True
     nwGUI.mainStatus.setUserIdle(True)
     nwGUI.mainStatus.updateTime(5)
     assert nwGUI.mainStatus.userIdle is True
@@ -84,10 +85,10 @@ def testGuiStatusBar_Main(qtbot, nwGUI, projPath, mockRnd):
     assert nwGUI.mainStatus.langText.text() == "American English"
 
     # Project Stats
-    nwGUI.mainStatus.mainConf.incNotesWCount = False
+    CONFIG.incNotesWCount = False
     nwGUI._updateStatusWordCount()
     assert nwGUI.mainStatus.statsText.text() == "Words: 9 (+9)"
-    nwGUI.mainStatus.mainConf.incNotesWCount = True
+    CONFIG.incNotesWCount = True
     nwGUI._updateStatusWordCount()
     assert nwGUI.mainStatus.statsText.text() == "Words: 11 (+11)"
 

--- a/tests/test_tools/test_tools_build.py
+++ b/tests/test_tools/test_tools_build.py
@@ -28,6 +28,7 @@ from tools import ODT_IGNORE, cmpFiles, getGuiItem
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QAction, QFileDialog
 
+from novelwriter import CONFIG
 from novelwriter.tools.build import GuiBuildNovel
 
 
@@ -67,7 +68,7 @@ def testToolBuild_Main(qtbot, monkeypatch, nwGUI, prjLipsum, tstPaths):
         assert not nwBuild._saveDocument(nwBuild.FMT_NWD)
 
     # Default Settings
-    nwGUI.mainConf._lastPath = prjLipsum
+    CONFIG._lastPath = prjLipsum
     qtbot.mouseClick(nwBuild.buildNovel, Qt.LeftButton)
 
     assert nwBuild._saveDocument(nwBuild.FMT_NWD)
@@ -231,7 +232,7 @@ def testToolBuild_Main(qtbot, monkeypatch, nwGUI, prjLipsum, tstPaths):
     assert (prjLipsum / "Lorem Ipsum.odt").is_file()
 
     # Print to PDF
-    if not nwGUI.mainConf.osDarwin:
+    if not CONFIG.osDarwin:
         assert nwBuild._saveDocument(nwBuild.FMT_PDF)
         assert (prjLipsum / "Lorem Ipsum.pdf").is_file()
 

--- a/tests/test_tools/test_tools_writingstats.py
+++ b/tests/test_tools/test_tools_writingstats.py
@@ -33,7 +33,7 @@ from novelwriter.tools.writingstats import GuiWritingStats
 
 
 @pytest.mark.gui
-def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath):
+def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     """Test the full writing stats tool.
     """
     # Create a project to work on
@@ -126,13 +126,10 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath):
     assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == "{:n}".format(200)
 
     assert sessLog._saveData(sessLog.FMT_CSV)
-    qtbot.wait(100)
-
     assert sessLog._saveData(sessLog.FMT_JSON)
-    qtbot.wait(100)
 
     # Check the exported files
-    jsonStats = fncPath / "sessionStats.json"
+    jsonStats = tstPaths.tmpDir / "sessionStats.json"
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
@@ -171,7 +168,7 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath):
     qtbot.mouseClick(sessLog.incNovel, Qt.LeftButton)
     assert sessLog._saveData(sessLog.FMT_JSON)
 
-    jsonStats = fncPath / "sessionStats.json"
+    jsonStats = tstPaths.tmpDir / "sessionStats.json"
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.loads(inFile.read())
 
@@ -217,7 +214,7 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath):
     qtbot.mouseClick(sessLog.incNotes, Qt.LeftButton)
     assert sessLog._saveData(sessLog.FMT_JSON)
 
-    jsonStats = fncPath / "sessionStats.json"
+    jsonStats = tstPaths.tmpDir / "sessionStats.json"
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
@@ -265,7 +262,7 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath):
 
     # qtbot.stop()
 
-    jsonStats = fncPath / "sessionStats.json"
+    jsonStats = tstPaths.tmpDir / "sessionStats.json"
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
@@ -295,7 +292,7 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath):
     qtbot.mouseClick(sessLog.hideZeros, Qt.LeftButton)
     assert sessLog._saveData(sessLog.FMT_JSON)
 
-    jsonStats = fncPath / "sessionStats.json"
+    jsonStats = tstPaths.tmpDir / "sessionStats.json"
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
@@ -348,7 +345,7 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath):
     qtbot.mouseClick(sessLog.groupByDay, Qt.LeftButton)
     assert sessLog._saveData(sessLog.FMT_JSON)
 
-    jsonStats = fncPath / "sessionStats.json"
+    jsonStats = tstPaths.tmpDir / "sessionStats.json"
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 


### PR DESCRIPTION
**Summary:**

This PR rewrites how the global CONFIG object is handled during testing. It is no longer mocked and replaced by a test config object, but is instead reset before each test is run. This means there is no need to assign the global CONFIG object to a class attribute at the initialisation of a class so it can be overridden in the tests. Since the CONFIG object is created immediately on first import, it is very tricky to mock.

With this change, CONFIG is accessed directly wherever access to the user's config settings are needed. This should also be marginally faster, as the object is no longer stored in a class dictionary, which adds a bit of overhead when accessing it.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
