### PR TITLE
Drop saving fullscreen flag

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -175,10 +175,9 @@ class Config:
         self.spellLanguage = "en"
 
         # State
-        self.isFullScreen = False  # Last fullscreen state
-        self.showRefPanel = True   # The reference panel for the viewer is visible
-        self.viewComments = True   # Comments are shown in the viewer
-        self.viewSynopsis = True   # Synopsis is shown in the viewer
+        self.showRefPanel = True  # The reference panel for the viewer is visible
+        self.viewComments = True  # Comments are shown in the viewer
+        self.viewSynopsis = True  # Synopsis is shown in the viewer
 
         # Search Bar Switches
         self.searchCase     = False
@@ -603,7 +602,6 @@ class Config:
 
         # State
         cnfSec = "State"
-        self.isFullScreen   = theConf.rdBool(cnfSec, "fullscreen", self.isFullScreen)
         self.showRefPanel   = theConf.rdBool(cnfSec, "showrefpanel", self.showRefPanel)
         self.viewComments   = theConf.rdBool(cnfSec, "viewcomments", self.viewComments)
         self.viewSynopsis   = theConf.rdBool(cnfSec, "viewsynopsis", self.viewSynopsis)
@@ -732,7 +730,6 @@ class Config:
         }
 
         theConf["State"] = {
-            "fullscreen":      str(self.isFullScreen),
             "showrefpanel":    str(self.showRefPanel),
             "viewcomments":    str(self.viewComments),
             "viewsynopsis":    str(self.viewSynopsis),

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -313,8 +313,6 @@ class GuiMain(QMainWindow):
 
         # Handle Windows Mode
         self.showNormal()
-        if CONFIG.isFullScreen:
-            self.toggleFullScreenMode()
 
         logger.debug("Ready: GUI")
 
@@ -1188,9 +1186,8 @@ class GuiMain(QMainWindow):
     #  Main Window Actions
     ##
 
-    def closeMain(self):
-        """Save everything, and close novelWriter.
-        """
+    def closeMain(self) -> bool:
+        """Save everything, and close novelWriter."""
         if self.hasProject:
             msgYes = self.askQuestion(
                 self.tr("Exit"),
@@ -1211,7 +1208,8 @@ class GuiMain(QMainWindow):
                 CONFIG.setViewPanePos(self.splitView.sizes())
 
         CONFIG.showRefPanel = self.viewMeta.isVisible()
-        if not CONFIG.isFullScreen:
+        if self.windowState() & Qt.WindowFullScreen != Qt.WindowFullScreen:
+            # Ignore window size if in full screen mode
             CONFIG.setMainWinSize(self.width(), self.height())
 
         if self.hasProject:
@@ -1297,23 +1295,9 @@ class GuiMain(QMainWindow):
 
         return True
 
-    def toggleFullScreenMode(self):
-        """Main GUI full screen mode. The mode is tracked by the flag
-        in config. This only tracks whether the window has been
-        maximised using the internal commands, and may not be correct
-        if the user uses the system window manager. Currently, Qt
-        doesn't have access to the exact state of the window.
-        """
+    def toggleFullScreenMode(self) -> None:
+        """Toggle full screen mode"""
         self.setWindowState(self.windowState() ^ Qt.WindowFullScreen)
-
-        winState = self.windowState() & Qt.WindowFullScreen == Qt.WindowFullScreen
-        if winState:
-            logger.debug("Activated full screen mode")
-        else:
-            logger.debug("Deactivated full screen mode")
-
-        CONFIG.isFullScreen = winState
-
         return
 
     ##

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2023-05-31 10:52:21
+timestamp = 2023-08-02 14:53:36
 
 [Main]
 theme = default
@@ -69,7 +69,6 @@ stopwhenidle = True
 useridletime = 300
 
 [State]
-fullscreen = False
 showrefpanel = True
 viewcomments = True
 viewsynopsis = True

--- a/tests/reference/guiPreferences_novelwriter.conf
+++ b/tests/reference/guiPreferences_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2022-11-11 12:48:20
+timestamp = 2023-08-02 14:53:40
 
 [Main]
 theme = default
@@ -10,11 +10,11 @@ localisation = en_GB
 hidevscroll = True
 hidehscroll = True
 lastnotes = 0x0
-lastpath = /home/vkbo/Code/novelWriter/Source/tests/temp/function
+lastpath = 
 
 [Sizes]
 mainwindow = 1200, 650
-preferences = 699, 614
+preferences = 765, 614
 projloadcols = 280, 60, 160
 mainpane = 300, 800
 viewpane = 500, 150
@@ -69,7 +69,6 @@ stopwhenidle = True
 useridletime = 300
 
 [State]
-fullscreen = False
 showrefpanel = True
 viewcomments = True
 viewsynopsis = True

--- a/tests/test_dialogs/test_dlg_about.py
+++ b/tests/test_dialogs/test_dlg_about.py
@@ -76,7 +76,7 @@ def testDlgAbout_QtDialog(monkeypatch, nwGUI):
 
     # Open About
     # All it can do is check against a crash
-    assert nwGUI.showAboutQtDialog() is True
+    nwGUI.showAboutQtDialog()
     nwGUI.mainMenu.aAboutQt.activate(QAction.Trigger)
 
 # END Test testDlgAbout_QtDialog

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -590,11 +590,11 @@ def testGuiMain_FocusFullMode(qtbot, nwGUI, projPath, mockRnd):
     # Full Screen Mode
     # ================
 
-    assert CONFIG.isFullScreen is False
+    assert nwGUI.windowState() & Qt.WindowFullScreen != Qt.WindowFullScreen
     nwGUI.toggleFullScreenMode()
-    assert CONFIG.isFullScreen is True
+    assert nwGUI.windowState() & Qt.WindowFullScreen == Qt.WindowFullScreen
     nwGUI.toggleFullScreenMode()
-    assert CONFIG.isFullScreen is False
+    assert nwGUI.windowState() & Qt.WindowFullScreen != Qt.WindowFullScreen
 
     # qtbot.stop()
 


### PR DESCRIPTION
**Summary:**

This PR removes the caching of the full screen state to the config file. This never worked properly anyway since the full screen flag internally in Qt doesn't necessarily match the window manager.

This PR also adds annotations to the main GUI class.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
