### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,7 +14,7 @@ jobs:
   testLinux:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           architecture: x64
       - name: Install Packages (brew)
         run: |

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           architecture: x64
       - name: Checkout Source
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ documentation.
 
 ## Implementation
 
-novelWriter is written with Python 3 (3.7+) using Qt5 and PyQt5 (5.10+), and is released on Linux,
+novelWriter is written with Python 3 (3.8+) using Qt5 and PyQt5 (5.10+), and is released on Linux,
 Windows and macOS. It can in principle run on any Operating System that also supports Qt, PyQt and
 Python.
 

--- a/docs/source/int_started.rst
+++ b/docs/source/int_started.rst
@@ -174,7 +174,7 @@ Installing Python on Windows
 In order to run novelWriter from source, or install from PyPi, you need to have Python set up on
 your system. Unlike Linux and MacOS, Windows does not come with Python pre-installed.
 
-You can download Python from `python.org`_. Python 3.7 or higher is required for running
+You can download Python from `python.org`_. Python 3.8 or higher is required for running
 novelWriter, but it is recommended that you install the latest version.
 
 Make sure you select the "Add Python to PATH" option during installation, otherwise the ``python``

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -170,9 +170,9 @@ def main(sysArgs: list | None = None):
     # Check Packages and Versions
     errorData = []
     errorCode = 0
-    if sys.hexversion < 0x030700f0:
+    if sys.hexversion < 0x030800f0:
         errorData.append(
-            "At least Python 3.7 is required, found %s" % CONFIG.verPyString
+            "At least Python 3.8 is required, found %s" % CONFIG.verPyString
         )
         errorCode |= 0x04
     if CONFIG.verQtValue < 0x050a00:

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -268,12 +268,8 @@ class NWDocument:
         docTemp = docPath.with_suffix(".tmp")
 
         try:
-            # ToDo: When Python 3.7 is dropped, these can be changed to
-            # path.unlink(missing_ok=True)
-            if docPath.exists():
-                docPath.unlink()
-            if docTemp.exists():
-                docTemp.unlink()
+            docPath.unlink(missing_ok=True)
+            docTemp.unlink(missing_ok=True)
         except Exception as exc:
             self._docError = formatException(exc)
             return False

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ license_files = LICENSE.md
 license = GNU General Public License v3
 classifiers =
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ project_urls =
 
 [options]
 zip_safe = False
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 packages = find_namespace:
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Development Status :: 5 - Production/Stable

--- a/setup/debian/control
+++ b/setup/debian/control
@@ -2,14 +2,14 @@ Source: novelwriter
 Maintainer: Veronica Berglyd Olsen <code@vkbo.net>
 Section: text
 Priority: optional
-Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.7), python3-pyqt5 (>= 5.10), python3-enchant (>= 2.0)
+Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.8), python3-pyqt5 (>= 5.10), python3-enchant (>= 2.0)
 Standards-Version: 4.5.1
 Homepage: https://novelwriter.io
-X-Python3-Version: >= 3.7
+X-Python3-Version: >= 3.8
 
 Package: novelwriter
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.7), python3-pyqt5 (>= 5.10), python3-enchant (>= 2.0)
+Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.8), python3-pyqt5 (>= 5.10), python3-enchant (>= 2.0)
 Description: A markdown-like text editor for planning and writing novels
  novelWriter is a plain text editor designed for writing novels assembled from
  many smaller text documents. It uses a minimal formatting syntax inspired by

--- a/setup/description_pypi.md
+++ b/setup/description_pypi.md
@@ -10,7 +10,7 @@ synchronisation tools. All text is saved as plain text files with a meta data he
 project structure is stored in a single project XML file, and other meta data is primarily saved as
 JSON files.
 
-The application is written with Python 3 (3.7+) using Qt5 and PyQt5 (5.3+). It is developed on
+The application is written with Python 3 (3.8+) using Qt5 and PyQt5 (5.3+). It is developed on
 Linux, but should in principle work fine on other operating systems as well as long as dependencies
 are met. It is regularly tested on Debian and Ubuntu Linux, Windows, and macOS.
 

--- a/setup/macos/build.sh
+++ b/setup/macos/build.sh
@@ -74,7 +74,7 @@ rm Miniconda3-latest-MacOSX-x86_64.sh
 export PATH="$HOME/miniconda/bin:$PATH"
 
 echo "Creating Conda env ..."
-conda create -n novelWriter -c conda-forge python=3.10 --yes
+conda create -n novelWriter -c conda-forge python=3.11 --yes
 source activate novelWriter
 
 echo "Installing dictionaries ..."


### PR DESCRIPTION
**Summary:**

This PR bumps minimum Python version to 3.7. MacOS and Windows tests now run on 3.11, and 3.12-dev has been added to Linux tests.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
