### PR TITLE
Refactor handling of spell checking

### DIFF
--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Iterator
 from pathlib import Path
 from functools import partial
 
-from PyQt5.QtCore import QCoreApplication, QObject, pyqtSignal
+from PyQt5.QtCore import QCoreApplication
 
 from novelwriter import CONFIG, SHARED, __version__, __hexversion__
 from novelwriter.enum import nwItemType, nwItemClass, nwItemLayout
@@ -55,13 +55,9 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class NWProject(QObject):
+class NWProject:
 
-    statusChanged = pyqtSignal(bool)
-    statusMessage = pyqtSignal(str)
-
-    def __init__(self, parent: QObject | None = None) -> None:
-        super().__init__(parent=parent)
+    def __init__(self) -> None:
 
         # Core Elements
         self._options = OptionState(self)    # Project-specific GUI options
@@ -206,7 +202,7 @@ class NWProject(QObject):
 
     def trashFolder(self) -> str:
         """Add the special trash root folder to the project."""
-        trashHandle = self._tree.trashRoot()
+        trashHandle = self._tree.trashRoot
         if trashHandle is None:
             label = trConst(nwLabels.CLASS_NAME[nwItemClass.TRASH])
             return self._tree.create(label, None, nwItemType.ROOT, nwItemClass.TRASH)
@@ -331,7 +327,7 @@ class NWProject(QObject):
         self.setProjectChanged(False)
         self._valid = True
 
-        self.statusMessage.emit(self.tr("Opened Project: {0}").format(self._data.name))
+        SHARED.newStatusMessage(self.tr("Opened Project: {0}").format(self._data.name))
 
         return True
 
@@ -381,7 +377,7 @@ class NWProject(QObject):
             )
 
         self._storage.writeLockFile()
-        self.statusMessage.emit(self.tr("Saved Project: {0}").format(self._data.name))
+        SHARED.newStatusMessage(self.tr("Saved Project: {0}").format(self._data.name))
         self.setProjectChanged(False)
 
         return True
@@ -403,7 +399,7 @@ class NWProject(QObject):
             return False
 
         logger.info("Backing up project")
-        self.statusMessage.emit(self.tr("Backing up project ..."))
+        SHARED.newStatusMessage(self.tr("Backing up project ..."))
 
         if not self._data.name:
             SHARED.error(self.tr(
@@ -434,7 +430,7 @@ class NWProject(QObject):
             SHARED.error(self.tr("Could not write backup archive."))
             return False
 
-        self.statusMessage.emit(self.tr("Project backed up to '{0}'").format(str(archName)))
+        SHARED.newStatusMessage(self.tr("Project backed up to '{0}'").format(str(archName)))
 
         return True
 
@@ -488,7 +484,7 @@ class NWProject(QObject):
         """
         if isinstance(status, bool):
             self._changed = status
-            self.statusChanged.emit(self._changed)
+            SHARED.setGlobalProjectState(self._changed)
         return self._changed
 
     ##

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -97,6 +97,7 @@ class NWSpellEnchant:
         if self._enchant is None:
             self._enchant = FakeEnchant()
         else:
+            self._userDict.load()
             for word in self._userDict:
                 self._enchant.add_to_session(word)
 
@@ -135,11 +136,6 @@ class NWSpellEnchant:
             self._userDict.save()
 
         return added
-
-    def loadUserWordList(self) -> None:
-        """Load the user word list from the project."""
-        self._userDict.load()
-        return
 
     def listDictionaries(self) -> list[tuple[str, str]]:
         """Wrapper function for pyenchant."""

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -29,6 +29,8 @@ import logging
 from typing import TYPE_CHECKING, Iterator
 from pathlib import Path
 
+from PyQt5.QtCore import QLocale
+
 from novelwriter.error import logException
 from novelwriter.constants import nwFiles
 
@@ -138,15 +140,15 @@ class NWSpellEnchant:
         return added
 
     def listDictionaries(self) -> list[tuple[str, str]]:
-        """Wrapper function for pyenchant."""
-        retList = []
+        """List available dictionaries."""
+        lang = []
         try:
             import enchant
-            for spTag, spProvider in enchant.list_dicts():
-                retList.append((spTag, spProvider.name))
+            tags = [x for x, _ in enchant.list_dicts()]
+            lang = [(x, f"{QLocale(x).nativeLanguageName().title()} [{x}]") for x in set(tags)]
         except Exception:
             logger.error("Failed to list languages for enchant spell checking")
-        return retList
+        return sorted(lang, key=lambda x: x[1])
 
     def describeDict(self) -> tuple[str, str]:
         """Describe the currently loaded dictionary."""

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+MAX_DEPTH = 1000  # Cap of tree traversing for loops (recursion limit)
+
 
 class NWTree:
     """Core: Project Tree Data Class
@@ -59,7 +61,7 @@ class NWTree:
     also used for file names.
     """
 
-    MAX_DEPTH = 1000  # Cap of tree traversing for loops
+    __slots__ = ("_project", "_tree", "_order", "_roots", "_trash", "_changed")
 
     def __init__(self, project: NWProject) -> None:
 
@@ -73,6 +75,15 @@ class NWTree:
         self._changed = False  # True if tree structure has changed
 
         return
+
+    ##
+    #  Properties
+    ##
+
+    @property
+    def trashRoot(self) -> str | None:
+        """Return the handle of the trash folder, or None."""
+        return self._trash
 
     ##
     #  Class Methods
@@ -320,7 +331,7 @@ class NWTree:
             return False
 
         iItem = tItem
-        for _ in range(self.MAX_DEPTH):
+        for _ in range(MAX_DEPTH):
             if iItem.itemParent is None:
                 tItem.setRoot(iItem.itemHandle)
                 tItem.setClassDefaults(iItem.itemClass)
@@ -349,7 +360,7 @@ class NWTree:
         tItem = self.__getitem__(tHandle)
         if tItem is not None:
             tTree.append(tHandle)
-            for _ in range(self.MAX_DEPTH):
+            for _ in range(MAX_DEPTH):
                 if tItem.itemParent is None:
                     return tTree
                 else:
@@ -399,14 +410,6 @@ class NWTree:
             elif tItem.itemRoot == self._trash:
                 return True
         return False
-
-    def trashRoot(self) -> str | None:
-        """Returns the handle of the trash folder, or None if there
-        isn't one.
-        """
-        if self._trash:
-            return self._trash
-        return None
 
     def findRoot(self, itemClass: nwItemClass | None) -> str | None:
         """Find the first root item for a given class."""

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -49,8 +49,6 @@ class GuiPreferences(NPagedDialog):
         logger.debug("Create: GuiPreferences")
         self.setObjectName("GuiPreferences")
 
-        self.mainGui = mainGui
-
         self.setWindowTitle(self.tr("Preferences"))
 
         self.tabGeneral  = GuiPreferencesGeneral(self)
@@ -645,8 +643,6 @@ class GuiPreferencesEditor(QWidget):
     def __init__(self, prefsGui):
         super().__init__(parent=prefsGui)
 
-        self.mainGui = prefsGui.mainGui
-
         # The Form
         self.mainForm = NConfigLayout()
         self.mainForm.setHelpTextStyle(SHARED.theme.helpText)
@@ -662,7 +658,7 @@ class GuiPreferencesEditor(QWidget):
         self.spellLanguage = QComboBox(self)
         self.spellLanguage.setMaximumWidth(mW)
 
-        langAvail = self.mainGui.docEditor.spEnchant.listDictionaries()
+        langAvail = SHARED.spelling.listDictionaries()
         if CONFIG.hasEnchant and langAvail:
             for spTag, spProv in langAvail:
                 qLocal = QLocale(spTag)

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 
 from PyQt5.QtGui import QFont
-from PyQt5.QtCore import Qt, QLocale
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QDialog, QWidget, QComboBox, QSpinBox, QPushButton, QDialogButtonBox,
     QLineEdit, QFileDialog, QFontDialog, QDoubleSpinBox
@@ -658,12 +658,9 @@ class GuiPreferencesEditor(QWidget):
         self.spellLanguage = QComboBox(self)
         self.spellLanguage.setMaximumWidth(mW)
 
-        langAvail = SHARED.spelling.listDictionaries()
-        if CONFIG.hasEnchant and langAvail:
-            for spTag, spProv in langAvail:
-                qLocal = QLocale(spTag)
-                spLang = qLocal.nativeLanguageName().title()
-                self.spellLanguage.addItem("%s [%s]" % (spLang, spProv), spTag)
+        if CONFIG.hasEnchant:
+            for tag, language in SHARED.spelling.listDictionaries():
+                self.spellLanguage.addItem(language, tag)
         else:
             self.spellLanguage.addItem(self.tr("None"), "")
             self.spellLanguage.setEnabled(False)

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -28,7 +28,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from PyQt5.QtGui import QIcon, QPixmap, QColor
-from PyQt5.QtCore import Qt, QLocale, pyqtSlot
+from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtWidgets import (
     QColorDialog, QComboBox, QDialogButtonBox, QHBoxLayout, QLabel, QLineEdit,
     QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
@@ -233,11 +233,9 @@ class GuiProjectEditMain(QWidget):
         self.spellLang = QComboBox(self)
         self.spellLang.setMaximumWidth(xW)
         self.spellLang.addItem(self.tr("Default"), "None")
-        langAvail = SHARED.spelling.listDictionaries()
-        for spTag, spProv in langAvail:
-            qLocal = QLocale(spTag)
-            spLang = qLocal.nativeLanguageName().title()
-            self.spellLang.addItem("%s [%s]" % (spLang, spProv), spTag)
+        if CONFIG.hasEnchant:
+            for tag, language in SHARED.spelling.listDictionaries():
+                self.spellLang.addItem(language, tag)
 
         self.mainForm.addRow(
             self.tr("Spell check language"),

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -199,8 +199,6 @@ class GuiProjectEditMain(QWidget):
     def __init__(self, projGui):
         super().__init__(parent=projGui)
 
-        self.mainGui = projGui.mainGui
-
         # The Form
         self.mainForm = NConfigLayout()
         self.mainForm.setHelpTextStyle(SHARED.theme.helpText)
@@ -244,7 +242,7 @@ class GuiProjectEditMain(QWidget):
         self.spellLang = QComboBox(self)
         self.spellLang.setMaximumWidth(xW)
         self.spellLang.addItem(self.tr("Default"), "None")
-        langAvail = self.mainGui.docEditor.spEnchant.listDictionaries()
+        langAvail = SHARED.spelling.listDictionaries()
         for spTag, spProv in langAvail:
             qLocal = QLocale(spTag)
             spLang = qLocal.nativeLanguageName().title()

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -89,9 +89,6 @@ class GuiProjectSettings(NPagedDialog):
         self.buttonBox.rejected.connect(self._doClose)
         self.addControls(self.buttonBox)
 
-        # Flags
-        self._spellChanged = False
-
         # Focus Tab
         self._focusTab(focusTab)
 
@@ -102,10 +99,6 @@ class GuiProjectSettings(NPagedDialog):
     def __del__(self):  # pragma: no cover
         logger.debug("Delete: GuiProjectSettings")
         return
-
-    @property
-    def spellChanged(self):
-        return self._spellChanged
 
     ##
     #  Slots
@@ -125,9 +118,7 @@ class GuiProjectSettings(NPagedDialog):
         project.data.setTitle(bookTitle)
         project.data.setAuthor(bookAuthor)
         project.data.setDoBackup(doBackup)
-
-        # Remember this as updating spell dictionary can be expensive
-        self._spellChanged = project.data.setSpellLang(spellLang)
+        project.data.setSpellLang(spellLang)
 
         if self.tabStatus.colChanged:
             newList, delList = self.tabStatus.getNewList()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -397,7 +397,7 @@ class GuiDocEditor(QTextEdit):
         self._checkDocSize(docSize)
         spTemp = self.highLight.spellCheck
         if self._bigDoc:
-            self.highLight.spellCheck = False
+            self.highLight.setSpellCheck(False)
 
         bfTime = time()
         self._allowAutoReplace(False)
@@ -418,7 +418,7 @@ class GuiDocEditor(QTextEdit):
         self.docHeader.setTitleFromHandle(self._docHandle)
         self.docFooter.setHandle(self._docHandle)
         self.updateDocMargins()
-        self.highLight.spellCheck = spTemp
+        self.highLight.setSpellCheck(spTemp)
 
         if tLine is None and self._nwItem is not None:
             # For large documents, we queue the repositioning until the

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -690,7 +690,7 @@ class GuiDocEditor(QTextEdit):
     #  Spell Checking
     ##
 
-    def toggleSpellCheck(self, state: bool) -> None:
+    def toggleSpellCheck(self, state: bool | None) -> None:
         """This is the main spell check setting function, and this one
         should call all other setSpellCheck functions in other classes.
         If the spell check mode (theMode) is not defined (None), then

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -73,7 +73,6 @@ class GuiDocEditor(QTextEdit):
     statusMessage = pyqtSignal(str)
     docCountsChanged = pyqtSignal(str, int, int, int)
     editedStatusChanged = pyqtSignal(bool)
-    spellDictionaryChanged = pyqtSignal(str, str)
     loadDocumentTagRequest = pyqtSignal(str, Enum)
     novelStructureChanged = pyqtSignal()
     novelItemMetaChanged = pyqtSignal(str)
@@ -301,7 +300,7 @@ class GuiDocEditor(QTextEdit):
         self._typPadAfter = CONFIG.fmtPadAfter
 
         # Reload spell check and dictionaries
-        self.setDictionaries()
+        SHARED.updateSpellCheckLanguage()
 
         # Set font
         textFont = QFont()
@@ -690,24 +689,6 @@ class GuiDocEditor(QTextEdit):
     ##
     #  Spell Checking
     ##
-
-    def setDictionaries(self):
-        """Set the spell checker dictionary language, and emit the
-        dictionary changed signal.
-        """
-        if SHARED.project.data.spellLang is None:
-            theLang = CONFIG.spellLanguage
-        else:
-            theLang = SHARED.project.data.spellLang
-
-        SHARED.spelling.setLanguage(theLang)
-        _, theProvider = SHARED.spelling.describeDict()
-
-        self.spellDictionaryChanged.emit(str(theLang), str(theProvider))
-        if not self._bigDoc:
-            self.spellCheckDocument()
-
-        return True
 
     def toggleSpellCheck(self, state: bool) -> None:
         """This is the main spell check setting function, and this one

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -29,7 +29,7 @@ from time import time
 
 from PyQt5.QtCore import Qt, QRegularExpression
 from PyQt5.QtGui import (
-    QColor, QTextCharFormat, QFont, QSyntaxHighlighter, QBrush
+    QColor, QTextCharFormat, QFont, QSyntaxHighlighter, QBrush, QTextDocument
 )
 
 from novelwriter import CONFIG, SHARED
@@ -46,13 +46,11 @@ class GuiDocHighlighter(QSyntaxHighlighter):
     BLOCK_META  = 2
     BLOCK_TITLE = 4
 
-    def __init__(self, theDoc, spEnchant):
-        super().__init__(theDoc)
+    def __init__(self, document: QTextDocument) -> None:
+        super().__init__(document)
 
         logger.debug("Create: GuiDocHighlighter")
 
-        self.theDoc     = theDoc
-        self.spEnchant  = spEnchant
         self.theHandle  = None
         self.spellCheck = False
         self.spellRx    = None
@@ -387,7 +385,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         rxSpell = self.spellRx.globalMatch(theText.replace("_", " "), 0)
         while rxSpell.hasNext():
             rxMatch = rxSpell.next()
-            if not self.spEnchant.checkWord(rxMatch.captured(0)):
+            if not SHARED.spelling.checkWord(rxMatch.captured(0)):
                 if rxMatch.captured(0).isupper() or rxMatch.captured(0).isnumeric():
                     continue
                 xPos = rxMatch.capturedStart(0)

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -436,4 +436,4 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         return charFormat
 
-# END Class DocHighlighter
+# END Class GuiDocHighlighter

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -798,7 +798,7 @@ class GuiProjectTree(QTreeWidget):
             logger.error("There is no item to delete")
             return False
 
-        trashHandle = SHARED.project.tree.trashRoot()
+        trashHandle = SHARED.project.tree.trashRoot
         if tHandle == trashHandle:
             logger.error("Cannot delete the Trash folder")
             return False
@@ -823,7 +823,7 @@ class GuiProjectTree(QTreeWidget):
             logger.error("No project open")
             return False
 
-        trashHandle = SHARED.project.tree.trashRoot()
+        trashHandle = SHARED.project.tree.trashRoot
 
         logger.debug("Emptying Trash folder")
         if trashHandle is None:
@@ -1201,7 +1201,7 @@ class GuiProjectTree(QTreeWidget):
         # Trash Folder
         # ============
 
-        trashHandle = SHARED.project.tree.trashRoot()
+        trashHandle = SHARED.project.tree.trashRoot
         if tItem.itemHandle == trashHandle and trashHandle is not None:
             # The trash folder only has one option
             aEmptyTrash = ctxMenu.addAction(self.tr("Empty Trash"))

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -121,7 +121,7 @@ class GuiMainStatus(QStatusBar):
     def clearStatus(self) -> None:
         """Reset all widgets on the status bar to default values."""
         self.setRefTime(-1.0)
-        self.setLanguage(None, "")
+        self.setLanguage(*SHARED.spelling.describeDict())
         self.setProjectStats(0, 0)
         self.setProjectStatus(StatusLED.S_NONE)
         self.setDocumentStatus(StatusLED.S_NONE)

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -3,8 +3,7 @@ novelWriter – GUI Main Window Status Bar
 ========================================
 
 File History:
-Created: 2019-04-20 [0.0.1] GuiMainStatus
-Created: 2020-05-17 [0.5.1] StatusLED
+Created: 2019-04-20 [0.0.1]
 
 This file is a part of novelWriter
 Copyright 2018–2023, Veronica Berglyd Olsen
@@ -208,13 +207,8 @@ class GuiMainStatus(QStatusBar):
             self.langText.setText(self.tr("None"))
             self.langText.setToolTip("")
         else:
-            qLocal = QLocale(language)
-            spLang = qLocal.nativeLanguageName().title()
-            self.langText.setText(spLang)
-            if provider:
-                self.langText.setToolTip("%s (%s)" % (language, provider))
-            else:
-                self.langText.setToolTip(language)
+            self.langText.setText(QLocale(language).nativeLanguageName().title())
+            self.langText.setToolTip(f"{language} ({provider})" if provider else language)
         return
 
     @pyqtSlot(bool)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -590,8 +590,8 @@ class GuiMain(QMainWindow):
         return True
 
     def openNextDocument(self, tHandle: str, wrapAround: bool = False) -> bool:
-        """Opens the next document in the project tree, following the
-        document with the given handle. Stops when reaching the end.
+        """Open the next document in the project tree, following the
+        document with the given handle. Stop when reaching the end.
         """
         if not SHARED.hasProject:
             logger.error("No project open")

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -234,6 +234,7 @@ class GuiMain(QMainWindow):
 
         SHARED.projectStatusChanged.connect(self.mainStatus.updateProjectStatus)
         SHARED.projectStatusMessage.connect(self.mainStatus.setStatusMessage)
+        SHARED.spellLanguageChanged.connect(self.mainStatus.setLanguage)
 
         self.viewsBar.viewChangeRequested.connect(self._changeView)
 
@@ -251,7 +252,6 @@ class GuiMain(QMainWindow):
         self.novelView.selectedItemChanged.connect(self.itemDetails.updateViewBox)
         self.novelView.openDocumentRequest.connect(self._openDocument)
 
-        self.docEditor.spellDictionaryChanged.connect(self.mainStatus.setLanguage)
         self.docEditor.editedStatusChanged.connect(self.mainStatus.updateDocumentStatus)
         self.docEditor.docCountsChanged.connect(self.itemDetails.updateCounts)
         self.docEditor.docCountsChanged.connect(self.projView.updateCounts)
@@ -428,7 +428,6 @@ class GuiMain(QMainWindow):
 
             SHARED.closeProject()
 
-            self.docEditor.setDictionaries()
             self._updateWindowTitle()
             self._changeView(nwView.PROJECT)
 
@@ -489,7 +488,6 @@ class GuiMain(QMainWindow):
         # Update GUI
         self._updateWindowTitle(SHARED.project.data.name)
         self.rebuildTrees()
-        self.docEditor.setDictionaries()
         self.docEditor.toggleSpellCheck(SHARED.project.data.spellCheck)
         self.mainStatus.setRefTime(SHARED.project.projOpened)
         self.projView.openProjectTasks()
@@ -907,8 +905,7 @@ class GuiMain(QMainWindow):
 
         if dlgProj.result() == QDialog.Accepted:
             logger.debug("Applying new project settings")
-            if dlgProj.spellChanged:
-                self.docEditor.setDictionaries()
+            SHARED.updateSpellCheckLanguage()
             self.itemDetails.refreshDetails()
             self._updateWindowTitle(SHARED.project.data.name)
 
@@ -982,7 +979,7 @@ class GuiMain(QMainWindow):
 
         if dlgWords.result() == QDialog.Accepted:
             logger.debug("Reloading word list")
-            self.docEditor.setDictionaries()
+            SHARED.updateSpellCheckLanguage(reload=True)
 
         return True
 

--- a/tests/test_base/test_base_shared.py
+++ b/tests/test_base/test_base_shared.py
@@ -42,6 +42,8 @@ def testBaseSharedData_Init():
         shared.theme
     with pytest.raises(Exception):
         shared.project
+    with pytest.raises(Exception):
+        shared.spelling
 
     # Create some mock objects
     mockGui = MockGuiMain()
@@ -113,7 +115,7 @@ def testBaseSharedData_Projects(fncPath, caplog: pytest.LogCaptureFixture):
     project.openProject(fncPath)  # First open with our independent project instance
     assert shared.hasProject is False
     assert shared.projectLock is None
-    assert shared.openProject(fncPath) is False  # Then with out shared instance
+    assert shared.openProject(fncPath) is False  # Then with our shared instance
     assert shared.hasProject is False
     assert isinstance(shared.projectLock, list)
 

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -119,7 +119,7 @@ def testCoreTree_BuildTree(mockGUI, mockItems):
     assert bool(theTree) is False
 
     # Check for archive and trash folders
-    assert theTree.trashRoot() is None
+    assert theTree.trashRoot is None
 
     aHandles = []
     for nwItem in mockItems:
@@ -146,7 +146,7 @@ def testCoreTree_BuildTree(mockGUI, mockItems):
     # ============
 
     # Check that we have the correct archive and trash folders
-    assert theTree.trashRoot() == "a000000000003"
+    assert theTree.trashRoot == "a000000000003"
     assert theTree.findRoot(nwItemClass.ARCHIVE) == "a000000000002"
     assert theTree.isTrash("a000000000003") is True
 
@@ -261,7 +261,7 @@ def testCoreTree_BuildTree(mockGUI, mockItems):
     del theTree["a000000000003"]
     assert len(theTree) == len(mockItems) - 3
     assert "a000000000003" not in theTree
-    assert theTree.trashRoot() is None
+    assert theTree.trashRoot is None
 
 # END Test testCoreTree_BuildTree
 
@@ -365,7 +365,7 @@ def testCoreTree_CheckConsistency(caplog: pytest.LogCaptureFixture, mockGUI, fnc
 
 
 @pytest.mark.core
-def testCoreTree_Methods(mockGUI, mockItems):
+def testCoreTree_Methods(monkeypatch, mockGUI, mockItems):
     """Test various class methods."""
     theProject = NWProject()
     theTree = NWTree(theProject)
@@ -389,11 +389,10 @@ def testCoreTree_Methods(mockGUI, mockItems):
     assert theTree.updateItemData("b000000000001") is True
 
     # Update item data, root is unreachable
-    maxDepth = theTree.MAX_DEPTH
-    theTree.MAX_DEPTH = 0  # type: ignore
-    with pytest.raises(RecursionError):
-        theTree.updateItemData("b000000000001")
-    theTree.MAX_DEPTH = maxDepth
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.tree.MAX_DEPTH", 0)
+        with pytest.raises(RecursionError):
+            theTree.updateItemData("b000000000001")
 
     # Check type
     assert theTree.checkType("blabla", nwItemType.FILE) is False
@@ -424,11 +423,10 @@ def testCoreTree_Methods(mockGUI, mockItems):
     ]
 
     # Cause recursion error
-    maxDepth = theTree.MAX_DEPTH
-    theTree.MAX_DEPTH = 0  # type: ignore
-    with pytest.raises(RecursionError):
-        theTree.getItemPath("c000000000001")
-    theTree.MAX_DEPTH = maxDepth
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.tree.MAX_DEPTH", 0)
+        with pytest.raises(RecursionError):
+            theTree.getItemPath("c000000000001")
 
     # Break the folder parent handle
     theTree["b000000000001"]._parent = "stuff"  # type: ignore

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -42,7 +42,7 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     """Test the preferences dialog."""
     monkeypatch.setattr(GuiPreferences, "exec_", lambda *a: None)
     monkeypatch.setattr(GuiPreferences, "result", lambda *a: QDialog.Accepted)
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "English [en]")])
 
     with monkeypatch.context() as mp:
         mp.setattr(GuiPreferences, "updateTheme", lambda *a: True)

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -30,7 +30,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox, QDialog, QAction, QFileDialog, QFontDialog
 )
 
-from novelwriter import CONFIG
+from novelwriter import CONFIG, SHARED
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 from novelwriter.dialogs.preferences import GuiPreferences
 
@@ -42,7 +42,7 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     """Test the preferences dialog."""
     monkeypatch.setattr(GuiPreferences, "exec_", lambda *a: None)
     monkeypatch.setattr(GuiPreferences, "result", lambda *a: QDialog.Accepted)
-    monkeypatch.setattr(nwGUI.docEditor.spEnchant, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
 
     with monkeypatch.context() as mp:
         mp.setattr(GuiPreferences, "updateTheme", lambda *a: True)

--- a/tests/test_dialogs/test_dlg_projsettings.py
+++ b/tests/test_dialogs/test_dlg_projsettings.py
@@ -43,7 +43,6 @@ def testDlgProjSettings_Dialog(qtbot, monkeypatch, nwGUI):
     # Block the GUI blocking thread
     monkeypatch.setattr(GuiProjectSettings, "exec_", lambda *a: None)
     monkeypatch.setattr(GuiProjectSettings, "result", lambda *a: QDialog.Accepted)
-    monkeypatch.setattr(GuiProjectSettings, "spellChanged", lambda *a: True)
 
     # Check that we cannot open when there is no project
     nwGUI.mainMenu.aProjectSettings.activate(QAction.Trigger)
@@ -129,7 +128,6 @@ def testDlgProjSettings_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockR
     assert tabMain.editName.text() == "Project Name"
     assert tabMain.editTitle.text() == "Project Title"
     assert tabMain.editAuthor.text() == "Jane Doe"
-    assert projSettings.spellChanged is False
 
     projSettings._doSave()
     assert theProject.data.name == "Project Name"

--- a/tests/test_dialogs/test_dlg_projsettings.py
+++ b/tests/test_dialogs/test_dlg_projsettings.py
@@ -84,10 +84,9 @@ def testDlgProjSettings_Dialog(qtbot, monkeypatch, nwGUI):
 
 @pytest.mark.gui
 def testDlgProjSettings_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
-    """Test the main tab of the project settings dialog.
-    """
+    """Test the main tab of the project settings dialog."""
     # Mock components
-    monkeypatch.setattr(nwGUI.docEditor.spEnchant, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
 
     # Create new project
     buildTestProject(nwGUI, projPath)
@@ -152,7 +151,7 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, fncPath, projPat
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
 
     # Mock components
-    monkeypatch.setattr(nwGUI.docEditor.spEnchant, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
 
     # Create new project
     mockRnd.reset()
@@ -348,12 +347,11 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, fncPath, projPat
 
 @pytest.mark.gui
 def testDlgProjSettings_Replace(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
-    """Test the auto-replace tab of the project settings dialog.
-    """
+    """Test the auto-replace tab of the project settings dialog."""
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
 
     # Mock components
-    monkeypatch.setattr(nwGUI.docEditor.spEnchant, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
 
     # Create new project
     mockRnd.reset()

--- a/tests/test_dialogs/test_dlg_projsettings.py
+++ b/tests/test_dialogs/test_dlg_projsettings.py
@@ -84,8 +84,7 @@ def testDlgProjSettings_Dialog(qtbot, monkeypatch, nwGUI):
 @pytest.mark.gui
 def testDlgProjSettings_Main(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
     """Test the main tab of the project settings dialog."""
-    # Mock components
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "English [en]")])
 
     # Create new project
     buildTestProject(nwGUI, projPath)
@@ -147,9 +146,7 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, fncPath, projPat
     dialog.
     """
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
-
-    # Mock components
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "English [en]")])
 
     # Create new project
     mockRnd.reset()
@@ -347,9 +344,7 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, fncPath, projPat
 def testDlgProjSettings_Replace(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
     """Test the auto-replace tab of the project settings dialog."""
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
-
-    # Mock components
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "none")])
+    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "English [en]")])
 
     # Create new project
     mockRnd.reset()

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -242,7 +242,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     assert nwGUI.projView.projTree._getTreeItem(C.hSceneDoc) is not None
 
     nwGUI.mainMenu.aSpellCheck.setChecked(True)
-    assert nwGUI.mainMenu._toggleSpellCheck()
+    nwGUI.mainMenu._toggleSpellCheck()
+    assert nwGUI.mainMenu.aSpellCheck.isChecked() is True
 
     # Change some settings
     CONFIG.hideHScroll = True

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -205,7 +205,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     assert len(SHARED.project.tree) == 0
     assert len(SHARED.project.tree._order) == 0
     assert len(SHARED.project.tree._roots) == 0
-    assert SHARED.project.tree.trashRoot() is None
+    assert SHARED.project.tree.trashRoot is None
     assert SHARED.project.data.name == ""
     assert SHARED.project.data.title == ""
     assert SHARED.project.data.author == ""
@@ -225,7 +225,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     assert len(SHARED.project.tree) == 8
     assert len(SHARED.project.tree._order) == 8
     assert len(SHARED.project.tree._roots) == 4
-    assert SHARED.project.tree.trashRoot() is None
+    assert SHARED.project.tree.trashRoot is None
     assert SHARED.project.data.name == "New Project"
     assert SHARED.project.data.title == "New Novel"
     assert SHARED.project.data.author == "Jane Doe"

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -243,7 +243,6 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     nwGUI.mainMenu.aSpellCheck.setChecked(True)
     nwGUI.mainMenu._toggleSpellCheck()
-    assert nwGUI.mainMenu.aSpellCheck.isChecked() is True
 
     # Change some settings
     CONFIG.hideHScroll = True

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -348,7 +348,7 @@ def testGuiProjTree_RequestDeleteItem(qtbot, caplog, monkeypatch, nwGUI, projPat
         C.hChapterDir, C.hChapterDoc, C.hSceneDoc,
         "0000000000010"
     ]
-    trashHandle = SHARED.project.tree.trashRoot()
+    trashHandle = SHARED.project.tree.trashRoot
     assert projTree.getTreeFromHandle(trashHandle) == [
         trashHandle, "0000000000012", "0000000000011"
     ]
@@ -541,7 +541,7 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     projTree.setExpandedFromHandle(None, True)
 
     projTree._addTrashRoot()
-    hTrashRoot = SHARED.project.tree.trashRoot()
+    hTrashRoot = SHARED.project.tree.trashRoot
 
     projTree.setSelectedHandle(C.hCharRoot)
     projTree.newTreeItem(nwItemType.FILE)


### PR DESCRIPTION
**Summary:**

This PR:
* Moves the spell check instance to the new shared data class, so that the object can be destroyed and re-created with the project.
* Cleans up loading of the user's own custom dictionary, which is per-project and must be handled correctly to prevent bleed-through between projects.
* Adds a way to change spell check language from the Tools menu.

Also:
* The project class is no longer a subclass of QObject.
* Various attributes of core classes have been converted to properties.
* The syntax highlighter class has received a cleanup.

**Related Issue(s):**

Closes #1260

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
