### PR TITLE
Display build details in Manuscript tool

### DIFF
--- a/i18n/nw_base.ts
+++ b/i18n/nw_base.ts
@@ -1986,53 +1986,53 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="80" />
+      <location filename="../novelwriter/tools/manuscript.py" line="82" />
       <source>Build Manuscript</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="110" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112" />
       <source>Add New Build</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="119" />
       <source>Delete Selected Build</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="124" />
+      <location filename="../novelwriter/tools/manuscript.py" line="126" />
       <source>Edit Selected Build</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="128" />
+      <location filename="../novelwriter/tools/manuscript.py" line="130" />
       <source>Builds</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="145" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164" />
       <source>Preview</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="148" />
+      <location filename="../novelwriter/tools/manuscript.py" line="167" />
       <source>Print</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="151" />
+      <location filename="../novelwriter/tools/manuscript.py" line="170" />
       <source>Build</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="154" />
+      <location filename="../novelwriter/tools/manuscript.py" line="173" />
       <source>Close</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="254" />
-      <location filename="../novelwriter/tools/manuscript.py" line="207" />
+      <location filename="../novelwriter/tools/manuscript.py" line="278" />
+      <location filename="../novelwriter/tools/manuscript.py" line="226" />
       <source>My Manuscript</source>
       <translation type="unfinished" />
     </message>
@@ -4488,6 +4488,34 @@
     </message>
   </context>
   <context>
+    <name>_DetailsWidget</name>
+    <message>
+      <location filename="../novelwriter/tools/manuscript.py" line="504" />
+      <source>Setting</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/tools/manuscript.py" line="504" />
+      <source>Value</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/tools/manuscript.py" line="573" />
+      <source>Name</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/tools/manuscript.py" line="579" />
+      <source>Selection</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/tools/manuscript.py" line="595" />
+      <source>Title</source>
+      <translation type="unfinished" />
+    </message>
+  </context>
+  <context>
     <name>_FilterTab</name>
     <message>
       <location filename="../novelwriter/tools/manussettings.py" line="314" />
@@ -4625,27 +4653,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="467" />
+      <location filename="../novelwriter/tools/manuscript.py" line="659" />
       <source>Press the "Build Preview" button to generate ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="565" />
+      <location filename="../novelwriter/tools/manuscript.py" line="757" />
       <source>Processing ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="594" />
+      <location filename="../novelwriter/tools/manuscript.py" line="786" />
       <source>Done</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="637" />
+      <location filename="../novelwriter/tools/manuscript.py" line="829" />
       <source>Unknown</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="638" />
+      <location filename="../novelwriter/tools/manuscript.py" line="830" />
       <source>Built</source>
       <translation type="unfinished" />
     </message>

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -58,13 +58,14 @@ VALID_MAP = {
     "GuiWordList": {"winWidth", "winHeight"},
     "GuiNovelView": {"lastCol", "lastColSize"},
     "GuiBuildSettings": {
-        "winWidth", "winHeight", "treeWidth", "filterWidth"
+        "winWidth", "winHeight", "treeWidth", "filterWidth",
     },
     "GuiManuscript": {
-        "winWidth", "winHeight", "optsWidth", "viewWidth"
+        "winWidth", "winHeight", "optsWidth", "viewWidth", "listHeight",
+        "detailsHeight", "detailsWidth", "detailsExpanded",
     },
     "GuiManuscriptBuild": {
-        "winWidth", "winHeight", "fmtWidth", "sumWidth"
+        "winWidth", "winHeight", "fmtWidth", "sumWidth",
     },
 }
 

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -600,7 +600,7 @@ class NWProject:
                 self._langData = json.load(inFile)
             logger.debug("Loaded project language file: %s", langFile.name)
         except Exception:
-            logger.error("Failed to project language file")
+            logger.error("Failed to load project language file")
             logException()
             return False
 

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -36,7 +36,6 @@ from functools import partial
 
 from PyQt5.QtCore import QCoreApplication, QRegularExpression
 
-from novelwriter import SHARED
 from novelwriter.enum import nwItemLayout
 from novelwriter.common import formatTimeStamp, numberToRoman, checkInt
 from novelwriter.constants import nwConst, nwHeadFmt, nwRegEx, nwUnicode
@@ -148,7 +147,7 @@ class Tokenizer(ABC):
         self._linkHeaders = False  # Add an anchor before headers
 
         # Instance Variables
-        self._hFormatter = HeadingFormatter()
+        self._hFormatter = HeadingFormatter(self._project)
         self._firstScene = False  # Flag to indicate that the first scene of the chapter
 
         # This File
@@ -772,7 +771,8 @@ class Tokenizer(ABC):
 
 class HeadingFormatter:
 
-    def __init__(self) -> None:
+    def __init__(self, project: NWProject) -> None:
+        self._project = project
         self._chCount = 0
         self._scChCount = 0
         self._scAbsCount = 0
@@ -801,7 +801,7 @@ class HeadingFormatter:
         hFormat = hFormat.replace(nwHeadFmt.SC_NUM, str(self._scChCount))
         hFormat = hFormat.replace(nwHeadFmt.SC_ABS, str(self._scAbsCount))
         if nwHeadFmt.CH_WORD in hFormat:
-            chWord = SHARED.project.localLookup(self._chCount)
+            chWord = self._project.localLookup(self._chCount)
             hFormat = hFormat.replace(nwHeadFmt.CH_WORD, chWord)
         if nwHeadFmt.CH_ROML in hFormat:
             chRom = numberToRoman(self._chCount, toLower=True)

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -36,6 +36,7 @@ from functools import partial
 
 from PyQt5.QtCore import QCoreApplication, QRegularExpression
 
+from novelwriter import SHARED
 from novelwriter.enum import nwItemLayout
 from novelwriter.common import formatTimeStamp, numberToRoman, checkInt
 from novelwriter.constants import nwConst, nwHeadFmt, nwRegEx, nwUnicode
@@ -147,7 +148,7 @@ class Tokenizer(ABC):
         self._linkHeaders = False  # Add an anchor before headers
 
         # Instance Variables
-        self._hFormatter = HeadingFormatter(self._project)
+        self._hFormatter = HeadingFormatter()
         self._firstScene = False  # Flag to indicate that the first scene of the chapter
 
         # This File
@@ -771,8 +772,7 @@ class Tokenizer(ABC):
 
 class HeadingFormatter:
 
-    def __init__(self, project: NWProject) -> None:
-        self._project = project
+    def __init__(self) -> None:
         self._chCount = 0
         self._scChCount = 0
         self._scAbsCount = 0
@@ -801,7 +801,7 @@ class HeadingFormatter:
         hFormat = hFormat.replace(nwHeadFmt.SC_NUM, str(self._scChCount))
         hFormat = hFormat.replace(nwHeadFmt.SC_ABS, str(self._scAbsCount))
         if nwHeadFmt.CH_WORD in hFormat:
-            chWord = self._project.localLookup(self._chCount)
+            chWord = SHARED.project.localLookup(self._chCount)
             hFormat = hFormat.replace(nwHeadFmt.CH_WORD, chWord)
         if nwHeadFmt.CH_ROML in hFormat:
             chRom = numberToRoman(self._chCount, toLower=True)

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -290,9 +290,10 @@ class GuiManuscript(QDialog):
     @pyqtSlot("QListWidgetItem*", "QListWidgetItem*")
     def _updateBuildDetails(self, current: QListWidgetItem, previous: QListWidgetItem) -> None:
         """Process change of build selection to update the details."""
-        build = self._builds.getBuild(current.data(self.D_KEY))
-        if build is not None:
-            self.buildDetails.updateInfo(build)
+        if isinstance(current, QListWidgetItem):
+            build = self._builds.getBuild(current.data(self.D_KEY))
+            if build is not None:
+                self.buildDetails.updateInfo(build)
         return
 
     @pyqtSlot()
@@ -586,7 +587,7 @@ class _DetailsWidget(QWidget):
                 item.addChild(sub)
 
         # Headings
-        hFmt = HeadingFormatter()
+        hFmt = HeadingFormatter(SHARED.project)
         hFmt.incChapter()
         hFmt.incScene()
         hFmt.resetScene()

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -40,11 +40,11 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtPrintSupport import QPrintPreviewDialog, QPrinter
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.core.tokenizer import HeadingFormatter
 from novelwriter.error import logException
 from novelwriter.common import checkInt, fuzzyTime
 from novelwriter.core.tohtml import ToHtml
 from novelwriter.core.docbuild import NWBuildDocument
+from novelwriter.core.tokenizer import HeadingFormatter
 from novelwriter.core.buildsettings import BuildCollection, BuildSettings
 from novelwriter.tools.manusbuild import GuiManuscriptBuild
 from novelwriter.tools.manussettings import GuiBuildSettings

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -545,9 +545,7 @@ class _DetailsWidget(QWidget):
         for i in range(self.listView.topLevelItemCount()):
             item = self.listView.topLevelItem(i)
             if isinstance(item, QTreeWidgetItem):
-                item.setExpanded(
-                    (state[i] if i < count else True) if item.childCount() > 0 else False
-                )
+                item.setExpanded((state[i] if i < count else True) and item.childCount() > 0)
         return
 
     ##

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -33,9 +33,9 @@ from datetime import datetime
 from PyQt5.QtGui import QCloseEvent, QColor, QCursor, QFont, QPalette, QResizeEvent
 from PyQt5.QtCore import QSize, QTimer, Qt, pyqtSlot
 from PyQt5.QtWidgets import (
-    QDialog, QGridLayout, QHBoxLayout, QLabel, QListWidget, QListWidgetItem,
-    QPushButton, QSplitter, QTextBrowser, QToolButton, QTreeWidget,
-    QTreeWidgetItem, QVBoxLayout, QWidget, qApp
+    QAbstractItemView, QDialog, QGridLayout, QHBoxLayout, QLabel, QListWidget,
+    QListWidgetItem, QPushButton, QSplitter, QTextBrowser, QToolButton,
+    QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget, qApp
 )
 from PyQt5.QtPrintSupport import QPrintPreviewDialog, QPrinter
 
@@ -500,8 +500,9 @@ class _DetailsWidget(QWidget):
 
         # Tree Vidget
         self.listView = QTreeWidget(self)
-        self.listView.setHeaderLabels(["Setting", "Value"])
+        self.listView.setHeaderLabels([self.tr("Setting"), self.tr("Value")])
         self.listView.setIndentation(SHARED.theme.baseIconSize)
+        self.listView.setSelectionMode(QAbstractItemView.NoSelection)
 
         # Assemble
         self.outerBox = QVBoxLayout()
@@ -542,8 +543,10 @@ class _DetailsWidget(QWidget):
         count = len(state)
         for i in range(self.listView.topLevelItemCount()):
             item = self.listView.topLevelItem(i)
-            if isinstance(item, QTreeWidgetItem) and i < count:
-                item.setExpanded(state[i])
+            if isinstance(item, QTreeWidgetItem):
+                item.setExpanded(
+                    (state[i] if i < count else True) if item.childCount() > 0 else False
+                )
         return
 
     ##

--- a/tests/test_core/test_core_buildsettings.py
+++ b/tests/test_core/test_core_buildsettings.py
@@ -377,6 +377,8 @@ def testCoreBuildSettings_Collection(monkeypatch, mockGUI, fncPath: Path, mockRn
     builds = BuildCollection(project)
     assert len(builds) == 0
     assert not buildsFile.exists()
+    assert builds.lastBuild == ""
+    assert builds.defaultBuild == ""
 
     # Create a default build
     buildOne = BuildSettings()
@@ -412,7 +414,9 @@ def testCoreBuildSettings_Collection(monkeypatch, mockGUI, fncPath: Path, mockRn
 
     # Check the file content
     data = json.loads(buildsFile.read_text(encoding="utf-8"))
-    assert list(data["novelWriter.builds"].keys()) == [buildIDOne, buildIDTwo]
+    assert list(data["novelWriter.builds"].keys()) == [
+        "lastBuild", "defaultBuild", buildIDOne, buildIDTwo
+    ]
 
     # Remove a build
     builds.removeBuild(buildIDOne)
@@ -423,12 +427,16 @@ def testCoreBuildSettings_Collection(monkeypatch, mockGUI, fncPath: Path, mockRn
 
     # Check the file content
     data = json.loads(buildsFile.read_text(encoding="utf-8"))
-    assert list(data["novelWriter.builds"].keys()) == [buildIDTwo]
+    assert list(data["novelWriter.builds"].keys()) == [
+        "lastBuild", "defaultBuild", buildIDTwo
+    ]
     builds.setBuild(buildOne)
     assert list(builds.builds()) == [
         (buildIDTwo, "Build Two"),
         (buildIDOne, "Build One"),
     ]
+    builds.setLastBuild(buildIDOne)
+    builds.setDefaultBuild(buildIDTwo)
 
     # Check errors: No valid path
     with monkeypatch.context() as mp:
@@ -447,7 +455,7 @@ def testCoreBuildSettings_Collection(monkeypatch, mockGUI, fncPath: Path, mockRn
     buildsFile.write_text("foobar")
     assert builds._loadCollection() is False
 
-    # Check errors: Valid jason file, but list instead of object
+    # Check errors: Valid json file, but list instead of object
     buildsFile.write_text("[]")
     assert builds._loadCollection() is False
     buildsFile.unlink()
@@ -459,5 +467,7 @@ def testCoreBuildSettings_Collection(monkeypatch, mockGUI, fncPath: Path, mockRn
         (buildIDTwo, "Build Two"),
         (buildIDOne, "Build One"),
     ]
+    assert another.lastBuild == buildIDOne
+    assert another.defaultBuild == buildIDTwo
 
 # END Test testCoreBuildSettings_Collection


### PR DESCRIPTION
**Summary:**

This PR adds a display widget to the Manuscript tool window that shows more details about the currently selected build.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
