### PR TITLE
Theme updates

### DIFF
--- a/novelwriter/assets/themes/default.conf
+++ b/novelwriter/assets/themes/default.conf
@@ -1,4 +1,4 @@
 [Main]
-name        = Default Theme
+name        = Qt Default Theme
 description = Qt standard colours
 icontheme   = typicons_light

--- a/novelwriter/assets/themes/default.conf
+++ b/novelwriter/assets/themes/default.conf
@@ -1,4 +1,3 @@
 [Main]
 name        = Qt Default Theme
 description = Qt standard colours
-icontheme   = typicons_light

--- a/novelwriter/assets/themes/default_dark.conf
+++ b/novelwriter/assets/themes/default_dark.conf
@@ -10,21 +10,22 @@ icontheme   = typicons_dark
 
 [Palette]
 window          =  54,  54,  54
-windowtext      = 174, 174, 174
+windowtext      = 204, 204, 204
 base            =  62,  62,  62
 alternatebase   =  78,  78,  78
-text            = 174, 174, 174
+text            = 204, 204, 204
 tooltipbase     = 255, 255, 192
 tooltiptext     =  21,  21,  13
 button          =  62,  62,  62
-buttontext      = 174, 174, 174
-brighttext      = 174, 174, 174
+buttontext      = 204, 204, 204
+brighttext      =  62,  62,  62
 highlight       =  44, 152, 247
 highlightedtext = 255, 255, 255
 link            =  44, 152, 247
 linkvisited     =  44, 152, 247
 
 [GUI]
+helptext        = 164, 164, 164
 statusnone      = 150, 152, 150
 statussaved     =  39, 135,  78
 statusunsaved   = 138,  32,  32

--- a/novelwriter/assets/themes/default_light.conf
+++ b/novelwriter/assets/themes/default_light.conf
@@ -1,0 +1,31 @@
+[Main]
+name        = Default Light Theme
+description = The novelWriter standard light theme
+author      = Veronica Berglyd Olsen
+credit      = Veronica Berglyd Olsen
+url         = https://github.com/vkbo/novelWriter
+license     = CC BY-SA 4.0
+licenseurl  = https://creativecommons.org/licenses/by-sa/4.0/
+icontheme   = typicons_light
+
+[Palette]
+window          = 239, 239, 239
+windowtext      =   0,   0,   0
+base            = 255, 255, 255
+alternatebase   = 239, 239, 239
+text            =   0,   0,   0
+tooltipbase     = 255, 255, 220
+tooltiptext     =   0,   0,   0
+button          = 239, 239, 239
+buttontext      =   0,   0,   0
+brighttext      = 255, 255, 255
+highlight       =  48, 135, 198
+highlightedtext = 255, 255, 255
+link            =   0,  84, 255
+linkvisited     =   0,  84, 255
+
+[GUI]
+helptext        =  92,  92,  92
+statusnone      = 120, 120, 120
+statussaved     = 200,  15,  39
+statusunsaved   =   2, 133,  37

--- a/novelwriter/assets/themes/solarized_dark.conf
+++ b/novelwriter/assets/themes/solarized_dark.conf
@@ -17,13 +17,14 @@ tooltipbase     = 133, 153,   0
 tooltiptext     =   0,  43,  54
 button          =   7,  54,  66
 buttontext      = 253, 246, 227
-brighttext      = 253, 246, 227
+brighttext      =   7,  54,  66
 highlight       =  42, 161, 152
 highlightedtext =   0,  43,  54
 link            =  38, 139, 210
 linkvisited     =  38, 139, 210
 
 [GUI]
+helptext        = 166, 161, 149
 statusnone      =  88, 110, 117
 statussaved     =  42, 161, 152
 statusunsaved   = 203,  75,  22

--- a/novelwriter/assets/themes/solarized_light.conf
+++ b/novelwriter/assets/themes/solarized_light.conf
@@ -17,13 +17,14 @@ tooltipbase     = 133, 153,   0
 tooltiptext     =   0,  43,  54
 button          = 238, 232, 213
 buttontext      =   0,  43,  54
-brighttext      =   0,  43,  54
+brighttext      = 253, 246, 227
 highlight       =  42, 161, 152
 highlightedtext = 253, 246, 227
 link            =  38, 139, 210
 linkvisited     =  38, 139, 210
 
 [GUI]
+helptext        =  78,  91,  95
 statusnone      =  88, 110, 117
 statussaved     =  42, 161, 152
 statusunsaved   = 203,  75,  22

--- a/novelwriter/extensions/pagedsidebar.py
+++ b/novelwriter/extensions/pagedsidebar.py
@@ -135,7 +135,7 @@ class NPagedToolButton(QToolButton):
 
     def paintEvent(self, event):
         """Overload the paint event to draw a simple, left aligned text
-        label, with a highlight when selected and alternative base
+        label, with a highlight when selected and a transparent base
         colour when hovered.
         """
         opt = QStyleOptionToolButton()
@@ -150,9 +150,9 @@ class NPagedToolButton(QToolButton):
         palette = self.palette()
 
         if opt.state & QStyle.State_MouseOver == QStyle.State_MouseOver:
-            backCol = palette.alternateBase()
+            backCol = palette.base()
             paint.setBrush(backCol)
-            paint.setOpacity(0.5)
+            paint.setOpacity(0.75)
             paint.drawRoundedRect(0, 0, width, height, self._cR, self._cR)
 
         if self.isChecked():

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -74,7 +74,6 @@ class GuiTheme:
         self.statUnsaved = [200, 15, 39]
         self.statSaved   = [2, 133, 37]
         self.helpText    = [0, 0, 0]
-        self.winBright   = [0, 0, 0]
 
         # Loaded Syntax Settings
         # ======================

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -122,8 +122,7 @@ def testGuiTheme_Main(qtbot, nwGUI, tstPaths):
 
 @pytest.mark.gui
 def testGuiTheme_Theme(qtbot, monkeypatch, nwGUI):
-    """Test the theme part of the class.
-    """
+    """Test the theme part of the class."""
     mainTheme: GuiTheme = nwGUI.mainTheme
 
     # List Themes
@@ -137,7 +136,8 @@ def testGuiTheme_Theme(qtbot, monkeypatch, nwGUI):
     # Load the theme info
     themesList = mainTheme.listThemes()
     assert themesList[0] == ("default_dark", "Default Dark Theme")
-    assert themesList[1] == ("default", "Default Theme")
+    assert themesList[1] == ("default_light", "Default Light Theme")
+    assert themesList[2] == ("default", "Qt Default Theme")
 
     # A second call should returned the cached list
     assert mainTheme.listThemes() == mainTheme._themeList
@@ -169,6 +169,18 @@ def testGuiTheme_Theme(qtbot, monkeypatch, nwGUI):
     wCol = QApplication.style().standardPalette().color(QPalette.Window).getRgb()
     assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == wCol
 
+    # Load Default Light Theme
+    # ========================
+
+    CONFIG.guiTheme = "default_light"
+    assert mainTheme.loadTheme() is True
+
+    # Check a few values
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb()        == (239, 239, 239, 255)
+    assert mainTheme._guiPalette.color(QPalette.WindowText).getRgb()    == (0, 0, 0, 255)
+    assert mainTheme._guiPalette.color(QPalette.Base).getRgb()          == (255, 255, 255, 255)
+    assert mainTheme._guiPalette.color(QPalette.AlternateBase).getRgb() == (239, 239, 239, 255)
+
     # Load Default Dark Theme
     # =======================
 
@@ -177,7 +189,7 @@ def testGuiTheme_Theme(qtbot, monkeypatch, nwGUI):
 
     # Check a few values
     assert mainTheme._guiPalette.color(QPalette.Window).getRgb()        == (54, 54, 54, 255)
-    assert mainTheme._guiPalette.color(QPalette.WindowText).getRgb()    == (174, 174, 174, 255)
+    assert mainTheme._guiPalette.color(QPalette.WindowText).getRgb()    == (204, 204, 204, 255)
     assert mainTheme._guiPalette.color(QPalette.Base).getRgb()          == (62, 62, 62, 255)
     assert mainTheme._guiPalette.color(QPalette.AlternateBase).getRgb() == (78, 78, 78, 255)
 


### PR DESCRIPTION
**Summary:**

This PR:
* Adds a proper light theme, but leaves the default theme as whatever Qt chooses.
* Selects default icon theme based on the lightness of the window colour.
* Adds the help text colour to the theme config file and sets it for the existing themes.

**Related Issue(s):**

Closes #1472
Closes #1473

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
