### PR TITLE
Remove lxml

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,7 +14,7 @@ jobs:
   testLinux:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,7 +40,6 @@ The following libraries are dependencies of novelWriter:
 
 * [Qt5](https://www.qt.io) by Qt Company
 * [PyQt5](https://www.riverbankcomputing.com/software/pyqt) by Riverbank Computing
-* [lxml](https://lxml.de) by Martijn Faassen
 * [Enchant](https://abiword.github.io/enchant) by Dom Lachowicz
 * [PyEnchant](https://pyenchant.github.io/pyenchant) by Dimitri Merejkowsky
 

--- a/docs/source/int_source.rst
+++ b/docs/source/int_source.rst
@@ -46,13 +46,10 @@ format of the main project file. Everything else is handled with standard Python
 The following Python packages are needed to run novelWriter:
 
 * ``PyQt5`` – needed for connecting with the Qt5 libraries.
-* ``lxml`` – needed for full XML support.
 * ``PyEnchant`` – needed for spell checking (optional).
 
 PyQt/Qt should be at least 5.10, but ideally 5.13 or higher for all features to work. For instance,
-searching using regular expressions with full Unicode support requires 5.13. There is no known
-minimum version requirement for package ``lxml``, but the code was originally written with 4.2,
-which is therefore set as the minimum. It may work on lower versions. You have to test it.
+searching using regular expressions with full Unicode support requires 5.13.
 
 If you want spell checking, you must install the ``PyEnchant`` package. The spell check library
 must be at least 3.0 to work with Windows. On Linux, 2.0 also works fine.

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -185,12 +185,6 @@ def main(sysArgs=None):
         )
         errorCode |= 0x10
 
-    try:
-        import lxml  # noqa: F401
-    except ImportError:
-        errorData.append("Python module 'lxml' is missing")
-        errorCode |= 0x20
-
     if errorData:
         errApp = QApplication([])
         errDlg = QErrorMessage()

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -155,13 +155,14 @@ def main(sysArgs=None):
         elif inOpt == "--testmode":
             testMode = True
 
-    # Set Logging
-    cHandle = logging.StreamHandler()
-    cHandle.setFormatter(logging.Formatter(fmt=logFormat, style="{"))
-
+    # Setup Logging
     pkgLogger = logging.getLogger(__package__)
-    pkgLogger.addHandler(cHandle)
     pkgLogger.setLevel(logLevel)
+    if len(pkgLogger.handlers) == 0:
+        # Make sure we only create one logger (mostly an issue with tests)
+        cHandle = logging.StreamHandler()
+        cHandle.setFormatter(logging.Formatter(fmt=logFormat, style="{"))
+        pkgLogger.addHandler(cHandle)
 
     logger.info("Starting novelWriter %s (%s) %s", __version__, __hexversion__, __date__)
 

--- a/novelwriter/assets/text/credits_en.htm
+++ b/novelwriter/assets/text/credits_en.htm
@@ -47,7 +47,6 @@ more contributions are listed on the project's <a href="https://crowdin.com/proj
 <p>
   <a href="https://www.qt.io">Qt5</a> by Qt Company<br>
   <a href="https://www.riverbankcomputing.com/software/pyqt">PyQt5</a> by Riverbank Computing<br>
-  <a href="https://lxml.de">lxml</a> by Martijn Faassen<br>
   <a href="https://abiword.github.io/enchant">Enchant</a> by Dom Lachowicz<br>
   <a href="https://pyenchant.github.io/pyenchant">PyEnchant</a> by Dimitri Merejkowsky
 </p>

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -569,7 +569,7 @@ class NWConfigParser(ConfigParser):
 #  Third Party Code
 # =============================================================================================== #
 
-def xmlIndent(tree, space="  ", level=0):
+def xmlIndent(tree, space="  ", level=0):  # pragma: no cover
     """The XML indent function from CPython, that was only added in Python 3.9.
     It is included here to support older versions of Python.
     https://github.com/python/cpython/blob/main/Lib/xml/etree/ElementTree.py

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -196,7 +196,6 @@ class Config:
 
         # Check Python Version
         self.verPyString = sys.version.split()[0]
-        self.verPyHexVal = sys.hexversion
 
         # Check OS Type
         self.osType    = sys.platform

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -25,17 +25,18 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+import sys
 import logging
+import xml.etree.ElementTree as ET
 
 from enum import Enum
-from lxml import etree
 from time import time
 from pathlib import Path
 
 from novelwriter import __version__, __hexversion__
 from novelwriter.common import (
     checkBool, checkInt, checkString, checkStringNone, formatTimeStamp,
-    hexToInt, simplified, yesNo
+    hexToInt, simplified, xmlIndent, yesNo
 )
 from novelwriter.constants import nwFiles
 
@@ -163,7 +164,7 @@ class ProjectXMLReader:
         logger.debug("Reading project XML")
 
         try:
-            xml = etree.parse(str(self._path))
+            xml = ET.parse(str(self._path))
             self._state = XMLReadState.NO_ERROR
 
         except Exception as exc:
@@ -174,7 +175,7 @@ class ProjectXMLReader:
             backFile = self._path.with_suffix(".bak")
             if backFile.is_file():
                 try:
-                    xml = etree.parse(str(backFile))
+                    xml = ET.parse(str(backFile))
                     self._state = XMLReadState.PARSED_BACKUP
                     logger.info("Backup project file parsed")
                 except Exception as exc:
@@ -500,7 +501,7 @@ class ProjectXMLWriter:
         tStart = time()
         logger.debug("Writing project XML")
 
-        xRoot = etree.Element("novelWriterXML", attrib={
+        xRoot = ET.Element("novelWriterXML", attrib={
             "appVersion":  str(__version__),
             "hexVersion":  str(__hexversion__),
             "fileVersion": FILE_VERSION,
@@ -515,13 +516,13 @@ class ProjectXMLWriter:
             "editTime": str(editTime),
         }
 
-        xProject = etree.SubElement(xRoot, "project", attrib=projAttr)
+        xProject = ET.SubElement(xRoot, "project", attrib=projAttr)
         self._packSingleValue(xProject, "name", projData.name)
         self._packSingleValue(xProject, "title", projData.title)
         self._packSingleValue(xProject, "author", projData.author)
 
         # Save Project Settings
-        xSettings = etree.SubElement(xRoot, "settings")
+        xSettings = ET.SubElement(xRoot, "settings")
         self._packSingleValue(xSettings, "doBackup", yesNo(projData.doBackup))
         self._packSingleValue(xSettings, "language", projData.language)
         self._packSingleValue(xSettings, "spellChecking", projData.spellLang, attrib={
@@ -532,11 +533,11 @@ class ProjectXMLWriter:
         self._packDictKeyValue(xSettings, "titleFormat", projData.titleFormat)
 
         # Save Status/Importance
-        xStatus = etree.SubElement(xSettings, "status")
+        xStatus = ET.SubElement(xSettings, "status")
         for label, attrib in projData.itemStatus.pack():
             self._packSingleValue(xStatus, "entry", label, attrib=attrib)
 
-        xImport = etree.SubElement(xSettings, "importance")
+        xImport = ET.SubElement(xSettings, "importance")
         for label, attrib in projData.itemImport.pack():
             self._packSingleValue(xImport, "entry", label, attrib=attrib)
 
@@ -547,11 +548,11 @@ class ProjectXMLWriter:
             "notesWords": str(projData.currCounts[1]),
         }
 
-        xContent = etree.SubElement(xRoot, "content", attrib=contAttr)
+        xContent = ET.SubElement(xRoot, "content", attrib=contAttr)
         for item in projContent:
-            xItem = etree.SubElement(xContent, "item", attrib=item.get("itemAttr", {}))
-            etree.SubElement(xItem, "meta", attrib=item.get("metaAttr", {}))
-            xName = etree.SubElement(xItem, "name", attrib=item.get("nameAttr", {}))
+            xItem = ET.SubElement(xContent, "item", attrib=item.get("itemAttr", {}))
+            ET.SubElement(xItem, "meta", attrib=item.get("metaAttr", {}))
+            xName = ET.SubElement(xItem, "name", attrib=item.get("nameAttr", {}))
             xName.text = item["name"]
 
         # Write the XML tree to file
@@ -559,9 +560,12 @@ class ProjectXMLWriter:
         tempFile = saveFile.with_suffix(".tmp")
         backFile = saveFile.with_suffix(".bak")
         try:
-            tempFile.write_bytes(etree.tostring(
-                xRoot, pretty_print=True, encoding="utf-8", xml_declaration=True
-            ))
+            xml = ET.ElementTree(xRoot)
+            if sys.hexversion < 0x030900f0:
+                xmlIndent(xml, space="  ")
+            else:
+                ET.indent(xml, space="  ")
+            xml.write(tempFile, encoding="utf-8", xml_declaration=True)
         except Exception as exc:
             self._error = exc
             return False
@@ -587,17 +591,17 @@ class ProjectXMLWriter:
     def _packSingleValue(self, xParent, name, value, attrib=None):
         """Pack a single value into an XML element.
         """
-        xItem = etree.SubElement(xParent, name, attrib=attrib)
+        xItem = ET.SubElement(xParent, name, attrib=attrib or {})
         xItem.text = str(value) or ""
         return
 
     def _packDictKeyValue(self, xParent, name, data):
         """Pack the entries of a dictionary into an XML element.
         """
-        xItem = etree.SubElement(xParent, name)
+        xItem = ET.SubElement(xParent, name)
         for key, value in data.items():
             if len(key) > 0:
-                xEntry = etree.SubElement(xItem, "entry", attrib={"key": key})
+                xEntry = ET.SubElement(xItem, "entry", attrib={"key": key})
                 xEntry.text = str(value) or ""
         return
 

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -25,7 +25,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-import sys
 import logging
 import xml.etree.ElementTree as ET
 
@@ -561,10 +560,7 @@ class ProjectXMLWriter:
         backFile = saveFile.with_suffix(".bak")
         try:
             xml = ET.ElementTree(xRoot)
-            if sys.hexversion < 0x030900f0:
-                xmlIndent(xml, space="  ")
-            else:
-                ET.indent(xml, space="  ")
+            xmlIndent(xml)
             xml.write(tempFile, encoding="utf-8", xml_declaration=True)
         except Exception as exc:
             self._error = exc

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -92,20 +92,20 @@ class ToOdt(Tokenizer):
 
         self._isFlat = isFlat  # Flat: .fodt, otherwise .odt
 
-        self._dFlat = None  # FODT file XML root
-        self._dCont = None  # ODT content.xml root
-        self._dMeta = None  # ODT meta.xml root
-        self._dStyl = None  # ODT styles.xml root
+        self._dFlat = ET.Element("")  # FODT file XML root
+        self._dCont = ET.Element("")  # ODT content.xml root
+        self._dMeta = ET.Element("")  # ODT meta.xml root
+        self._dStyl = ET.Element("")  # ODT styles.xml root
 
-        self._xMeta = None  # Office meta root
-        self._xFont = None  # Office font face declaration
-        self._xFnt2 = None  # Office font face declaration, secondary
-        self._xStyl = None  # Office styles root
-        self._xAuto = None  # Office auto-styles root
-        self._xAut2 = None  # Office auto-styles root, secondary
-        self._xMast = None  # Office master-styles root
-        self._xBody = None  # Office body root
-        self._xText = None  # Office text root
+        self._xMeta = ET.Element("")  # Office meta root
+        self._xFont = ET.Element("")  # Office font face declaration
+        self._xFnt2 = ET.Element("")  # Office font face declaration, secondary
+        self._xStyl = ET.Element("")  # Office styles root
+        self._xAuto = ET.Element("")  # Office auto-styles root
+        self._xAut2 = ET.Element("")  # Office auto-styles root, secondary
+        self._xMast = ET.Element("")  # Office master-styles root
+        self._xBody = ET.Element("")  # Office body root
+        self._xText = ET.Element("")  # Office text root
 
         self._mainPara = {}  # User-accessible paragraph styles
         self._autoPara = {}  # Auto-generated paragraph styles
@@ -502,7 +502,7 @@ class ToOdt(Tokenizer):
         """
         with open(savePath, mode="wb") as outFile:
             xml = ET.ElementTree(self._dFlat)
-            xmlIndent(xml, space="  ")
+            xmlIndent(xml)
             xml.write(outFile, encoding="utf-8", xml_declaration=True)
         return
 
@@ -529,7 +529,6 @@ class ToOdt(Tokenizer):
         def putInZip(name, xObj, zipObj):
             with zipObj.open(name, mode="w") as fObj:
                 xml = ET.ElementTree(xObj)
-                xmlIndent(xml, space="  ")
                 xml.write(fObj, encoding="utf-8", xml_declaration=True)
 
         with ZipFile(savePath, mode="w") as outZip:
@@ -1337,8 +1336,8 @@ class XMLParagraph:
     def __init__(self, xRoot):
 
         self._xRoot = xRoot
-        self._xTail = None
-        self._xSing = None
+        self._xTail = ET.Element("")
+        self._xSing = ET.Element("")
 
         self._nState = X_ROOT_TEXT
         self._chrPos = 0

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -24,13 +24,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging
+import xml.etree.ElementTree as ET
 
-from lxml import etree
 from hashlib import sha256
 from zipfile import ZipFile
 from datetime import datetime
 
 from novelwriter import __version__
+from novelwriter.common import xmlIndent
 from novelwriter.constants import nwKeyWords, nwLabels
 from novelwriter.core.tokenizer import Tokenizer, stripEscape
 
@@ -38,30 +39,27 @@ logger = logging.getLogger(__name__)
 
 # Main XML NameSpaces
 XML_NS = {
-    "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
-    "style":  "urn:oasis:names:tc:opendocument:xmlns:style:1.0",
-    "loext":  "urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0",
-    "text":   "urn:oasis:names:tc:opendocument:xmlns:text:1.0",
-    "meta":   "urn:oasis:names:tc:opendocument:xmlns:meta:1.0",
-    "fo":     "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0",
-    "dc":     "http://purl.org/dc/elements/1.1/",
+    "manifest": "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0",
+    "office":   "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
+    "style":    "urn:oasis:names:tc:opendocument:xmlns:style:1.0",
+    "loext":    "urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0",
+    "text":     "urn:oasis:names:tc:opendocument:xmlns:text:1.0",
+    "meta":     "urn:oasis:names:tc:opendocument:xmlns:meta:1.0",
+    "fo":       "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0",
+    "dc":       "http://purl.org/dc/elements/1.1/",
 }
-MANI_NS = {
-    "manifest": "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"
-}
-OFFICE_NS = {
-    "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
-}
+for ns, uri in XML_NS.items():
+    ET.register_namespace(ns, uri)
 
 
-def _mkTag(nsName, tagName, nsMap=XML_NS):
+def _mkTag(ns, tag):
     """Assemble namespace and tag name.
     """
-    theNS = nsMap.get(nsName, "")
-    if theNS:
-        return f"{{{theNS}}}{tagName}"
-    logger.warning("Missing xml namespace '%s'", nsName)
-    return tagName
+    uri = XML_NS.get(ns, "")
+    if uri:
+        return f"{{{uri}}}{tag}"
+    logger.warning("Missing xml namespace '%s'", ns)
+    return tag
 
 
 # Mimetype and Version
@@ -284,16 +282,16 @@ class ToOdt(Tokenizer):
             tAttr[_mkTag("office", "mimetype")] = X_MIME
 
             tFlat = _mkTag("office", "document")
-            self._dFlat = etree.Element(tFlat, attrib=tAttr, nsmap=XML_NS)
+            self._dFlat = ET.Element(tFlat, attrib=tAttr)
 
-            self._xMeta = etree.SubElement(self._dFlat, _mkTag("office", "meta"))
-            self._xFont = etree.SubElement(self._dFlat, _mkTag("office", "font-face-decls"))
-            self._xStyl = etree.SubElement(self._dFlat, _mkTag("office", "styles"))
-            self._xAuto = etree.SubElement(self._dFlat, _mkTag("office", "automatic-styles"))
-            self._xMast = etree.SubElement(self._dFlat, _mkTag("office", "master-styles"))
-            self._xBody = etree.SubElement(self._dFlat, _mkTag("office", "body"))
+            self._xMeta = ET.SubElement(self._dFlat, _mkTag("office", "meta"))
+            self._xFont = ET.SubElement(self._dFlat, _mkTag("office", "font-face-decls"))
+            self._xStyl = ET.SubElement(self._dFlat, _mkTag("office", "styles"))
+            self._xAuto = ET.SubElement(self._dFlat, _mkTag("office", "automatic-styles"))
+            self._xMast = ET.SubElement(self._dFlat, _mkTag("office", "master-styles"))
+            self._xBody = ET.SubElement(self._dFlat, _mkTag("office", "body"))
 
-            etree.SubElement(self._xFont, _mkTag("style", "font-face"), attrib=fAttr)
+            ET.SubElement(self._xFont, _mkTag("style", "font-face"), attrib=fAttr)
 
         else:
 
@@ -305,59 +303,59 @@ class ToOdt(Tokenizer):
             tStyl = _mkTag("office", "document-styles")
 
             # content.xml
-            self._dCont = etree.Element(tCont, attrib=tAttr, nsmap=XML_NS)
-            self._xFont = etree.SubElement(self._dCont, _mkTag("office", "font-face-decls"))
-            self._xAuto = etree.SubElement(self._dCont, _mkTag("office", "automatic-styles"))
-            self._xBody = etree.SubElement(self._dCont, _mkTag("office", "body"))
+            self._dCont = ET.Element(tCont, attrib=tAttr)
+            self._xFont = ET.SubElement(self._dCont, _mkTag("office", "font-face-decls"))
+            self._xAuto = ET.SubElement(self._dCont, _mkTag("office", "automatic-styles"))
+            self._xBody = ET.SubElement(self._dCont, _mkTag("office", "body"))
 
             # meta.xml
-            self._dMeta = etree.Element(tMeta, attrib=tAttr, nsmap=XML_NS)
-            self._xMeta = etree.SubElement(self._dMeta, _mkTag("office", "meta"))
+            self._dMeta = ET.Element(tMeta, attrib=tAttr)
+            self._xMeta = ET.SubElement(self._dMeta, _mkTag("office", "meta"))
 
             # styles.xml
-            self._dStyl = etree.Element(tStyl, attrib=tAttr, nsmap=XML_NS)
-            self._xFnt2 = etree.SubElement(self._dStyl, _mkTag("office", "font-face-decls"))
-            self._xStyl = etree.SubElement(self._dStyl, _mkTag("office", "styles"))
-            self._xAut2 = etree.SubElement(self._dStyl, _mkTag("office", "automatic-styles"))
-            self._xMast = etree.SubElement(self._dStyl, _mkTag("office", "master-styles"))
+            self._dStyl = ET.Element(tStyl, attrib=tAttr)
+            self._xFnt2 = ET.SubElement(self._dStyl, _mkTag("office", "font-face-decls"))
+            self._xStyl = ET.SubElement(self._dStyl, _mkTag("office", "styles"))
+            self._xAut2 = ET.SubElement(self._dStyl, _mkTag("office", "automatic-styles"))
+            self._xMast = ET.SubElement(self._dStyl, _mkTag("office", "master-styles"))
 
-            etree.SubElement(self._xFont, _mkTag("style", "font-face"), attrib=fAttr)
-            etree.SubElement(self._xFnt2, _mkTag("style", "font-face"), attrib=fAttr)
+            ET.SubElement(self._xFont, _mkTag("style", "font-face"), attrib=fAttr)
+            ET.SubElement(self._xFnt2, _mkTag("style", "font-face"), attrib=fAttr)
 
         # Finalise
         # ========
 
-        self._xText = etree.SubElement(self._xBody, _mkTag("office", "text"))
+        self._xText = ET.SubElement(self._xBody, _mkTag("office", "text"))
 
         timeStamp = datetime.now().isoformat(sep="T", timespec="seconds")
 
         # Office Meta Data
-        xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "creation-date"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("meta", "creation-date"))
         xMeta.text = timeStamp
 
-        xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "generator"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("meta", "generator"))
         xMeta.text = f"novelWriter/{__version__}"
 
-        xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "initial-creator"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("meta", "initial-creator"))
         xMeta.text = self.theProject.data.author
 
-        xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "editing-cycles"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("meta", "editing-cycles"))
         xMeta.text = str(self.theProject.data.saveCount)
 
         # Format is: PnYnMnDTnHnMnS
         # https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#duration
         eT = self.theProject.data.editTime
-        xMeta = etree.SubElement(self._xMeta, _mkTag("meta", "editing-duration"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("meta", "editing-duration"))
         xMeta.text = f"P{eT//86400:d}DT{eT%86400//3600:d}H{eT%3600//60:d}M{eT%60:d}S"
 
         # Dublin Core Meta Data
-        xMeta = etree.SubElement(self._xMeta, _mkTag("dc", "title"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("dc", "title"))
         xMeta.text = self.theProject.data.title or self.theProject.data.name
 
-        xMeta = etree.SubElement(self._xMeta, _mkTag("dc", "date"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("dc", "date"))
         xMeta.text = timeStamp
 
-        xMeta = etree.SubElement(self._xMeta, _mkTag("dc", "creator"))
+        xMeta = ET.SubElement(self._xMeta, _mkTag("dc", "creator"))
         xMeta.text = self.theProject.data.author
 
         self._pageStyles()
@@ -503,51 +501,44 @@ class ToOdt(Tokenizer):
         """Save the data to an .fodt file.
         """
         with open(savePath, mode="wb") as outFile:
-            outFile.write(etree.tostring(
-                self._dFlat,
-                pretty_print=True,
-                encoding="utf-8",
-                xml_declaration=True
-            ))
+            xml = ET.ElementTree(self._dFlat)
+            xmlIndent(xml, space="  ")
+            xml.write(outFile, encoding="utf-8", xml_declaration=True)
         return
 
     def saveOpenDocText(self, savePath):
         """Save the data to an .odt file.
         """
-        mMani = _mkTag("manifest", "manifest", nsMap=MANI_NS)
-        mVers = _mkTag("manifest", "version", nsMap=MANI_NS)
-        mPath = _mkTag("manifest", "full-path", nsMap=MANI_NS)
-        mType = _mkTag("manifest", "media-type", nsMap=MANI_NS)
-        mFile = _mkTag("manifest", "file-entry", nsMap=MANI_NS)
+        mMani = _mkTag("manifest", "manifest")
+        mVers = _mkTag("manifest", "version")
+        mPath = _mkTag("manifest", "full-path")
+        mType = _mkTag("manifest", "media-type")
+        mFile = _mkTag("manifest", "file-entry")
 
-        xMani = etree.Element(mMani, attrib={mVers: X_VERS}, nsmap=MANI_NS)
-        etree.SubElement(xMani, mFile, attrib={mPath: "/", mVers: X_VERS, mType: X_MIME})
-        etree.SubElement(xMani, mFile, attrib={mPath: "settings.xml", mType: "text/xml"})
-        etree.SubElement(xMani, mFile, attrib={mPath: "content.xml", mType: "text/xml"})
-        etree.SubElement(xMani, mFile, attrib={mPath: "meta.xml", mType: "text/xml"})
-        etree.SubElement(xMani, mFile, attrib={mPath: "styles.xml", mType: "text/xml"})
+        xMani = ET.Element(mMani, attrib={mVers: X_VERS})
+        ET.SubElement(xMani, mFile, attrib={mPath: "/", mVers: X_VERS, mType: X_MIME})
+        ET.SubElement(xMani, mFile, attrib={mPath: "settings.xml", mType: "text/xml"})
+        ET.SubElement(xMani, mFile, attrib={mPath: "content.xml", mType: "text/xml"})
+        ET.SubElement(xMani, mFile, attrib={mPath: "meta.xml", mType: "text/xml"})
+        ET.SubElement(xMani, mFile, attrib={mPath: "styles.xml", mType: "text/xml"})
 
-        oRoot = _mkTag("office", "document-settings", nsMap=OFFICE_NS)
-        oVers = _mkTag("office", "version", nsMap=OFFICE_NS)
-        xSett = etree.Element(oRoot, nsmap=OFFICE_NS, attrib={oVers: X_VERS})
+        oRoot = _mkTag("office", "document-settings")
+        oVers = _mkTag("office", "version")
+        xSett = ET.Element(oRoot, attrib={oVers: X_VERS})
 
-        with ZipFile(savePath, mode="w") as outFile:
-            outFile.writestr("mimetype", X_MIME)
-            outFile.writestr("META-INF/manifest.xml", etree.tostring(
-                xMani, pretty_print=False, encoding="utf-8", xml_declaration=True
-            ))
-            outFile.writestr("settings.xml", etree.tostring(
-                xSett, pretty_print=False, encoding="utf-8", xml_declaration=True
-            ))
-            outFile.writestr("content.xml", etree.tostring(
-                self._dCont, pretty_print=False, encoding="utf-8", xml_declaration=True
-            ))
-            outFile.writestr("meta.xml", etree.tostring(
-                self._dMeta, pretty_print=False, encoding="utf-8", xml_declaration=True
-            ))
-            outFile.writestr("styles.xml", etree.tostring(
-                self._dStyl, pretty_print=False, encoding="utf-8", xml_declaration=True
-            ))
+        def putInZip(name, xObj, zipObj):
+            with zipObj.open(name, mode="w") as fObj:
+                xml = ET.ElementTree(xObj)
+                xmlIndent(xml, space="  ")
+                xml.write(fObj, encoding="utf-8", xml_declaration=True)
+
+        with ZipFile(savePath, mode="w") as outZip:
+            outZip.writestr("mimetype", X_MIME)
+            putInZip("META-INF/manifest.xml", xMani, outZip)
+            putInZip("settings.xml", xSett, outZip)
+            putInZip("content.xml", self._dCont, outZip)
+            putInZip("meta.xml", self._dMeta, outZip)
+            putInZip("styles.xml", self._dStyl, outZip)
 
         return
 
@@ -604,7 +595,7 @@ class ToOdt(Tokenizer):
             tAttr[_mkTag("text", "outline-level")] = oLevel
 
         pTag = "h" if isHead else "p"
-        xElem = etree.SubElement(self._xText, _mkTag("text", pTag), attrib=tAttr)
+        xElem = ET.SubElement(self._xText, _mkTag("text", pTag), attrib=tAttr)
 
         # It's important to set the initial text field to empty, otherwise
         # lxml will add a line break if the first subelement is a span.
@@ -732,25 +723,25 @@ class ToOdt(Tokenizer):
         theAttr = {}
         theAttr[_mkTag("style", "name")] = "PM1"
         if self._isFlat:
-            xPage = etree.SubElement(self._xAuto, _mkTag("style", "page-layout"), attrib=theAttr)
+            xPage = ET.SubElement(self._xAuto, _mkTag("style", "page-layout"), attrib=theAttr)
         else:
-            xPage = etree.SubElement(self._xAut2, _mkTag("style", "page-layout"), attrib=theAttr)
+            xPage = ET.SubElement(self._xAut2, _mkTag("style", "page-layout"), attrib=theAttr)
 
         theAttr = {}
         theAttr[_mkTag("fo", "margin-top")]    = self._mDocTop
         theAttr[_mkTag("fo", "margin-bottom")] = self._mDocBtm
         theAttr[_mkTag("fo", "margin-left")]   = self._mDocLeft
         theAttr[_mkTag("fo", "margin-right")]  = self._mDocRight
-        etree.SubElement(xPage, _mkTag("style", "page-layout-properties"), attrib=theAttr)
+        ET.SubElement(xPage, _mkTag("style", "page-layout-properties"), attrib=theAttr)
 
-        xHead = etree.SubElement(xPage, _mkTag("style", "header-style"))
+        xHead = ET.SubElement(xPage, _mkTag("style", "header-style"))
 
         theAttr = {}
         theAttr[_mkTag("fo", "min-height")]    = "0.600cm"
         theAttr[_mkTag("fo", "margin-left")]   = "0.000cm"
         theAttr[_mkTag("fo", "margin-right")]  = "0.000cm"
         theAttr[_mkTag("fo", "margin-bottom")] = "0.500cm"
-        etree.SubElement(xHead, _mkTag("style", "header-footer-properties"), attrib=theAttr)
+        ET.SubElement(xHead, _mkTag("style", "header-footer-properties"), attrib=theAttr)
 
         return
 
@@ -762,13 +753,13 @@ class ToOdt(Tokenizer):
 
         theAttr = {}
         theAttr[_mkTag("style", "family")] = "paragraph"
-        xStyl = etree.SubElement(self._xStyl, _mkTag("style", "default-style"), attrib=theAttr)
+        xStyl = ET.SubElement(self._xStyl, _mkTag("style", "default-style"), attrib=theAttr)
 
         theAttr = {}
         theAttr[_mkTag("style", "line-break")]        = "strict"
         theAttr[_mkTag("style", "tab-stop-distance")] = "1.251cm"
         theAttr[_mkTag("style", "writing-mode")]      = "page"
-        etree.SubElement(xStyl, _mkTag("style", "paragraph-properties"), attrib=theAttr)
+        ET.SubElement(xStyl, _mkTag("style", "paragraph-properties"), attrib=theAttr)
 
         theAttr = {}
         theAttr[_mkTag("style", "font-name")]   = self._textFont
@@ -776,7 +767,7 @@ class ToOdt(Tokenizer):
         theAttr[_mkTag("fo",    "font-size")]   = self._fSizeText
         theAttr[_mkTag("fo",    "language")]    = self._dLanguage
         theAttr[_mkTag("fo",    "country")]     = self._dCountry
-        etree.SubElement(xStyl, _mkTag("style", "text-properties"), attrib=theAttr)
+        ET.SubElement(xStyl, _mkTag("style", "text-properties"), attrib=theAttr)
 
         # Add Standard Paragraph Style
         # ============================
@@ -785,13 +776,13 @@ class ToOdt(Tokenizer):
         theAttr[_mkTag("style", "name")]   = "Standard"
         theAttr[_mkTag("style", "family")] = "paragraph"
         theAttr[_mkTag("style", "class")]  = "text"
-        xStyl = etree.SubElement(self._xStyl, _mkTag("style", "style"), attrib=theAttr)
+        xStyl = ET.SubElement(self._xStyl, _mkTag("style", "style"), attrib=theAttr)
 
         theAttr = {}
         theAttr[_mkTag("style", "font-name")]   = self._textFont
         theAttr[_mkTag("fo",    "font-family")] = self._fontFamily
         theAttr[_mkTag("fo",    "font-size")]   = self._fSizeText
-        etree.SubElement(xStyl, _mkTag("style", "text-properties"), attrib=theAttr)
+        ET.SubElement(xStyl, _mkTag("style", "text-properties"), attrib=theAttr)
 
         # Add Default Heading Style
         # =========================
@@ -802,19 +793,19 @@ class ToOdt(Tokenizer):
         theAttr[_mkTag("style", "parent-style-name")] = "Standard"
         theAttr[_mkTag("style", "next-style-name")]   = "Text_20_body"
         theAttr[_mkTag("style", "class")]             = "text"
-        xStyl = etree.SubElement(self._xStyl, _mkTag("style", "style"), attrib=theAttr)
+        xStyl = ET.SubElement(self._xStyl, _mkTag("style", "style"), attrib=theAttr)
 
         theAttr = {}
         theAttr[_mkTag("fo", "margin-top")]     = self._mTopHead
         theAttr[_mkTag("fo", "margin-bottom")]  = self._mBotHead
         theAttr[_mkTag("fo", "keep-with-next")] = "always"
-        etree.SubElement(xStyl, _mkTag("style", "paragraph-properties"), attrib=theAttr)
+        ET.SubElement(xStyl, _mkTag("style", "paragraph-properties"), attrib=theAttr)
 
         theAttr = {}
         theAttr[_mkTag("style", "font-name")]   = self._textFont
         theAttr[_mkTag("fo",    "font-family")] = self._fontFamily
         theAttr[_mkTag("fo",    "font-size")]   = self._fSizeHead
-        etree.SubElement(xStyl, _mkTag("style", "text-properties"), attrib=theAttr)
+        ET.SubElement(xStyl, _mkTag("style", "text-properties"), attrib=theAttr)
 
         # Add Header and Footer Styles
         # ============================
@@ -824,7 +815,7 @@ class ToOdt(Tokenizer):
         theAttr[_mkTag("style", "family")]            = "paragraph"
         theAttr[_mkTag("style", "parent-style-name")] = "Standard"
         theAttr[_mkTag("style", "class")]             = "extra"
-        etree.SubElement(self._xStyl, _mkTag("style", "style"), attrib=theAttr)
+        ET.SubElement(self._xStyl, _mkTag("style", "style"), attrib=theAttr)
 
         return
 
@@ -989,23 +980,23 @@ class ToOdt(Tokenizer):
         theAttr = {}
         theAttr[_mkTag("style", "name")]             = "Standard"
         theAttr[_mkTag("style", "page-layout-name")] = "PM1"
-        xPage = etree.SubElement(self._xMast, _mkTag("style", "master-page"), attrib=theAttr)
+        xPage = ET.SubElement(self._xMast, _mkTag("style", "master-page"), attrib=theAttr)
 
         # Standard Page Header
-        xHead = etree.SubElement(xPage, _mkTag("style", "header"))
-        xPar = etree.SubElement(xHead, _mkTag("text", "p"), attrib={
+        xHead = ET.SubElement(xPage, _mkTag("style", "header"))
+        xPar = ET.SubElement(xHead, _mkTag("text", "p"), attrib={
             _mkTag("text", "style-name"): "Header"
         })
         xPar.text = self._headerText.strip() + " "
 
-        xTail = etree.SubElement(xPar, _mkTag("text", "page-number"), attrib={
+        xTail = ET.SubElement(xPar, _mkTag("text", "page-number"), attrib={
             _mkTag("text", "select-page"): "current"
         })
         xTail.text = "2"
 
         # First Page Header
-        xHead = etree.SubElement(xPage, _mkTag("style", "header-first"))
-        xPar = etree.SubElement(xHead, _mkTag("text", "p"), attrib={
+        xHead = ET.SubElement(xPage, _mkTag("style", "header-first"))
+        xPar = ET.SubElement(xHead, _mkTag("text", "p"), attrib={
             _mkTag("text", "style-name"): "Header"
         })
 
@@ -1209,7 +1200,7 @@ class ODTParagraphStyle:
             if aVal is not None:
                 theAttr[_mkTag(aNm, aName)] = aVal
 
-        xEntry = etree.SubElement(xParent, _mkTag("style", "style"), attrib=theAttr)
+        xEntry = ET.SubElement(xParent, _mkTag("style", "style"), attrib=theAttr)
 
         theAttr = {}
         for aName, (aNm, aVal) in self._pAttr.items():
@@ -1217,7 +1208,7 @@ class ODTParagraphStyle:
                 theAttr[_mkTag(aNm, aName)] = aVal
 
         if theAttr:
-            etree.SubElement(xEntry, _mkTag("style", "paragraph-properties"), attrib=theAttr)
+            ET.SubElement(xEntry, _mkTag("style", "paragraph-properties"), attrib=theAttr)
 
         theAttr = {}
         for aName, (aNm, aVal) in self._tAttr.items():
@@ -1225,7 +1216,7 @@ class ODTParagraphStyle:
                 theAttr[_mkTag(aNm, aName)] = aVal
 
         if theAttr:
-            etree.SubElement(xEntry, _mkTag("style", "text-properties"), attrib=theAttr)
+            ET.SubElement(xEntry, _mkTag("style", "text-properties"), attrib=theAttr)
 
         return
 
@@ -1296,7 +1287,7 @@ class ODTTextStyle:
         theAttr = {}
         theAttr[_mkTag("style", "name")] = xName
         theAttr[_mkTag("style", "family")] = "text"
-        xEntry = etree.SubElement(xParent, _mkTag("style", "style"), attrib=theAttr)
+        xEntry = ET.SubElement(xParent, _mkTag("style", "style"), attrib=theAttr)
 
         theAttr = {}
         for aName, (aNm, aVal) in self._tAttr.items():
@@ -1304,7 +1295,7 @@ class ODTTextStyle:
                 theAttr[_mkTag(aNm, aName)] = aVal
 
         if theAttr:
-            etree.SubElement(xEntry, _mkTag("style", "text-properties"), attrib=theAttr)
+            ET.SubElement(xEntry, _mkTag("style", "text-properties"), attrib=theAttr)
 
         return
 
@@ -1377,26 +1368,26 @@ class XMLParagraph:
 
             if c == "\n":
                 if self._nState in (X_ROOT_TEXT, X_ROOT_TAIL):
-                    self._xTail = etree.SubElement(self._xRoot, TAG_BR)
+                    self._xTail = ET.SubElement(self._xRoot, TAG_BR)
                     self._xTail.tail = ""
                     self._nState = X_ROOT_TAIL
                     self._chrPos += 1
 
                 elif self._nState in (X_SPAN_TEXT, X_SPAN_SING):
-                    self._xSing = etree.SubElement(self._xTail, TAG_BR)
+                    self._xSing = ET.SubElement(self._xTail, TAG_BR)
                     self._xSing.tail = ""
                     self._nState = X_SPAN_SING
                     self._chrPos += 1
 
             elif c == "\t":
                 if self._nState in (X_ROOT_TEXT, X_ROOT_TAIL):
-                    self._xTail = etree.SubElement(self._xRoot, TAG_TAB)
+                    self._xTail = ET.SubElement(self._xRoot, TAG_TAB)
                     self._xTail.tail = ""
                     self._nState = X_ROOT_TAIL
                     self._chrPos += 1
 
                 elif self._nState in (X_SPAN_TEXT, X_SPAN_SING):
-                    self._xSing = etree.SubElement(self._xTail, TAG_TAB)
+                    self._xSing = ET.SubElement(self._xTail, TAG_TAB)
                     self._xSing.tail = ""
                     self._chrPos += 1
                     self._nState = X_SPAN_SING
@@ -1426,7 +1417,7 @@ class XMLParagraph:
         Therefore we return to the root element level when we're done
         processing the text of the span.
         """
-        self._xTail = etree.SubElement(self._xRoot, TAG_SPAN, attrib={
+        self._xTail = ET.SubElement(self._xRoot, TAG_SPAN, attrib={
             TAG_STNM: tFmt
         })
         self._xTail.text = ""  # Defaults to None
@@ -1478,20 +1469,20 @@ class XMLParagraph:
 
         if nSpaces == 2:
             if self._nState in (X_ROOT_TEXT, X_ROOT_TAIL):
-                self._xTail = etree.SubElement(self._xRoot, TAG_SPC)
+                self._xTail = ET.SubElement(self._xRoot, TAG_SPC)
                 self._xTail.tail = ""
                 self._nState = X_ROOT_TAIL
                 self._chrPos += nSpaces - 1
 
             elif self._nState in (X_SPAN_TEXT, X_SPAN_SING):
-                self._xSing = etree.SubElement(self._xTail, TAG_SPC)
+                self._xSing = ET.SubElement(self._xTail, TAG_SPC)
                 self._xSing.tail = ""
                 self._nState = X_SPAN_SING
                 self._chrPos += nSpaces - 1
 
         elif nSpaces > 2:
             if self._nState in (X_ROOT_TEXT, X_ROOT_TAIL):
-                self._xTail = etree.SubElement(self._xRoot, TAG_SPC, attrib={
+                self._xTail = ET.SubElement(self._xRoot, TAG_SPC, attrib={
                     TAG_NSPC: str(nSpaces - 1)
                 })
                 self._xTail.tail = ""
@@ -1499,7 +1490,7 @@ class XMLParagraph:
                 self._chrPos += nSpaces - 1
 
             elif self._nState in (X_SPAN_TEXT, X_SPAN_SING):
-                self._xSing = etree.SubElement(self._xTail, TAG_SPC, attrib={
+                self._xSing = ET.SubElement(self._xTail, TAG_SPC, attrib={
                     TAG_NSPC: str(nSpaces - 1)
                 })
                 self._xSing.tail = ""

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -597,7 +597,7 @@ class ToOdt(Tokenizer):
         xElem = ET.SubElement(self._xText, _mkTag("text", pTag), attrib=tAttr)
 
         # It's important to set the initial text field to empty, otherwise
-        # lxml will add a line break if the first subelement is a span.
+        # xmlIndent will add a line break if the first subelement is a span.
         xElem.text = ""
 
         if not theText:
@@ -1314,8 +1314,6 @@ X_SPAN_SING = 3
 class XMLParagraph:
     """This is a helper class to manage the text content of a single
     XML element using mixed content tags.
-
-    See: https://lxml.de/tutorial.html#the-element-class
 
     Rules:
      * The root tag can only have text set, never tail.

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -992,6 +992,7 @@ class ToOdt(Tokenizer):
             _mkTag("text", "select-page"): "current"
         })
         xTail.text = "2"
+        xTail.tail = ""  # Prevent line break in indented XML
 
         # First Page Header
         xHead = ET.SubElement(xPage, _mkTag("style", "header-first"))

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -129,12 +129,6 @@ class NWErrorMessage(QDialog):
             kernelVersion = "Unknown"
 
         try:
-            import lxml
-            lxmlVersion = lxml.__version__  # type: ignore
-        except Exception:
-            lxmlVersion = "Unknown"
-
-        try:
             import enchant
             enchantVersion = enchant.__version__
         except Exception:
@@ -148,7 +142,6 @@ class NWErrorMessage(QDialog):
                 f"Host OS: {sys.platform} ({kernelVersion})\n"
                 f"Python: {sys.version.split()[0]} ({sys.hexversion:#x})\n"
                 f"Qt: {QT_VERSION_STR}, PyQt: {PYQT_VERSION_STR}\n"
-                f"lxml: {lxmlVersion}\n"
                 f"enchant: {enchantVersion}\n\n"
                 f"{exType.__name__}:\n{str(exValue)}\n\n"
                 f"Traceback:\n{exTrace}\n"

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -23,6 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+import sys
 import logging
 
 from enum import Enum
@@ -31,10 +32,10 @@ from pathlib import Path
 from datetime import datetime
 
 from PyQt5.QtCore import Qt, QTimer, QThreadPool, pyqtSlot
-from PyQt5.QtGui import QIcon, QKeySequence, QCursor
+from PyQt5.QtGui import QCursor, QIcon, QKeySequence
 from PyQt5.QtWidgets import (
-    qApp, QMainWindow, QVBoxLayout, QWidget, QSplitter, QFileDialog, QShortcut,
-    QMessageBox, QDialog, QStackedWidget
+    qApp, QDialog, QFileDialog, QMainWindow, QMessageBox, QShortcut, QSplitter,
+    QStackedWidget, QVBoxLayout, QWidget
 )
 
 from novelwriter import CONFIG, __hexversion__
@@ -88,7 +89,7 @@ class GuiMain(QMainWindow):
         logger.info("Host: %s", CONFIG.hostName)
         logger.info("Qt5: %s (0x%06x)", CONFIG.verQtString, CONFIG.verQtValue)
         logger.info("PyQt5: %s (0x%06x)", CONFIG.verPyQtString, CONFIG.verPyQtValue)
-        logger.info("Python: %s (0x%08x)", CONFIG.verPyString, CONFIG.verPyHexVal)
+        logger.info("Python: %s (0x%08x)", CONFIG.verPyString, sys.hexversion)
         logger.info("GUI Language: %s", CONFIG.guiLocale)
 
         # Core Classes

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-04-15 20:52:06">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1475" autoCount="237" editTime="74579">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 16:50:14">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1483" autoCount="237" editTime="74603">
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
@@ -25,7 +25,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sf12341" count="4" red="100" green="100" blue="100">New</entry>
@@ -45,111 +45,111 @@
   </settings>
   <content items="27" novelWords="954" notesWords="409">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="95" wordCount="19" paraCount="2" cursorPos="31"/>
+      <meta expanded="no" heading="H1" charCount="95" wordCount="19" paraCount="2" cursorPos="31" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277"/>
+      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277" />
       <name status="sf12341" import="ia857f0" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="7031beac91f75" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s90e6c9" import="ia857f0" active="yes">Part One</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="7031beac91f75" root="7031beac91f75" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291"/>
+      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291" />
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="67"/>
+      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="1090" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465"/>
+      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465" />
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310"/>
+      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0" />
       <name status="sf24ce6" import="ia857f0" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="7031beac91f75" root="7031beac91f75" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188"/>
+      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="88706ddc78b1b" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0" />
       <name status="s90e6c9" import="ia857f0" active="yes">We Found John!</name>
     </item>
     <item handle="e5e47ebf63b1c" parent="None" root="e5e47ebf63b1c" order="1" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Sequel</name>
     </item>
     <item handle="bacb7059e3083" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100"/>
+      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="a520879ca0b45" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104"/>
+      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="f6622b4617424" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="f6622b4617424" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="sf12341" import="icfb3a5" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="f6622b4617424" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="sf12341" import="i2d7a54" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="15c4492bd5107" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="sf12341" import="i56be10" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="15c4492bd5107" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="sf12341" import="icfb3a5" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="15c4492bd5107" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="sf12341" import="i2d7a54" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="4" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="6827118336ac1" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="6827118336ac1" order="0" type="FILE" class="ARCHIVE" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239"/>
+      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239" />
       <name status="s90e6c9" import="ia857f0" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="5" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="98acd8c76c93a" order="0" type="FILE" class="TRASH" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="sf12341" import="ia857f0" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 16:50:14">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1483" autoCount="237" editTime="74603">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 21:29:35">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1505" autoCount="237" editTime="74902">
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
@@ -65,7 +65,7 @@
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="1090" />
+      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="1369" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ include_package_data = True
 packages = find_namespace:
 install_requires =
     pyqt5>=5.10
-    lxml>=4.2.0
     pyenchant>=3.0.0
 
 [options.packages.find]

--- a/setup/debian/control
+++ b/setup/debian/control
@@ -2,14 +2,14 @@ Source: novelwriter
 Maintainer: Veronica Berglyd Olsen <code@vkbo.net>
 Section: text
 Priority: optional
-Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.7), python3-pyqt5 (>= 5.10), python3-lxml (>= 4.0), python3-enchant (>= 2.0)
+Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.7), python3-pyqt5 (>= 5.10), python3-enchant (>= 2.0)
 Standards-Version: 4.5.1
 Homepage: https://novelwriter.io
 X-Python3-Version: >= 3.7
 
 Package: novelwriter
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.7), python3-pyqt5 (>= 5.10), python3-lxml (>= 4.0), python3-enchant (>= 2.0)
+Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.7), python3-pyqt5 (>= 5.10), python3-enchant (>= 2.0)
 Description: A markdown-like text editor for planning and writing novels
  novelWriter is a plain text editor designed for writing novels assembled from
  many smaller text documents. It uses a minimal formatting syntax inspired by

--- a/setup/windows_install.bat
+++ b/setup/windows_install.bat
@@ -19,7 +19,7 @@ if exist setup.py (
 )
 echo.
 
-:: Install the PyQt5, lxml and pyenchant dependencies
+:: Install the PyQt5 and pyenchant dependencies
 pip install --user pywin32 -r requirements.txt
 
 :: Create the desktop and start menu icons

--- a/setup/windows_uninstall.bat
+++ b/setup/windows_uninstall.bat
@@ -29,7 +29,7 @@ goto afterUninst
 :: Remove the desktop and start menu icons
 python setup.py win-uninstall
 
-:: Remove the PyQt5, lxml and pyenchant dependencies
+:: Remove the PyQt5 and pyenchant dependencies
 pip uninstall --yes -r requirements.txt
 
 :afterUninst

--- a/tests/files/nwProject-1.5.nwx
+++ b/tests/files/nwProject-1.5.nwx
@@ -25,7 +25,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sf12341" count="4" red="100" green="100" blue="100">New</entry>
@@ -45,111 +45,111 @@
   </settings>
   <content items="27" novelWords="954" notesWords="409">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="93" wordCount="19" paraCount="2" cursorPos="119"/>
+      <meta expanded="no" heading="H1" charCount="93" wordCount="19" paraCount="2" cursorPos="119" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277"/>
+      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277" />
       <name status="sf12341" import="ia857f0" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="7031beac91f75" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H1" charCount="26" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s90e6c9" import="ia857f0" active="yes">Part One</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="7031beac91f75" root="7031beac91f75" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291"/>
+      <meta expanded="yes" heading="H2" charCount="95" wordCount="18" paraCount="1" cursorPos="291" />
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="67"/>
+      <meta expanded="no" heading="H3" charCount="2687" wordCount="479" paraCount="14" cursorPos="67" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465"/>
+      <meta expanded="no" heading="H3" charCount="548" wordCount="108" paraCount="3" cursorPos="465" />
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310"/>
+      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="310" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="1909" wordCount="346" paraCount="7" cursorPos="0" />
       <name status="sf24ce6" import="ia857f0" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="7031beac91f75" root="7031beac91f75" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188"/>
+      <meta expanded="yes" heading="H2" charCount="139" wordCount="28" paraCount="1" cursorPos="188" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="88706ddc78b1b" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="189" wordCount="37" paraCount="1" cursorPos="0" />
       <name status="s90e6c9" import="ia857f0" active="yes">We Found John!</name>
     </item>
     <item handle="e5e47ebf63b1c" parent="None" root="e5e47ebf63b1c" order="1" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Sequel</name>
     </item>
     <item handle="bacb7059e3083" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100"/>
+      <meta expanded="no" heading="H1" charCount="27" wordCount="5" paraCount="1" cursorPos="100" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="a520879ca0b45" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104"/>
+      <meta expanded="no" heading="H2" charCount="299" wordCount="55" paraCount="2" cursorPos="104" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="f6622b4617424" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="f6622b4617424" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H1" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="sf12341" import="icfb3a5" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="f6622b4617424" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H1" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="sf12341" import="i2d7a54" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="15c4492bd5107" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H1" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="sf12341" import="i56be10" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="15c4492bd5107" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H1" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="sf12341" import="icfb3a5" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="15c4492bd5107" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H1" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="sf12341" import="i2d7a54" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="4" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="6827118336ac1" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="6827118336ac1" order="0" type="FILE" class="ARCHIVE" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239"/>
+      <meta expanded="no" heading="H3" charCount="232" wordCount="42" paraCount="1" cursorPos="239" />
       <name status="s90e6c9" import="ia857f0" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="5" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="98acd8c76c93a" order="0" type="FILE" class="TRASH" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H3" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="sf12341" import="ia857f0" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/lipsum/nwProject.nwx
+++ b/tests/lipsum/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:00:43">
-  <project id="5ac0df12-8b8b-476b-9905-21d33685687c" saveCount="38" autoCount="24" editTime="1900">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:10:19">
+  <project id="5ac0df12-8b8b-476b-9905-21d33685687c" saveCount="40" autoCount="24" editTime="1905">
     <name>Lorem Ipsum</name>
     <title>Lorem Ipsum</title>
     <author>lipsum.com</author>
@@ -24,7 +24,7 @@
       <entry key="chapter">Chapter %ch%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sbaa94f" count="3" red="100" green="100" blue="100">New</entry>
@@ -41,87 +41,87 @@
   </settings>
   <content items="21" novelWords="3109" notesWords="738">
     <item handle="b3643d0f92e32" parent="None" root="b3643d0f92e32" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">Novel</name>
     </item>
     <item handle="7a992350f3eb6" parent="b3643d0f92e32" root="b3643d0f92e32" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="230" wordCount="40" paraCount="3" cursorPos="148"/>
+      <meta expanded="no" heading="H1" charCount="230" wordCount="40" paraCount="3" cursorPos="148" />
       <name status="sedd043" import="i613591" active="yes">Lorem Ipsum</name>
     </item>
     <item handle="8c58a65414c23" parent="b3643d0f92e32" root="b3643d0f92e32" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="1058" wordCount="176" paraCount="2" cursorPos="43"/>
+      <meta expanded="no" heading="H0" charCount="1058" wordCount="176" paraCount="2" cursorPos="43" />
       <name status="sedd043" import="i613591" active="yes">Front Matter</name>
     </item>
     <item handle="88d59a277361b" parent="b3643d0f92e32" root="b3643d0f92e32" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="584" wordCount="92" paraCount="1" cursorPos="4"/>
+      <meta expanded="no" heading="H2" charCount="584" wordCount="92" paraCount="1" cursorPos="4" />
       <name status="s92a87b" import="i613591" active="yes">Prologue</name>
     </item>
     <item handle="db7e733775d4d" parent="b3643d0f92e32" root="b3643d0f92e32" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="35" wordCount="6" paraCount="1" cursorPos="42"/>
+      <meta expanded="no" heading="H1" charCount="35" wordCount="6" paraCount="1" cursorPos="42" />
       <name status="sbaa94f" import="i613591" active="yes">Act One</name>
     </item>
     <item handle="45e6b01ca35c1" parent="b3643d0f92e32" root="b3643d0f92e32" order="4" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s92a87b" import="i613591">Chapter One</name>
     </item>
     <item handle="fb609cd8319dc" parent="45e6b01ca35c1" root="b3643d0f92e32" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="419" wordCount="67" paraCount="1" cursorPos="56"/>
+      <meta expanded="no" heading="H2" charCount="419" wordCount="67" paraCount="1" cursorPos="56" />
       <name status="s92a87b" import="i613591" active="yes">Chapter One</name>
     </item>
     <item handle="88243afbe5ed8" parent="45e6b01ca35c1" root="b3643d0f92e32" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2758" wordCount="404" paraCount="4" cursorPos="1528"/>
+      <meta expanded="no" heading="H3" charCount="2758" wordCount="404" paraCount="4" cursorPos="1528" />
       <name status="sedd043" import="i613591" active="yes">Scene One</name>
     </item>
     <item handle="f96ec11c6a3da" parent="45e6b01ca35c1" root="b3643d0f92e32" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="4043" wordCount="600" paraCount="6" cursorPos="2335"/>
+      <meta expanded="no" heading="H3" charCount="4043" wordCount="600" paraCount="6" cursorPos="2335" />
       <name status="sedd043" import="i613591" active="yes">Scene Two</name>
     </item>
     <item handle="846352075de7d" parent="b3643d0f92e32" root="b3643d0f92e32" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="631" wordCount="109" paraCount="3" cursorPos="376"/>
+      <meta expanded="no" heading="H2" charCount="631" wordCount="109" paraCount="3" cursorPos="376" />
       <name status="sbaa94f" import="i613591" active="no">Interlude</name>
     </item>
     <item handle="6bd935d2490cd" parent="b3643d0f92e32" root="b3643d0f92e32" order="6" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s92a87b" import="i613591">Chapter Two</name>
     </item>
     <item handle="441420a886d82" parent="6bd935d2490cd" root="b3643d0f92e32" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="477" wordCount="70" paraCount="1" cursorPos="56"/>
+      <meta expanded="no" heading="H2" charCount="477" wordCount="70" paraCount="1" cursorPos="56" />
       <name status="s92a87b" import="i613591" active="yes">Chapter Two</name>
     </item>
     <item handle="eb103bc70c90c" parent="6bd935d2490cd" root="b3643d0f92e32" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3006" wordCount="439" paraCount="4" cursorPos="57"/>
+      <meta expanded="no" heading="H3" charCount="3006" wordCount="439" paraCount="4" cursorPos="57" />
       <name status="sedd043" import="i613591" active="yes">Scene Three</name>
     </item>
     <item handle="f8c0562e50f1b" parent="6bd935d2490cd" root="b3643d0f92e32" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3839" wordCount="563" paraCount="6" cursorPos="56"/>
+      <meta expanded="no" heading="H3" charCount="3839" wordCount="563" paraCount="6" cursorPos="56" />
       <name status="sedd043" import="i613591" active="yes">Scene Four</name>
     </item>
     <item handle="47666c91c7ccf" parent="6bd935d2490cd" root="b3643d0f92e32" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3644" wordCount="543" paraCount="5" cursorPos="351"/>
+      <meta expanded="no" heading="H3" charCount="3644" wordCount="543" paraCount="5" cursorPos="351" />
       <name status="sedd043" import="i613591" active="yes">Scene Five</name>
     </item>
     <item handle="67a8707f2f249" parent="None" root="67a8707f2f249" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">Characters</name>
     </item>
     <item handle="4c4f28287af27" parent="67a8707f2f249" root="67a8707f2f249" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1864" wordCount="284" paraCount="3" cursorPos="1883"/>
+      <meta expanded="no" heading="H1" charCount="1864" wordCount="284" paraCount="3" cursorPos="1883" />
       <name status="sbaa94f" import="i613591" active="yes">Mr. Nobody</name>
     </item>
     <item handle="6c6afb1247750" parent="None" root="6c6afb1247750" order="2" type="ROOT" class="PLOT">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">Plot</name>
     </item>
     <item handle="2426c6f0ca922" parent="6c6afb1247750" root="6c6afb1247750" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1369" wordCount="195" paraCount="2" cursorPos="1387"/>
+      <meta expanded="no" heading="H1" charCount="1369" wordCount="195" paraCount="2" cursorPos="1387" />
       <name status="sbaa94f" import="i613591" active="yes">Main</name>
     </item>
     <item handle="60bdf227455cc" parent="None" root="60bdf227455cc" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sbaa94f" import="i613591">World</name>
     </item>
     <item handle="04468803b92e1" parent="60bdf227455cc" root="60bdf227455cc" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="1770" wordCount="259" paraCount="3" cursorPos="1792"/>
+      <meta expanded="no" heading="H1" charCount="1770" wordCount="259" paraCount="3" cursorPos="1792" />
       <name status="sbaa94f" import="i613591" active="yes">Ancient Europe</name>
     </item>
   </content>

--- a/tests/reference/coreProject_NewFileFolder_nwProject.nwx
+++ b/tests/reference/coreProject_NewFileFolder_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:05:22">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:13:44">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="7" red="100" green="100" blue="100">New</entry>
@@ -38,47 +38,47 @@
   </settings>
   <content items="11" novelWords="10" notesWords="3">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">World</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000010" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Stuff</name>
     </item>
     <item handle="0000000000011" parent="0000000000010" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="5" wordCount="1" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="5" wordCount="1" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Hello</name>
     </item>
     <item handle="0000000000012" parent="000000000000a" root="000000000000a" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="11" wordCount="3" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="11" wordCount="3" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Jane</name>
     </item>
   </content>

--- a/tests/reference/coreProject_NewRoot_nwProject.nwx
+++ b/tests/reference/coreProject_NewRoot_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 13:05:22">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:13:44">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="6" red="100" green="100" blue="100">New</entry>
@@ -38,67 +38,67 @@
   </settings>
   <content items="16" novelWords="9" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">World</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000010" parent="None" root="0000000000010" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000011" parent="None" root="0000000000011" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000012" parent="None" root="0000000000012" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000013" parent="None" root="0000000000013" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="0000000000014" parent="None" root="0000000000014" order="0" type="ROOT" class="TIMELINE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Timeline</name>
     </item>
     <item handle="0000000000015" parent="None" root="0000000000015" order="0" type="ROOT" class="OBJECT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Objects</name>
     </item>
     <item handle="0000000000016" parent="None" root="0000000000016" order="0" type="ROOT" class="CUSTOM">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Custom</name>
     </item>
     <item handle="0000000000017" parent="None" root="0000000000017" order="0" type="ROOT" class="CUSTOM">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Custom</name>
     </item>
   </content>

--- a/tests/reference/coreToOdt_SaveFlat_document.fodt
+++ b/tests/reference/coreToOdt_SaveFlat_document.fodt
@@ -1,81 +1,82 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
+<office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-02-12T15:10:11</meta:creation-date>
-    <meta:generator>novelWriter/2.0.4</meta:generator>
+    <meta:creation-date>2023-05-29T19:49:56</meta:creation-date>
+    <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>Jane Smith</meta:initial-creator>
     <meta:editing-cycles>1234</meta:editing-cycles>
     <meta:editing-duration>P42DT12H34M56S</meta:editing-duration>
     <dc:title>Test Project</dc:title>
-    <dc:date>2023-02-12T15:10:11</dc:date>
+    <dc:date>2023-05-29T19:49:56</dc:date>
     <dc:creator>Jane Smith</dc:creator>
   </office:meta>
   <office:font-face-decls>
-    <style:font-face style:name="Liberation Serif" style:font-pitch="variable"/>
+    <style:font-face style:name="Liberation Serif" style:font-pitch="variable" />
   </office:font-face-decls>
   <office:styles>
     <style:default-style style:family="paragraph">
-      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:language="nb" fo:country="NO"/>
+      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:language="nb" fo:country="NO" />
     </style:default-style>
     <style:style style:name="Standard" style:family="paragraph" style:class="text">
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt"/>
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" />
     </style:style>
     <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" fo:keep-with-next="always"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt"/>
+      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" fo:keep-with-next="always" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt" />
     </style:style>
-    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra"/>
+    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra" />
     <style:style style:name="Text_20_body" style:family="paragraph" style:display-name="Text body" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%" fo:text-align="left"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%" fo:text-align="left" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" />
     </style:style>
     <style:style style:name="Text_20_Meta" style:family="paragraph" style:display-name="Text Meta" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:color="#813709" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:color="#813709" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Title" style:family="paragraph" style:display-name="Title" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
-      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm" fo:text-align="center"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="30pt" fo:font-weight="bold"/>
+      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm" fo:text-align="center" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="30pt" fo:font-weight="bold" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="24pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="24pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_2" style:family="paragraph" style:display-name="Heading 2" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="2" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.353cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="19pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.353cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="19pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_3" style:family="paragraph" style:display-name="Heading 3" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="3" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="16pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="16pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_4" style:family="paragraph" style:display-name="Heading 4" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="4" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Header" style:family="paragraph" style:display-name="Header" style:parent-style-name="Header_20_and_20_Footer">
-      <style:paragraph-properties fo:text-align="right"/>
+      <style:paragraph-properties fo:text-align="right" />
     </style:style>
   </office:styles>
   <office:automatic-styles>
     <style:page-layout style:name="PM1">
-      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm"/>
+      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm"/>
+        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
       </style:header-style>
     </style:page-layout>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Heading_20_2">
-      <style:paragraph-properties fo:break-before="page"/>
+      <style:paragraph-properties fo:break-before="page" />
     </style:style>
   </office:automatic-styles>
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number></text:p>
+        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number>
+        </text:p>
       </style:header>
       <style:header-first>
-        <text:p text:style-name="Header"/>
+        <text:p text:style-name="Header" />
       </style:header-first>
     </style:master-page>
   </office:master-styles>

--- a/tests/reference/coreToOdt_SaveFlat_document.fodt
+++ b/tests/reference/coreToOdt_SaveFlat_document.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-05-29T19:49:56</meta:creation-date>
+    <meta:creation-date>2023-05-29T22:10:15</meta:creation-date>
     <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>Jane Smith</meta:initial-creator>
     <meta:editing-cycles>1234</meta:editing-cycles>
     <meta:editing-duration>P42DT12H34M56S</meta:editing-duration>
     <dc:title>Test Project</dc:title>
-    <dc:date>2023-05-29T19:49:56</dc:date>
+    <dc:date>2023-05-29T22:10:15</dc:date>
     <dc:creator>Jane Smith</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -72,8 +72,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number>
-        </text:p>
+        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number></text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/reference/coreToOdt_SaveFull_content.xml
+++ b/tests/reference/coreToOdt_SaveFull_content.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3">
+<office:document-content xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3">
   <office:font-face-decls>
-    <style:font-face style:name="Liberation Serif" style:font-pitch="variable"/>
+    <style:font-face style:name="Liberation Serif" style:font-pitch="variable" />
   </office:font-face-decls>
   <office:automatic-styles>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Heading_20_2">
-      <style:paragraph-properties fo:break-before="page"/>
+      <style:paragraph-properties fo:break-before="page" />
     </style:style>
   </office:automatic-styles>
   <office:body>

--- a/tests/reference/coreToOdt_SaveFull_manifest.xml
+++ b/tests/reference/coreToOdt_SaveFull_manifest.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.3">
-  <manifest:file-entry manifest:full-path="/" manifest:version="1.3" manifest:media-type="application/vnd.oasis.opendocument.text"/>
-  <manifest:file-entry manifest:full-path="settings.xml" manifest:media-type="text/xml"/>
-  <manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>
-  <manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>
-  <manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>
+  <manifest:file-entry manifest:full-path="/" manifest:version="1.3" manifest:media-type="application/vnd.oasis.opendocument.text" />
+  <manifest:file-entry manifest:full-path="settings.xml" manifest:media-type="text/xml" />
+  <manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml" />
+  <manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml" />
+  <manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml" />
 </manifest:manifest>

--- a/tests/reference/coreToOdt_SaveFull_meta.xml
+++ b/tests/reference/coreToOdt_SaveFull_meta.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document-meta xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3">
+<office:document-meta xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" office:version="1.3">
   <office:meta>
-    <meta:creation-date>2023-02-12T15:09:03</meta:creation-date>
-    <meta:generator>novelWriter/2.0.4</meta:generator>
+    <meta:creation-date>2023-05-29T19:48:33</meta:creation-date>
+    <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>Jane Smith</meta:initial-creator>
     <meta:editing-cycles>1234</meta:editing-cycles>
     <meta:editing-duration>P42DT12H34M56S</meta:editing-duration>
     <dc:title>Test Project</dc:title>
-    <dc:date>2023-02-12T15:09:03</dc:date>
+    <dc:date>2023-05-29T19:48:33</dc:date>
     <dc:creator>Jane Smith</dc:creator>
   </office:meta>
 </office:document-meta>

--- a/tests/reference/coreToOdt_SaveFull_settings.xml
+++ b/tests/reference/coreToOdt_SaveFull_settings.xml
@@ -1,2 +1,2 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document-settings xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" office:version="1.3"/>
+<office:document-settings xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" office:version="1.3" />

--- a/tests/reference/coreToOdt_SaveFull_styles.xml
+++ b/tests/reference/coreToOdt_SaveFull_styles.xml
@@ -1,68 +1,69 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document-styles xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3">
+<office:document-styles xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3">
   <office:font-face-decls>
-    <style:font-face style:name="Liberation Serif" style:font-pitch="variable"/>
+    <style:font-face style:name="Liberation Serif" style:font-pitch="variable" />
   </office:font-face-decls>
   <office:styles>
     <style:default-style style:family="paragraph">
-      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:language="en" fo:country="GB"/>
+      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:language="en" fo:country="GB" />
     </style:default-style>
     <style:style style:name="Standard" style:family="paragraph" style:class="text">
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt"/>
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" />
     </style:style>
     <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" fo:keep-with-next="always"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt"/>
+      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" fo:keep-with-next="always" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt" />
     </style:style>
-    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra"/>
+    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra" />
     <style:style style:name="Text_20_body" style:family="paragraph" style:display-name="Text body" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%" fo:text-align="left"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%" fo:text-align="left" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" />
     </style:style>
     <style:style style:name="Text_20_Meta" style:family="paragraph" style:display-name="Text Meta" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:color="None" loext:opacity="None"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.247cm" fo:line-height="115%" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="12pt" fo:color="None" loext:opacity="None" />
     </style:style>
     <style:style style:name="Title" style:family="paragraph" style:display-name="Title" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
-      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm" fo:text-align="center"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="30pt" fo:font-weight="bold"/>
+      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm" fo:text-align="center" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="30pt" fo:font-weight="bold" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="24pt" fo:font-weight="bold" fo:color="None" loext:opacity="None"/>
+      <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="24pt" fo:font-weight="bold" fo:color="None" loext:opacity="None" />
     </style:style>
     <style:style style:name="Heading_20_2" style:family="paragraph" style:display-name="Heading 2" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="2" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.353cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="19pt" fo:font-weight="bold" fo:color="None" loext:opacity="None"/>
+      <style:paragraph-properties fo:margin-top="0.353cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="19pt" fo:font-weight="bold" fo:color="None" loext:opacity="None" />
     </style:style>
     <style:style style:name="Heading_20_3" style:family="paragraph" style:display-name="Heading 3" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="3" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="16pt" fo:font-weight="bold" fo:color="None" loext:opacity="None"/>
+      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="16pt" fo:font-weight="bold" fo:color="None" loext:opacity="None" />
     </style:style>
     <style:style style:name="Heading_20_4" style:family="paragraph" style:display-name="Heading 4" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="4" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm"/>
-      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt" fo:font-weight="bold" fo:color="None" loext:opacity="None"/>
+      <style:paragraph-properties fo:margin-top="0.247cm" fo:margin-bottom="0.212cm" />
+      <style:text-properties style:font-name="Liberation Serif" fo:font-family="'Liberation Serif'" fo:font-size="14pt" fo:font-weight="bold" fo:color="None" loext:opacity="None" />
     </style:style>
     <style:style style:name="Header" style:family="paragraph" style:display-name="Header" style:parent-style-name="Header_20_and_20_Footer">
-      <style:paragraph-properties fo:text-align="right"/>
+      <style:paragraph-properties fo:text-align="right" />
     </style:style>
   </office:styles>
   <office:automatic-styles>
     <style:page-layout style:name="PM1">
-      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm"/>
+      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm"/>
+        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
       </style:header-style>
     </style:page-layout>
   </office:automatic-styles>
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number></text:p>
+        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number>
+        </text:p>
       </style:header>
       <style:header-first>
-        <text:p text:style-name="Header"/>
+        <text:p text:style-name="Header" />
       </style:header-first>
     </style:master-page>
   </office:master-styles>

--- a/tests/reference/coreTools_NewCustomA_nwProject.nwx
+++ b/tests/reference/coreTools_NewCustomA_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-27 16:39:14">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:01:04">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Custom</name>
     <title>Test Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="15" red="100" green="100" blue="100">New</entry>
@@ -38,91 +38,91 @@
   </settings>
   <content items="22" novelWords="0" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000a" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Chapter 1</name>
     </item>
     <item handle="000000000000b" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1.1</name>
     </item>
     <item handle="000000000000c" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1.2</name>
     </item>
     <item handle="000000000000d" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1.3</name>
     </item>
     <item handle="000000000000e" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Chapter 2</name>
     </item>
     <item handle="000000000000f" parent="000000000000e" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2.1</name>
     </item>
     <item handle="0000000000010" parent="000000000000e" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2.2</name>
     </item>
     <item handle="0000000000011" parent="000000000000e" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2.3</name>
     </item>
     <item handle="0000000000012" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Chapter 3</name>
     </item>
     <item handle="0000000000013" parent="0000000000012" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3.1</name>
     </item>
     <item handle="0000000000014" parent="0000000000012" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3.2</name>
     </item>
     <item handle="0000000000015" parent="0000000000012" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3.3</name>
     </item>
     <item handle="0000000000016" parent="None" root="0000000000016" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000017" parent="0000000000016" root="0000000000016" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Plot</name>
     </item>
     <item handle="0000000000018" parent="None" root="0000000000018" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000019" parent="0000000000018" root="0000000000018" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Protagonist</name>
     </item>
     <item handle="000000000001a" parent="None" root="000000000001a" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="000000000001b" parent="000000000001a" root="000000000001a" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Location</name>
     </item>
     <item handle="000000000001c" parent="None" root="000000000001c" order="0" type="ROOT" class="ARCHIVE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Archive</name>
     </item>
     <item handle="000000000001d" parent="None" root="000000000001d" order="0" type="ROOT" class="TRASH">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Trash</name>
     </item>
   </content>

--- a/tests/reference/coreTools_NewCustomB_nwProject.nwx
+++ b/tests/reference/coreTools_NewCustomB_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-27 16:39:14">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:01:04">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Custom</name>
     <title>Test Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="9" red="100" green="100" blue="100">New</entry>
@@ -38,67 +38,67 @@
   </settings>
   <content items="16" novelWords="0" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000a" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 1</name>
     </item>
     <item handle="000000000000b" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 2</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 3</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 4</name>
     </item>
     <item handle="000000000000e" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 5</name>
     </item>
     <item handle="000000000000f" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Scene 6</name>
     </item>
     <item handle="0000000000010" parent="None" root="0000000000010" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000011" parent="0000000000010" root="0000000000010" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Plot</name>
     </item>
     <item handle="0000000000012" parent="None" root="0000000000012" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000013" parent="0000000000012" root="0000000000012" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Protagonist</name>
     </item>
     <item handle="0000000000014" parent="None" root="0000000000014" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="0000000000015" parent="0000000000014" root="0000000000014" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Main Location</name>
     </item>
     <item handle="0000000000016" parent="None" root="0000000000016" order="0" type="ROOT" class="ARCHIVE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Archive</name>
     </item>
     <item handle="0000000000017" parent="None" root="0000000000017" order="0" type="ROOT" class="TRASH">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Trash</name>
     </item>
   </content>

--- a/tests/reference/coreTools_NewMinimal_nwProject.nwx
+++ b/tests/reference/coreTools_NewMinimal_nwProject.nwx
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-27 16:39:14">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:01:04">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>New Project</name>
     <title>New Project</title>
-    <author></author>
+    <author />
   </project>
   <settings>
     <doBackup>yes</doBackup>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="5" red="100" green="100" blue="100">New</entry>
@@ -38,35 +38,35 @@
   </settings>
   <content items="8" novelWords="0" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="0000000000009" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000a" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000b" parent="000000000000a" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="000000000000c" parent="None" root="000000000000c" order="0" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000d" parent="None" root="000000000000d" order="0" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000e" parent="None" root="000000000000e" order="0" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Locations</name>
     </item>
     <item handle="000000000000f" parent="None" root="000000000000f" order="0" type="ROOT" class="ARCHIVE">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Archive</name>
     </item>
   </content>

--- a/tests/reference/guiBuild_Tool_Step1_Lorem_Ipsum.fodt
+++ b/tests/reference/guiBuild_Tool_Step1_Lorem_Ipsum.fodt
@@ -1,106 +1,110 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
+<office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-02-12T14:52:03</meta:creation-date>
-    <meta:generator>novelWriter/2.0.4</meta:generator>
+    <meta:creation-date>2023-05-29T20:00:01</meta:creation-date>
+    <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
-    <meta:editing-cycles>38</meta:editing-cycles>
-    <meta:editing-duration>P0DT0H31M40S</meta:editing-duration>
+    <meta:editing-cycles>40</meta:editing-cycles>
+    <meta:editing-duration>P0DT0H31M45S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2023-02-12T14:52:03</dc:date>
+    <dc:date>2023-05-29T20:00:01</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
-    <style:font-face style:name="DejaVu Sans" style:font-pitch="variable"/>
+    <style:font-face style:name="DejaVu Sans" style:font-pitch="variable" />
   </office:font-face-decls>
   <office:styles>
     <style:default-style style:family="paragraph">
-      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:language="en" fo:country="GB"/>
+      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:language="en" fo:country="GB" />
     </style:default-style>
     <style:style style:name="Standard" style:family="paragraph" style:class="text">
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt"/>
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" />
     </style:style>
     <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" fo:keep-with-next="always"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" fo:keep-with-next="always" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" />
     </style:style>
-    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra"/>
+    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra" />
     <style:style style:name="Text_20_body" style:family="paragraph" style:display-name="Text body" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" fo:text-align="left"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" fo:text-align="left" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" />
     </style:style>
     <style:style style:name="Text_20_Meta" style:family="paragraph" style:display-name="Text Meta" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:color="#813709" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:color="#813709" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Title" style:family="paragraph" style:display-name="Title" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
-      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" fo:text-align="center"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="28pt" fo:font-weight="bold"/>
+      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" fo:text-align="center" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="28pt" fo:font-weight="bold" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="22pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="22pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_2" style:family="paragraph" style:display-name="Heading 2" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="2" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.324cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="18pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.324cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="18pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_3" style:family="paragraph" style:display-name="Heading 3" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="3" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_4" style:family="paragraph" style:display-name="Heading 4" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="4" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Header" style:family="paragraph" style:display-name="Header" style:parent-style-name="Header_20_and_20_Footer">
-      <style:paragraph-properties fo:text-align="right"/>
+      <style:paragraph-properties fo:text-align="right" />
     </style:style>
   </office:styles>
   <office:automatic-styles>
     <style:page-layout style:name="PM1">
-      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm"/>
+      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm"/>
+        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
       </style:header-style>
     </style:page-layout>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Text_20_body">
-      <style:paragraph-properties fo:text-align="center"/>
+      <style:paragraph-properties fo:text-align="center" />
     </style:style>
     <style:style style:name="P2" style:family="paragraph" style:parent-style-name="Heading_20_2">
-      <style:paragraph-properties fo:break-before="page"/>
+      <style:paragraph-properties fo:break-before="page" />
     </style:style>
     <style:style style:name="P3" style:family="paragraph" style:parent-style-name="Heading_20_1">
-      <style:paragraph-properties fo:text-align="center" fo:break-before="page"/>
+      <style:paragraph-properties fo:text-align="center" fo:break-before="page" />
     </style:style>
     <style:style style:name="T1" style:family="text">
-      <style:text-properties fo:font-weight="bold"/>
+      <style:text-properties fo:font-weight="bold" />
     </style:style>
     <style:style style:name="T2" style:family="text">
-      <style:text-properties fo:font-style="italic"/>
+      <style:text-properties fo:font-style="italic" />
     </style:style>
   </office:automatic-styles>
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number></text:p>
+        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number>
+        </text:p>
       </style:header>
       <style:header-first>
-        <text:p text:style-name="Header"/>
+        <text:p text:style-name="Header" />
       </style:header-first>
     </style:master-page>
   </office:master-styles>
   <office:body>
     <office:text>
       <text:p text:style-name="Title">Lorem Ipsum</text:p>
-      <text:p text:style-name="P1"><text:span text:style-name="T1">By lipsum.com</text:span></text:p>
+      <text:p text:style-name="P1">
+        <text:span text:style-name="T1">By lipsum.com</text:span>
+      </text:p>
       <text:p text:style-name="P1">“Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit…”</text:p>
       <text:p text:style-name="P1">“There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain…”</text:p>
       <text:p text:style-name="Text_20_body">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of “de Finibus Bonorum et Malorum” (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, “Lorem ipsum dolor sit amet..”, comes from a line in section 1.10.32.</text:p>
       <text:p text:style-name="Text_20_body">The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from “de Finibus Bonorum et Malorum” by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.</text:p>
       <text:h text:style-name="P2" text:outline-level="2">Prologue</text:h>
-      <text:p text:style-name="Text_20_body"><text:span text:style-name="T2">Lorem Ipsum</text:span> is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</text:p>
+      <text:p text:style-name="Text_20_body">
+        <text:span text:style-name="T2">Lorem Ipsum</text:span> is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</text:p>
       <text:h text:style-name="P3" text:outline-level="1">Act One</text:h>
       <text:p text:style-name="P1">“Fusce maximus felis libero”</text:p>
       <text:h text:style-name="P2" text:outline-level="2">Chapter 1: Chapter One</text:h>

--- a/tests/reference/guiBuild_Tool_Step1_Lorem_Ipsum.fodt
+++ b/tests/reference/guiBuild_Tool_Step1_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-05-29T20:00:01</meta:creation-date>
+    <meta:creation-date>2023-05-29T20:51:32</meta:creation-date>
     <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
     <meta:editing-cycles>40</meta:editing-cycles>
     <meta:editing-duration>P0DT0H31M45S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2023-05-29T20:00:01</dc:date>
+    <dc:date>2023-05-29T20:51:32</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -95,16 +95,13 @@
   <office:body>
     <office:text>
       <text:p text:style-name="Title">Lorem Ipsum</text:p>
-      <text:p text:style-name="P1">
-        <text:span text:style-name="T1">By lipsum.com</text:span>
-      </text:p>
+      <text:p text:style-name="P1"><text:span text:style-name="T1">By lipsum.com</text:span></text:p>
       <text:p text:style-name="P1">“Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit…”</text:p>
       <text:p text:style-name="P1">“There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain…”</text:p>
       <text:p text:style-name="Text_20_body">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of “de Finibus Bonorum et Malorum” (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, “Lorem ipsum dolor sit amet..”, comes from a line in section 1.10.32.</text:p>
       <text:p text:style-name="Text_20_body">The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from “de Finibus Bonorum et Malorum” by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.</text:p>
       <text:h text:style-name="P2" text:outline-level="2">Prologue</text:h>
-      <text:p text:style-name="Text_20_body">
-        <text:span text:style-name="T2">Lorem Ipsum</text:span> is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</text:p>
+      <text:p text:style-name="Text_20_body"><text:span text:style-name="T2">Lorem Ipsum</text:span> is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</text:p>
       <text:h text:style-name="P3" text:outline-level="1">Act One</text:h>
       <text:p text:style-name="P1">“Fusce maximus felis libero”</text:p>
       <text:h text:style-name="P2" text:outline-level="2">Chapter 1: Chapter One</text:h>

--- a/tests/reference/guiBuild_Tool_Step1_Lorem_Ipsum.fodt
+++ b/tests/reference/guiBuild_Tool_Step1_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-05-29T20:51:32</meta:creation-date>
+    <meta:creation-date>2023-05-29T22:10:29</meta:creation-date>
     <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
     <meta:editing-cycles>40</meta:editing-cycles>
     <meta:editing-duration>P0DT0H31M45S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2023-05-29T20:51:32</dc:date>
+    <dc:date>2023-05-29T22:10:29</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -84,8 +84,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number>
-        </text:p>
+        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number></text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/reference/guiBuild_Tool_Step2_Lorem_Ipsum.fodt
+++ b/tests/reference/guiBuild_Tool_Step2_Lorem_Ipsum.fodt
@@ -1,105 +1,106 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
+<office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-02-12T15:00:22</meta:creation-date>
-    <meta:generator>novelWriter/2.0.4</meta:generator>
+    <meta:creation-date>2023-05-29T20:57:00</meta:creation-date>
+    <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
-    <meta:editing-cycles>38</meta:editing-cycles>
-    <meta:editing-duration>P0DT0H31M40S</meta:editing-duration>
+    <meta:editing-cycles>40</meta:editing-cycles>
+    <meta:editing-duration>P0DT0H31M45S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2023-02-12T15:00:22</dc:date>
+    <dc:date>2023-05-29T20:57:00</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
-    <style:font-face style:name="DejaVu Sans" style:font-pitch="variable"/>
+    <style:font-face style:name="DejaVu Sans" style:font-pitch="variable" />
   </office:font-face-decls>
   <office:styles>
     <style:default-style style:family="paragraph">
-      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:language="en" fo:country="GB"/>
+      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:language="en" fo:country="GB" />
     </style:default-style>
     <style:style style:name="Standard" style:family="paragraph" style:class="text">
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt"/>
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" />
     </style:style>
     <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" fo:keep-with-next="always"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" fo:keep-with-next="always" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" />
     </style:style>
-    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra"/>
+    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra" />
     <style:style style:name="Text_20_body" style:family="paragraph" style:display-name="Text body" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" fo:text-align="justify"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" fo:text-align="justify" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" />
     </style:style>
     <style:style style:name="Text_20_Meta" style:family="paragraph" style:display-name="Text Meta" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:color="#813709" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:color="#813709" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Title" style:family="paragraph" style:display-name="Title" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
-      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" fo:text-align="center"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="28pt" fo:font-weight="bold"/>
+      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" fo:text-align="center" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="28pt" fo:font-weight="bold" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="22pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="22pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_2" style:family="paragraph" style:display-name="Heading 2" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="2" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.324cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="18pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.324cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="18pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_3" style:family="paragraph" style:display-name="Heading 3" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="3" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_4" style:family="paragraph" style:display-name="Heading 4" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="4" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Header" style:family="paragraph" style:display-name="Header" style:parent-style-name="Header_20_and_20_Footer">
-      <style:paragraph-properties fo:text-align="right"/>
+      <style:paragraph-properties fo:text-align="right" />
     </style:style>
   </office:styles>
   <office:automatic-styles>
     <style:page-layout style:name="PM1">
-      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm"/>
+      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm"/>
+        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
       </style:header-style>
     </style:page-layout>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Text_20_body">
-      <style:paragraph-properties fo:text-align="center"/>
+      <style:paragraph-properties fo:text-align="center" />
     </style:style>
     <style:style style:name="P2" style:family="paragraph" style:parent-style-name="Text_20_Meta">
-      <style:paragraph-properties fo:break-before="page"/>
+      <style:paragraph-properties fo:break-before="page" />
     </style:style>
     <style:style style:name="P3" style:family="paragraph" style:parent-style-name="Heading_20_2">
-      <style:paragraph-properties fo:break-before="page"/>
+      <style:paragraph-properties fo:break-before="page" />
     </style:style>
     <style:style style:name="P4" style:family="paragraph" style:parent-style-name="Heading_20_1">
-      <style:paragraph-properties fo:text-align="center" fo:break-before="page"/>
+      <style:paragraph-properties fo:text-align="center" fo:break-before="page" />
     </style:style>
     <style:style style:name="P5" style:family="paragraph" style:parent-style-name="Text_20_Meta">
-      <style:paragraph-properties fo:margin-bottom="0.000cm"/>
+      <style:paragraph-properties fo:margin-bottom="0.000cm" />
     </style:style>
     <style:style style:name="P6" style:family="paragraph" style:parent-style-name="Text_20_Meta">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm" />
     </style:style>
     <style:style style:name="P7" style:family="paragraph" style:parent-style-name="Title">
-      <style:paragraph-properties fo:text-align="center" fo:break-before="page"/>
+      <style:paragraph-properties fo:text-align="center" fo:break-before="page" />
     </style:style>
     <style:style style:name="T1" style:family="text">
-      <style:text-properties fo:font-weight="bold"/>
+      <style:text-properties fo:font-weight="bold" />
     </style:style>
     <style:style style:name="T2" style:family="text">
-      <style:text-properties fo:font-style="italic"/>
+      <style:text-properties fo:font-style="italic" />
     </style:style>
   </office:automatic-styles>
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number></text:p>
+        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number>
+        </text:p>
       </style:header>
       <style:header-first>
-        <text:p text:style-name="Header"/>
+        <text:p text:style-name="Header" />
       </style:header-first>
     </style:master-page>
   </office:master-styles>
@@ -147,9 +148,9 @@
       <text:p text:style-name="Text_20_body">Ut et consequat enim, quis ornare nibh. In lectus neque, mollis et suscipit et, vestibulum vitae augue. Praesent id ante sit amet odio venenatis placerat a at erat. Sed sed metus sed nisi dictum varius. Integer tincidunt fermentum purus ac porta. Fusce porttitor non risus eget tristique. Donec augue nunc, maximus at fermentum vel, varius et neque. Ut sed consectetur mauris. Quisque ipsum enim, porttitor vitae imperdiet sit amet, tempor et mauris. Aliquam malesuada tincidunt lectus quis blandit. Sed commodo orci felis, quis ultrices tellus facilisis sed. Nunc vel varius est. Duis ullamcorper eu metus in pulvinar. Morbi at sapien dictum, rutrum mauris eget, interdum tellus.</text:p>
       <text:h text:style-name="P3" text:outline-level="2">Why do we use it?</text:h>
       <text:p text:style-name="Text_20_Meta"><text:span text:style-name="T1">Comment:</text:span> Exctracted from the lipsum.com website.</text:p>
-      <text:p text:style-name="Text_20_body"><text:tab/>It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.</text:p>
-      <text:p text:style-name="Text_20_body"><text:tab/>The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</text:p>
-      <text:p text:style-name="Text_20_body"><text:tab/>Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).</text:p>
+      <text:p text:style-name="Text_20_body"><text:tab />It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.</text:p>
+      <text:p text:style-name="Text_20_body"><text:tab />The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</text:p>
+      <text:p text:style-name="Text_20_body"><text:tab />Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).</text:p>
       <text:h text:style-name="P3" text:outline-level="2">Chapter Two: Chapter Two</text:h>
       <text:p text:style-name="P5"><text:span text:style-name="T1">Point of View:</text:span> Bod</text:p>
       <text:p text:style-name="P6"><text:span text:style-name="T1">Plot:</text:span> Main</text:p>

--- a/tests/reference/guiBuild_Tool_Step2_Lorem_Ipsum.fodt
+++ b/tests/reference/guiBuild_Tool_Step2_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-05-29T20:57:00</meta:creation-date>
+    <meta:creation-date>2023-05-29T22:11:22</meta:creation-date>
     <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
     <meta:editing-cycles>40</meta:editing-cycles>
     <meta:editing-duration>P0DT0H31M45S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2023-05-29T20:57:00</dc:date>
+    <dc:date>2023-05-29T22:11:22</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -96,8 +96,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number>
-        </text:p>
+        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number></text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/reference/guiBuild_Tool_Step3_Lorem_Ipsum.fodt
+++ b/tests/reference/guiBuild_Tool_Step3_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-05-29T21:06:32</meta:creation-date>
+    <meta:creation-date>2023-05-29T22:11:58</meta:creation-date>
     <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
     <meta:editing-cycles>40</meta:editing-cycles>
     <meta:editing-duration>P0DT0H31M45S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2023-05-29T21:06:32</dc:date>
+    <dc:date>2023-05-29T22:11:58</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -96,8 +96,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number>
-        </text:p>
+        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number></text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/reference/guiBuild_Tool_Step3_Lorem_Ipsum.fodt
+++ b/tests/reference/guiBuild_Tool_Step3_Lorem_Ipsum.fodt
@@ -1,105 +1,106 @@
 <?xml version='1.0' encoding='utf-8'?>
-<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
+<office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-02-12T15:01:25</meta:creation-date>
-    <meta:generator>novelWriter/2.0.4</meta:generator>
+    <meta:creation-date>2023-05-29T21:06:32</meta:creation-date>
+    <meta:generator>novelWriter/2.0.7</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
-    <meta:editing-cycles>38</meta:editing-cycles>
-    <meta:editing-duration>P0DT0H31M40S</meta:editing-duration>
+    <meta:editing-cycles>40</meta:editing-cycles>
+    <meta:editing-duration>P0DT0H31M45S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2023-02-12T15:01:25</dc:date>
+    <dc:date>2023-05-29T21:06:32</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
-    <style:font-face style:name="DejaVu Sans" style:font-pitch="variable"/>
+    <style:font-face style:name="DejaVu Sans" style:font-pitch="variable" />
   </office:font-face-decls>
   <office:styles>
     <style:default-style style:family="paragraph">
-      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:language="en" fo:country="GB"/>
+      <style:paragraph-properties style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="page" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:language="en" fo:country="GB" />
     </style:default-style>
     <style:style style:name="Standard" style:family="paragraph" style:class="text">
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt"/>
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" />
     </style:style>
     <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" fo:keep-with-next="always"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" fo:keep-with-next="always" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" />
     </style:style>
-    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra"/>
+    <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra" />
     <style:style style:name="Text_20_body" style:family="paragraph" style:display-name="Text body" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" fo:text-align="justify"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" fo:text-align="justify" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" />
     </style:style>
     <style:style style:name="Text_20_Meta" style:family="paragraph" style:display-name="Text Meta" style:parent-style-name="Standard" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:color="#813709" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.227cm" fo:line-height="115%" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="11pt" fo:color="#813709" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Title" style:family="paragraph" style:display-name="Title" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
-      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" fo:text-align="center"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="28pt" fo:font-weight="bold"/>
+      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" fo:text-align="center" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="28pt" fo:font-weight="bold" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="22pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.388cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="22pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_2" style:family="paragraph" style:display-name="Heading 2" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="2" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.324cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="18pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.324cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="18pt" fo:font-weight="bold" fo:color="#2a6099" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_3" style:family="paragraph" style:display-name="Heading 3" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="3" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="14pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Heading_20_4" style:family="paragraph" style:display-name="Heading 4" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="4" style:class="text">
-      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm"/>
-      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%"/>
+      <style:paragraph-properties fo:margin-top="0.227cm" fo:margin-bottom="0.194cm" />
+      <style:text-properties style:font-name="DejaVu Sans" fo:font-family="'DejaVu Sans'" fo:font-size="13pt" fo:font-weight="bold" fo:color="#444444" loext:opacity="100%" />
     </style:style>
     <style:style style:name="Header" style:family="paragraph" style:display-name="Header" style:parent-style-name="Header_20_and_20_Footer">
-      <style:paragraph-properties fo:text-align="right"/>
+      <style:paragraph-properties fo:text-align="right" />
     </style:style>
   </office:styles>
   <office:automatic-styles>
     <style:page-layout style:name="PM1">
-      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm"/>
+      <style:page-layout-properties fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm"/>
+        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
       </style:header-style>
     </style:page-layout>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Text_20_body">
-      <style:paragraph-properties fo:text-align="center"/>
+      <style:paragraph-properties fo:text-align="center" />
     </style:style>
     <style:style style:name="P2" style:family="paragraph" style:parent-style-name="Text_20_Meta">
-      <style:paragraph-properties fo:break-before="page"/>
+      <style:paragraph-properties fo:break-before="page" />
     </style:style>
     <style:style style:name="P3" style:family="paragraph" style:parent-style-name="Heading_20_2">
-      <style:paragraph-properties fo:break-before="page"/>
+      <style:paragraph-properties fo:break-before="page" />
     </style:style>
     <style:style style:name="P4" style:family="paragraph" style:parent-style-name="Heading_20_1">
-      <style:paragraph-properties fo:text-align="center" fo:break-before="page"/>
+      <style:paragraph-properties fo:text-align="center" fo:break-before="page" />
     </style:style>
     <style:style style:name="P5" style:family="paragraph" style:parent-style-name="Text_20_Meta">
-      <style:paragraph-properties fo:margin-bottom="0.000cm"/>
+      <style:paragraph-properties fo:margin-bottom="0.000cm" />
     </style:style>
     <style:style style:name="P6" style:family="paragraph" style:parent-style-name="Text_20_Meta">
-      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm"/>
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm" />
     </style:style>
     <style:style style:name="P7" style:family="paragraph" style:parent-style-name="Title">
-      <style:paragraph-properties fo:text-align="center" fo:break-before="page"/>
+      <style:paragraph-properties fo:text-align="center" fo:break-before="page" />
     </style:style>
     <style:style style:name="T1" style:family="text">
-      <style:text-properties fo:font-weight="bold"/>
+      <style:text-properties fo:font-weight="bold" />
     </style:style>
     <style:style style:name="T2" style:family="text">
-      <style:text-properties fo:font-style="italic"/>
+      <style:text-properties fo:font-style="italic" />
     </style:style>
   </office:automatic-styles>
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number></text:p>
+        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number>
+        </text:p>
       </style:header>
       <style:header-first>
-        <text:p text:style-name="Header"/>
+        <text:p text:style-name="Header" />
       </style:header-first>
     </style:master-page>
   </office:master-styles>
@@ -147,9 +148,9 @@
       <text:p text:style-name="Text_20_body">Ut et consequat enim, quis ornare nibh. In lectus neque, mollis et suscipit et, vestibulum vitae augue. Praesent id ante sit amet odio venenatis placerat a at erat. Sed sed metus sed nisi dictum varius. Integer tincidunt fermentum purus ac porta. Fusce porttitor non risus eget tristique. Donec augue nunc, maximus at fermentum vel, varius et neque. Ut sed consectetur mauris. Quisque ipsum enim, porttitor vitae imperdiet sit amet, tempor et mauris. Aliquam malesuada tincidunt lectus quis blandit. Sed commodo orci felis, quis ultrices tellus facilisis sed. Nunc vel varius est. Duis ullamcorper eu metus in pulvinar. Morbi at sapien dictum, rutrum mauris eget, interdum tellus.</text:p>
       <text:h text:style-name="P3" text:outline-level="2">Why do we use it?</text:h>
       <text:p text:style-name="Text_20_Meta"><text:span text:style-name="T1">Comment:</text:span> Exctracted from the lipsum.com website.</text:p>
-      <text:p text:style-name="Text_20_body"><text:tab/>It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.</text:p>
-      <text:p text:style-name="Text_20_body"><text:tab/>The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</text:p>
-      <text:p text:style-name="Text_20_body"><text:tab/>Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).</text:p>
+      <text:p text:style-name="Text_20_body"><text:tab />It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.</text:p>
+      <text:p text:style-name="Text_20_body"><text:tab />The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</text:p>
+      <text:p text:style-name="Text_20_body"><text:tab />Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).</text:p>
       <text:h text:style-name="P3" text:outline-level="2">Chapter Two: Chapter Two</text:h>
       <text:p text:style-name="P5"><text:span text:style-name="T1">Point of View:</text:span> Bod</text:p>
       <text:p text:style-name="P6"><text:span text:style-name="T1">Plot:</text:span> Main</text:p>

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc2" hexVersion="0x020000c2" fileVersion="1.5" timeStamp="2022-11-15 15:14:31">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:09:41">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="3">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">0000000000008</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="5" red="100" green="100" blue="100">New</entry>
@@ -38,47 +38,47 @@
   </settings>
   <content items="11" novelWords="136" notesWords="27">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="1" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="781" wordCount="129" paraCount="14" cursorPos="1010"/>
+      <meta expanded="no" heading="H1" charCount="781" wordCount="129" paraCount="14" cursorPos="1010" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="1" type="ROOT" class="PLOT">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000011" parent="0000000000009" root="0000000000009" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="48" wordCount="10" paraCount="1" cursorPos="69"/>
+      <meta expanded="no" heading="H1" charCount="48" wordCount="10" paraCount="1" cursorPos="69" />
       <name status="s000000" import="i000004" active="yes">New Note</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="0000000000010" parent="000000000000a" root="000000000000a" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="34" wordCount="8" paraCount="1" cursorPos="51"/>
+      <meta expanded="no" heading="H1" charCount="34" wordCount="8" paraCount="1" cursorPos="51" />
       <name status="s000000" import="i000004" active="yes">New Note</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000004">World</name>
     </item>
     <item handle="0000000000012" parent="000000000000b" root="000000000000b" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="51" wordCount="9" paraCount="1" cursorPos="68"/>
+      <meta expanded="no" heading="H1" charCount="51" wordCount="9" paraCount="1" cursorPos="68" />
       <name status="s000000" import="i000004" active="yes">New Note</name>
     </item>
   </content>

--- a/tests/reference/guiEditor_Main_Initial_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Initial_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.0-rc1" hexVersion="0x020000c1" fileVersion="1.5" timeStamp="2022-11-07 12:57:21">
+<novelWriterXML appVersion="2.0.7" hexVersion="0x020007f0" fileVersion="1.5" timeStamp="2023-05-29 17:01:12">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="2" autoCount="1" editTime="0">
     <name>New Project</name>
     <title>New Novel</title>
@@ -15,13 +15,13 @@
       <entry key="novelTree">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
-    <autoReplace/>
+    <autoReplace />
     <titleFormat>
       <entry key="title">%title%</entry>
       <entry key="chapter">%title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">* * *</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="5" red="100" green="100" blue="100">New</entry>
@@ -38,35 +38,35 @@
   </settings>
   <content items="8" novelWords="9" notesWords="0">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
     </item>
     <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">Title Page</name>
     </item>
     <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="1" type="FOLDER" class="NOVEL">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">New Chapter</name>
     </item>
     <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0"/>
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="1" type="ROOT" class="PLOT">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">Characters</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="3" type="ROOT" class="WORLD">
-      <meta expanded="no"/>
+      <meta expanded="no" />
       <name status="s000000" import="i000004">World</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy10.nwx
+++ b/tests/reference/projectXML_ReadLegacy10.nwx
@@ -25,7 +25,7 @@
       <entry key="chapter">Chapter %ch%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -45,91 +45,91 @@
   </settings>
   <content items="22" novelWords="0" notesWords="0">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78"/>
+      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="208" wordCount="40" paraCount="2" cursorPos="213"/>
+      <meta expanded="no" heading="H0" charCount="208" wordCount="40" paraCount="2" cursorPos="213" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215"/>
+      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="1199" wordCount="216" paraCount="7" cursorPos="527"/>
+      <meta expanded="no" heading="H0" charCount="1199" wordCount="216" paraCount="7" cursorPos="527" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="551"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="551" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238"/>
+      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238" />
       <name status="s000006" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="3" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="0" wordCount="0" paraCount="0" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy11.nwx
+++ b/tests/reference/projectXML_ReadLegacy11.nwx
@@ -25,7 +25,7 @@
       <entry key="chapter">Chapter %ch%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -45,91 +45,91 @@
   </settings>
   <content items="22" novelWords="0" notesWords="0">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78"/>
+      <meta expanded="no" heading="H0" charCount="72" wordCount="15" paraCount="2" cursorPos="78" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="210" wordCount="40" paraCount="2" cursorPos="213"/>
+      <meta expanded="no" heading="H0" charCount="210" wordCount="40" paraCount="2" cursorPos="213" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="23" wordCount="5" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215"/>
+      <meta expanded="no" heading="H0" charCount="12" wordCount="3" paraCount="0" cursorPos="215" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="1483" wordCount="263" paraCount="8" cursorPos="1086"/>
+      <meta expanded="no" heading="H0" charCount="1483" wordCount="263" paraCount="8" cursorPos="1086" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="428"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="428" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238"/>
+      <meta expanded="no" heading="H0" charCount="633" wordCount="101" paraCount="3" cursorPos="1238" />
       <name status="s000006" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1721" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="3" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy12.nwx
+++ b/tests/reference/projectXML_ReadLegacy12.nwx
@@ -25,7 +25,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -45,103 +45,103 @@
   </settings>
   <content items="25" novelWords="840" notesWords="376">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="241" wordCount="42" paraCount="3" cursorPos="252"/>
+      <meta expanded="no" heading="H0" charCount="241" wordCount="42" paraCount="3" cursorPos="252" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="125" wordCount="26" paraCount="2" cursorPos="127"/>
+      <meta expanded="no" heading="H0" charCount="125" wordCount="26" paraCount="2" cursorPos="127" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="30"/>
+      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="30" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279"/>
+      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="61"/>
+      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="61" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="1137"/>
+      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="1137" />
       <name status="s000000" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="3" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Outtakes</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="None" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="315" wordCount="55" paraCount="1" cursorPos="322"/>
+      <meta expanded="no" heading="H0" charCount="315" wordCount="55" paraCount="1" cursorPos="322" />
       <name status="s000003" import="i000007" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="4" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy13.nwx
+++ b/tests/reference/projectXML_ReadLegacy13.nwx
@@ -25,7 +25,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="s000000" count="0" red="100" green="100" blue="100">New</entry>
@@ -45,103 +45,103 @@
   </settings>
   <content items="25" novelWords="830" notesWords="376">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000002" import="i000007">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="2"/>
+      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="2" />
       <name status="s000002" import="i000007" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="186" wordCount="39" paraCount="2" cursorPos="212"/>
+      <meta expanded="no" heading="H0" charCount="186" wordCount="39" paraCount="2" cursorPos="212" />
       <name status="s000000" import="i000007" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="33"/>
+      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="33" />
       <name status="s000000" import="i000007" active="yes">Part One</name>
     </item>
     <item handle="e7ded148d6e4a" parent="7031beac91f75" root="None" order="3" type="FOLDER" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000003" import="i000007">A Folder</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="e7ded148d6e4a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279"/>
+      <meta expanded="no" heading="H0" charCount="75" wordCount="14" paraCount="1" cursorPos="279" />
       <name status="s000001" import="i000007" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="e7ded148d6e4a" root="None" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="62"/>
+      <meta expanded="no" heading="H0" charCount="2429" wordCount="432" paraCount="14" cursorPos="62" />
       <name status="s000003" import="i000007" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="e7ded148d6e4a" root="None" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577"/>
+      <meta expanded="no" heading="H0" charCount="476" wordCount="93" paraCount="3" cursorPos="577" />
       <name status="s000003" import="i000007" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="e7ded148d6e4a" root="None" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="4"/>
+      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="4" />
       <name status="s000000" import="i000007" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="e7ded148d6e4a" root="None" order="4" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110"/>
+      <meta expanded="no" heading="H0" charCount="1692" wordCount="313" paraCount="6" cursorPos="1110" />
       <name status="s000004" import="i000007" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="e7ded148d6e4a" root="None" order="5" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343"/>
+      <meta expanded="no" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="343" />
       <name status="s000003" import="i000007" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="e7ded148d6e4a" root="None" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="224" />
       <name status="s000003" import="i000007" active="yes">We Found John!</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="1" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="None" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="None" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="s000000" import="i000008" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="None" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="s000000" import="i000009" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="2" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="None" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="s000000" import="i00000a" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="None" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="s000000" import="i000008" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="None" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="s000000" import="i000009" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="3" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="None" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="314" wordCount="55" paraCount="1" cursorPos="322"/>
+      <meta expanded="no" heading="H0" charCount="314" wordCount="55" paraCount="1" cursorPos="322" />
       <name status="s000003" import="i000007" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="4" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="s000000" import="i000007">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="None" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s000000" import="i000007" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/reference/projectXML_ReadLegacy14.nwx
+++ b/tests/reference/projectXML_ReadLegacy14.nwx
@@ -25,7 +25,7 @@
       <entry key="chapter">Chapter %chw%: %title%</entry>
       <entry key="unnumbered">%title%</entry>
       <entry key="scene">Scene %ch%.%sc%: %title%</entry>
-      <entry key="section"></entry>
+      <entry key="section" />
     </titleFormat>
     <status>
       <entry key="sf12341" count="4" red="100" green="100" blue="100">New</entry>
@@ -45,111 +45,111 @@
   </settings>
   <content items="27" novelWords="954" notesWords="409">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="119"/>
+      <meta expanded="no" heading="H0" charCount="93" wordCount="19" paraCount="2" cursorPos="119" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277"/>
+      <meta expanded="no" heading="H0" charCount="251" wordCount="50" paraCount="2" cursorPos="277" />
       <name status="sf12341" import="ia857f0" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="7031beac91f75" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="26" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="s90e6c9" import="ia857f0" active="yes">Part One</name>
     </item>
     <item handle="6a2d6d5f4f401" parent="7031beac91f75" root="7031beac91f75" order="3" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H0" charCount="95" wordCount="18" paraCount="1" cursorPos="291"/>
+      <meta expanded="yes" heading="H0" charCount="95" wordCount="18" paraCount="1" cursorPos="291" />
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="2687" wordCount="479" paraCount="14" cursorPos="67"/>
+      <meta expanded="no" heading="H0" charCount="2687" wordCount="479" paraCount="14" cursorPos="67" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="548" wordCount="108" paraCount="3" cursorPos="465"/>
+      <meta expanded="no" heading="H0" charCount="548" wordCount="108" paraCount="3" cursorPos="465" />
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="310"/>
+      <meta expanded="no" heading="H0" charCount="617" wordCount="101" paraCount="3" cursorPos="310" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="1909" wordCount="346" paraCount="7" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="1909" wordCount="346" paraCount="7" cursorPos="0" />
       <name status="sf24ce6" import="ia857f0" active="no">A Note on Structure</name>
     </item>
     <item handle="88706ddc78b1b" parent="7031beac91f75" root="7031beac91f75" order="6" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="yes" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="188"/>
+      <meta expanded="yes" heading="H0" charCount="139" wordCount="28" paraCount="1" cursorPos="188" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter Two</name>
     </item>
     <item handle="ae7339df26ded" parent="88706ddc78b1b" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="0"/>
+      <meta expanded="no" heading="H0" charCount="189" wordCount="37" paraCount="1" cursorPos="0" />
       <name status="s90e6c9" import="ia857f0" active="yes">We Found John!</name>
     </item>
     <item handle="e5e47ebf63b1c" parent="None" root="e5e47ebf63b1c" order="1" type="ROOT" class="NOVEL">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Sequel</name>
     </item>
     <item handle="bacb7059e3083" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="27" wordCount="5" paraCount="1" cursorPos="100"/>
+      <meta expanded="no" heading="H0" charCount="27" wordCount="5" paraCount="1" cursorPos="100" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="a520879ca0b45" parent="e5e47ebf63b1c" root="e5e47ebf63b1c" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="299" wordCount="55" paraCount="2" cursorPos="104"/>
+      <meta expanded="no" heading="H0" charCount="299" wordCount="55" paraCount="2" cursorPos="104" />
       <name status="s90e6c9" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="f6622b4617424" parent="None" root="f6622b4617424" order="2" type="ROOT" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Characters</name>
     </item>
     <item handle="f7e2d9f330615" parent="f6622b4617424" root="f6622b4617424" order="0" type="FOLDER" class="CHARACTER">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Main Characters</name>
     </item>
     <item handle="14298de4d9524" parent="f7e2d9f330615" root="f6622b4617424" order="0" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24"/>
+      <meta expanded="no" heading="H0" charCount="49" wordCount="9" paraCount="1" cursorPos="24" />
       <name status="sf12341" import="icfb3a5" active="yes">John Smith</name>
     </item>
     <item handle="bb2c23b3c42cc" parent="f7e2d9f330615" root="f6622b4617424" order="1" type="FILE" class="CHARACTER" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25"/>
+      <meta expanded="no" heading="H0" charCount="55" wordCount="9" paraCount="1" cursorPos="25" />
       <name status="sf12341" import="i2d7a54" active="yes">Jane Smith</name>
     </item>
     <item handle="15c4492bd5107" parent="None" root="15c4492bd5107" order="3" type="ROOT" class="WORLD">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Locations</name>
     </item>
     <item handle="b3e74dbc1f584" parent="15c4492bd5107" root="15c4492bd5107" order="0" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20"/>
+      <meta expanded="no" heading="H0" charCount="76" wordCount="15" paraCount="1" cursorPos="20" />
       <name status="sf12341" import="i56be10" active="yes">Earth</name>
     </item>
     <item handle="f1471bef9f2ae" parent="15c4492bd5107" root="15c4492bd5107" order="1" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133"/>
+      <meta expanded="no" heading="H0" charCount="115" wordCount="24" paraCount="1" cursorPos="133" />
       <name status="sf12341" import="icfb3a5" active="yes">Space</name>
     </item>
     <item handle="5eaea4e8cdee8" parent="15c4492bd5107" root="15c4492bd5107" order="2" type="FILE" class="WORLD" layout="NOTE">
-      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45"/>
+      <meta expanded="no" heading="H0" charCount="28" wordCount="6" paraCount="1" cursorPos="45" />
       <name status="sf12341" import="i2d7a54" active="yes">Mars</name>
     </item>
     <item handle="6827118336ac1" parent="None" root="6827118336ac1" order="4" type="ROOT" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Archive</name>
     </item>
     <item handle="ae9bf3c3ea159" parent="6827118336ac1" root="6827118336ac1" order="0" type="FOLDER" class="ARCHIVE">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Scenes</name>
     </item>
     <item handle="8a5deb88c0e97" parent="ae9bf3c3ea159" root="6827118336ac1" order="0" type="FILE" class="ARCHIVE" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="232" wordCount="42" paraCount="1" cursorPos="239"/>
+      <meta expanded="no" heading="H0" charCount="232" wordCount="42" paraCount="1" cursorPos="239" />
       <name status="s90e6c9" import="ia857f0" active="yes">Old File</name>
     </item>
     <item handle="98acd8c76c93a" parent="None" root="98acd8c76c93a" order="5" type="ROOT" class="TRASH">
-      <meta expanded="yes"/>
+      <meta expanded="yes" />
       <name status="sf12341" import="ia857f0">Trash</name>
     </item>
     <item handle="b8136a5a774a0" parent="98acd8c76c93a" root="98acd8c76c93a" order="0" type="FILE" class="TRASH" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36"/>
+      <meta expanded="no" heading="H0" charCount="30" wordCount="6" paraCount="1" cursorPos="36" />
       <name status="sf12341" import="ia857f0" active="yes">Delete Me!</name>
     </item>
   </content>

--- a/tests/test_base/test_base_init.py
+++ b/tests/test_base/test_base_init.py
@@ -154,7 +154,6 @@ def testBaseInit_Imports(caplog, monkeypatch, fncPath):
     monkeypatch.setattr("PyQt5.QtWidgets.QErrorMessage.__init__", lambda *a: None)
     monkeypatch.setattr("PyQt5.QtWidgets.QErrorMessage.resize", lambda *a: None)
     monkeypatch.setattr("PyQt5.QtWidgets.QErrorMessage.showMessage", lambda *a: None)
-    monkeypatch.setitem(sys.modules, "lxml", None)
     monkeypatch.setattr("sys.hexversion", 0x0)
     monkeypatch.setattr("novelwriter.CONFIG.verQtValue", 0x050000)
     monkeypatch.setattr("novelwriter.CONFIG.verPyQtValue", 0x050000)
@@ -167,11 +166,9 @@ def testBaseInit_Imports(caplog, monkeypatch, fncPath):
     assert ex.value.code & 4 == 4    # Python version not satisfied
     assert ex.value.code & 8 == 8    # Qt version not satisfied
     assert ex.value.code & 16 == 16  # PyQt version not satisfied
-    assert ex.value.code & 32 == 32  # lxml package missing
 
     assert "At least Python" in caplog.messages[0]
     assert "At least Qt5" in caplog.messages[1]
     assert "At least PyQt5" in caplog.messages[2]
-    assert "lxml" in caplog.messages[3]
 
 # END Test testBaseInit_Imports

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -226,7 +226,7 @@ def testCoreProjectXML_ReadCurrent(monkeypatch, tstPaths, fncPath):
 
     # Fail saving
     with monkeypatch.context() as mp:
-        mp.setattr("pathlib.Path.write_bytes", causeOSError)
+        mp.setattr("xml.etree.ElementTree.ElementTree.write", causeOSError)
         assert xmlWriter.write(data, packedContent, timeStamp, 1000) is False
         assert str(xmlWriter.error) == "Mock OSError"
 

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -21,12 +21,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 import zipfile
+import xml.etree.ElementTree as ET
 
-from lxml import etree
 from shutil import copyfile
 
 from tools import ODT_IGNORE, cmpFiles
 
+from novelwriter.common import xmlIndent
 from novelwriter.core.toodt import ToOdt, ODTParagraphStyle, ODTTextStyle, XMLParagraph, _mkTag
 from novelwriter.core.project import NWProject
 
@@ -44,7 +45,7 @@ XML_NS = [
 def xmlToText(xElem):
     """Get the text content of an XML element.
     """
-    rTxt = etree.tostring(xElem, encoding="utf-8", xml_declaration=False).decode()
+    rTxt = ET.tostring(xElem, encoding="utf-8", xml_declaration=False).decode()
     for nSpace in XML_NS:
         rTxt = rTxt.replace(nSpace, "")
     return rTxt
@@ -113,7 +114,7 @@ def testCoreToOdt_TextFormatting(mockGUI):
     theDoc = ToOdt(theProject, isFlat=True)
 
     theDoc.initDocument()
-    assert xmlToText(theDoc._xText) == "<office:text/>"
+    assert xmlToText(theDoc._xText) == "<office:text />"
 
     # Paragraph Style
     # ===============
@@ -147,7 +148,7 @@ def testCoreToOdt_TextFormatting(mockGUI):
     theDoc._addTextPar("Standard", oStyle, "")
     assert xmlToText(theDoc._xText) == (
         "<office:text>"
-        "<text:p text:style-name=\"Standard\"></text:p>"
+        "<text:p text:style-name=\"Standard\" />"
         "</office:text>"
     )
 
@@ -217,7 +218,7 @@ def testCoreToOdt_TextFormatting(mockGUI):
     assert theDoc.getErrors() == []
     assert xmlToText(theDoc._xText) == (
         "<office:text>"
-        "<text:p text:style-name=\"Standard\">Hello<text:line-break/><text:tab/>World</text:p>"
+        "<text:p text:style-name=\"Standard\">Hello<text:line-break /><text:tab />World</text:p>"
         "</office:text>"
     )
 
@@ -366,7 +367,7 @@ def testCoreToOdt_Convert(mockGUI):
     assert theDoc.getErrors() == []
     assert xmlToText(theDoc._xText) == (
         '<office:text>'
-        '<text:p text:style-name="Text_20_body">Some text.<text:line-break/>Next line</text:p>'
+        '<text:p text:style-name="Text_20_body">Some text.<text:line-break />Next line</text:p>'
         '</office:text>'
     )
 
@@ -379,7 +380,7 @@ def testCoreToOdt_Convert(mockGUI):
     assert theDoc.getErrors() == []
     assert xmlToText(theDoc._xText) == (
         '<office:text>'
-        '<text:p text:style-name="Text_20_body"><text:tab/>Item 1<text:tab/>Item 2</text:p>'
+        '<text:p text:style-name="Text_20_body"><text:tab />Item 1<text:tab />Item 2</text:p>'
         '</office:text>'
     )
 
@@ -393,7 +394,7 @@ def testCoreToOdt_Convert(mockGUI):
     assert xmlToText(theDoc._xText) == (
         '<office:text>'
         '<text:p text:style-name="Text_20_body">Some <text:span text:style-name="T4">'
-        'bold<text:tab/>text</text:span></text:p>'
+        'bold<text:tab />text</text:span></text:p>'
         '</office:text>'
     )
 
@@ -413,8 +414,8 @@ def testCoreToOdt_Convert(mockGUI):
         '<office:text>'
         '<text:h text:style-name="Heading_20_3" text:outline-level="3">Scene</text:h>'
         '<text:p text:style-name="Text_20_body">Hello World</text:p>'
-        '<text:p text:style-name="Text_20_body">Hello <text:s/>World</text:p>'
-        '<text:p text:style-name="Text_20_body">Hello <text:s text:c="2"/>World</text:p>'
+        '<text:p text:style-name="Text_20_body">Hello <text:s />World</text:p>'
+        '<text:p text:style-name="Text_20_body">Hello <text:s text:c="2" />World</text:p>'
         '</office:text>'
     )
 
@@ -474,9 +475,9 @@ def testCoreToOdt_Convert(mockGUI):
     assert theDoc.getErrors() == []
     assert xmlToText(theDoc._xText) == (
         '<office:text>'
-        '<text:p text:style-name="Text_20_body"></text:p>'
+        '<text:p text:style-name="Text_20_body" />'
         '<text:p text:style-name="Text_20_body">Text</text:p>'
-        '<text:p text:style-name="Text_20_body"></text:p>'
+        '<text:p text:style-name="Text_20_body" />'
         '<text:p text:style-name="Text_20_body">Text</text:p>'
         '</office:text>'
     )
@@ -540,7 +541,7 @@ def testCoreToOdt_Convert(mockGUI):
         '<office:text>'
         '<text:h text:style-name="Heading_20_3" text:outline-level="3">Scene</text:h>'
         '<text:p text:style-name="Text_20_body">Regular paragraph</text:p>'
-        '<text:p text:style-name="P9">with<text:line-break/>break</text:p>'
+        '<text:p text:style-name="P9">with<text:line-break />break</text:p>'
         '<text:p text:style-name="P9">Left Align</text:p>'
         '</office:text>'
     )
@@ -592,7 +593,7 @@ def testCoreToOdt_ConvertDirect(mockGUI):
     assert (
         '<style:style style:name="P1" style:family="paragraph" '
         'style:parent-style-name="Text_20_body">'
-        '<style:paragraph-properties fo:text-align="justify"/>'
+        '<style:paragraph-properties fo:text-align="justify" />'
         '</style:style>'
     ) in xmlToText(theDoc._xAuto)
     assert xmlToText(theDoc._xText) == (
@@ -613,7 +614,7 @@ def testCoreToOdt_ConvertDirect(mockGUI):
     assert (
         '<style:style style:name="P1" style:family="paragraph" '
         'style:parent-style-name="Text_20_body">'
-        '<style:paragraph-properties fo:break-after="page"/>'
+        '<style:paragraph-properties fo:break-after="page" />'
         '</style:style>'
     ) in xmlToText(theDoc._xAuto)
     assert xmlToText(theDoc._xText) == (
@@ -723,15 +724,10 @@ def testCoreToOdt_SaveFull(mockGUI, fncPath, tstPaths):
     stylOut = tstPaths.outDir / "coreToOdt_SaveFull" / "styles.xml"
 
     def prettifyXml(inFile, outFile):
-        with open(outFile, mode="wb") as fileStream:
-            fileStream.write(
-                etree.tostring(
-                    etree.parse(str(inFile)),
-                    pretty_print=True,
-                    encoding="utf-8",
-                    xml_declaration=True
-                )
-            )
+        with open(outFile, mode="wb") as fStream:
+            xml = ET.parse(inFile)
+            xmlIndent(xml, space="  ")
+            xml.write(fStream, encoding="utf-8", xml_declaration=True)
 
     prettifyXml(maniOut, maniFile)
     prettifyXml(settOut, settFile)
@@ -949,20 +945,16 @@ def testCoreToOdt_ODTParagraphStyle():
 
     # Pack XML
     # ========
-    xStyle = etree.Element("test", nsmap={
-        "style": "urn:oasis:names:tc:opendocument:xmlns:style:1.0",
-        "loext": "urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0",
-        "fo":    "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0",
-    })
+    xStyle = ET.Element("test")
     parStyle.packXML(xStyle, "test")
     assert xmlToText(xStyle) == (
         '<test>'
         '<style:style style:name="test" style:family="paragraph" style:display-name="Name" '
         'style:parent-style-name="Name" style:next-style-name="Name">'
         '<style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm" '
-        'fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:line-height="1.15"/>'
+        'fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:line-height="1.15" />'
         '<style:text-properties style:font-name="Verdana" fo:font-family="Verdana" '
-        'fo:font-size="12pt" fo:color="#000000" loext:opacity="1.00"/>'
+        'fo:font-size="12pt" fo:color="#000000" loext:opacity="1.00" />'
         '</style:style>'
         '</test>'
     )
@@ -1059,15 +1051,12 @@ def testCoreToOdt_ODTTextStyle():
     txtStyle.setFontStyle("italic")
     txtStyle.setStrikeStyle("solid")
     txtStyle.setStrikeType("single")
-    xStyle = etree.Element("test", nsmap={
-        "style": "urn:oasis:names:tc:opendocument:xmlns:style:1.0",
-        "fo":    "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0",
-    })
+    xStyle = ET.Element("test")
     txtStyle.packXML(xStyle, "test")
     assert xmlToText(xStyle) == (
         '<test><style:style style:name="test" style:family="text"><style:text-properties '
         'fo:font-weight="bold" fo:font-style="italic" style:text-line-through-style="solid" '
-        'style:text-line-through-type="single"/></style:style></test>'
+        'style:text-line-through-type="single" /></style:style></test>'
     )
 
 # END Test testCoreToOdt_ODTTextStyle
@@ -1077,20 +1066,11 @@ def testCoreToOdt_ODTTextStyle():
 def testCoreToOdt_XMLParagraph():
     """Test XML encoding of paragraph.
     """
-    nsMap = {
-        "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
-        "style":  "urn:oasis:names:tc:opendocument:xmlns:style:1.0",
-        "loext":  "urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0",
-        "text":   "urn:oasis:names:tc:opendocument:xmlns:text:1.0",
-        "meta":   "urn:oasis:names:tc:opendocument:xmlns:meta:1.0",
-        "fo":     "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0",
-    }
-
     # Stage 1 : Text
     # ==============
 
-    xRoot = etree.Element("root", nsmap=nsMap)
-    xElem = etree.SubElement(xRoot, "{%s}p" % nsMap["text"])
+    xRoot = ET.Element("root")
+    xElem = ET.SubElement(xRoot, _mkTag("text", "p"))
     xmlPar = XMLParagraph(xElem)
 
     # Plain Text
@@ -1126,15 +1106,15 @@ def testCoreToOdt_XMLParagraph():
     # Stage 2 : Line Breaks
     # =====================
 
-    xRoot = etree.Element("root", nsmap=nsMap)
-    xElem = etree.SubElement(xRoot, "{%s}p" % nsMap["text"])
+    xRoot = ET.Element("root")
+    xElem = ET.SubElement(xRoot, _mkTag("text", "p"))
     xmlPar = XMLParagraph(xElem)
 
     # Plain Text w/Line Break
     xmlPar.appendText("Hello\nWorld\n!!")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello<text:line-break/>World<text:line-break/>!!</text:p>'
+        '<text:p>Hello<text:line-break />World<text:line-break />!!</text:p>'
         '</root>'
     )
 
@@ -1142,8 +1122,8 @@ def testCoreToOdt_XMLParagraph():
     xmlPar.appendSpan("spanned\ntext", "T1")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello<text:line-break/>World<text:line-break/>!!'
-        '<text:span text:style-name="T1">spanned<text:line-break/>text</text:span></text:p>'
+        '<text:p>Hello<text:line-break />World<text:line-break />!!'
+        '<text:span text:style-name="T1">spanned<text:line-break />text</text:span></text:p>'
         '</root>'
     )
 
@@ -1151,9 +1131,9 @@ def testCoreToOdt_XMLParagraph():
     xmlPar.appendText("more\ntext")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello<text:line-break/>World<text:line-break/>!!'
-        '<text:span text:style-name="T1">spanned<text:line-break/>text</text:span>'
-        'more<text:line-break/>text</text:p>'
+        '<text:p>Hello<text:line-break />World<text:line-break />!!'
+        '<text:span text:style-name="T1">spanned<text:line-break />text</text:span>'
+        'more<text:line-break />text</text:p>'
         '</root>'
     )
 
@@ -1162,15 +1142,15 @@ def testCoreToOdt_XMLParagraph():
     # Stage 3 : Tabs
     # ==============
 
-    xRoot = etree.Element("root", nsmap=nsMap)
-    xElem = etree.SubElement(xRoot, "{%s}p" % nsMap["text"])
+    xRoot = ET.Element("root")
+    xElem = ET.SubElement(xRoot, _mkTag("text", "p"))
     xmlPar = XMLParagraph(xElem)
 
     # Plain Text w/Line Break
     xmlPar.appendText("Hello\tWorld\t!!")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello<text:tab/>World<text:tab/>!!</text:p>'
+        '<text:p>Hello<text:tab />World<text:tab />!!</text:p>'
         '</root>'
     )
 
@@ -1178,8 +1158,8 @@ def testCoreToOdt_XMLParagraph():
     xmlPar.appendSpan("spanned\ttext", "T1")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello<text:tab/>World<text:tab/>!!'
-        '<text:span text:style-name="T1">spanned<text:tab/>text</text:span></text:p>'
+        '<text:p>Hello<text:tab />World<text:tab />!!'
+        '<text:span text:style-name="T1">spanned<text:tab />text</text:span></text:p>'
         '</root>'
     )
 
@@ -1187,9 +1167,9 @@ def testCoreToOdt_XMLParagraph():
     xmlPar.appendText("more\ttext")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello<text:tab/>World<text:tab/>!!'
-        '<text:span text:style-name="T1">spanned<text:tab/>text</text:span>'
-        'more<text:tab/>text</text:p>'
+        '<text:p>Hello<text:tab />World<text:tab />!!'
+        '<text:span text:style-name="T1">spanned<text:tab />text</text:span>'
+        'more<text:tab />text</text:p>'
         '</root>'
     )
 
@@ -1198,15 +1178,15 @@ def testCoreToOdt_XMLParagraph():
     # Stage 4 : Spaces
     # ================
 
-    xRoot = etree.Element("root", nsmap=nsMap)
-    xElem = etree.SubElement(xRoot, "{%s}p" % nsMap["text"])
+    xRoot = ET.Element("root")
+    xElem = ET.SubElement(xRoot, _mkTag("text", "p"))
     xmlPar = XMLParagraph(xElem)
 
     # Plain Text w/Spaces
     xmlPar.appendText("Hello  World   !!")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello <text:s/>World <text:s text:c="2"/>!!</text:p>'
+        '<text:p>Hello <text:s />World <text:s text:c="2" />!!</text:p>'
         '</root>'
     )
 
@@ -1214,8 +1194,8 @@ def testCoreToOdt_XMLParagraph():
     xmlPar.appendSpan("spanned    text", "T1")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello <text:s/>World <text:s text:c="2"/>!!'
-        '<text:span text:style-name="T1">spanned <text:s text:c="3"/>text</text:span></text:p>'
+        '<text:p>Hello <text:s />World <text:s text:c="2" />!!'
+        '<text:span text:style-name="T1">spanned <text:s text:c="3" />text</text:span></text:p>'
         '</root>'
     )
 
@@ -1223,9 +1203,9 @@ def testCoreToOdt_XMLParagraph():
     xmlPar.appendText("more     text")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p>Hello <text:s/>World <text:s text:c="2"/>!!'
-        '<text:span text:style-name="T1">spanned <text:s text:c="3"/>text</text:span>'
-        'more <text:s text:c="4"/>text</text:p>'
+        '<text:p>Hello <text:s />World <text:s text:c="2" />!!'
+        '<text:span text:style-name="T1">spanned <text:s text:c="3" />text</text:span>'
+        'more <text:s text:c="4" />text</text:p>'
         '</root>'
     )
 
@@ -1234,15 +1214,15 @@ def testCoreToOdt_XMLParagraph():
     # Stage 5 : Lots of Spaces
     # ========================
 
-    xRoot = etree.Element("root", nsmap=nsMap)
-    xElem = etree.SubElement(xRoot, "{%s}p" % nsMap["text"])
+    xRoot = ET.Element("root")
+    xElem = ET.SubElement(xRoot, _mkTag("text", "p"))
     xmlPar = XMLParagraph(xElem)
 
     # Plain Text w/Many Spaces
     xmlPar.appendText("  \t A \n  B ")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p><text:s text:c="2"/><text:tab/> A <text:line-break/> <text:s/>B </text:p>'
+        '<text:p><text:s text:c="2" /><text:tab /> A <text:line-break /> <text:s />B </text:p>'
         '</root>'
     )
 
@@ -1250,9 +1230,9 @@ def testCoreToOdt_XMLParagraph():
     xmlPar.appendSpan("  C  \t  D \n E ", "T1")
     assert xmlToText(xRoot) == (
         '<root>'
-        '<text:p><text:s text:c="2"/><text:tab/> A <text:line-break/> <text:s/>B '
-        '<text:span text:style-name="T1"> <text:s/>C <text:s/><text:tab/> <text:s/>D '
-        '<text:line-break/> E </text:span></text:p>'
+        '<text:p><text:s text:c="2" /><text:tab /> A <text:line-break /> <text:s />B '
+        '<text:span text:style-name="T1"> <text:s />C <text:s /><text:tab /> <text:s />D '
+        '<text:line-break /> E </text:span></text:p>'
         '</root>'
     )
 
@@ -1261,8 +1241,8 @@ def testCoreToOdt_XMLParagraph():
     # Check Error
     # ===========
 
-    xRoot = etree.Element("root", nsmap=nsMap)
-    xElem = etree.SubElement(xRoot, "{%s}p" % nsMap["text"])
+    xRoot = ET.Element("root")
+    xElem = ET.SubElement(xRoot, _mkTag("text", "p"))
     xmlPar = XMLParagraph(xElem)
 
     xmlPar.appendText("A")

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -64,21 +64,21 @@ def testCoreToOdt_Init(mockGUI):
     theDoc.initDocument()
 
     # Document XML
-    assert theDoc._dFlat is not None
-    assert theDoc._dCont is None
-    assert theDoc._dMeta is None
-    assert theDoc._dStyl is None
+    assert theDoc._dFlat.tag == _mkTag("office", "document")
+    assert theDoc._dCont.tag == ""
+    assert theDoc._dMeta.tag == ""
+    assert theDoc._dStyl.tag == ""
 
     # Content XML
-    assert theDoc._xMeta is not None
-    assert theDoc._xFont is not None
-    assert theDoc._xFnt2 is None
-    assert theDoc._xStyl is not None
-    assert theDoc._xAuto is not None
-    assert theDoc._xAut2 is None
-    assert theDoc._xMast is not None
-    assert theDoc._xBody is not None
-    assert theDoc._xText is not None
+    assert theDoc._xMeta.tag == _mkTag("office", "meta")
+    assert theDoc._xFont.tag == _mkTag("office", "font-face-decls")
+    assert theDoc._xFnt2.tag == ""
+    assert theDoc._xStyl.tag == _mkTag("office", "styles")
+    assert theDoc._xAuto.tag == _mkTag("office", "automatic-styles")
+    assert theDoc._xAut2.tag == ""
+    assert theDoc._xMast.tag == _mkTag("office", "master-styles")
+    assert theDoc._xBody.tag == _mkTag("office", "body")
+    assert theDoc._xText.tag == _mkTag("office", "text")
 
     # ODT Doc
     # =======
@@ -87,21 +87,22 @@ def testCoreToOdt_Init(mockGUI):
     theDoc.initDocument()
 
     # Document XML
-    assert theDoc._dFlat is None
-    assert theDoc._dCont is not None
-    assert theDoc._dMeta is not None
-    assert theDoc._dStyl is not None
+    assert theDoc._dFlat.tag == ""
+    assert theDoc._dCont.tag == _mkTag("office", "document-content")
+    assert theDoc._dMeta.tag == _mkTag("office", "document-meta")
+    assert theDoc._dStyl.tag == _mkTag("office", "document-styles")
 
     # Content XML
-    assert theDoc._xMeta is not None
-    assert theDoc._xFont is not None
-    assert theDoc._xFnt2 is not None
-    assert theDoc._xStyl is not None
-    assert theDoc._xAuto is not None
-    assert theDoc._xAut2 is not None
-    assert theDoc._xMast is not None
-    assert theDoc._xBody is not None
-    assert theDoc._xText is not None
+    assert theDoc._xMeta.tag == _mkTag("office", "meta")
+    assert theDoc._xFont.tag == _mkTag("office", "font-face-decls")
+    assert theDoc._xFnt2.tag == _mkTag("office", "font-face-decls")
+    assert theDoc._xStyl.tag == _mkTag("office", "styles")
+    assert theDoc._xAuto.tag == _mkTag("office", "automatic-styles")
+    assert theDoc._xAut2.tag == _mkTag("office", "automatic-styles")
+    assert theDoc._xMast.tag == _mkTag("office", "master-styles")
+    assert theDoc._xBody.tag == _mkTag("office", "body")
+    assert theDoc._xText.tag == _mkTag("office", "text")
+
 
 # END Test testCoreToOdt_Init
 
@@ -726,7 +727,7 @@ def testCoreToOdt_SaveFull(mockGUI, fncPath, tstPaths):
     def prettifyXml(inFile, outFile):
         with open(outFile, mode="wb") as fStream:
             xml = ET.parse(inFile)
-            xmlIndent(xml, space="  ")
+            xmlIndent(xml)
             xml.write(fStream, encoding="utf-8", xml_declaration=True)
 
     prettifyXml(maniOut, maniFile)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from PyQt5.QtWidgets import qApp
 
 XML_IGNORE = ("<novelWriterXML", "<project")
-ODT_IGNORE = ("<meta:generator", "<meta:creation-date", "<dc:date")
+ODT_IGNORE = ("<meta:generator", "<meta:creation-date", "<dc:date", "<meta:editing")
 
 
 class C:


### PR DESCRIPTION
**Summary:**

This PR:
* Replaces lxml with Python standard library xml package in the Project XML read/write classes.
* Replaces lxml with Python standard library xml package in the ODT writer class.
* Adds a custom xml indent function based on the one from the standard library. This one behaves more closely to how the indentation from lxml was added. In particular, it allows inline elements that do not have line breaks by explicitly requiring that text and tail attributes are set to None before breaks are added.
* Update all test and test reference files.
* Drop CI for Python 3.7, but Python 3.7 support itself is not yet officially dropped. It will likely be dropped before 2.1 is released though.
* Remove all references to the lxml package in the source, install files, documentation, and tests.

**Related Issue(s):**

Closes #1257

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
