### PR TITLE
Change default font on macOS

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -354,8 +354,8 @@ class Config:
             logger.warning("Unknown font '%s'", family)
             if self.osWindows and "Arial" in fontFam:
                 self.textFont = "Arial"
-            elif self.osDarwin and "Courier" in fontFam:
-                self.textFont = "Courier"
+            elif self.osDarwin and "Helvetica" in fontFam:
+                self.textFont = "Helvetica"
             else:
                 self.textFont = fontDB.systemFont(QFontDatabase.GeneralFont).family()
         else:


### PR DESCRIPTION
**Summary:**

This PR changes the default font on macOS to Helvetica

**Related Issue(s):**

Related to #1463

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
