### PR TITLE
Rename and restructure project meta files

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -104,8 +104,7 @@ def checkBool(value: Any, default: bool) -> bool:
 
 
 def checkHandle(value, default, allowNone=False):
-    """Check if a value is a handle.
-    """
+    """Check if a value is a handle."""
     if allowNone and (value is None or value == "None"):
         return None
     if isHandle(value):

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -91,6 +91,7 @@ class nwFiles:
     OPTS_FILE   = "options.json"
     PROJ_DICT   = "wordlist.txt"
     SESS_STATS  = "sessionStats.log"
+    SESS_FILE   = "sessions.jsonl"
 
 # END Class nwFiles
 

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -87,8 +87,8 @@ class nwFiles:
 
     # Project Meta Files
     BUILDS_FILE = "builds.json"
-    INDEX_FILE  = "tagsIndex.json"
-    OPTS_FILE   = "guiOptions.json"
+    INDEX_FILE  = "index.json"
+    OPTS_FILE   = "options.json"
     PROJ_DICT   = "wordlist.txt"
     SESS_STATS  = "sessionStats.log"
 

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -90,7 +90,7 @@ class nwFiles:
     INDEX_FILE  = "index.json"
     OPTS_FILE   = "options.json"
     PROJ_DICT   = "wordlist.txt"
-    SESS_STATS  = "sessionStats.log"
+    DICT_FILE   = "userdict.json"
     SESS_FILE   = "sessions.jsonl"
 
 # END Class nwFiles

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -89,7 +89,6 @@ class nwFiles:
     BUILDS_FILE = "builds.json"
     INDEX_FILE  = "index.json"
     OPTS_FILE   = "options.json"
-    PROJ_DICT   = "wordlist.txt"
     DICT_FILE   = "userdict.json"
     SESS_FILE   = "sessions.jsonl"
 

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -1,7 +1,6 @@
 """
 novelWriter – Project Document Tools
 ====================================
-A collection of tools to create and manipulate documents
 
 File History:
 Created: 2022-10-02 [2.0rc1] DocMerger
@@ -28,7 +27,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import shutil
 import logging
 
-from time import time
 from functools import partial
 
 from PyQt5.QtCore import QCoreApplication
@@ -319,7 +317,7 @@ class ProjectBuilder:
         project.data.setTitle(projTitle)
         project.data.setAuthor(projAuthor)
         project.setDefaultStatusImport()
-        project._projOpened = int(time())
+        project.session.startSession()
 
         # Add Root Folders
         hNovelRoot = project.newRoot(nwItemClass.NOVEL)

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -517,7 +517,7 @@ class NWIndex:
         """Count the number of words in the novel project."""
         wCount = 0
         for _, _, hItem in self._itemIndex.iterNovelStructure(skipExcl=skipExcl):
-            wCount += hItem.wordCount if isinstance(hItem, IndexHeading) else 0
+            wCount += hItem.wordCount
         return wCount
 
     def getNovelTitleCounts(self, skipExcl: bool = True) -> list[int]:

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -79,7 +79,7 @@ class OptionState:
 
     def __init__(self, project: NWProject):
         self._project = project
-        self._theState = {}
+        self._state = {}
         return
 
     ##
@@ -93,24 +93,25 @@ class OptionState:
         if not isinstance(stateFile, Path):
             return False
 
-        theState = {}
+        data = {}
         if stateFile.exists():
             logger.debug("Loading GUI options file")
             try:
                 with open(stateFile, mode="r", encoding="utf-8") as inFile:
-                    theState = json.load(inFile)
+                    data = json.load(inFile)
             except Exception:
                 logger.error("Failed to load GUI options file")
                 logException()
                 return False
 
         # Filter out unused variables
-        for aGroup in theState:
+        state = data.get("novelWriter.guiOptions", {})
+        for aGroup in state:
             if aGroup in VALID_MAP:
-                self._theState[aGroup] = {}
-                for anOpt in theState[aGroup]:
+                self._state[aGroup] = {}
+                for anOpt in state[aGroup]:
                     if anOpt in VALID_MAP[aGroup]:
-                        self._theState[aGroup][anOpt] = theState[aGroup][anOpt]
+                        self._state[aGroup][anOpt] = state[aGroup][anOpt]
 
         return True
 
@@ -123,7 +124,8 @@ class OptionState:
         logger.debug("Saving GUI options file")
         try:
             with open(stateFile, mode="w+", encoding="utf-8") as fObj:
-                fObj.write(jsonEncode(self._theState, nmax=3))
+                data = {"novelWriter.guiOptions": self._state}
+                fObj.write(jsonEncode(data, nmax=4))
         except Exception:
             logger.error("Failed to save GUI options file")
             logException()
@@ -145,13 +147,13 @@ class OptionState:
             logger.error("Unknown option name '%s'", name)
             return False
 
-        if group not in self._theState:
-            self._theState[group] = {}
+        if group not in self._state:
+            self._state[group] = {}
 
         if isinstance(value, Enum):
-            self._theState[group][name] = value.name
+            self._state[group][name] = value.name
         else:
-            self._theState[group][name] = value
+            self._state[group][name] = value
 
         return True
 
@@ -163,40 +165,40 @@ class OptionState:
         """Return an arbitrary type value, if it exists. Otherwise,
         return the default value.
         """
-        if group in self._theState:
-            return self._theState[group].get(name, default)
+        if group in self._state:
+            return self._state[group].get(name, default)
         return default
 
     def getString(self, group: str, name: str, default: str) -> str:
         """Return the value as a string, if it exists. Otherwise, return
         the default value.
         """
-        if group in self._theState:
-            return checkString(self._theState[group].get(name, default), default)
+        if group in self._state:
+            return checkString(self._state[group].get(name, default), default)
         return default
 
     def getInt(self, group: str, name: str, default: int) -> int:
         """Return the value as an int, if it exists. Otherwise, return
         the default value.
         """
-        if group in self._theState:
-            return checkInt(self._theState[group].get(name, default), default)
+        if group in self._state:
+            return checkInt(self._state[group].get(name, default), default)
         return default
 
     def getFloat(self, group: str, name: str, default: float) -> float:
         """Return the value as a float, if it exists. Otherwise, return
         the default value.
         """
-        if group in self._theState:
-            return checkFloat(self._theState[group].get(name, default), default)
+        if group in self._state:
+            return checkFloat(self._state[group].get(name, default), default)
         return default
 
     def getBool(self, group: str, name: str, default: bool) -> bool:
         """Return the value as a bool, if it exists. Otherwise, return
         the default value.
         """
-        if group in self._theState:
-            return checkBool(self._theState[group].get(name, default), default)
+        if group in self._state:
+            return checkBool(self._state[group].get(name, default), default)
         return default
 
     def getEnum(self, group: str, name: str, lookup: type, default: Enum) -> Enum:
@@ -204,9 +206,9 @@ class OptionState:
         default value.
         """
         if issubclass(lookup, Enum):
-            if group in self._theState:
-                if name in self._theState[group]:
-                    value = self._theState[group][name]
+            if group in self._state:
+                if name in self._state[group]:
+                    value = self._state[group][name]
                     if value in lookup.__members__:
                         return lookup[value]
         return default

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 from pathlib import Path
 
 from novelwriter.error import logException
-from novelwriter.common import checkBool, checkFloat, checkInt, checkString
+from novelwriter.common import checkBool, checkFloat, checkInt, checkString, jsonEncode
 from novelwriter.constants import nwFiles
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -47,7 +47,7 @@ VALID_MAP = {
         "hideZeros", "hideNegative", "groupByDay", "showIdleTime", "histMax",
     },
     "GuiDocSplit": {"spLevel", "intoFolder", "docHierarchy"},
-    "GuiOutline": {"headerOrder", "columnWidth", "columnHidden"},
+    "GuiOutline": {"columnState"},
     "GuiProjectSettings": {
         "winWidth", "winHeight", "replaceColW", "statusColW", "importColW",
     },
@@ -122,8 +122,8 @@ class OptionState:
 
         logger.debug("Saving GUI options file")
         try:
-            with open(stateFile, mode="w+", encoding="utf-8") as outFile:
-                json.dump(self._theState, outFile, indent=2)
+            with open(stateFile, mode="w+", encoding="utf-8") as fObj:
+                fObj.write(jsonEncode(self._theState, nmax=3))
         except Exception:
             logger.error("Failed to save GUI options file")
             logException()

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -34,7 +34,6 @@ from functools import partial
 from PyQt5.QtCore import QCoreApplication, QObject, pyqtSignal
 
 from novelwriter import CONFIG, __version__, __hexversion__
-from novelwriter.core.sessions import NWSessionLog
 from novelwriter.enum import nwItemType, nwItemClass, nwItemLayout, nwAlert
 from novelwriter.error import logException
 from novelwriter.constants import trConst, nwLabels
@@ -43,6 +42,7 @@ from novelwriter.core.item import NWItem
 from novelwriter.core.index import NWIndex
 from novelwriter.core.options import OptionState
 from novelwriter.core.storage import NWStorage
+from novelwriter.core.sessions import NWSessionLog
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.projectdata import NWProjectData
 from novelwriter.common import (

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -27,7 +27,7 @@ import json
 import logging
 
 from time import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterator
 from pathlib import Path
 
 from novelwriter.error import logException
@@ -108,6 +108,20 @@ class NWSessionLog:
             return False
 
         return True
+
+    def iterRecords(self) -> Iterator[dict]:
+        """Iterate through all records in the log."""
+        sessFile = self._project.storage.getMetaFile(nwFiles.SESS_FILE)
+        if not isinstance(sessFile, Path):
+            return
+        try:
+            with open(sessFile, mode="r", encoding="utf-8") as fObj:
+                for line in fObj:
+                    yield json.loads(line)
+        except Exception:
+            logger.error("Failed to process session stats file")
+            logException()
+        return
 
     def createInitial(self, total: int) -> str:
         """Low level function to create the initial log file record."""

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -112,7 +112,7 @@ class NWSessionLog:
     def iterRecords(self) -> Iterator[dict]:
         """Iterate through all records in the log."""
         sessFile = self._project.storage.getMetaFile(nwFiles.SESS_FILE)
-        if isinstance(sessFile, Path):
+        if isinstance(sessFile, Path) and sessFile.is_file():
             try:
                 with open(sessFile, mode="r", encoding="utf-8") as fObj:
                     for line in fObj:

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -34,7 +34,7 @@ from novelwriter.error import logException
 from novelwriter.common import formatTimeStamp
 from novelwriter.constants import nwFiles
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from novelwriter.core.project import NWProject
 
 logger = logging.getLogger(__name__)
@@ -112,15 +112,14 @@ class NWSessionLog:
     def iterRecords(self) -> Iterator[dict]:
         """Iterate through all records in the log."""
         sessFile = self._project.storage.getMetaFile(nwFiles.SESS_FILE)
-        if not isinstance(sessFile, Path):
-            return
-        try:
-            with open(sessFile, mode="r", encoding="utf-8") as fObj:
-                for line in fObj:
-                    yield json.loads(line)
-        except Exception:
-            logger.error("Failed to process session stats file")
-            logException()
+        if isinstance(sessFile, Path):
+            try:
+                with open(sessFile, mode="r", encoding="utf-8") as fObj:
+                    for line in fObj:
+                        yield json.loads(line)
+            except Exception:
+                logger.error("Failed to process session stats file")
+                logException()
         return
 
     def createInitial(self, total: int) -> str:

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -1,0 +1,125 @@
+"""
+novelWriter – Project Session Log Class
+=======================================
+
+File History:
+Created:   2023-06-11 [2.1b1]
+
+This file is a part of novelWriter
+Copyright 2018–2023, Veronica Berglyd Olsen
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from time import time
+from typing import TYPE_CHECKING
+from pathlib import Path
+
+from novelwriter.error import logException
+from novelwriter.common import formatTimeStamp
+from novelwriter.constants import nwFiles
+
+if TYPE_CHECKING:
+    from novelwriter.core.project import NWProject
+
+logger = logging.getLogger(__name__)
+
+
+class NWSessionLog:
+    """Core: Session JSON Lines Log File
+
+    The class that wraps the session log file, which is in JSON Lines
+    format. That is, one JSON object per line.
+    """
+
+    def __init__(self, project: NWProject):
+        self._project = project
+        self._start = 0.0
+        return
+
+    ##
+    #  Properties
+    ##
+
+    @property
+    def start(self) -> float:
+        """The session start time."""
+        return self._start
+
+    ##
+    #  Methods
+    ##
+
+    def startSession(self):
+        """Start the writng session."""
+        self._start = time()
+        return
+
+    def appendSession(self, idleTime: float) -> bool:
+        """Append session statistics to the sessions log file."""
+        sessFile = self._project.storage.getMetaFile(nwFiles.SESS_FILE)
+        if not isinstance(sessFile, Path):
+            return False
+
+        now = time()
+        iNovel, iNotes = self._project.data.initCounts
+        cNovel, cNotes = self._project.data.currCounts
+        iTotal = iNovel + iNotes
+        wDiff = cNovel + cNotes - iTotal
+        sTime = now - self._start
+
+        logger.info("The session lasted %d sec and added %d words", int(sTime), wDiff)
+        if sTime < 300 and wDiff == 0:
+            logger.info("Session too short, skipping log entry")
+            return False
+
+        try:
+            if not sessFile.exists():
+                with open(sessFile, mode="w", encoding="utf-8") as fObj:
+                    fObj.write(self.createInitial(iTotal))
+
+            with open(sessFile, mode="a+", encoding="utf-8") as fObj:
+                fObj.write(self.createRecord(
+                    start=formatTimeStamp(self._start),
+                    end=formatTimeStamp(now),
+                    novel=cNovel,
+                    notes=cNotes,
+                    idle=round(idleTime)
+                ))
+
+        except Exception:
+            logger.error("Failed to write to session stats file")
+            logException()
+            return False
+
+        return True
+
+    def createInitial(self, total: int) -> str:
+        """Low level function to create the initial log file record."""
+        data = json.dumps({"type": "initial", "offset": total})
+        return f"{data}\n"
+
+    def createRecord(self, start: str, end: str, novel: int, notes: int, idle: int) -> str:
+        """Low level function to create a log record."""
+        data = json.dumps({
+            "type": "record", "start": start, "end": end,
+            "novel": novel, "notes": notes, "idle": idle,
+        })
+        return f"{data}\n"
+
+# END Class NWSessionLog

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -325,7 +325,7 @@ class NWStorage:
                 self._legacyDataFolder(path, child)
 
         # Check for no longer used files, and delete them
-        self._deleteDeprecatedFiles(path)
+        self._deprecatedFiles(path)
 
         return True
 
@@ -372,9 +372,10 @@ class NWStorage:
 
         return
 
-    def _deleteDeprecatedFiles(self, path: Path):
-        """Delete files that are no longer used by novelWriter."""
+    def _deprecatedFiles(self, path: Path):
+        """Handle files that are no longer used by novelWriter."""
         remove = [
+            path / "meta" / "tagsIndex.json",          # Renamed in 2.1 Beta 1
             path / "meta" / "mainOptions.json",        # Replaced in 0.5
             path / "meta" / "exportOptions.json",      # Replaced in 0.5
             path / "meta" / "outlineOptions.json",     # Replaced in 0.5
@@ -395,6 +396,17 @@ class NWStorage:
                     logger.info("Deleted: %s", item)
                 except Exception as exc:
                     logger.warning("Failed to delete: %s", item, exc_info=exc)
+
+        # Renamed in 2.1 Beta 1, but this file we want to keep
+        oldOpt = path / "meta" / "guiOptions.json"
+        newOpt = path / "meta" / nwFiles.OPTS_FILE
+        if oldOpt.is_file():
+            try:
+                oldOpt.rename(newOpt)
+                logger.info("Renamed: %s > %s", oldOpt, newOpt)
+            except Exception as exc:
+                logger.warning("Failed to rename: %s", oldOpt, exc_info=exc)
+
         return
 
 # END Class NWStorage

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -114,7 +114,7 @@ class GuiAbout(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiAbout")
         return
 

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -113,7 +113,7 @@ class GuiDocMerge(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiDocMerge")
         return
 

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -142,7 +142,7 @@ class GuiDocSplit(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiDocSplit")
         return
 

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -87,7 +87,7 @@ class GuiPreferences(NPagedDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiPreferences")
         return
 

--- a/novelwriter/dialogs/projdetails.py
+++ b/novelwriter/dialogs/projdetails.py
@@ -82,7 +82,7 @@ class GuiProjectDetails(NPagedDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiProjectDetails")
         return
 

--- a/novelwriter/dialogs/projload.py
+++ b/novelwriter/dialogs/projload.py
@@ -151,7 +151,7 @@ class GuiProjectLoad(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiProjectLoad")
         return
 

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -97,7 +97,7 @@ class GuiProjectSettings(NPagedDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiProjectSettings")
         return
 

--- a/novelwriter/dialogs/updates.py
+++ b/novelwriter/dialogs/updates.py
@@ -117,7 +117,7 @@ class GuiUpdates(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiUpdates")
         return
 

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -114,7 +114,7 @@ class GuiWordList(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiWordList")
         return
 
@@ -122,25 +122,25 @@ class GuiWordList(QDialog):
     #  Slots
     ##
 
-    def _doAdd(self) -> bool:
+    def _doAdd(self):
         """Add a new word to the word list."""
         word = self.newEntry.text().strip()
         if word == "":
             self.mainGui.makeAlert(self.tr(
                 "Cannot add a blank word."
             ), nwAlert.ERROR)
-            return False
+            return
 
         if self.listBox.findItems(word, Qt.MatchExactly):
             self.mainGui.makeAlert(self.tr(
                 "The word '{0}' is already in the word list."
             ).format(word), nwAlert.ERROR)
-            return False
+            return
 
         self.listBox.addItem(word)
         self.newEntry.setText("")
 
-        return True
+        return
 
     def _doDelete(self):
         """Delete the selected item."""

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -95,7 +95,7 @@ class NWErrorMessage(QDialog):
         self.mainBox.setSpacing(16)
 
         # Pick a random window title from a set of error messages by
-        # Hex, the computer, from Discworld
+        # Hex the computer, Unseen University, Ankh-Morpork, Discworld
         self.setWindowTitle([
             "+++ Out of Cheese Error +++",
             "+++ Divide by Cucumber Error +++",

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -95,7 +95,8 @@ class NWErrorMessage(QDialog):
             "+++ Divide by Cucumber Error +++",
             "+++ Whoops! Here Comes The Cheese! +++",
             "+++ Please Reinstall Universe and Reboot +++",
-        ][random.randint(0, 3)])
+            "+++ Error At Address 14, Treacle Mine Road +++",
+        ][random.randint(0, 4)])
 
         self.setLayout(self.mainBox)
 

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -27,6 +27,7 @@ import sys
 import random
 import logging
 
+from PyQt5.QtGui import QFont, QFontDatabase
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     qApp, QDialog, QGridLayout, QStyle, QPlainTextEdit, QLabel,
@@ -74,7 +75,12 @@ class NWErrorMessage(QDialog):
         self.msgHead.setOpenExternalLinks(True)
         self.msgHead.setWordWrap(True)
 
+        font = QFont()
+        font.setPointSize(round(0.9*self.font().pointSize()))
+        font.setFamily(QFontDatabase.systemFont(QFontDatabase.FixedFont).family())
+
         self.msgBody = QPlainTextEdit()
+        self.msgBody.setFont(font)
         self.msgBody.setReadOnly(True)
 
         self.btnBox = QDialogButtonBox(QDialogButtonBox.Close)
@@ -119,7 +125,7 @@ class NWErrorMessage(QDialog):
         self.msgHead.setText(
             "<p>An unhandled error has been encountered.</p>"
             "<p>Please report this error by submitting an issue report on "
-            "GitHub, providing a description and including the error "
+            "GitHub, providing a description, and including the error "
             "message and traceback shown below.</p>"
             f"<p>URL: <a href='{nwConst.URL_REPORT}'>{nwConst.URL_REPORT}</a></p>"
         )

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -611,9 +611,9 @@ class GuiDocEditor(QTextEdit):
 
     def getText(self):
         """Get the text content of the current document. This method uses
-        QTextDocument->toRawText instead of toPlainText(). The former preserves
+        QTextDocument->toRawText instead of toPlainText. The former preserves
         non-breaking spaces, the latter does not. We still want to get rid of
-        page and line separators though.
+        paragraph and line separators though.
         See: https://doc.qt.io/qt-5/qtextdocument.html#toPlainText
         """
         theText = self.document().toRawText()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -52,7 +52,7 @@ from PyQt5.QtWidgets import (
 from novelwriter import CONFIG
 from novelwriter.enum import nwAlert, nwDocAction, nwDocInsert, nwDocMode, nwItemClass
 from novelwriter.common import minmax, transferCase
-from novelwriter.constants import nwConst, nwFiles, nwKeyWords, nwUnicode
+from novelwriter.constants import nwConst, nwKeyWords, nwUnicode
 from novelwriter.core.index import countWords
 from novelwriter.core.spellcheck import NWSpellEnchant
 from novelwriter.gui.dochighlight import GuiDocHighlighter
@@ -131,7 +131,7 @@ class GuiDocEditor(QTextEdit):
         self.docSearch = GuiDocEditSearch(self)
 
         # Syntax
-        self.spEnchant = NWSpellEnchant()
+        self.spEnchant = NWSpellEnchant(self.theProject)
         self.highLight = GuiDocHighlighter(qDoc, self.mainGui, self.spEnchant)
 
         # Context Menu
@@ -703,8 +703,7 @@ class GuiDocEditor(QTextEdit):
         else:
             theLang = self.theProject.data.spellLang
 
-        projDict = self.theProject.storage.getMetaFile(nwFiles.PROJ_DICT)
-        self.spEnchant.setLanguage(theLang, projDict)
+        self.spEnchant.setLanguage(theLang)
         _, theProvider = self.spEnchant.describeDict()
 
         self.spellDictionaryChanged.emit(str(theLang), str(theProvider))

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -47,6 +47,7 @@ from novelwriter.enum import (
 )
 from novelwriter.common import checkInt
 from novelwriter.constants import nwHeaders, trConst, nwKeyWords, nwLabels
+from novelwriter.error import logException
 from novelwriter.gui.components import NovelSelector
 
 
@@ -577,20 +578,23 @@ class GuiOutlineTree(QTreeWidget):
         and column width.
         """
         # Load whatever we saved last time, regardless of wether it
-        # contains the correct names or number of columns. The names
-        # must be valid though.
+        # contains the correct names or number of columns.
         colState = self.theProject.options.getValue("GuiOutline", "columnState", {})
 
         tmpOrder = []
         tmpHidden = {}
         tmpWidth = {}
-        for name, (hidden, width) in colState.items():
-            if name not in nwOutline.__members__:
-                logger.warning("Ignored unknown outline column '%s'", str(name))
-                continue
-            tmpOrder.append(nwOutline[name])
-            tmpHidden[nwOutline[name]] = hidden
-            tmpWidth[nwOutline[name]] = CONFIG.pxInt(width)
+        try:
+            for name, (hidden, width) in colState.items():
+                if name not in nwOutline.__members__:
+                    logger.warning("Ignored unknown outline column '%s'", str(name))
+                    continue
+                tmpOrder.append(nwOutline[name])
+                tmpHidden[nwOutline[name]] = hidden
+                tmpWidth[nwOutline[name]] = CONFIG.pxInt(width)
+        except Exception:
+            logger.error("Invalid column state")
+            logException()
 
         # Add columns that was not in the file to the treeOrder array.
         for hItem in nwOutline:

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -601,15 +601,9 @@ class GuiOutlineTree(QTreeWidget):
             if hItem not in tmpOrder:
                 tmpOrder.append(hItem)
 
-        # Check that we now have a complete list, and only if so, save
-        # the order loaded from file. Otherwise, we keep the default.
-        if len(tmpOrder) == self._treeNCols:
-            self._treeOrder = tmpOrder
-            self._colHidden.update(tmpHidden)
-            self._colWidth.update(tmpWidth)
-        else:
-            logger.error("Failed to extract outline column order from previous session")
-            logger.error("Column count doesn't match %d != %d", len(tmpOrder), self._treeNCols)
+        self._treeOrder = tmpOrder
+        self._colHidden.update(tmpHidden)
+        self._colWidth.update(tmpWidth)
 
         self.hiddenStateChanged.emit()
 

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -78,7 +78,7 @@ class GuiOutlineView(QWidget):
 
         # Assemble
         self.outerBox = QVBoxLayout()
-        self.outerBox.setContentsMargins(0, 0, 0, 0)
+        self.outerBox.setContentsMargins(0, 0, CONFIG.pxInt(4), 0)
         self.outerBox.addWidget(self.outlineBar)
         self.outerBox.addWidget(self.splitOutline)
 
@@ -663,7 +663,7 @@ class GuiOutlineTree(QTreeWidget):
             self.setColumnHidden(self._colIdx[nwOutline.TITLE], False)
 
             headItem = self.headerItem()
-            if headItem is not None:
+            if isinstance(headItem, QTreeWidgetItem):
                 headItem.setTextAlignment(self._colIdx[nwOutline.CCOUNT], Qt.AlignRight)
                 headItem.setTextAlignment(self._colIdx[nwOutline.WCOUNT], Qt.AlignRight)
                 headItem.setTextAlignment(self._colIdx[nwOutline.PCOUNT], Qt.AlignRight)

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -45,9 +45,9 @@ from novelwriter import CONFIG
 from novelwriter.enum import (
     nwDocMode, nwItemClass, nwItemLayout, nwItemType, nwOutline
 )
+from novelwriter.error import logException
 from novelwriter.common import checkInt
 from novelwriter.constants import nwHeaders, trConst, nwKeyWords, nwLabels
-from novelwriter.error import logException
 from novelwriter.gui.components import NovelSelector
 
 

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -111,7 +111,7 @@ class GuiLipsum(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiLipsum")
         return
 

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -196,6 +196,8 @@ class GuiManuscriptBuild(QDialog):
         self.mainSplit.setHandleWidth(sp16)
         self.mainSplit.setCollapsible(0, False)
         self.mainSplit.setCollapsible(1, False)
+        self.mainSplit.setStretchFactor(0, 0)
+        self.mainSplit.setStretchFactor(1, 1)
         self.mainSplit.setSizes([
             CONFIG.pxInt(pOptions.getInt("GuiManuscriptBuild", "fmtWidth", wWin//2)),
             CONFIG.pxInt(pOptions.getInt("GuiManuscriptBuild", "sumWidth", wWin//2)),

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -235,8 +235,7 @@ class GuiManuscriptBuild(QDialog):
 
         return
 
-    def __del__(self):
-        """For debug use only."""
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiManuscriptBuild")
         return
 

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -177,6 +177,8 @@ class GuiManuscript(QDialog):
         self.mainSplit = QSplitter()
         self.mainSplit.addWidget(self.optsWidget)
         self.mainSplit.addWidget(self.docPreview)
+        self.mainSplit.setCollapsible(0, False)
+        self.mainSplit.setCollapsible(1, False)
         self.mainSplit.setStretchFactor(0, 0)
         self.mainSplit.setStretchFactor(1, 1)
         self.mainSplit.setSizes([

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -196,8 +196,7 @@ class GuiManuscript(QDialog):
 
         return
 
-    def __del__(self):
-        """For debug use only."""
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiManuscript")
         return
 

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -167,8 +167,7 @@ class GuiBuildSettings(QDialog):
 
         return
 
-    def __del__(self):
-        """For debug use only."""
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiBuildSettings")
 
     def loadContent(self):

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -371,8 +371,6 @@ class _FilterTab(QWidget):
         # ============
 
         pOptions = self.theProject.options
-        wTree = CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "treeWidth", 0))
-        fTree = CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "filterWidth", 0))
 
         self.selectionBox = QVBoxLayout()
         self.selectionBox.addWidget(self.optTree)
@@ -387,8 +385,12 @@ class _FilterTab(QWidget):
         self.mainSplit.addWidget(self.filterOpt)
         self.mainSplit.setCollapsible(0, False)
         self.mainSplit.setCollapsible(1, False)
-        if wTree > 0:
-            self.mainSplit.setSizes([wTree, fTree])
+        self.mainSplit.setStretchFactor(0, 0)
+        self.mainSplit.setStretchFactor(1, 1)
+        self.mainSplit.setSizes([
+            CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "treeWidth", 1)),
+            CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "filterWidth", 1))
+        ])
 
         self.outerBox = QHBoxLayout()
         self.outerBox.addWidget(self.mainSplit)

--- a/novelwriter/tools/projwizard.py
+++ b/novelwriter/tools/projwizard.py
@@ -80,7 +80,7 @@ class GuiProjectWizard(QWizard):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiProjectWizard")
         return
 

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -471,7 +471,7 @@ class GuiWritingStats(QDialog):
         self.notesWords.setText(f"{ttNotes:n}")
         self.totalWords.setText(f"{ttWords:n}")
 
-        return True
+        return
 
     ##
     #  Slots

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -297,7 +297,7 @@ class GuiWritingStats(QDialog):
 
         return
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiWritingStats")
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,8 +61,7 @@ def resetConfigVars():
 
 @pytest.fixture(scope="session", autouse=True)
 def sessionFixture():
-    """A session wide fixture to set up the test environment.
-    """
+    """A session wide fixture to set up the test environment."""
     if _TMP_ROOT.exists():
         shutil.rmtree(_TMP_ROOT)
     _TMP_ROOT.mkdir()
@@ -111,8 +110,7 @@ def tstPaths():
 
 @pytest.fixture(scope="function")
 def fncPath():
-    """A temporary folder for a single test function.
-    """
+    """A temporary folder for a single test function."""
     fncPath = _TMP_ROOT / "function"
     if fncPath.is_dir():
         shutil.rmtree(fncPath)
@@ -139,16 +137,14 @@ def projPath(fncPath):
 
 @pytest.fixture(scope="function")
 def mockGUI():
-    """Create a mock instance of novelWriter's main GUI class.
-    """
+    """Create a mock instance of novelWriter's main GUI class."""
     theGui = MockGuiMain()
     return theGui
 
 
 @pytest.fixture(scope="function")
 def nwGUI(qtbot, monkeypatch, functionFixture):
-    """Create an instance of the novelWriter GUI.
-    """
+    """Create an instance of the novelWriter GUI."""
     monkeypatch.setattr(QMessageBox, "warning", lambda *a: QMessageBox.Ok)
     monkeypatch.setattr(QMessageBox, "critical", lambda *a: QMessageBox.Ok)
     monkeypatch.setattr(QMessageBox, "information", lambda *a: QMessageBox.Ok)

--- a/tests/reference/coreIndex_LoadSave_tagsIndex.json
+++ b/tests/reference/coreIndex_LoadSave_tagsIndex.json
@@ -1,10 +1,10 @@
 {
-  "tagsIndex": {
+  "novelWriter.tagsIndex": {
     "Bod": {"handle": "4c4f28287af27", "heading": "T0001", "class": "CHARACTER"},
     "Main": {"handle": "2426c6f0ca922", "heading": "T0001", "class": "PLOT"},
     "Europe": {"handle": "04468803b92e1", "heading": "T0001", "class": "WORLD"}
   },
-  "itemIndex": {
+  "novelWriter.itemIndex": {
     "7a992350f3eb6": {
       "headings": {
         "T0001": {"level": "H1", "title": "Lorem Ipsum", "line": 1, "tag": "", "cCount": 230, "wCount": 40, "pCount": 3, "synopsis": ""}

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -125,7 +125,7 @@ def testCoreIndex_LoadSave(monkeypatch, prjLipsum, mockGUI, tstPaths):
     assert theIndex.indexBroken is True
 
     # Write an index file that passes loading, but is still empty
-    writeFile(projFile, '{"tagsIndex": {}, "itemIndex": {}}')
+    writeFile(projFile, '{"novelWriter.tagsIndex": {}, "novelWriter.itemIndex": {}}')
     assert theIndex.loadIndex() is True
     assert theIndex.indexBroken is False
 
@@ -1071,13 +1071,13 @@ def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
     assert nStruct[3][0] == uHandle
 
     # Novel structure with root handle set
-    nStruct = list(itemIndex.iterNovelStructure(rootHandle=C.hNovelRoot))
+    nStruct = list(itemIndex.iterNovelStructure(rHandle=C.hNovelRoot))
     assert len(nStruct) == 3
     assert nStruct[0][0] == nHandle
     assert nStruct[1][0] == cHandle
     assert nStruct[2][0] == sHandle
 
-    nStruct = list(itemIndex.iterNovelStructure(rootHandle=mHandle))
+    nStruct = list(itemIndex.iterNovelStructure(rHandle=mHandle))
     assert len(nStruct) == 1
     assert nStruct[0][0] == uHandle
 

--- a/tests/test_core/test_core_options.py
+++ b/tests/test_core/test_core_options.py
@@ -42,15 +42,17 @@ def testCoreOptions_LoadSave(monkeypatch, mockGUI, fncPath):
     # Write a test file
     optFile = metaDir / nwFiles.OPTS_FILE
     optFile.write_text(json.dumps({
-        "GuiProjectSettings": {
-            "winWidth": 570,
-            "winHeight": 375,
-            "replaceColW": 130,
-            "statusColW": 130,
-            "importColW": 130
-        },
-        "MockGroup": {
-            "mockItem": None,
+        "novelWriter.guiOptions": {
+            "GuiProjectSettings": {
+                "winWidth": 570,
+                "winHeight": 375,
+                "replaceColW": 130,
+                "statusColW": 130,
+                "importColW": 130
+            },
+            "MockGroup": {
+                "mockItem": None,
+            },
         },
     }), encoding="utf-8")
 

--- a/tests/test_core/test_core_options.py
+++ b/tests/test_core/test_core_options.py
@@ -73,7 +73,7 @@ def testCoreOptions_LoadSave(monkeypatch, mockGUI, fncPath):
     assert theOpts.loadSettings()
 
     # Check that unwanted items have been removed
-    assert theOpts._theState == {
+    assert theOpts._state == {
         "GuiProjectSettings": {
             "winWidth": 570,
             "winHeight": 375,
@@ -88,7 +88,7 @@ def testCoreOptions_LoadSave(monkeypatch, mockGUI, fncPath):
 
     # Load again to check we get the values back
     assert theOpts.loadSettings()
-    assert theOpts._theState == {
+    assert theOpts._state == {
         "GuiProjectSettings": {
             "winWidth": 570,
             "winHeight": 375,

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -487,7 +487,7 @@ def testCoreProject_Methods(monkeypatch, mockGUI, fncPath, mockRnd):
 
     # Edit Time
     theProject.data.setEditTime(1234)
-    theProject._projOpened = 1600000000
+    theProject._session._start = 1600000000
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.project.time", lambda: 1600005600)
         assert theProject.getCurrentEditTime() == 6834
@@ -585,32 +585,32 @@ def testCoreProject_Methods(monkeypatch, mockGUI, fncPath, mockRnd):
     # No path for writing
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
-        assert theProject._appendSessionStats(idleTime=0) is False
+        assert theProject.session.appendSession(idleTime=0) is False
 
     # Block open
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", causeOSError)
-        assert theProject._appendSessionStats(idleTime=0) is False
+        assert theProject.session.appendSession(idleTime=0) is False
 
     # Session too short
-    theProject._projOpened = time()
+    theProject._session._start = time()
     theProject.data.setInitCounts(50, 50)
     theProject.data.setCurrCounts(50, 50)
-    assert theProject._appendSessionStats(idleTime=0) is False
+    assert theProject.session.appendSession(idleTime=0) is False
 
     # Write entry
-    statsFile = theProject.storage.getMetaFile(nwFiles.SESS_STATS)
+    statsFile = theProject.storage.getMetaFile(nwFiles.SESS_FILE)
     assert isinstance(statsFile, Path)
     if statsFile.exists():
         statsFile.unlink()
 
-    theProject._projOpened = 1600002000
+    theProject._session._start = 1600002000
     theProject.data._initCounts = [50, 50]
     theProject.data._currCounts = [200, 100]
 
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.project.time", lambda: 1600005600)
-        assert theProject._appendSessionStats(idleTime=99)
+        assert theProject.session.appendSession(idleTime=99)
 
     assert statsFile.read_text(encoding="utf-8") == (
         "# Offset 100\n"

--- a/tests/test_core/test_core_sessions.py
+++ b/tests/test_core/test_core_sessions.py
@@ -1,0 +1,114 @@
+"""
+novelWriter – NWSessionLog Class Tester
+=======================================
+
+This file is a part of novelWriter
+Copyright 2018–2023, Veronica Berglyd Olsen
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+
+from time import sleep
+from pathlib import Path
+
+from tools import buildTestProject
+from mocked import causeOSError
+
+from novelwriter.constants import nwFiles
+from novelwriter.core.project import NWProject
+from novelwriter.core.sessions import NWSessionLog
+
+
+@pytest.mark.core
+def testCoreSessions_Main(monkeypatch, mockGUI, fncPath):
+    """Test log file handling of the NWSessionLog class."""
+    project = NWProject(mockGUI)
+    buildTestProject(project, fncPath)
+
+    logFile = project.storage.getMetaFile(nwFiles.SESS_FILE)
+    assert isinstance(logFile, Path)
+
+    # Set some moch word counts
+    project.data.setInitCounts(50, 60)
+    project.data.setCurrCounts(160, 150)
+
+    # The project init should already have created the session
+    sessLog = project.session
+    assert isinstance(sessLog, NWSessionLog)
+    assert sessLog.start > 0.0
+
+    # Starting the session again should reset the timer
+    currTime = sessLog.start
+    sleep(0.015)  # Make sure we don't hit clock resolution issues on Windows
+    sessLog.startSession()
+    assert sessLog.start > currTime
+
+    # There should not be a logfile
+    assert not logFile.exists()
+    assert len(list(sessLog.iterRecords())) == 0
+
+    # Create the initial and first records
+    assert sessLog.appendSession(0.8) is True
+    assert logFile.exists()  # Logfile now exists
+    records = list(sessLog.iterRecords())
+    assert len(records) == 2
+    assert records[0]["type"] == "initial"
+    assert records[0]["offset"] == 110  # Sum of initial word counts
+    assert records[1]["type"] == "record"
+    assert records[1]["novel"] == 160
+    assert records[1]["notes"] == 150
+    assert records[1]["idle"] == 1  # Should be rounded to full seconds
+
+    # Adding another record without changing word count should do nothing
+    project.data.setInitCounts(160, 150)
+    project.data.setCurrCounts(160, 150)
+    assert sessLog.appendSession(1.6) is False
+    assert len(list(sessLog.iterRecords())) == 2
+
+    # But adding when count has changed should
+    project.data.setInitCounts(160, 150)
+    project.data.setCurrCounts(270, 240)
+    sessLog._start -= 350.0  # Backdate the session start to allow logging
+    assert sessLog.appendSession(1.6) is True
+    records = list(sessLog.iterRecords())
+    assert len(records) == 3
+    assert records[2]["novel"] == 270
+    assert records[2]["notes"] == 240
+    assert records[2]["idle"] == 2  # Should be rounded to full seconds
+
+    # Make file path unresolvable, and try appending another record
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        assert sessLog.appendSession(1.6) is False
+    assert len(list(sessLog.iterRecords())) == 3
+
+    # Make the file open fail, and check that it's handled
+    with monkeypatch.context() as mp:
+        mp.setattr("builtins.open", causeOSError)
+        assert sessLog.appendSession(1.6) is False
+    assert len(list(sessLog.iterRecords())) == 3
+
+    # Make the file load fail, and check that it's handled
+    with monkeypatch.context() as mp:
+        mp.setattr("builtins.open", causeOSError)
+        assert len(list(sessLog.iterRecords())) == 0
+
+    # Make file path unresolvable
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        assert len(list(sessLog.iterRecords())) == 0
+
+# END Test testCoreSessions_Main

--- a/tests/test_core/test_core_spellcheck.py
+++ b/tests/test_core/test_core_spellcheck.py
@@ -37,18 +37,18 @@ def testCoreSpell_FakeEnchant(monkeypatch):
         mp.setitem(sys.modules, "enchant", None)
         spChk = NWSpellEnchant()
         spChk.setLanguage("en_US", "")
-        assert isinstance(spChk._theDict, FakeEnchant)
+        assert isinstance(spChk._dictObj, FakeEnchant)
 
     # Request a non-existent dictionary
     spChk = NWSpellEnchant()
     spChk.setLanguage("whatchamajig", "")
-    assert isinstance(spChk._theDict, FakeEnchant)
+    assert isinstance(spChk._dictObj, FakeEnchant)
 
     # Request an emety language string
     # See issue https://github.com/vkbo/novelWriter/issues/1096
     spChk = NWSpellEnchant()
     spChk.setLanguage("", "")
-    assert isinstance(spChk._theDict, FakeEnchant)
+    assert isinstance(spChk._dictObj, FakeEnchant)
 
     # FakeEnchant should handle requests
     fkChk = FakeEnchant()
@@ -96,7 +96,7 @@ def testCoreSpell_Enchant(monkeypatch, fncPath):
 
     assert spChk._readProjectDictionary(None) is False
     assert spChk._readProjectDictionary(wList) is True
-    assert spChk._projectDict == wList
+    assert spChk._userDictPath == wList
 
     # Cannot write to file
     with monkeypatch.context() as mp:

--- a/tests/test_core/test_core_spellcheck.py
+++ b/tests/test_core/test_core_spellcheck.py
@@ -21,33 +21,118 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import sys
 import pytest
+import enchant
 
+from pathlib import Path
+
+from tools import buildTestProject
 from mocked import causeOSError
-from tools import readFile, writeFile
 
-from novelwriter.core.spellcheck import FakeEnchant, NWSpellEnchant
+from novelwriter.constants import nwFiles
+from novelwriter.core.project import NWProject
+from novelwriter.core.spellcheck import FakeEnchant, NWSpellEnchant, UserDictionary
 
 
 @pytest.mark.core
-def testCoreSpell_FakeEnchant(monkeypatch):
-    """Test the FakeEnchant spell checker fallback.
-    """
+def testCoreSpell_UserDictionary(monkeypatch, mockGUI, fncPath):
+    """Test the UserDictionary class."""
+    project = NWProject(mockGUI)
+    buildTestProject(project, fncPath)
+
+    # Check that there is no file before we start
+    dictFile = project.storage.getMetaFile(nwFiles.DICT_FILE)
+    assert isinstance(dictFile, Path)
+    assert not dictFile.exists()
+
+    # Add a couple of words
+    userDict = UserDictionary(project)
+    assert userDict.add("foo") is True
+    assert userDict.add("bar") is True
+    assert userDict.add("bar") is False  # No duplicates
+
+    # Check that we have them
+    assert "foo" in userDict
+    assert "bar" in userDict
+
+    # Check the iterator
+    assert sorted(userDict) == ["bar", "foo"]
+
+    # Save the file, but fail
+    assert userDict._path is None
+    with monkeypatch.context() as mp:
+        mp.setattr("builtins.open", causeOSError)
+        userDict.save()
+
+    # There should be no file, but the file path should now be cached
+    assert userDict._path == dictFile
+    assert not dictFile.exists()
+
+    # Break the path check
+    userDict._path = None
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        userDict.save()
+
+    # There should still be no file
+    assert not dictFile.exists()
+
+    # Save proper
+    userDict.save()
+    assert dictFile.exists()
+
+    # Clear the dictionary
+    userDict._words = set()
+    assert sorted(userDict) == []
+
+    # Load the file, but fail
+    userDict._path = None
+    with monkeypatch.context() as mp:
+        mp.setattr("builtins.open", causeOSError)
+        userDict.load()
+
+    # Path is now set, but no words
+    assert userDict._path == dictFile
+    assert sorted(userDict) == []
+
+    # Break the path check
+    userDict._path = None
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        userDict.load()
+
+    # Path is now None, and no words
+    assert userDict._path is None
+    assert sorted(userDict) == []
+
+    # Load the words again, properly
+    userDict.load()
+    assert sorted(userDict) == ["bar", "foo"]
+
+# END Test testCoreSpell_UserDictionary
+
+
+@pytest.mark.core
+def testCoreSpell_FakeEnchant(monkeypatch, mockGUI, fncPath):
+    """Test the FakeEnchant spell checker fallback."""
+    project = NWProject(mockGUI)
+    buildTestProject(project, fncPath)
+
     # Make package import fail
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "enchant", None)
-        spChk = NWSpellEnchant()
-        spChk.setLanguage("en_US", "")
+        spChk = NWSpellEnchant(project)
+        spChk.setLanguage("en_US")
         assert isinstance(spChk._dictObj, FakeEnchant)
 
     # Request a non-existent dictionary
-    spChk = NWSpellEnchant()
-    spChk.setLanguage("whatchamajig", "")
+    spChk = NWSpellEnchant(project)
+    spChk.setLanguage("whatchamajig")
     assert isinstance(spChk._dictObj, FakeEnchant)
 
-    # Request an emety language string
+    # Request an empty language string
     # See issue https://github.com/vkbo/novelWriter/issues/1096
-    spChk = NWSpellEnchant()
-    spChk.setLanguage("", "")
+    spChk = NWSpellEnchant(project)
+    spChk.setLanguage("")
     assert isinstance(spChk._dictObj, FakeEnchant)
 
     # FakeEnchant should handle requests
@@ -62,103 +147,53 @@ def testCoreSpell_FakeEnchant(monkeypatch):
 
 
 @pytest.mark.core
-def testCoreSpell_Enchant(monkeypatch, fncPath):
-    """Test the pyenchant spell checker.
-    """
-    wList = fncPath / "wordlist.txt"
-    writeFile(wList, "a_word\nb_word\nc_word\n")
+def testCoreSpell_Enchant(monkeypatch, mockGUI, fncPath):
+    """Test the pyenchant spell checker."""
+    project = NWProject(mockGUI)
+    buildTestProject(project, fncPath)
 
     # Break the enchant package, and check error handling
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "enchant", None)
-        spChk = NWSpellEnchant()
+        spChk = NWSpellEnchant(project)
+        assert spChk.spellLanguage is None
         assert spChk.listDictionaries() == []
         assert spChk.describeDict() == ("", "")
 
-    # Set the dict to None, and check dictionary call error handling
-    spChk = NWSpellEnchant()
-    spChk.theDict = None
+        spChk.setLanguage("en_US")
+        assert spChk.spellLanguage is None
+
+        # Check that the FakeEnchant class is actually handling this
+        assert isinstance(spChk._dictObj, FakeEnchant)
+        assert spChk.checkWord("word") is True
+        assert spChk.suggestWords("word") == []
+        assert spChk.addWord("word") is True
+
+    # Set the dict to None, and check enchant error handling
+    spChk = NWSpellEnchant(project)
+    spChk._dictObj = None  # type: ignore
     assert spChk.checkWord("word") is True
     assert spChk.suggestWords("word") == []
     assert spChk.addWord("word") is False
+    assert spChk.addWord("\n\t ") is False
+    assert spChk.describeDict() == ("", "")
 
     # Load the proper enchant package (twice)
-    spChk = NWSpellEnchant()
-    spChk.setLanguage("en_US", wList)
-    spChk.setLanguage("en_US", wList)
+    spChk = NWSpellEnchant(project)
+    spChk.setLanguage("en_US")
+    spChk.setLanguage("en_US")
+    assert isinstance(spChk._dictObj, enchant.Dict)
     assert spChk.spellLanguage == "en_US"
+    assert spChk.listDictionaries() != []
+    assert spChk.describeDict() != ("", "")
 
-    # Add a word to the user's dictionary
-    assert spChk._readProjectDictionary("stuff") is False
+    # Set to non-existent language
+    spChk.setLanguage("foo_bar")
+
+    # Block the broker from figuring out the language
     with monkeypatch.context() as mp:
-        mp.setattr("builtins.open", causeOSError)
-        assert spChk._readProjectDictionary(wList) is False
-
-    assert spChk._readProjectDictionary(None) is False
-    assert spChk._readProjectDictionary(wList) is True
-    assert spChk._userDictPath == wList
-
-    # Cannot write to file
-    with monkeypatch.context() as mp:
-        mp.setattr("builtins.open", causeOSError)
-        assert spChk.addWord("d_word") is False
-
-    assert readFile(wList) == "a_word\nb_word\nc_word\n"
-    assert spChk.addWord("d_word") is True
-    assert readFile(wList) == "a_word\nb_word\nc_word\nd_word\n"
-    assert spChk.addWord("d_word") is False
-
-    # Check words
-    assert spChk.checkWord("a_word") is True
-    assert spChk.checkWord("b_word") is True
-    assert spChk.checkWord("c_word") is True
-    assert spChk.checkWord("d_word") is True
-    assert spChk.checkWord("e_word") is False
-
-    spChk.addWord("d_word")
-    assert spChk.checkWord("d_word") is True
-
-    wSuggest = spChk.suggestWords("wrod")
-    assert len(wSuggest) > 0
-    assert "word" in wSuggest
-
-    dList = spChk.listDictionaries()
-    assert len(dList) > 0
-
-    aTag, aName = spChk.describeDict()
-    assert aTag == "en_US"
-    assert aName != ""
+        mp.setattr("enchant.Broker.request_dict", lambda *a: None)
+        spChk.setLanguage("en_US")
+        assert isinstance(spChk._dictObj, FakeEnchant)
 
 # END Test testCoreSpell_Enchant
-
-
-@pytest.mark.core
-def testCoreSpell_SessionWords(fncPath):
-    """Test the handling of the custom word list in the spell checker.
-    New project sessions should not inherit the project word list from
-    other sessions, so this test checks that they don't bleed through.
-    """
-    wList1 = fncPath / "wordlist1.txt"
-    wList2 = fncPath / "wordlist2.txt"
-    writeFile(wList1, "a_word\nb_word\nc_word\n")
-    writeFile(wList2, "d_word\ne_word\nf_word\n")
-
-    spChk = NWSpellEnchant()
-
-    spChk.setLanguage("en_US", wList1)
-    assert spChk.checkWord("a_word") is True
-    assert spChk.checkWord("b_word") is True
-    assert spChk.checkWord("c_word") is True
-    assert spChk.checkWord("d_word") is False
-    assert spChk.checkWord("e_word") is False
-    assert spChk.checkWord("f_word") is False
-
-    spChk.setLanguage("en_US", wList2)
-    assert spChk.checkWord("a_word") is False
-    assert spChk.checkWord("b_word") is False
-    assert spChk.checkWord("c_word") is False
-    assert spChk.checkWord("d_word") is True
-    assert spChk.checkWord("e_word") is True
-    assert spChk.checkWord("f_word") is True
-
-# END Test testCoreSpell_SessionWords

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -19,8 +19,11 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from zipfile import ZipFile
+import json
 import pytest
+
+from pathlib import Path
+from zipfile import ZipFile
 
 from tools import C, buildTestProject, writeFile
 from mocked import causeOSError
@@ -28,13 +31,12 @@ from mocked import causeOSError
 from novelwriter import CONFIG
 from novelwriter.constants import nwFiles
 from novelwriter.core.project import NWProject
-from novelwriter.core.storage import NWStorage
+from novelwriter.core.storage import NWStorage, _LegacyStorage
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter
 
 
 class MockProject:
     """Test class for projects."""
-
     pass
 
 
@@ -112,7 +114,7 @@ def testCoreStorage_LockFile(monkeypatch, fncPath):
     """Test the project lock file."""
     monkeypatch.setattr("novelwriter.core.storage.time", lambda: 1000.0)
 
-    storage = NWStorage(MockProject())
+    storage = NWStorage(MockProject())  # type: ignore
     assert storage.isOpen() is False
 
     # Project not open, so cannot read/write lock file
@@ -170,9 +172,45 @@ def testCoreStorage_LockFile(monkeypatch, fncPath):
 
 
 @pytest.mark.core
+def testCoreStorage_ZipIt(monkeypatch, mockGUI, fncPath, tstPaths, mockRnd):
+    """Test making a zip archive of a project."""
+    zipFile = tstPaths.tmpDir / "project.zip"
+
+    theProject = NWProject(mockGUI)
+    storage = theProject.storage
+    assert storage.zipIt(zipFile) is False
+
+    # Make a project
+    mockRnd.reset()
+    buildTestProject(theProject, fncPath)
+
+    # Fail to create archive
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.storage.ZipFile.write", causeOSError)
+        assert storage.zipIt(zipFile) is False
+
+    # Create archive
+    assert storage.zipIt(zipFile) is True
+
+    # Check content
+    with ZipFile(zipFile, mode="r") as archive:
+        names = archive.namelist()
+        assert nwFiles.PROJ_FILE in names
+        assert f"meta/{nwFiles.OPTS_FILE}" in names
+        assert f"meta/{nwFiles.INDEX_FILE}" in names
+        assert f"content/{C.hTitlePage}.nwd" in names
+        assert f"content/{C.hChapterDoc}.nwd" in names
+        assert f"content/{C.hSceneDoc}.nwd" in names
+
+    theProject.closeProject()
+
+# END Test testCoreStorage_ZipIt
+
+
+@pytest.mark.core
 def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
     """Test the project path preparation functions."""
-    storage = NWStorage(MockProject())
+    storage = NWStorage(MockProject())  # type: ignore
     assert storage.isOpen() is False
 
     # No path set
@@ -208,9 +246,18 @@ def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
     storage._runtimePath = fncPath
     assert storage._prepareStorage(checkLegacy=False, newProject=True) is False
 
-    # Legacy Data Folder
-    # ==================
+# END Test testCoreStorage_PrepareStorage
+
+
+@pytest.mark.core
+def testCoreStorage_LegacyDataFolder(monkeypatch, fncPath):
+    """Test project file format 1.0 folder structure conversion."""
+    project = MockProject()
+    storage = NWStorage(project)  # type: ignore
+    assert storage.isOpen() is False
     storage._runtimePath = fncPath
+    assert storage._prepareStorage() is True
+    legacy = _LegacyStorage(project)  # type: ignore
 
     data = []
     files = []
@@ -235,7 +282,7 @@ def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
 
     # Process folders
     for i in range(9):
-        storage._legacyDataFolder(fncPath, data[i])
+        legacy.legacyDataFolder(fncPath, data[i])
 
     # Files form 0 to 8 should now be in content
     for c in "012345678":
@@ -250,14 +297,14 @@ def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
     assert data[8].exists()
 
     # So does folder X, which is invalid
-    storage._legacyDataFolder(fncPath, data[16])
+    legacy.legacyDataFolder(fncPath, data[16])
     assert data[16].exists()
 
     # Fail cleanup of folder 9
     with monkeypatch.context() as mp:
         mp.setattr("pathlib.Path.rename", causeOSError)
         mp.setattr("pathlib.Path.unlink", causeOSError)
-        storage._legacyDataFolder(fncPath, data[9])
+        legacy.legacyDataFolder(fncPath, data[9])
         assert data[9].exists()
         assert not (fncPath / "content" / "9000000000009.nwd").exists()
 
@@ -266,10 +313,24 @@ def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
     for c in "0123456789abcdef":
         assert (fncPath / "content" / f"{c}00000000000{c}.nwd").exists()
 
-    # Deprecated Files
-    # ================
+# END Test testCoreStorage_LegacyDataFolder
+
+
+@pytest.mark.core
+def testCoreStorage_DeprecatedFiles(monkeypatch, fncPath):
+    """Test cleanup of deprecated files."""
+    project = MockProject()
+    storage = NWStorage(project)  # type: ignore
+    assert storage.isOpen() is False
+    storage._runtimePath = fncPath
+    assert storage._prepareStorage() is True
+    legacy = _LegacyStorage(project)  # type: ignore
+
+    # Files/Folders to be Deleted or Renamed
+    # ======================================
 
     remove = [
+        fncPath / "meta" / "tagsIndex.json",
         fncPath / "meta" / "mainOptions.json",
         fncPath / "meta" / "exportOptions.json",
         fncPath / "meta" / "outlineOptions.json",
@@ -286,48 +347,130 @@ def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
 
     with monkeypatch.context() as mp:
         mp.setattr("pathlib.Path.unlink", causeOSError)
-        storage._deprecatedFiles(fncPath)
+        legacy.deprecatedFiles(fncPath)
         for depFile in remove:
             assert depFile.exists()
 
-    storage._deprecatedFiles(fncPath)
+    legacy.deprecatedFiles(fncPath)
     for depFile in remove:
         assert not depFile.exists()
 
-# END Test testCoreStorage_PrepareStorage
+# END Test testCoreStorage_DeprecatedFiles
 
 
 @pytest.mark.core
-def testCoreStorage_ZipIt(monkeypatch, mockGUI, fncPath, tstPaths, mockRnd):
-    """Test making a zip archive of a project."""
-    zipFile = tstPaths.tmpDir / "project.zip"
+def testCoreStorage_OldFormatConvert(monkeypatch, mockGUI, fncPath):
+    """Test cleanup of deprecated files that needs to be converted."""
+    project = NWProject(mockGUI)
+    buildTestProject(project, fncPath)
+    legacy = _LegacyStorage(project)
 
-    theProject = NWProject(mockGUI)
-    storage = theProject.storage
-    assert storage.zipIt(zipFile) is False
+    # The build project functions saves the project, so we must delete
+    # the old gui options file
+    (fncPath / "meta" / nwFiles.OPTS_FILE).unlink()
 
-    # Make a project
-    mockRnd.reset()
-    buildTestProject(theProject, fncPath)
+    # Word List
+    wordListOld: Path = fncPath / "meta" / "wordlist.txt"
+    wordListNew: Path = fncPath / "meta" / nwFiles.DICT_FILE
 
-    # Fail to create archive
+    wordListOld.write_text((
+        "word_a\n"
+        "word_b\n"
+        "word_c\n"
+    ), encoding="utf-8")
+
+    assert wordListOld.exists() is True
+    assert wordListNew.exists() is False
+
+    # Log File
+    sessLogOld: Path = fncPath / "meta" / "sessionStats.log"
+    sessLogNew: Path = fncPath / "meta" / nwFiles.SESS_FILE
+
+    sessLogOld.write_text((
+        "# Offset 150\n"
+        "# Start Time         End Time                Novel     Notes    Idle\n"
+        "2021-02-02 02:02:02  2021-02-02 03:03:03       200      200       10\n"
+        "2021-03-03 03:03:03  2021-03-03 04:04:04       300      300       20\n"
+    ), encoding="utf-8")
+
+    assert sessLogOld.exists() is True
+    assert sessLogNew.exists() is False
+
+    # Options File
+    optionsOld: Path = fncPath / "meta" / "guiOptions.json"
+    optionsNew: Path = fncPath / "meta" / nwFiles.OPTS_FILE
+
+    optionsOld.write_text(json.dumps({
+        "GuiProjectSettings": {
+            "winWidth": 570,
+            "winHeight": 375,
+        },
+        "GuiOutline": {
+            "headerOrder": ["TITLE", "LEVEL", "LABEL", "LINE"],
+            "columnWidth": {"TITLE": 325, "LEVEL": 40, "LABEL": 267, "LINE": 40},
+            "columnHidden": {"TITLE": False, "LEVEL": True, "LABEL": False, "LINE": True},
+        },
+    }, indent=2), encoding="utf-8")
+
+    assert optionsOld.exists() is True
+    assert optionsNew.exists() is False
+
+    # Check Failure
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.ZipFile.write", causeOSError)
-        assert storage.zipIt(zipFile) is False
+        mp.setattr("builtins.open", causeOSError)
+        legacy.deprecatedFiles(fncPath)
+        assert wordListOld.exists() is True
+        assert wordListNew.exists() is False
+        assert sessLogOld.exists() is True
+        assert sessLogNew.exists() is False
+        assert optionsOld.exists() is True
+        assert optionsNew.exists() is False
 
-    # Create archive
-    assert storage.zipIt(zipFile) is True
+    # Check Success
+    legacy.deprecatedFiles(fncPath)
+    assert wordListOld.exists() is False
+    assert wordListNew.exists() is True
+    assert sessLogOld.exists() is False
+    assert sessLogNew.exists() is True
+    assert optionsOld.exists() is False
+    assert optionsNew.exists() is True
 
-    # Check content
-    with ZipFile(zipFile, mode="r") as archive:
-        names = archive.namelist()
-        assert nwFiles.PROJ_FILE in names
-        assert f"meta/{nwFiles.OPTS_FILE}" in names
-        assert f"meta/{nwFiles.INDEX_FILE}" in names
-        assert f"content/{C.hTitlePage}.nwd" in names
-        assert f"content/{C.hChapterDoc}.nwd" in names
-        assert f"content/{C.hSceneDoc}.nwd" in names
+    # Check Word List
+    data = json.loads(wordListNew.read_text(encoding="utf-8"))
+    assert "word_a" in data["novelWriter.userDict"]
+    assert "word_b" in data["novelWriter.userDict"]
+    assert "word_c" in data["novelWriter.userDict"]
 
-    theProject.closeProject()
+    # Check Session Log
+    data = list(project.session.iterRecords())
+    assert data[0] == {"type": "initial", "offset": 150}
+    assert data[1] == {
+        "type": "record",
+        "start": "2021-02-02 02:02:02",
+        "end": "2021-02-02 03:03:03",
+        "novel": 200,
+        "notes": 200,
+        "idle": 10,
+    }
+    assert data[2] == {
+        "type": "record",
+        "start": "2021-03-03 03:03:03",
+        "end": "2021-03-03 04:04:04",
+        "novel": 300,
+        "notes": 300,
+        "idle": 20,
+    }
 
-# END Test testCoreStorage_ZipIt
+    # Check Options File
+    data = json.loads(optionsNew.read_text(encoding="utf-8"))
+    assert data["novelWriter.guiOptions"]["GuiProjectSettings"] == {
+        "winWidth": 570, "winHeight": 375
+    }
+    assert data["novelWriter.guiOptions"]["columnState"] == {
+        "TITLE": [False, 325],
+        "LEVEL": [True, 40],
+        "LABEL": [False, 267],
+        "LINE": [True, 40]
+    }
+
+# END Test testCoreStorage_OldFormatConvert

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -286,11 +286,11 @@ def testCoreStorage_PrepareStorage(monkeypatch, fncPath):
 
     with monkeypatch.context() as mp:
         mp.setattr("pathlib.Path.unlink", causeOSError)
-        storage._deleteDeprecatedFiles(fncPath)
+        storage._deprecatedFiles(fncPath)
         for depFile in remove:
             assert depFile.exists()
 
-    storage._deleteDeprecatedFiles(fncPath)
+    storage._deprecatedFiles(fncPath)
     for depFile in remove:
         assert not depFile.exists()
 

--- a/tests/test_dialogs/test_dlg_wordlist.py
+++ b/tests/test_dialogs/test_dlg_wordlist.py
@@ -27,7 +27,6 @@ from PyQt5.QtWidgets import QDialog, QAction
 from tools import buildTestProject, writeFile, readFile, getGuiItem
 from mocked import causeOSError
 
-from novelwriter.constants import nwFiles
 from novelwriter.dialogs.wordlist import GuiWordList
 
 
@@ -43,7 +42,7 @@ def testDlgWordList_Dialog(qtbot, monkeypatch, nwGUI, projPath):
 
     # Open project
     nwGUI.openProject(projPath)
-    dictFile = projPath / "meta" / nwFiles.PROJ_DICT
+    dictFile = projPath / "meta" / "wordlist.txt"
 
     # Load the dialog
     nwGUI.mainMenu.aEditWordList.activate(QAction.Trigger)

--- a/tests/test_tools/test_tools_writingstats.py
+++ b/tests/test_tools/test_tools_writingstats.py
@@ -28,7 +28,6 @@ from tools import getGuiItem, writeFile, buildTestProject
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QAction, QFileDialog
 
-from novelwriter.constants import nwFiles
 from novelwriter.tools.writingstats import GuiWritingStats
 
 
@@ -40,7 +39,7 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     buildTestProject(nwGUI, projPath)
     qtbot.wait(100)
     assert nwGUI.saveProject()
-    sessFile = projPath / "meta" / nwFiles.SESS_STATS
+    sessFile = projPath / "meta" / "sessionStats.log"
 
     # Open the Writing Stats dialog
     nwGUI.mainMenu.aWritingStats.activate(QAction.Trigger)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -19,7 +19,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-import time
 import shutil
 
 from pathlib import Path
@@ -201,7 +200,7 @@ def buildTestProject(theObject, projPath):
     aDoc.writeDocument("### %s\n\n" % theProject.tr("New Scene"))
     theProject.index.reIndexHandle(xHandle[8])
 
-    theProject._projOpened = time.time()
+    theProject.session.startSession()
     theProject.setProjectChanged(True)
     theProject.saveProject(autoSave=True)
 


### PR DESCRIPTION
**Summary:**

This PR:
* Index: Renames index cache file to `index.json` and adds annotations to the whole NWIndex class. The root JSON objects are also given the `novelWriter.` prefix. This file is generated anew when the project is loaded.
* Options: Renames the options file to `options.json` and adds annotations to the OptionState class. A new root JSON object is added named `novelWriter.guiOptions`. The way header states are stored for the Outline View are also rewritten into a single dictionary instead of three lists. This file is generated anew when the project is loaded.
* User Dictionary: Replaces the plain text `wordlist.txt` file with a new JSON file with `novelWriter.userDict` as the root object, and a list of the words as the only data value. This file is converted when the project is loaded.
* Session Log: Replaces the plain text `sessionsStats.log` file with a new JSON Lines file with a JSON object per record. The new file is wrapped in a new NWSessionLog class. The old session log file is converted when the project is loaded.

The main motivation for these changes are:
* More robust parsing/serialisation since the JSON class handles most of the work.
* Standard file formats for all meta data.
* All files can be combined into a single JSON file, which in the future may allow for a single JSON file storage.
* All files are still diffable, since they are indented. They are also easy to process and generate by external tools.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
