### PR TITLE
Add duplication of files and folders

### DIFF
--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -292,6 +292,7 @@ class DocDuplicator:
             hMap[tHandle] = newItem.itemHandle
             if newItem.itemParent in hMap:
                 newItem.setParent(hMap[newItem.itemParent])
+                self._project.tree.updateItemData(newItem.itemHandle)
             if newItem.isFileType():
                 oldDoc = self._project.storage.getDocument(tHandle)
                 newDoc = self._project.storage.getDocument(newItem.itemHandle)

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -23,10 +23,12 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from __future__ import annotations
 
 import shutil
 import logging
 
+from typing import TYPE_CHECKING, Iterable
 from functools import partial
 
 from PyQt5.QtCore import QCoreApplication
@@ -35,7 +37,11 @@ from novelwriter import CONFIG
 from novelwriter.enum import nwAlert
 from novelwriter.common import minmax, simplified
 from novelwriter.constants import nwItemClass
+from novelwriter.core.item import NWItem
 from novelwriter.core.project import NWProject
+
+if TYPE_CHECKING:
+    from novelwriter.guimain import GuiMain
 
 logger = logging.getLogger(__name__)
 
@@ -46,26 +52,22 @@ class DocMerger:
     GuiDocMerge dialog.
     """
 
-    def __init__(self, theProject):
-
-        self.theProject = theProject
-
+    def __init__(self, project: NWProject) -> None:
+        self._project = project
         self._error = ""
         self._targetDoc = None
         self._targetText = []
-
         return
 
     ##
     #  Methods
     ##
 
-    def getError(self):
-        """Return any collected errors.
-        """
+    def getError(self) -> str:
+        """Return any collected errors."""
         return self._error
 
-    def setTargetDoc(self, tHandle):
+    def setTargetDoc(self, tHandle: str) -> None:
         """Set the target document for the merging. Calling this
         function resets the class.
         """
@@ -73,33 +75,33 @@ class DocMerger:
         self._targetText = []
         return
 
-    def newTargetDoc(self, srcHandle, docLabel):
+    def newTargetDoc(self, srcHandle: str, docLabel: str) -> str | None:
         """Create a barnd new target document based on a source handle
         and a new doc label. Calling this function resets the class.
         """
-        srcItem = self.theProject.tree[srcHandle]
+        srcItem = self._project.tree[srcHandle]
         if srcItem is None:
             return None
 
-        newHandle = self.theProject.newFile(docLabel, srcItem.itemParent)
-        newItem = self.theProject.tree[newHandle]
-        newItem.setLayout(srcItem.itemLayout)
-        newItem.setStatus(srcItem.itemStatus)
-        newItem.setImport(srcItem.itemImport)
+        newHandle = self._project.newFile(docLabel, srcItem.itemParent)
+        newItem = self._project.tree[newHandle]
+        if isinstance(newItem, NWItem):
+            newItem.setLayout(srcItem.itemLayout)
+            newItem.setStatus(srcItem.itemStatus)
+            newItem.setImport(srcItem.itemImport)
 
         self._targetDoc = newHandle
         self._targetText = []
 
         return newHandle
 
-    def appendText(self, srcHandle, addComment, cmtPrefix):
-        """Append text from an existing document to the text buffer.
-        """
-        srcItem = self.theProject.tree[srcHandle]
+    def appendText(self, srcHandle: str, addComment: bool, cmtPrefix: str) -> bool:
+        """Append text from an existing document to the text buffer."""
+        srcItem = self._project.tree[srcHandle]
         if srcItem is None:
             return False
 
-        inDoc = self.theProject.storage.getDocument(srcHandle)
+        inDoc = self._project.storage.getDocument(srcHandle)
         docText = (inDoc.readDocument() or "").rstrip("\n")
 
         if addComment:
@@ -112,14 +114,14 @@ class DocMerger:
 
         return True
 
-    def writeTargetDoc(self):
+    def writeTargetDoc(self) -> bool:
         """Write the accumulated text into the designated target
         document, appending any existing text.
         """
         if self._targetDoc is None:
             return False
 
-        outDoc = self.theProject.storage.getDocument(self._targetDoc)
+        outDoc = self._project.storage.getDocument(self._targetDoc)
         docText = (outDoc.readDocument() or "").rstrip("\n")
         if docText:
             self._targetText.insert(0, docText)
@@ -139,9 +141,9 @@ class DocSplitter:
     GuiDocSplit dialog.
     """
 
-    def __init__(self, theProject, sHandle):
+    def __init__(self, project: NWProject, sHandle: str) -> None:
 
-        self.theProject = theProject
+        self._project = project
 
         self._error = ""
         self._parHandle = None
@@ -151,7 +153,7 @@ class DocSplitter:
         self._inFolder = False
         self._rawData = []
 
-        srcItem = self.theProject.tree[sHandle]
+        srcItem = self._project.tree[sHandle]
         if srcItem is not None and srcItem.isFileType():
             self._srcHandle = sHandle
             self._srcItem = srcItem
@@ -162,12 +164,11 @@ class DocSplitter:
     #  Methods
     ##
 
-    def getError(self):
-        """Return any collected errors.
-        """
+    def getError(self) -> str:
+        """Return any collected errors."""
         return self._error
 
-    def setParentItem(self, pHandle):
+    def setParentItem(self, pHandle: str) -> None:
         """Set the item that will be the top level parent item for the
         new documents.
         """
@@ -175,25 +176,27 @@ class DocSplitter:
         self._inFolder = False
         return
 
-    def newParentFolder(self, pHandle, folderLabel):
+    def newParentFolder(self, pHandle: str, folderLabel: str) -> str | None:
         """Create a new folder that will be the top level parent item
         for the new documents.
         """
         if self._srcItem is None:
             return None
 
-        newHandle = self.theProject.newFolder(folderLabel, pHandle)
-        newItem = self.theProject.tree[newHandle]
-        newItem.setStatus(self._srcItem.itemStatus)
-        newItem.setImport(self._srcItem.itemImport)
+        newHandle = self._project.newFolder(folderLabel, pHandle)
+        newItem = self._project.tree[newHandle]
+        if isinstance(newItem, NWItem):
+            newItem.setStatus(self._srcItem.itemStatus)
+            newItem.setImport(self._srcItem.itemImport)
 
         self._parHandle = newHandle
         self._inFolder = True
 
         return newHandle
 
-    def splitDocument(self, splitData, splitText):
-        """Loop through the split data record and perform the split job.
+    def splitDocument(self, splitData: list, splitText: list[str]) -> None:
+        """Loop through the split data record and perform the split job
+        on a list of text lines.
         """
         self._rawData = []
         buffer = splitText.copy()
@@ -201,10 +204,9 @@ class DocSplitter:
             chunk = buffer[lineNo:]
             buffer = buffer[:lineNo]
             self._rawData.insert(0, (chunk, hLevel, hLabel))
+        return
 
-        return True
-
-    def writeDocuments(self, docHierarchy):
+    def writeDocuments(self, docHierarchy: bool) -> Iterable[tuple[bool, str | None, str | None]]:
         """An iterator that will write each document in the buffer, and
         return its new handle, parent handle, and sibling handle.
         """
@@ -237,14 +239,15 @@ class DocSplitter:
                 elif hLevel > pLevel:
                     nHandle = pHandle
 
-            dHandle = self.theProject.newFile(docLabel, pHandle)
+            dHandle = self._project.newFile(docLabel, pHandle)
             hHandle[hLevel] = dHandle
 
-            newItem = self.theProject.tree[dHandle]
-            newItem.setStatus(self._srcItem.itemStatus)
-            newItem.setImport(self._srcItem.itemImport)
+            newItem = self._project.tree[dHandle]
+            if isinstance(newItem, NWItem):
+                newItem.setStatus(self._srcItem.itemStatus)
+                newItem.setImport(self._srcItem.itemImport)
 
-            outDoc = self.theProject.storage.getDocument(dHandle)
+            outDoc = self._project.storage.getDocument(dHandle)
             status = outDoc.writeDocument("\n".join(docText))
             if not status:
                 self._error = outDoc.getError()
@@ -265,7 +268,7 @@ class ProjectBuilder:
     parameter provided by the New Projecty Wizard.
     """
 
-    def __init__(self, mainGui):
+    def __init__(self, mainGui: GuiMain) -> None:
         self.mainGui = mainGui
         self.tr = partial(QCoreApplication.translate, "NWProject")
         return
@@ -274,7 +277,7 @@ class ProjectBuilder:
     #  Methods
     ##
 
-    def buildProject(self, data):
+    def buildProject(self, data: dict) -> bool:
         """Build a project from a data dictionary of specifications
         provided by the wizard.
         """
@@ -416,7 +419,7 @@ class ProjectBuilder:
     #  Internal Functions
     ##
 
-    def _extractSampleProject(self, data):
+    def _extractSampleProject(self, data: dict) -> bool:
         """Make a copy of the sample project by extracting the
         sample.zip file to the new path.
         """

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -22,14 +22,22 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from __future__ import annotations
 
 import logging
+
+from typing import TYPE_CHECKING, Any
+
+from PyQt5.QtGui import QIcon
 
 from novelwriter.enum import nwItemType, nwItemClass, nwItemLayout
 from novelwriter.common import (
     checkInt, isHandle, isItemClass, isItemLayout, isItemType, simplified, yesNo
 )
 from novelwriter.constants import nwHeaders, nwLabels, trConst
+
+if TYPE_CHECKING:  # pragma: no cover
+    from novelwriter.core.project import NWProject
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +51,7 @@ class NWItem:
         "_paraCount", "_cursorPos", "_initCount",
     )
 
-    def __init__(self, project):
+    def __init__(self, project: NWProject) -> None:
 
         self._project  = project
         self._name     = ""
@@ -69,10 +77,10 @@ class NWItem:
 
         return
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<NWItem handle={self._handle}, parent={self._parent}, name='{self._name}'>"
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return self._handle is not None
 
     ##
@@ -80,87 +88,86 @@ class NWItem:
     ##
 
     @property
-    def itemName(self):
+    def itemName(self) -> str:
         return self._name
 
     @property
-    def itemHandle(self):
+    def itemHandle(self) -> str | None:
         return self._handle
 
     @property
-    def itemParent(self):
+    def itemParent(self) -> str | None:
         return self._parent
 
     @property
-    def itemRoot(self):
+    def itemRoot(self) -> str | None:
         return self._root
 
     @property
-    def itemOrder(self):
+    def itemOrder(self) -> int:
         return self._order
 
     @property
-    def itemType(self):
+    def itemType(self) -> nwItemType:
         return self._type
 
     @property
-    def itemClass(self):
+    def itemClass(self) -> nwItemClass:
         return self._class
 
     @property
-    def itemLayout(self):
+    def itemLayout(self) -> nwItemLayout:
         return self._layout
 
     @property
-    def itemStatus(self):
+    def itemStatus(self) -> str | None:
         return self._status
 
     @property
-    def itemImport(self):
+    def itemImport(self) -> str | None:
         return self._import
 
     @property
-    def isActive(self):
+    def isActive(self) -> bool:
         return self._active
 
     @property
-    def isExpanded(self):
+    def isExpanded(self) -> bool:
         return self._expanded
 
     @property
-    def mainHeading(self):
+    def mainHeading(self) -> str:
         return self._heading
 
     @property
-    def charCount(self):
+    def charCount(self) -> int:
         return self._charCount
 
     @property
-    def wordCount(self):
+    def wordCount(self) -> int:
         return self._wordCount
 
     @property
-    def paraCount(self):
+    def paraCount(self) -> int:
         return self._paraCount
 
     @property
-    def initCount(self):
+    def initCount(self) -> int:
         return self._initCount
 
     @property
-    def cursorPos(self):
+    def cursorPos(self) -> int:
         return self._cursorPos
 
     ##
     #  Pack/Unpack Data
     ##
 
-    def pack(self):
-        """Pack all the data in the class instance into a dictionary.
-        """
-        item = {}
-        meta = {}
-        name = {}
+    def pack(self) -> dict[str, dict[str, str]]:
+        """Pack all the data in the class instance into a dictionary."""
+        item: dict[str, str] = {}
+        meta: dict[str, str] = {}
+        name: dict[str, str] = {}
 
         item["handle"]   = str(self._handle)
         item["parent"]   = str(self._parent)
@@ -190,9 +197,8 @@ class NWItem:
 
         return data
 
-    def unpack(self, data):
-        """Set the values from a data dictionary.
-        """
+    def unpack(self, data: dict[str, dict[str, Any]]) -> bool:
+        """Set the values from a data dictionary."""
         item = data.get("itemAttr", {})
         meta = data.get("metaAttr", {})
         name = data.get("nameAttr", {})
@@ -243,9 +249,8 @@ class NWItem:
     #  Lookup Methods
     ##
 
-    def describeMe(self):
-        """Return a string description of the item.
-        """
+    def describeMe(self) -> str:
+        """Return a string description of the item."""
         descKey = "none"
         if self._type == nwItemType.ROOT:
             descKey = "root"
@@ -268,7 +273,7 @@ class NWItem:
 
         return trConst(nwLabels.ITEM_DESCRIPTION.get(descKey, ""))
 
-    def getImportStatus(self, incIcon=True):
+    def getImportStatus(self, incIcon: bool = True) -> tuple[str, QIcon | None]:
         """Return the relevant importance or status label and icon for
         the current item based on its class.
         """
@@ -284,51 +289,43 @@ class NWItem:
     #  Checker Methods
     ##
 
-    def isNovelLike(self):
-        """Returns true if the item is of a novel-like class.
-        """
+    def isNovelLike(self) -> bool:
+        """Check if the item is of a novel-like class."""
         return self._class in (nwItemClass.NOVEL, nwItemClass.ARCHIVE)
 
-    def documentAllowed(self):
-        """Returns true if the item is allowed to be of document layout.
-        """
+    def documentAllowed(self) -> bool:
+        """Check if the item is allowed to be of document layout."""
         return self._class in (nwItemClass.NOVEL, nwItemClass.ARCHIVE, nwItemClass.TRASH)
 
-    def isInactiveClass(self):
-        """Returns true if the item is in an inactive class.
-        """
+    def isInactiveClass(self) -> bool:
+        """Check if the item is in an inactive class."""
         return self._class in (nwItemClass.NO_CLASS, nwItemClass.ARCHIVE, nwItemClass.TRASH)
 
-    def isRootType(self):
+    def isRootType(self) -> bool:
+        """Check if item is a root item."""
         return self._type == nwItemType.ROOT
 
-    def isFolderType(self):
+    def isFolderType(self) -> bool:
+        """Check if item is a folder item."""
         return self._type == nwItemType.FOLDER
 
-    def isFileType(self):
+    def isFileType(self) -> bool:
+        """Check if item is a file item."""
         return self._type == nwItemType.FILE
 
-    def isNoteLayout(self):
+    def isNoteLayout(self) -> bool:
+        """Check if item is a project note."""
         return self._layout == nwItemLayout.NOTE
 
-    def isDocumentLayout(self):
+    def isDocumentLayout(self) -> bool:
+        """Check if item is a novel document."""
         return self._layout == nwItemLayout.DOCUMENT
 
     ##
     #  Special Setters
     ##
 
-    def setImportStatus(self, value):
-        """Update the importance or status value based on class. This is
-        a wrapper setter for setStatus and setImport.
-        """
-        if self.isNovelLike():
-            self.setStatus(value)
-        else:
-            self.setImport(value)
-        return
-
-    def setClassDefaults(self, itemClass):
+    def setClassDefaults(self, itemClass: nwItemClass) -> None:
         """Set the default values based on the item's class and the
         project settings.
         """
@@ -358,27 +355,24 @@ class NWItem:
     #  Set Item Values
     ##
 
-    def setName(self, name):
-        """Set the item name.
-        """
+    def setName(self, name: Any) -> None:
+        """Set the item name."""
         if isinstance(name, str):
             self._name = simplified(name)
         else:
             self._name = ""
         return
 
-    def setHandle(self, handle):
-        """Set the item handle, and ensure it is valid.
-        """
+    def setHandle(self, handle: Any) -> None:
+        """Set the item handle, and ensure it is valid."""
         if isHandle(handle):
             self._handle = handle
         else:
             self._handle = None
         return
 
-    def setParent(self, handle):
-        """Set the parent handle, and ensure it is valid.
-        """
+    def setParent(self, handle: Any) -> None:
+        """Set the parent handle, and ensure it is valid."""
         if handle is None:
             self._parent = None
         elif isHandle(handle):
@@ -387,9 +381,8 @@ class NWItem:
             self._parent = None
         return
 
-    def setRoot(self, handle):
-        """Set the root handle, and ensure it is valid.
-        """
+    def setRoot(self, handle: Any) -> None:
+        """Set the root handle, and ensure it is valid."""
         if handle is None:
             self._root = None
         elif isHandle(handle):
@@ -398,7 +391,7 @@ class NWItem:
             self._root = None
         return
 
-    def setOrder(self, order):
+    def setOrder(self, order: Any) -> None:
         """Set the item order, and ensure that it is valid. This value
         is purely a meta value, and not actually used by novelWriter at
         the moment.
@@ -406,7 +399,7 @@ class NWItem:
         self._order = checkInt(order, 0)
         return
 
-    def setType(self, value):
+    def setType(self, value: Any) -> None:
         """Set the item type from either a proper nwItemType, or set it
         from a string representing an nwItemType.
         """
@@ -419,7 +412,7 @@ class NWItem:
             self._type = nwItemType.NO_TYPE
         return
 
-    def setClass(self, value):
+    def setClass(self, value: Any) -> None:
         """Set the item class from either a proper nwItemClass, or set
         it from a string representing an nwItemClass.
         """
@@ -432,7 +425,7 @@ class NWItem:
             self._class = nwItemClass.NO_CLASS
         return
 
-    def setLayout(self, value):
+    def setLayout(self, value: Any) -> None:
         """Set the item layout from either a proper nwItemLayout, or set
         it from a string representing an nwItemLayout.
         """
@@ -445,32 +438,30 @@ class NWItem:
             self._layout = nwItemLayout.NO_LAYOUT
         return
 
-    def setStatus(self, value):
+    def setStatus(self, value: Any) -> None:
         """Set the item status by looking it up in the valid status
         items of the current project.
         """
         self._status = self._project.data.itemStatus.check(value)
         return
 
-    def setImport(self, value):
+    def setImport(self, value: Any) -> None:
         """Set the item importance by looking it up in the valid import
         items of the current project.
         """
         self._import = self._project.data.itemImport.check(value)
         return
 
-    def setActive(self, state):
-        """Set the active flag.
-        """
+    def setActive(self, state: Any) -> None:
+        """Set the active flag."""
         if isinstance(state, bool):
             self._active = state
         else:
             self._active = False
         return
 
-    def setExpanded(self, state):
-        """Set the expanded status of an item in the project tree.
-        """
+    def setExpanded(self, state: Any) -> None:
+        """Set the expanded status of an item in the project tree."""
         if isinstance(state, bool):
             self._expanded = state
         else:
@@ -481,52 +472,46 @@ class NWItem:
     #  Set Document Meta Data
     ##
 
-    def setMainHeading(self, value):
-        """Set the main heading level.
-        """
+    def setMainHeading(self, value: str) -> None:
+        """Set the main heading level."""
         if value in nwHeaders.H_LEVEL:
             self._heading = value
         return
 
-    def setCharCount(self, count):
-        """Set the character count, and ensure that it is an integer.
-        """
+    def setCharCount(self, count: Any) -> None:
+        """Set the character count, and ensure that it is an integer."""
         if isinstance(count, int):
             self._charCount = max(0, count)
         else:
             self._charCount = 0
         return
 
-    def setWordCount(self, count):
-        """Set the word count, and ensure that it is an integer.
-        """
+    def setWordCount(self, count: Any) -> None:
+        """Set the word count, and ensure that it is an integer."""
         if isinstance(count, int):
             self._wordCount = max(0, count)
         else:
             self._wordCount = 0
         return
 
-    def setParaCount(self, count):
-        """Set the paragraph count, and ensure that it is an integer.
-        """
+    def setParaCount(self, count: Any) -> None:
+        """Set the paragraph count, and ensure that it is an integer."""
         if isinstance(count, int):
             self._paraCount = max(0, count)
         else:
             self._paraCount = 0
         return
 
-    def setCursorPos(self, position):
-        """Set the cursor position, and ensure that it is an integer.
-        """
+    def setCursorPos(self, position: Any) -> None:
+        """Set the cursor position, and ensure that it is an integer."""
         if isinstance(position, int):
             self._cursorPos = max(0, position)
         else:
             self._cursorPos = 0
         return
 
-    def saveInitialCount(self):
-        """Save the initial word count.
-        """
+    def saveInitialCount(self) -> None:
+        """Save the initial word count."""
         self._initCount = self._wordCount
         return
 

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -83,6 +83,29 @@ class NWItem:
     def __bool__(self) -> bool:
         return self._handle is not None
 
+    def __copy__(self) -> NWItem:
+        """Make a shallow copy of the current item."""
+        item = NWItem(self._project)
+        item._name      = self._name
+        item._handle    = self._handle
+        item._parent    = self._parent
+        item._root      = self._root
+        item._order     = self._order
+        item._type      = self._type
+        item._class     = self._class
+        item._layout    = self._layout
+        item._status    = self._status
+        item._import    = self._import
+        item._active    = self._active
+        item._expanded  = self._expanded
+        item._heading   = self._heading
+        item._charCount = self._charCount
+        item._wordCount = self._wordCount
+        item._paraCount = self._paraCount
+        item._cursorPos = self._cursorPos
+        item._initCount = self._initCount
+        return item
+
     ##
     #  Properties
     ##
@@ -163,7 +186,7 @@ class NWItem:
     #  Pack/Unpack Data
     ##
 
-    def pack(self) -> dict[str, dict[str, str]]:
+    def pack(self) -> dict:
         """Pack all the data in the class instance into a dictionary."""
         item: dict[str, str] = {}
         meta: dict[str, str] = {}
@@ -197,7 +220,7 @@ class NWItem:
 
         return data
 
-    def unpack(self, data: dict[str, dict[str, Any]]) -> bool:
+    def unpack(self, data: dict) -> bool:
         """Set the values from a data dictionary."""
         item = data.get("itemAttr", {})
         meta = data.get("metaAttr", {})

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -81,6 +81,7 @@ class NWItem:
         return f"<NWItem handle={self._handle}, parent={self._parent}, name='{self._name}'>"
 
     def __bool__(self) -> bool:
+        """Evaluate to False if itemHandle is not set."""
         return self._handle is not None
 
     def __copy__(self) -> NWItem:

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -24,10 +24,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
+import copy
 import random
 import logging
 
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Iterator
 from pathlib import Path
 
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
@@ -114,7 +115,17 @@ class NWTree:
 
         return True
 
-    def pack(self) -> list[dict[str, dict[str, str]]]:
+    def duplicate(self, sHandle: str) -> NWItem | None:
+        """Duplicate an item and set a new handle."""
+        sItem = self.__getitem__(sHandle)
+        if isinstance(sItem, NWItem):
+            nItem = copy.copy(sItem)
+            if self.append(None, sItem.itemParent, nItem):
+                logger.info("Duplicated item '%s' -> '%s'", sHandle, nItem.itemHandle)
+                return nItem
+        return None
+
+    def pack(self) -> list[dict]:
         """Pack the content of the tree into a list of doctionaries of
         items. In the order defined by the _treeOrder list.
         """
@@ -125,7 +136,7 @@ class NWTree:
                 tree.append(tItem.pack())
         return tree
 
-    def unpack(self, data: list[dict[str, dict[str, Any]]]) -> None:
+    def unpack(self, data: list[dict]) -> None:
         """Iterate through all items of a list and add them to the
         project tree.
         """
@@ -348,11 +359,11 @@ class NWTree:
         """True if there are any items in the project."""
         return bool(self._treeOrder)
 
-    def __getitem__(self, tHandle: str) -> NWItem | None:
+    def __getitem__(self, tHandle: str | None) -> NWItem | None:
         """Return a project item based on its handle. Returns None if
         the handle doesn't exist in the project.
         """
-        if tHandle in self._projTree:
+        if tHandle and tHandle in self._projTree:
             return self._projTree[tHandle]
         logger.error("No tree item with handle '%s'", str(tHandle))
         return None

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1687,14 +1687,13 @@ class GuiProjectTree(QTreeWidget):
         docDup = DocDuplicator(self.theProject)
         dupCount = 0
         for dHandle, nHandle in docDup.duplicate(itemTree):
-            print(dHandle, nHandle)
             self.theProject.index.reIndexHandle(dHandle)
             self.revealNewTreeItem(dHandle, nHandle=nHandle, wordCount=True)
             self._alertTreeChange(dHandle, flush=False)
             dupCount += 1
 
         if dupCount != nItems:
-            self.mainGui.makeAlert(self.tr("Could not duplicate all items."), nwAlert.ERROR)
+            self.mainGui.makeAlert(self.tr("Could not duplicate all items."), nwAlert.WARN)
 
         self.saveTreeOrder()
 

--- a/tests/reference/coreTools_DocDuplicator_nwProject.nwx
+++ b/tests/reference/coreTools_DocDuplicator_nwProject.nwx
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='utf-8'?>
+<novelWriterXML appVersion="2.1-beta1" hexVersion="0x020100b1" fileVersion="1.5" fileRevision="1" timeStamp="2023-07-20 20:33:41">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
+    <name>New Project</name>
+    <title>New Novel</title>
+    <author>Jane Doe</author>
+  </project>
+  <settings>
+    <doBackup>yes</doBackup>
+    <language>None</language>
+    <spellChecking auto="no">None</spellChecking>
+    <lastHandle>
+      <entry key="editor">None</entry>
+      <entry key="viewer">None</entry>
+      <entry key="novelTree">None</entry>
+      <entry key="outline">None</entry>
+    </lastHandle>
+    <autoReplace />
+    <status>
+      <entry key="s000000" count="15" red="100" green="100" blue="100">New</entry>
+      <entry key="s000001" count="0" red="200" green="50" blue="0">Note</entry>
+      <entry key="s000002" count="0" red="200" green="150" blue="0">Draft</entry>
+      <entry key="s000003" count="0" red="50" green="200" blue="0">Finished</entry>
+    </status>
+    <importance>
+      <entry key="i000004" count="3" red="100" green="100" blue="100">New</entry>
+      <entry key="i000005" count="0" red="200" green="50" blue="0">Minor</entry>
+      <entry key="i000006" count="0" red="200" green="150" blue="0">Major</entry>
+      <entry key="i000007" count="0" red="50" green="200" blue="0">Main</entry>
+    </importance>
+  </settings>
+  <content items="18" novelWords="26" notesWords="0">
+    <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">Novel</name>
+    </item>
+    <item handle="0000000000009" parent="None" root="0000000000009" order="0" type="ROOT" class="PLOT">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">Plot</name>
+    </item>
+    <item handle="000000000000a" parent="None" root="000000000000a" order="0" type="ROOT" class="CHARACTER">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">Characters</name>
+    </item>
+    <item handle="000000000000b" parent="None" root="000000000000b" order="0" type="ROOT" class="WORLD">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">World</name>
+    </item>
+    <item handle="000000000000c" parent="0000000000008" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">Title Page</name>
+    </item>
+    <item handle="000000000000d" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">New Chapter</name>
+    </item>
+    <item handle="000000000000e" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Chapter</name>
+    </item>
+    <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Scene</name>
+    </item>
+    <item handle="0000000000010" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Scene</name>
+    </item>
+    <item handle="0000000000011" parent="0000000000008" root="0000000000008" order="0" type="FOLDER" class="NOVEL">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">New Chapter</name>
+    </item>
+    <item handle="0000000000012" parent="0000000000011" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Chapter</name>
+    </item>
+    <item handle="0000000000013" parent="0000000000011" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Scene</name>
+    </item>
+    <item handle="0000000000014" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">Novel</name>
+    </item>
+    <item handle="0000000000015" parent="0000000000014" root="0000000000014" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H1" charCount="20" wordCount="5" paraCount="1" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">Title Page</name>
+    </item>
+    <item handle="0000000000016" parent="0000000000014" root="0000000000014" order="0" type="FOLDER" class="NOVEL">
+      <meta expanded="no" />
+      <name status="s000000" import="i000004">New Chapter</name>
+    </item>
+    <item handle="0000000000017" parent="0000000000016" root="0000000000014" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Chapter</name>
+    </item>
+    <item handle="0000000000018" parent="0000000000016" root="0000000000014" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H3" charCount="9" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Scene</name>
+    </item>
+    <item handle="0000000000019" parent="000000000000d" root="0000000000008" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
+      <meta expanded="no" heading="H2" charCount="11" wordCount="2" paraCount="0" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">New Chapter</name>
+    </item>
+  </content>
+</novelWriterXML>

--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -19,11 +19,11 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from pathlib import Path
 import uuid
 import pytest
 
 from shutil import copyfile
+from pathlib import Path
 from zipfile import ZipFile
 
 from mocked import causeOSError

--- a/tests/test_core/test_core_document.py
+++ b/tests/test_core/test_core_document.py
@@ -31,8 +31,7 @@ from novelwriter.core.document import NWDocument
 
 @pytest.mark.core
 def testCoreDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
-    """Test loading and saving a document with the NWDocument class.
-    """
+    """Test loading and saving a document with the NWDocument class."""
     theProject = NWProject(mockGUI)
     mockRnd.reset()
     buildTestProject(theProject, fncPath)
@@ -44,27 +43,32 @@ def testCoreDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     theDoc = NWDocument(theProject, "stuff")
     assert bool(theDoc) is False
     assert theDoc.readDocument() is None
+    assert theDoc.fileExists() is False
 
     # Non-existent handle
     theDoc = NWDocument(theProject, C.hInvalid)
     assert theDoc.readDocument() is None
     assert theDoc._currHash is None
+    assert theDoc.fileExists() is False
 
     # No content path
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.storage.NWStorage.contentPath", property(lambda *a: None))
         theDoc = NWDocument(theProject, C.hSceneDoc)
         assert theDoc.readDocument() is None
+        assert theDoc.fileExists() is False
 
     # Cause open() to fail while loading
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", causeOSError)
         theDoc = NWDocument(theProject, C.hSceneDoc)
+        assert theDoc.fileExists() is True
         assert theDoc.readDocument() is None
         assert theDoc.getError() == "OSError: Mock OSError"
 
     # Load the text
     theDoc = NWDocument(theProject, C.hSceneDoc)
+    assert theDoc.fileExists() is True
     assert theDoc.readDocument() == "### New Scene\n\n"
 
     # Try to open a new (non-existent) file

--- a/tests/test_core/test_core_item.py
+++ b/tests/test_core/test_core_item.py
@@ -262,18 +262,10 @@ def testCoreItem_Methods(mockGUI, mockRnd, fncPath):
     assert stT == "Note"
     assert isinstance(stI, QIcon)
 
-    theItem.setImportStatus(C.sDraft)
-    stT, stI = theItem.getImportStatus()
-    assert stT == "Draft"
-
     theItem.setClass("CHARACTER")
     stT, stI = theItem.getImportStatus()
     assert stT == "Minor"
     assert isinstance(stI, QIcon)
-
-    theItem.setImportStatus(C.iMajor)
-    stT, stI = theItem.getImportStatus()
-    assert stT == "Major"
 
     # Representation
     # ==============

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -149,7 +149,6 @@ def testCoreTree_BuildTree(mockGUI, mockItems):
     assert theTree.trashRoot() == "a000000000003"
     assert theTree.findRoot(nwItemClass.ARCHIVE) == "a000000000002"
     assert theTree.isTrash("a000000000003") is True
-    assert theTree.isRoot("a000000000002") is True
 
     # Check that we have the root classes
     assert theTree.rootClasses() == {
@@ -255,7 +254,7 @@ def testCoreTree_PackUnpack(mockGUI, mockItems):
     theTree.clear()
     assert len(theTree) == 0
     assert theTree.handles() == []
-    assert theTree.unpack(tree) is True
+    theTree.unpack(tree)
     assert theTree.handles() == aHandles
 
 # END Test testCoreTree_PackUnpack
@@ -338,13 +337,6 @@ def testCoreTree_Methods(mockGUI, mockItems):
     assert theTree.getItemPath("c000000000001") == [
         "c000000000001", "b000000000001", "a000000000001"
     ]
-
-    # Change file layout
-    assert theTree.setFileItemLayout("stuff", nwItemLayout.DOCUMENT) is False
-    assert theTree.setFileItemLayout("b000000000001", nwItemLayout.DOCUMENT) is False
-    assert theTree.setFileItemLayout("c000000000001", "stuff") is False
-    assert theTree.setFileItemLayout("c000000000001", nwItemLayout.NOTE) is True
-    assert theTree["c000000000001"].itemLayout == nwItemLayout.NOTE
 
 # END Test testCoreTree_Methods
 

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -22,15 +22,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 from pathlib import Path
 import pytest
 
-from mocked import causeOSError
-from novelwriter.guimain import GuiMain
 from tools import C, buildTestProject
+from mocked import causeOSError
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMessageBox, QMenu, QTreeWidgetItem, QDialog
 
 from novelwriter import CONFIG
 from novelwriter.enum import nwItemLayout, nwItemType, nwItemClass
+from novelwriter.guimain import GuiMain
 from novelwriter.gui.projtree import GuiProjectTree
 from novelwriter.dialogs.docmerge import GuiDocMerge
 from novelwriter.dialogs.docsplit import GuiDocSplit

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -19,8 +19,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from pathlib import Path
 import pytest
+
+from pathlib import Path
 
 from tools import C, buildTestProject
 from mocked import causeOSError

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -37,8 +37,7 @@ from novelwriter.dialogs.editlabel import GuiEditLabel
 
 @pytest.mark.gui
 def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, projPath, mockRnd):
-    """Test adding and removing items from the project tree.
-    """
+    """Test adding and removing items from the project tree."""
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
 
     projView = nwGUI.projView
@@ -158,6 +157,9 @@ def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, projPath, mockRn
     # Add an item that cannot be displayed in the tree
     nHandle = theProject.newFile("Test", None)
     assert projView.projTree.revealNewTreeItem(nHandle) is False
+
+    # Adding an invalid item directly to the tree should also fail
+    assert projView.projTree._addTreeItem(None) is None
 
     # Clean up
     # qtbot.stop()


### PR DESCRIPTION
**Summary:**

This PR adds functionality to duplicate either individual files, or whole hierarchies up to and including root folders.

In addition, this PR:
* Adds annotations to a bunch of core classes, and bits here and there.
* Improves the function that adds tree widget items to the project tree so that it also allows controlling where root folders appear. This is needed for #1259 as well, but here it is used to ensure that a duplicated root folder appears next to the folder it duplicates.

**Related Issue(s):**

Closes #1469

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
