### PR TITLE
Change tree nav shortcut modifier and update docs

### DIFF
--- a/docs/source/usage_shortcuts.rst
+++ b/docs/source/usage_shortcuts.rst
@@ -7,144 +7,190 @@ Keyboard Shortcuts
 Most features in novelWriter are available as keyboard shortcuts. This is a reference list if these
 shortcuts. Most of them are also listed in the application.
 
-
-.. _a_kb_main:
-
-Main Shortcuts
-==============
-
-The main shorcuts are as follows:
-
-.. csv-table:: Keyboard Shortcuts
-   :header: "Shortcut", "Description"
-   :widths: 22, 78
-   :class: "tight-table"
-
-   ":kbd:`F1`",                          "Open the online user manual."
-   ":kbd:`F2`",                          "If in the project tree, edit an item's label."
-   ":kbd:`F3`",                          "Find next occurrence of search word in current document."
-   ":kbd:`F5`",                          "Open the :guilabel:`Build Novel Project` dialog."
-   ":kbd:`F6`",                          "Open the :guilabel:`Writing Statistics` dialog."
-   ":kbd:`F7`",                          "Re-run spell checker."
-   ":kbd:`F8`",                          "Toggle :guilabel:`Focus Mode`."
-   ":kbd:`F9`",                          "Re-build the project index."
-   ":kbd:`F11`",                         "Toggle full screen mode."
-   ":kbd:`Return`",                      "If in the project tree, open a document for editing."
-   ":kbd:`Alt`:kbd:`1`",                 "Switch focus to the project tree. On Windows, use :kbd:`Ctrl`:kbd:`Alt`:kbd:`1`."
-   ":kbd:`Alt`:kbd:`2`",                 "Switch focus to document editor. On Windows, use :kbd:`Ctrl`:kbd:`Alt`:kbd:`2`."
-   ":kbd:`Alt`:kbd:`3`",                 "Switch focus to document viewer. On Windows, use :kbd:`Ctrl`:kbd:`Alt`:kbd:`3`."
-   ":kbd:`Alt`:kbd:`4`",                 "Switch focus to outline view. On Windows, use :kbd:`Ctrl`:kbd:`Alt`:kbd:`4`."
-   ":kbd:`Alt`:kbd:`Left`",              "Move backward in the view history of the document viewer."
-   ":kbd:`Alt`:kbd:`Right`",             "Move forward in the view history of the document viewer."
-   ":kbd:`Ctrl`:kbd:`.`",                "Open the context menu in the project tree or the document editor."
-   ":kbd:`Ctrl`:kbd:`,`",                "Open the :guilabel:`Preferences` dialog."
-   ":kbd:`Ctrl`:kbd:`/`",                "Toggle block format as comment."
-   ":kbd:`Ctrl`:kbd:`0`",                "Remove block formatting for block under cursor."
-   ":kbd:`Ctrl`:kbd:`1`",                "Change block format to header level 1."
-   ":kbd:`Ctrl`:kbd:`2`",                "Change block format to header level 2."
-   ":kbd:`Ctrl`:kbd:`3`",                "Change block format to header level 3."
-   ":kbd:`Ctrl`:kbd:`4`",                "Change block format to header level 4."
-   ":kbd:`Ctrl`:kbd:`5`",                "Change block alignment to left-aligned."
-   ":kbd:`Ctrl`:kbd:`6`",                "Change block alignment to centred."
-   ":kbd:`Ctrl`:kbd:`7`",                "Change block alignment to right-aligned."
-   ":kbd:`Ctrl`:kbd:`8`",                "Add a left margin to the block."
-   ":kbd:`Ctrl`:kbd:`9`",                "Add a right margin to the block."
-   ":kbd:`Ctrl`:kbd:`A`",                "Select all text in the document."
-   ":kbd:`Ctrl`:kbd:`B`",                "Format selected text, or word under cursor, with strong emphasis (bold)."
-   ":kbd:`Ctrl`:kbd:`C`",                "Copy selected text to clipboard."
-   ":kbd:`Ctrl`:kbd:`D`",                "Strikethrough selected text, or word under cursor."
-   ":kbd:`Ctrl`:kbd:`F`",                "Open the search bar and search for the selected word, if any is selected."
-   ":kbd:`Ctrl`:kbd:`G`",                "Find next occurrence of search word in current document."
-   ":kbd:`Ctrl`:kbd:`H`",                "Open the search and replace tool and search for the selected word, if any is selected. (On Mac, this is :kbd:`Cmd`:kbd:`=`.)"
-   ":kbd:`Ctrl`:kbd:`I`",                "Format selected text, or word under cursor, with emphasis (italic)."
-   ":kbd:`Ctrl`:kbd:`K`",                "Activate the insert commands. The commands are listed in :ref:`a_kb_ins`."
-   ":kbd:`Ctrl`:kbd:`L`",                "Open the :guilabel:`Quick Links` menu in the Project Tree."
-   ":kbd:`Ctrl`:kbd:`N`",                "Open the Create New Item menu in the Project Tree."
-   ":kbd:`Ctrl`:kbd:`O`",                "Open selected document."
-   ":kbd:`Ctrl`:kbd:`Q`",                "Exit novelWriter."
-   ":kbd:`Ctrl`:kbd:`R`",                "If in the project tree, open a document for viewing. If in the editor, open current document for viewing."
-   ":kbd:`Ctrl`:kbd:`S`",                "Save the current document in the document editor."
-   ":kbd:`Ctrl`:kbd:`V`",                "Paste text from clipboard to cursor position."
-   ":kbd:`Ctrl`:kbd:`W`",                "Close the current document in the document editor."
-   ":kbd:`Ctrl`:kbd:`X`",                "Cut selected text to clipboard."
-   ":kbd:`Ctrl`:kbd:`Y`",                "Redo latest undo."
-   ":kbd:`Ctrl`:kbd:`Z`",                "Undo latest changes."
-   ":kbd:`Ctrl`:kbd:`F7`",               "Toggle spell checking."
-   ":kbd:`Ctrl`:kbd:`Up`",               "Move item one step up in the project tree."
-   ":kbd:`Ctrl`:kbd:`Down`",             "Move item one step down in the project tree."
-   ":kbd:`Ctrl`:kbd:`Del`",              "Delete next word in editor."
-   ":kbd:`Ctrl`:kbd:`Backspace`",        "Delete previous word in editor."
-   ":kbd:`Ctrl`:kbd:`'`",                "Wrap selected text, or word under cursor, in single quotes."
-   ":kbd:`Ctrl`:kbd:`""`",               "Wrap selected text, or word under cursor, in double quotes."
-   ":kbd:`Ctrl`:kbd:`Return`",           "Open the tag or reference under the cursor in the Viewer."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`,`",    "Open the :guilabel:`Project Settings` dialog."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`/`",    "Remove block formatting for block under cursor."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`1`",    "Replace occurrence of search word in current document, and search for next occurrence."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`A`",    "Select all text in current paragraph."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`G`",    "Find previous occurrence of search word in current document."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`I`",    "Import text to the current document from a text file."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`O`",    "Open a project."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`R`",    "Close the document viewer."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`S`",    "Save the current project."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`W`",    "Close the current project."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`Z`",    "Undo move of project tree item."
-   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`Del`",  "If in the project tree, move an item to Trash."
-   ":kbd:`Shift`:kbd:`F1`",              "Open the local user manual (PDF) if it is available."
-   ":kbd:`Shift`:kbd:`F3`",              "Find previous occurrence of search word in current document."
-   ":kbd:`Shift`:kbd:`F6`",              "Open the :guilabel:`Project Details` dialog."
-   ":kbd:`Shift`:kbd:`Up`",              "Go to the previous item at same level in the project tree."
-   ":kbd:`Shift`:kbd:`Down`",            "Go to the next item at same level in the project tree."
-   ":kbd:`Shift`:kbd:`Left`",            "Go to the parent item in the project tree."
-   ":kbd:`Shift`:kbd:`Right`",           "Go to the first child item in the project tree."
-
 .. note::
    On macOS, replace :kbd:`Ctrl` with :kbd:`Cmd`.
 
 
+.. _a_kb_main:
+
+Main Window Shortcuts
+=====================
+
+.. csv-table::
+   :header: "Shortcut", "Description"
+
+   ":kbd:`F1`",                       "Open the online user manual"
+   ":kbd:`F5`",                       "Open the :guilabel:`Build Manuscript` tool"
+   ":kbd:`F6`",                       "Open the :guilabel:`Writing Statistics` tool"
+   ":kbd:`F8`",                       "Toggle :guilabel:`Focus Mode`"
+   ":kbd:`F9`",                       "Re-build the project index"
+   ":kbd:`F11`",                      "Toggle full screen mode"
+   ":kbd:`Alt`:kbd:`1`",              "Switch focus to the project tree (Windows :kbd:`Ctrl`:kbd:`Alt`:kbd:`1`)"
+   ":kbd:`Alt`:kbd:`2`",              "Switch focus to document editor (Windows :kbd:`Ctrl`:kbd:`Alt`:kbd:`2`)"
+   ":kbd:`Alt`:kbd:`3`",              "Switch focus to document viewer (Windows :kbd:`Ctrl`:kbd:`Alt`:kbd:`3`)"
+   ":kbd:`Alt`:kbd:`4`",              "Switch focus to outline view (Windows :kbd:`Ctrl`:kbd:`Alt`:kbd:`4`)"
+   ":kbd:`Ctrl`:kbd:`,`",             "Open the :guilabel:`Preferences` dialog"
+   ":kbd:`Ctrl`:kbd:`Q`",             "Exit novelWriter"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`,`", "Open the :guilabel:`Project Settings` dialog"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`O`", "Open a project"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`S`", "Save the current project"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`W`", "Close the current project"
+   ":kbd:`Shift`:kbd:`F1`",           "Open the local user manual (PDF) if it is available"
+   ":kbd:`Shift`:kbd:`F6`",           "Open the :guilabel:`Project Details` dialog"
+
+.. _a_kb_tree:
+
+Project Tree Shortcuts
+======================
+
+.. csv-table::
+   :header: "Shortcut", "Description"
+
+   ":kbd:`F2`",                         "Edit the label of the selected item"
+   ":kbd:`Return`",                     "Open the selected document in the editor"
+   ":kbd:`Alt`:kbd:`Up`",               "Jump or go to the previous item at same level in the tree"
+   ":kbd:`Alt`:kbd:`Down`",             "Jump or go to the next item at same level in the tree"
+   ":kbd:`Alt`:kbd:`Left`",             "Jump to the parent item in the tree"
+   ":kbd:`Alt`:kbd:`Right`",            "Jump to the first child item in the project tree"
+   ":kbd:`Ctrl`:kbd:`.`",               "Open the context menu on the selected item"
+   ":kbd:`Ctrl`:kbd:`L`",               "Open the :guilabel:`Quick Links` menu"
+   ":kbd:`Ctrl`:kbd:`N`",               "Open the :guilabel:`Create New Item` menu"
+   ":kbd:`Ctrl`:kbd:`O`",               "Open selected document"
+   ":kbd:`Ctrl`:kbd:`R`",               "Open the selected document in the viewer"
+   ":kbd:`Ctrl`:kbd:`Up`",              "Move selected item one step up in the tree"
+   ":kbd:`Ctrl`:kbd:`Down`",            "Move selected item one step down in the tree"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`Z`",   "Undo the last move of a project item, if possible"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`Del`", "Move the selected item to Trash"
+
+
+.. _a_kb_editor:
+
+Document Editor Shortcuts
+=========================
+
+
+Text Search Shortcuts
+---------------------
+
+.. csv-table::
+   :header: "Shortcut", "Description"
+
+   ":kbd:`F3`",                       "Find the next occurrence of the search word"
+   ":kbd:`Ctrl`:kbd:`F`",             "Open the search bar and search for the selected word, if any is selected"
+   ":kbd:`Ctrl`:kbd:`G`",             "Find next occurrence of search word in current document"
+   ":kbd:`Ctrl`:kbd:`H`",             "Open the search tool and populate with the selected word (Mac :kbd:`Cmd`:kbd:`=`)"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`1`", "Replace selected occurrence of the search word, and move to the next"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`G`", "Find previous occurrence of the search word"
+   ":kbd:`Shift`:kbd:`F3`",           "Find the previous occurrence of the search word"
+
+
+Text Formatting Shortcuts
+-------------------------
+
+.. csv-table::
+   :header: "Shortcut", "Description"
+
+   ":kbd:`Ctrl`:kbd:`/`",             "Toggle block format as comment"
+   ":kbd:`Ctrl`:kbd:`0`",             "Remove block formatting for block under cursor"
+   ":kbd:`Ctrl`:kbd:`1`",             "Change block format to header level 1"
+   ":kbd:`Ctrl`:kbd:`2`",             "Change block format to header level 2"
+   ":kbd:`Ctrl`:kbd:`3`",             "Change block format to header level 3"
+   ":kbd:`Ctrl`:kbd:`4`",             "Change block format to header level 4"
+   ":kbd:`Ctrl`:kbd:`5`",             "Change block alignment to left-aligned"
+   ":kbd:`Ctrl`:kbd:`6`",             "Change block alignment to centred"
+   ":kbd:`Ctrl`:kbd:`7`",             "Change block alignment to right-aligned"
+   ":kbd:`Ctrl`:kbd:`8`",             "Add a left margin to the block"
+   ":kbd:`Ctrl`:kbd:`9`",             "Add a right margin to the block"
+   ":kbd:`Ctrl`:kbd:`B`",             "Format selected text, or word under cursor, with strong emphasis (bold)"
+   ":kbd:`Ctrl`:kbd:`D`",             "Strikethrough selected text, or word under cursor"
+   ":kbd:`Ctrl`:kbd:`I`",             "Format selected text, or word under cursor, with emphasis (italic)"
+   ":kbd:`Ctrl`:kbd:`'`",             "Wrap selected text, or word under cursor, in single quotes"
+   ":kbd:`Ctrl`:kbd:`""`",            "Wrap selected text, or word under cursor, in double quotes"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`/`", "Remove block formatting for block under cursor"
+
+
+Other Editor Shortcuts
+----------------------
+
+.. csv-table::
+   :header: "Shortcut", "Description"
+
+   ":kbd:`F7`",                       "Re-run the spell checker"
+   ":kbd:`Ctrl`:kbd:`.`",             "Open the context menu at the current cursor location"
+   ":kbd:`Ctrl`:kbd:`A`",             "Select all text in the document"
+   ":kbd:`Ctrl`:kbd:`C`",             "Copy selected text to clipboard"
+   ":kbd:`Ctrl`:kbd:`K`",             "Activate the insert commands (see list in :ref:`a_kb_ins`)"
+   ":kbd:`Ctrl`:kbd:`R`",             "Open or reload the current document in the viewer"
+   ":kbd:`Ctrl`:kbd:`S`",             "Save the current document"
+   ":kbd:`Ctrl`:kbd:`V`",             "Paste text from clipboard to cursor position"
+   ":kbd:`Ctrl`:kbd:`W`",             "Close the current document"
+   ":kbd:`Ctrl`:kbd:`X`",             "Cut selected text to clipboard"
+   ":kbd:`Ctrl`:kbd:`Y`",             "Redo latest undo"
+   ":kbd:`Ctrl`:kbd:`Z`",             "Undo latest changes"
+   ":kbd:`Ctrl`:kbd:`Del`",           "Delete the word after the cursor"
+   ":kbd:`Ctrl`:kbd:`Backspace`",     "Delete the word before the cursor"
+   ":kbd:`Ctrl`:kbd:`Return`",        "Open the tag or reference under the cursor in the viewer"
+   ":kbd:`Ctrl`:kbd:`F7`",            "Toggle spell checking"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`A`", "Select all text in the current paragraph"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`I`", "Import text to the current document from a text file"
+
 .. _a_kb_ins:
 
 Insert Shortcuts
-================
+----------------
 
 A set of insert features are also available through shortcuts, but they require a double
 combination of key sequences. The insert feature is activated with :kbd:`Ctrl`:kbd:`K`, followed by
 a key or key combination for the inserted content.
 
-.. csv-table:: Keyboard Shortcuts
+.. csv-table::
    :header: "Shortcut", "Description"
-   :widths: 30, 70
-   :class: "tight-table"
 
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`−`",                 "Insert a short dash (en dash)."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`_`",                 "Insert a long dash (em dash)."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`_`",      "Insert a horizontal bar (quotation dash)."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`~`",                 "Insert a figure dash (same width as a number)."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`1`",                 "Insert a left single quote."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`2`",                 "Insert a right single quote."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`3`",                 "Insert a left double quote."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`4`",                 "Insert a right double quote."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`'`",                 "Insert a modifier apostrophe."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`.`",                 "Insert an ellipsis."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`'`",      "Insert a prime."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`""`",     "Insert a double prime."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Space`",             "Insert a non-breaking space."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Shift`:kbd:`Space`", "Insert a thin space."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`Space`",  "Insert a thin non-breaking space."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`*`",                 "Insert a list bullet."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`−`",      "Insert a hyphen bullet (alternative bullet)."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`*`",      "Insert a flower mark (alternative bullet)."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`%`",                 "Insert a per mille symbol."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`O`",      "Insert a degree symbol."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`X`",      "Insert a times sign."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`D`",      "Insert a division sign."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`G`",                 "Insert a ``@tag`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`V`",                 "Insert a ``@pov`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`F`",                 "Insert a ``@focus`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`C`",                 "Insert a ``@char`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`P`",                 "Insert a ``@plot`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`S`",                 "Insert a synopsis comment."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`T`",                 "Insert a ``@time`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`L`",                 "Insert a ``@location`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`O`",                 "Insert an ``@object`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`E`",                 "Insert an ``@entity`` keyword."
-   ":kbd:`Ctrl`:kbd:`K`, :kbd:`X`",                 "Insert a ``@custom`` keyword."
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`−`",                 "Insert a short dash (en dash)"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`_`",                 "Insert a long dash (em dash)"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`_`",      "Insert a horizontal bar (quotation dash)"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`~`",                 "Insert a figure dash (same width as a number)"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`1`",                 "Insert a left single quote"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`2`",                 "Insert a right single quote"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`3`",                 "Insert a left double quote"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`4`",                 "Insert a right double quote"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`'`",                 "Insert a modifier apostrophe"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`.`",                 "Insert an ellipsis"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`'`",      "Insert a prime"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`""`",     "Insert a double prime"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Space`",             "Insert a non-breaking space"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Shift`:kbd:`Space`", "Insert a thin space"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`Space`",  "Insert a thin non-breaking space"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`*`",                 "Insert a list bullet"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`−`",      "Insert a hyphen bullet (alternative bullet)"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`*`",      "Insert a flower mark (alternative bullet)"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`%`",                 "Insert a per mille symbol"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`O`",      "Insert a degree symbol"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`X`",      "Insert a times sign"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`Ctrl`:kbd:`D`",      "Insert a division sign"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`G`",                 "Insert a ``@tag`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`V`",                 "Insert a ``@pov`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`F`",                 "Insert a ``@focus`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`C`",                 "Insert a ``@char`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`P`",                 "Insert a ``@plot`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`S`",                 "Insert a synopsis comment"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`T`",                 "Insert a ``@time`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`L`",                 "Insert a ``@location`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`O`",                 "Insert an ``@object`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`E`",                 "Insert an ``@entity`` keyword"
+   ":kbd:`Ctrl`:kbd:`K`, :kbd:`X`",                 "Insert a ``@custom`` keyword"
+
+
+.. _a_kb_viewer:
+
+Document Viewer Shortcuts
+=========================
+
+.. csv-table::
+   :header: "Shortcut", "Description"
+
+   ":kbd:`Alt`:kbd:`Left`",           "Move backward in the view history"
+   ":kbd:`Alt`:kbd:`Right`",          "Move forward in the view history"
+   ":kbd:`Ctrl`:kbd:`C`",             "Copy selected text to clipboard"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`A`", "Select all text in the current paragraph"
+   ":kbd:`Ctrl`:kbd:`Shift`:kbd:`R`", "Close the document viewer"

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -108,22 +108,22 @@ class GuiProjectView(QWidget):
         self.keyMoveDn.activated.connect(lambda: self.projTree.moveTreeItem(1))
 
         self.keyGoPrev = QShortcut(self.projTree)
-        self.keyGoPrev.setKey("Shift+Up")
+        self.keyGoPrev.setKey("Alt+Up")
         self.keyGoPrev.setContext(Qt.WidgetShortcut)
         self.keyGoPrev.activated.connect(lambda: self.projTree.moveToNextItem(-1))
 
         self.keyGoNext = QShortcut(self.projTree)
-        self.keyGoNext.setKey("Shift+Down")
+        self.keyGoNext.setKey("Alt+Down")
         self.keyGoNext.setContext(Qt.WidgetShortcut)
         self.keyGoNext.activated.connect(lambda: self.projTree.moveToNextItem(1))
 
         self.keyGoUp = QShortcut(self.projTree)
-        self.keyGoUp.setKey("Shift+Left")
+        self.keyGoUp.setKey("Alt+Left")
         self.keyGoUp.setContext(Qt.WidgetShortcut)
         self.keyGoUp.activated.connect(lambda: self.projTree.moveToLevel(-1))
 
         self.keyGoDown = QShortcut(self.projTree)
-        self.keyGoDown.setKey("Shift+Right")
+        self.keyGoDown.setKey("Alt+Right")
         self.keyGoDown.setContext(Qt.WidgetShortcut)
         self.keyGoDown.activated.connect(lambda: self.projTree.moveToLevel(1))
 


### PR DESCRIPTION
**Summary:**

* Change the modifier for the special navigation of the project tree to use Alt instead of Shift
* Restructure the keyboard shortcuts documentation

**Related Issue(s):**

See #1348

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
