### PR TITLE
Fix MacOS release for 2.1b1

### DIFF
--- a/docs/source/int_source.rst
+++ b/docs/source/int_source.rst
@@ -4,7 +4,6 @@
 Running from Source
 *******************
 
-.. _main website: https://novelwriter.io
 .. _GitHub: https://github.com/vkbo/novelWriter/releases
 .. _PyPi: https://pypi.org/project/novelWriter/
 .. _Sphinx Docs: https://www.sphinx-doc.org/
@@ -24,11 +23,6 @@ by running:
 .. code-block:: bash
 
    python pkgutils.py help
-
-.. warning::
-
-   Calling ``setup.py install`` has been deprecated for a while, and this approach is no longer
-   actively supported in novelWriter either.
 
 
 .. _a_source_depend:
@@ -92,7 +86,7 @@ With the tool installed, run the following command from the root of the novelWri
 
 This should generate two files in the ``dist/`` folder at your current location. One with file
 extension ``.tar.gz`` and one with extension ``.whl``. The latter is the package you want to
-install, here with example version number 2.0.7, but your may be different:
+install, here with example version number 2.0.7, but yours may be different:
 
 .. code-block:: bash
 

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -189,7 +189,7 @@ def main(sysArgs=None):
         errDlg = QErrorMessage()
         errDlg.resize(500, 300)
         errDlg.showMessage((
-            "<h3>A critical error has been encountered</h3>"
+            "<h3>A critical error was encountered</h3>"
             "<p>novelWriter cannot start due to the following issues:<p>"
             "<p>&nbsp;-&nbsp;%s</p>"
             "<p>Shutting down ...</p>"

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from datetime import datetime
 
 from PyQt5.QtCore import Qt, QTimer, QThreadPool, pyqtSlot
-from PyQt5.QtGui import QCursor, QIcon, QKeySequence, QWindow
+from PyQt5.QtGui import QCursor, QIcon, QKeySequence
 from PyQt5.QtWidgets import (
     qApp, QDialog, QFileDialog, QMainWindow, QMessageBox, QShortcut, QSplitter,
     QStackedWidget, QVBoxLayout, QWidget
@@ -349,27 +349,6 @@ class GuiMain(QMainWindow):
         self._updateWindowTitle()
 
         return True
-
-    def restackGUI(self):
-        """Reorder the visibility of windows."""
-        subOne: list[QWindow] = []
-        subTwo: list[QWindow] = []
-        for window in qApp.allWindows():
-            name = window.objectName()
-            if name == "GuiManuscriptWindow":
-                subOne.append(window)
-            elif name == "GuiBuildSettingsWindow":
-                subTwo.append(window)
-            elif name == "GuiManuscriptBuildWindow":
-                subTwo.append(window)
-        self.raise_()
-        for window in subOne:
-            if window.isExposed():
-                window.raise_()
-        for window in subTwo:
-            if window.isExposed():
-                window.raise_()
-        return
 
     def initMain(self):
         """Initialise elements that depend on user settings.

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -21,6 +21,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from __future__ import annotations
 
 import sys
 import logging
@@ -31,7 +32,7 @@ from pathlib import Path
 from datetime import datetime
 
 from PyQt5.QtCore import Qt, QTimer, QThreadPool, pyqtSlot
-from PyQt5.QtGui import QCursor, QIcon, QKeySequence
+from PyQt5.QtGui import QCursor, QIcon, QKeySequence, QWindow
 from PyQt5.QtWidgets import (
     qApp, QDialog, QFileDialog, QMainWindow, QMessageBox, QShortcut, QSplitter,
     QStackedWidget, QVBoxLayout, QWidget
@@ -348,6 +349,27 @@ class GuiMain(QMainWindow):
         self._updateWindowTitle()
 
         return True
+
+    def restackGUI(self):
+        """Reorder the visibility of windows."""
+        subOne: list[QWindow] = []
+        subTwo: list[QWindow] = []
+        for window in qApp.allWindows():
+            name = window.objectName()
+            if name == "GuiManuscriptWindow":
+                subOne.append(window)
+            elif name == "GuiBuildSettingsWindow":
+                subTwo.append(window)
+            elif name == "GuiManuscriptBuildWindow":
+                subTwo.append(window)
+        self.raise_()
+        for window in subOne:
+            if window.isExposed():
+                window.raise_()
+        for window in subTwo:
+            if window.isExposed():
+                window.raise_()
+        return
 
     def initMain(self):
         """Initialise elements that depend on user settings.

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1000,7 +1000,7 @@ class GuiMain(QMainWindow):
             dlgDetails = GuiProjectDetails(self)
         assert isinstance(dlgDetails, GuiProjectDetails)
 
-        dlgDetails.setModal(False)
+        dlgDetails.setModal(True)
         dlgDetails.show()
         dlgDetails.raise_()
         dlgDetails.updateValues()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -301,9 +301,6 @@ class GuiMain(QMainWindow):
         # Forward Functions
         self.setStatus = self.mainStatus.setStatus
 
-        # Force a show of the GUI
-        self.show()
-
         # Check that config loaded fine
         self.reportConfErr()
 

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -46,6 +46,8 @@ class GuiLipsum(QDialog):
 
         logger.debug("Create: GuiLipsum")
         self.setObjectName("GuiLipsum")
+        if CONFIG.osDarwin:
+            self.setWindowFlag(Qt.WindowType.Tool)
 
         self.mainGui   = mainGui
         self.mainTheme = mainGui.mainTheme

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -65,7 +65,6 @@ class GuiManuscriptBuild(QDialog):
         logger.debug("Create: GuiManuscriptBuild")
         self.setObjectName("GuiManuscriptBuild")
 
-        self.guiParent  = parent
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -250,7 +250,7 @@ class GuiManuscriptBuild(QDialog):
         """
         self._saveSettings()
         event.accept()
-        self.guiParent.raise_()  # Issue #1494
+        self.mainGui.restackGUI()
         self.deleteLater()
         return
 
@@ -278,8 +278,7 @@ class GuiManuscriptBuild(QDialog):
         )
         if savePath:
             self.buildPath.setText(savePath)
-        self.guiParent.raise_()  # Issue #1494
-        self.raise_()  # Issue #1494
+        self.mainGui.restackGUI()
         return
 
     @pyqtSlot()

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -65,6 +65,7 @@ class GuiManuscriptBuild(QDialog):
         logger.debug("Create: GuiManuscriptBuild")
         self.setObjectName("GuiManuscriptBuild")
 
+        self.guiParent  = parent
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
@@ -249,6 +250,7 @@ class GuiManuscriptBuild(QDialog):
         """
         self._saveSettings()
         event.accept()
+        self.guiParent.raise_()  # Issue #1494
         self.deleteLater()
         return
 
@@ -276,6 +278,8 @@ class GuiManuscriptBuild(QDialog):
         )
         if savePath:
             self.buildPath.setText(savePath)
+        self.guiParent.raise_()  # Issue #1494
+        self.raise_()  # Issue #1494
         return
 
     @pyqtSlot()

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -250,7 +250,6 @@ class GuiManuscriptBuild(QDialog):
         """
         self._saveSettings()
         event.accept()
-        self.mainGui.restackGUI()
         self.deleteLater()
         return
 
@@ -278,7 +277,6 @@ class GuiManuscriptBuild(QDialog):
         )
         if savePath:
             self.buildPath.setText(savePath)
-        self.mainGui.restackGUI()
         return
 
     @pyqtSlot()

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -69,6 +69,8 @@ class GuiManuscript(QDialog):
 
         logger.debug("Create: GuiManuscript")
         self.setObjectName("GuiManuscript")
+        if CONFIG.osDarwin:
+            self.setWindowFlag(Qt.WindowType.Tool)
 
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -74,6 +74,8 @@ class GuiBuildSettings(QDialog):
 
         logger.debug("Create: GuiBuildSettings")
         self.setObjectName("GuiBuildSettings")
+        if CONFIG.osDarwin:
+            self.setWindowFlag(Qt.WindowType.Tool)
 
         self.guiParent  = parent
         self.mainGui    = mainGui
@@ -225,7 +227,6 @@ class GuiBuildSettings(QDialog):
         self._askToSaveBuild()
         self._saveSettings()
         event.accept()
-        self.mainGui.restackGUI()
         self.deleteLater()
         return
 
@@ -1163,7 +1164,6 @@ class _FormatTab(QWidget):
         if theStatus:
             self.textFont.setText(theFont.family())
             self.textSize.setValue(theFont.pointSize())
-        self.mainGui.restackGUI()
         return
 
     @pyqtSlot(int)

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -225,7 +225,7 @@ class GuiBuildSettings(QDialog):
         self._askToSaveBuild()
         self._saveSettings()
         event.accept()
-        self.guiParent.raise_()  # Issue #1494
+        self.mainGui.restackGUI()
         self.deleteLater()
         return
 
@@ -1163,8 +1163,7 @@ class _FormatTab(QWidget):
         if theStatus:
             self.textFont.setText(theFont.family())
             self.textSize.setValue(theFont.pointSize())
-        self.buildMain.guiParent.raise_()  # Issue #1494
-        self.buildMain.raise_()  # Issue #1494
+        self.mainGui.restackGUI()
         return
 
     @pyqtSlot(int)

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -209,10 +209,8 @@ class GuiBuildSettings(QDialog):
         elif role == QDialogButtonBox.AcceptRole:
             self._emitBuildData()
             self.close()
-            self.guiParent.raise_()  # Issue #1494
         elif role == QDialogButtonBox.RejectRole:
             self.close()
-            self.guiParent.raise_()  # Issue #1494
         return
 
     ##
@@ -227,6 +225,7 @@ class GuiBuildSettings(QDialog):
         self._askToSaveBuild()
         self._saveSettings()
         event.accept()
+        self.guiParent.raise_()  # Issue #1494
         self.deleteLater()
         return
 

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -75,6 +75,7 @@ class GuiBuildSettings(QDialog):
         logger.debug("Create: GuiBuildSettings")
         self.setObjectName("GuiBuildSettings")
 
+        self.guiParent  = parent
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject
@@ -208,8 +209,10 @@ class GuiBuildSettings(QDialog):
         elif role == QDialogButtonBox.AcceptRole:
             self._emitBuildData()
             self.close()
+            self.guiParent.raise_()  # Issue #1494
         elif role == QDialogButtonBox.RejectRole:
             self.close()
+            self.guiParent.raise_()  # Issue #1494
         return
 
     ##
@@ -941,6 +944,7 @@ class _FormatTab(QWidget):
     def __init__(self, buildMain: GuiBuildSettings, build: BuildSettings):
         super().__init__(parent=buildMain)
 
+        self.buildMain  = buildMain
         self.mainGui    = buildMain.mainGui
         self.mainTheme  = buildMain.mainGui.mainTheme
 
@@ -1160,6 +1164,8 @@ class _FormatTab(QWidget):
         if theStatus:
             self.textFont.setText(theFont.family())
             self.textSize.setValue(theFont.pointSize())
+        self.buildMain.guiParent.raise_()  # Issue #1494
+        self.buildMain.raise_()  # Issue #1494
         return
 
     @pyqtSlot(int)

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -77,7 +77,6 @@ class GuiBuildSettings(QDialog):
         if CONFIG.osDarwin:
             self.setWindowFlag(Qt.WindowType.Tool)
 
-        self.guiParent  = parent
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme
         self.theProject = mainGui.theProject

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -69,6 +69,8 @@ class GuiWritingStats(QDialog):
 
         logger.debug("Create: GuiWritingStats")
         self.setObjectName("GuiWritingStats")
+        if CONFIG.osDarwin:
+            self.setWindowFlag(Qt.WindowType.Tool)
 
         self.mainGui    = mainGui
         self.mainTheme  = mainGui.mainTheme

--- a/pkgutils.py
+++ b/pkgutils.py
@@ -1857,7 +1857,7 @@ if __name__ == "__main__":
         "",
         "    help           Print the help message.",
         "    pip            Install all package dependencies for novelWriter using pip.",
-        "    version        Print the novelWriter version.",
+        "    version        Print the novelWriter version. Add -c for short version.",
         "    build-clean    Will attempt to delete 'build' and 'dist' folders.",
         "",
         "Additional Builds:",
@@ -1914,7 +1914,11 @@ if __name__ == "__main__":
     if "version" in sys.argv:
         sys.argv.remove("version")
         numVers, _, _ = extractVersion(beQuiet=True)
-        print(numVers, end=None)
+        if "-c" in sys.argv:
+            sys.argv.remove("-c")
+            print(compactVersion(numVers), end=None)
+        else:
+            print(numVers, end=None)
         sys.exit(0)
 
     if "pip" in sys.argv:

--- a/pkgutils.py
+++ b/pkgutils.py
@@ -50,8 +50,8 @@ def extractVersion(beQuiet=False):
         theBits = theString.partition("=")
         return theBits[2].strip().strip('"')
 
-    numVers = "Unknown"
-    hexVers = "Unknown"
+    numVers = "0"
+    hexVers = "0x0"
     relDate = "Unknown"
     initFile = os.path.join("novelwriter", "__init__.py")
     try:
@@ -396,17 +396,15 @@ def buildQtI18nTS(sysArgs):
 
 def genMacOSPlist():
     """Set necessary values for .plist file for MacOS build."""
-    numVers, _, _ = extractVersion()
-    pkgVers = compactVersion(numVers)
     outDir = "setup/macos"
-
+    numVers = extractVersion()[0].partition("-")[0]
     copyrightYear = datetime.datetime.now().year
 
     # These keys are no longer used but are present for compatability
-    pkgVersMaj, pkgVersMin = pkgVers.split(".")[:2]
+    pkgVersMaj, pkgVersMin = numVers.split(".")[:2]
 
     plistXML = readFile(f"{outDir}/Info.plist.template").format(
-        macosBundleSVers=pkgVers,
+        macosBundleSVers=numVers,
         macosBundleVers=numVers,
         macosBundleVersMajor=pkgVersMaj,
         macosBundleVersMinor=pkgVersMin,

--- a/setup/macos/build.sh
+++ b/setup/macos/build.sh
@@ -24,7 +24,7 @@ echo "Build Dir: $BUILD_DIR"
 
 pushd "$SRC_DIR" || exit 1
 
-VERSION="$(python3 pkgutils.py version)"
+VERSION="$(python3 pkgutils.py version -c)"
 echo "novelWriter Version: $VERSION"
 
 # --- Prepare Files ----------------------------------------------------------------------------- #


### PR DESCRIPTION
**Summary:**

This PR fixes two issues:
* An issue with dialog windows being hidden behind the main window in certain circumstances, like opening a file system dialog. These dialogs have now been marked as a "Tool", i.e. a Panel as far as MacOS is concerned. This is only applied for Mac.
* The version number for the beta release is not allowed in the MacOS plist file, so it now just uses the numerical part.

A new DMG image for release 2.1-beta1 has been uploaded with these changes. The file is versioned as 2.1b1-post1.

**Related Issue(s):**

Closes #1494 

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
