### PR TITLE
Sidebar cleanup and minor fixes

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -460,9 +460,8 @@ class GuiDocEditor(QTextEdit):
 
         return True
 
-    def updateTagHighLighting(self):
-        """Rerun the syntax highlighter on all meta data lines.
-        """
+    def updateTagHighLighting(self) -> None:
+        """Rerun the syntax highlighter on all meta data lines."""
         self.highLight.rehighlightByType(GuiDocHighlighter.BLOCK_META)
         return
 
@@ -672,7 +671,7 @@ class GuiDocEditor(QTextEdit):
             self._nwItem.setCursorPos(cursPos)
         return
 
-    def setCursorLine(self, line: int) -> bool:
+    def setCursorLine(self, line: int | None) -> bool:
         """Move the cursor to a given line in the document."""
         if not isinstance(line, int):
             return False

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -367,7 +367,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                     self.setFormat(tLen-1, tLen, self._hStyles["keyword"])
                     return
 
-            # Regular text
+            # Regular Text
             self.setCurrentBlockState(self.BLOCK_TEXT)
             for rX, xFmt in self.rxRules:
                 rxItt = rX.globalMatch(text, 0)
@@ -389,7 +389,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         while rxSpell.hasNext():
             rxMatch = rxSpell.next()
             if not SHARED.spelling.checkWord(rxMatch.captured(0)):
-                if rxMatch.captured(0).isupper() or rxMatch.captured(0).isnumeric():
+                if not rxMatch.captured(0).isalpha() or rxMatch.captured(0).isupper():
                     continue
                 xPos = rxMatch.capturedStart(0)
                 xLen = rxMatch.capturedLength(0)

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -329,7 +329,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 self.setFormat(0, 4, self._hStyles["header4h"])
                 self.setFormat(4, len(text), self._hStyles["header4"])
 
-            if text.startswith("#! "):  # Title
+            elif text.startswith("#! "):  # Title
                 self.setFormat(0, 2, self._hStyles["header1h"])
                 self.setFormat(2, len(text), self._hStyles["header1"])
 

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -40,18 +40,6 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class PopRightMenu(QMenu):
-
-    def event(self, event: QEvent):
-        """Overload the show event and move the menu popup location."""
-        if event.type() == QEvent.Show:
-            parent = self.parent()
-            if isinstance(parent, QWidget):
-                offset = QPoint(parent.width(), parent.height() - self.height())
-                self.move(parent.mapToGlobal(offset))
-        return super(PopRightMenu, self).event(event)
-
-
 class GuiSideBar(QWidget):
 
     viewChangeRequested = pyqtSignal(nwView)
@@ -104,7 +92,7 @@ class GuiSideBar(QWidget):
         self.tbSettings.setIconSize(iconSize)
         self.tbSettings.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
 
-        self.mSettings = PopRightMenu(self.tbSettings)
+        self.mSettings = _PopRightMenu(self.tbSettings)
         self.mSettings.addAction(self.mainGui.mainMenu.aEditWordList)
         self.mSettings.addAction(self.mainGui.mainMenu.aProjectSettings)
         self.mSettings.addSeparator()
@@ -171,3 +159,17 @@ class GuiSideBar(QWidget):
         return
 
 # END Class GuiSideBar
+
+
+class _PopRightMenu(QMenu):
+
+    def event(self, event: QEvent):
+        """Overload the show event and move the menu popup location."""
+        if event.type() == QEvent.Show:
+            parent = self.parent()
+            if isinstance(parent, QWidget):
+                offset = QPoint(parent.width(), parent.height() - self.height())
+                self.move(parent.mapToGlobal(offset))
+        return super(_PopRightMenu, self).event(event)
+
+# END Class _PopRightMenu

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -67,7 +67,7 @@ class GuiSideBar(QWidget):
         iconSize = QSize(iPx, iPx)
         self.setContentsMargins(0, 0, 0, 0)
 
-        # Actions
+        # Buttons
         self.tbProject = QToolButton(self)
         self.tbProject.setToolTip(self.tr("Project Tree View"))
         self.tbProject.setIconSize(iconSize)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -143,7 +143,7 @@ class GuiMain(QMainWindow):
         self.itemDetails = GuiItemDetails(self)
         self.outlineView = GuiOutlineView(self)
         self.mainMenu    = GuiMainMenu(self)
-        self.viewsBar    = GuiSideBar(self)
+        self.sideBar     = GuiSideBar(self)
 
         # Project Tree Stack
         self.projStack = QStackedWidget(self)
@@ -224,7 +224,7 @@ class GuiMain(QMainWindow):
 
         # Assemble Main Window Elements
         self.mainBox = QHBoxLayout(self)
-        self.mainBox.addWidget(self.viewsBar)
+        self.mainBox.addWidget(self.sideBar)
         self.mainBox.addWidget(self.mainStack)
         self.mainBox.setContentsMargins(0, 0, 0, 0)
         self.mainBox.setSpacing(0)
@@ -244,7 +244,7 @@ class GuiMain(QMainWindow):
         SHARED.projectStatusMessage.connect(self.mainStatus.setStatusMessage)
         SHARED.spellLanguageChanged.connect(self.mainStatus.setLanguage)
 
-        self.viewsBar.viewChangeRequested.connect(self._changeView)
+        self.sideBar.viewChangeRequested.connect(self._changeView)
 
         self.projView.selectedItemChanged.connect(self.itemDetails.updateViewBox)
         self.projView.openDocumentRequest.connect(self._openDocument)
@@ -880,7 +880,7 @@ class GuiMain(QMainWindow):
                 SHARED.theme.loadTheme()
                 self.docEditor.updateTheme()
                 self.docViewer.updateTheme()
-                self.viewsBar.updateTheme()
+                self.sideBar.updateTheme()
                 self.projView.updateTheme()
                 self.novelView.updateTheme()
                 self.outlineView.updateTheme()
@@ -1154,7 +1154,7 @@ class GuiMain(QMainWindow):
         self.treePane.setVisible(isVisible)
         self.mainStatus.setVisible(isVisible)
         self.mainMenu.setVisible(isVisible)
-        self.viewsBar.setVisible(isVisible)
+        self.sideBar.setVisible(isVisible)
 
         hideDocFooter = self.isFocusMode and CONFIG.hideFocusFooter
         self.docEditor.docFooter.setVisible(not hideDocFooter)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -33,8 +33,8 @@ from datetime import datetime
 from PyQt5.QtCore import Qt, QTimer, QThreadPool, pyqtSlot
 from PyQt5.QtGui import QCloseEvent, QCursor, QIcon, QKeySequence
 from PyQt5.QtWidgets import (
-    qApp, QDialog, QFileDialog, QMainWindow, QMessageBox, QShortcut, QSplitter,
-    QStackedWidget, QVBoxLayout, QWidget
+    QDialog, QFileDialog, QHBoxLayout, QMainWindow, QMessageBox, QShortcut,
+    QSplitter, QStackedWidget, QVBoxLayout, QWidget, qApp
 )
 
 from novelwriter import CONFIG, SHARED, __hexversion__
@@ -95,7 +95,7 @@ class GuiMain(QMainWindow):
 
         logger.debug("Create: GUI")
         self.setObjectName("GuiMain")
-        self.threadPool = QThreadPool()
+        self.threadPool = QThreadPool(self)
 
         # System Info
         # ===========
@@ -146,14 +146,14 @@ class GuiMain(QMainWindow):
         self.viewsBar    = GuiSideBar(self)
 
         # Project Tree Stack
-        self.projStack = QStackedWidget()
+        self.projStack = QStackedWidget(self)
         self.projStack.addWidget(self.projView)
         self.projStack.addWidget(self.novelView)
         self.projStack.currentChanged.connect(self._projStackChanged)
 
         # Project Tree View
-        self.treePane = QWidget()
-        self.treeBox = QVBoxLayout()
+        self.treePane = QWidget(self)
+        self.treeBox = QVBoxLayout(self)
         self.treeBox.setContentsMargins(0, 0, 0, 0)
         self.treeBox.setSpacing(mPx)
         self.treeBox.addWidget(self.projStack)
@@ -161,7 +161,7 @@ class GuiMain(QMainWindow):
         self.treePane.setLayout(self.treeBox)
 
         # Splitter : Document Viewer / Document Meta
-        self.splitView = QSplitter(Qt.Vertical)
+        self.splitView = QSplitter(Qt.Vertical, self)
         self.splitView.addWidget(self.docViewer)
         self.splitView.addWidget(self.viewMeta)
         self.splitView.setHandleWidth(hWd)
@@ -169,7 +169,7 @@ class GuiMain(QMainWindow):
         self.splitView.setSizes(CONFIG.viewPanePos)
 
         # Splitter : Document Editor / Document Viewer
-        self.splitDocs = QSplitter(Qt.Horizontal)
+        self.splitDocs = QSplitter(Qt.Horizontal, self)
         self.splitDocs.addWidget(self.docEditor)
         self.splitDocs.addWidget(self.splitView)
         self.splitDocs.setOpaqueResize(False)
@@ -185,7 +185,7 @@ class GuiMain(QMainWindow):
         self.splitMain.setSizes(CONFIG.mainPanePos)
 
         # Main Stack : Editor / Outline
-        self.mainStack = QStackedWidget()
+        self.mainStack = QStackedWidget(self)
         self.mainStack.addWidget(self.splitMain)
         self.mainStack.addWidget(self.outlineView)
         self.mainStack.currentChanged.connect(self._mainStackChanged)
@@ -222,11 +222,19 @@ class GuiMain(QMainWindow):
         # Initialise the Project Tree
         self.rebuildTrees()
 
-        # Set Main Window Elements
+        # Assemble Main Window Elements
+        self.mainBox = QHBoxLayout(self)
+        self.mainBox.addWidget(self.viewsBar)
+        self.mainBox.addWidget(self.mainStack)
+        self.mainBox.setContentsMargins(0, 0, 0, 0)
+        self.mainBox.setSpacing(0)
+
+        self.mainWidget = QWidget(self)
+        self.mainWidget.setLayout(self.mainBox)
+
         self.setMenuBar(self.mainMenu)
-        self.setCentralWidget(self.mainStack)
+        self.setCentralWidget(self.mainWidget)
         self.setStatusBar(self.mainStatus)
-        self.addToolBar(Qt.LeftToolBarArea, self.viewsBar)
         self.setContextMenuPolicy(Qt.NoContextMenu)  # Issue #1147
 
         # Connect Signals
@@ -269,15 +277,15 @@ class GuiMain(QMainWindow):
         # =======================
 
         # Set Up Auto-Save Project Timer
-        self.asProjTimer = QTimer()
+        self.asProjTimer = QTimer(self)
         self.asProjTimer.timeout.connect(self._autoSaveProject)
 
         # Set Up Auto-Save Document Timer
-        self.asDocTimer = QTimer()
+        self.asDocTimer = QTimer(self)
         self.asDocTimer.timeout.connect(self._autoSaveDocument)
 
         # Main Clock
-        self.mainTimer = QTimer()
+        self.mainTimer = QTimer(self)
         self.mainTimer.setInterval(1000)
         self.mainTimer.timeout.connect(self._timeTick)
         self.mainTimer.start()
@@ -1022,7 +1030,7 @@ class GuiMain(QMainWindow):
 
     def showAboutQtDialog(self) -> None:
         """Show the about dialog for Qt."""
-        msgBox = QMessageBox()
+        msgBox = QMessageBox(self)
         msgBox.aboutQt(self, "About Qt")
         return
 

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -72,8 +72,7 @@ def testGuiMain_ProjectBlocker(nwGUI):
 
 @pytest.mark.gui
 def testGuiMain_Launch(qtbot, monkeypatch, nwGUI, prjLipsum):
-    """Test the handling of launch tasks.
-    """
+    """Test the handling of launch tasks."""
     monkeypatch.setattr(GuiProjectLoad, "exec_", lambda *a: None)
     monkeypatch.setattr(GuiProjectLoad, "result", lambda *a: QDialog.Accepted)
     CONFIG.lastNotes = "0x0"
@@ -140,8 +139,7 @@ def testGuiMain_NewProject(monkeypatch, nwGUI, projPath):
 
 @pytest.mark.gui
 def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
-    """Test handling of project tree items based on GUI focus states.
-    """
+    """Test handling of project tree items based on GUI focus states."""
     buildTestProject(nwGUI, projPath)
 
     sHandle = "000000000000f"
@@ -190,8 +188,7 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
 @pytest.mark.gui
 def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
-    """Test the document editor.
-    """
+    """Test the document editor."""
     monkeypatch.setattr(GuiProjectTree, "hasFocus", lambda *a: True)
     monkeypatch.setattr(GuiDocEditor, "hasFocus", lambda *a: True)
     monkeypatch.setattr(QInputDialog, "getText", lambda *a, text: (text, True))
@@ -555,9 +552,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
 
 @pytest.mark.gui
-def testGuiMain_FocusFullMode(qtbot, nwGUI, projPath, mockRnd):
-    """Test toggling focus mode in main window.
-    """
+def testGuiMain_Features(qtbot, nwGUI, projPath, mockRnd):
+    """Test various features of the main window."""
     buildTestProject(nwGUI, projPath)
     assert nwGUI.isFocusMode is False
 
@@ -576,7 +572,7 @@ def testGuiMain_FocusFullMode(qtbot, nwGUI, projPath, mockRnd):
     assert nwGUI.treePane.isVisible() is False
     assert nwGUI.mainStatus.isVisible() is False
     assert nwGUI.mainMenu.isVisible() is False
-    assert nwGUI.viewsBar.isVisible() is False
+    assert nwGUI.sideBar.isVisible() is False
     assert nwGUI.splitView.isVisible() is False
 
     # Disable focus mode
@@ -584,7 +580,7 @@ def testGuiMain_FocusFullMode(qtbot, nwGUI, projPath, mockRnd):
     assert nwGUI.treePane.isVisible() is True
     assert nwGUI.mainStatus.isVisible() is True
     assert nwGUI.mainMenu.isVisible() is True
-    assert nwGUI.viewsBar.isVisible() is True
+    assert nwGUI.sideBar.isVisible() is True
     assert nwGUI.splitView.isVisible() is True
 
     # Full Screen Mode
@@ -596,6 +592,13 @@ def testGuiMain_FocusFullMode(qtbot, nwGUI, projPath, mockRnd):
     nwGUI.toggleFullScreenMode()
     assert nwGUI.windowState() & Qt.WindowFullScreen != Qt.WindowFullScreen
 
+    # SideBar Menu
+    # ============
+
+    # Just make sure the custom event handler executes and don't fail
+    nwGUI.sideBar.mSettings.show()
+    nwGUI.sideBar.mSettings.hide()
+
     # qtbot.stop()
 
-# END Test testGuiMain_FocusFullMode
+# END Test testGuiMain_Features

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -595,7 +595,7 @@ def testGuiMain_Features(qtbot, nwGUI, projPath, mockRnd):
     # SideBar Menu
     # ============
 
-    # Just make sure the custom event handler executes and don't fail
+    # Just make sure the custom event handler executes and doesn't fail
     nwGUI.sideBar.mSettings.show()
     nwGUI.sideBar.mSettings.hide()
 


### PR DESCRIPTION
**Summary:**

This PR:
* Fixes a few minor issues in the code.
* Changes the spell checker to only spell check words with only letters in them (Python `str.isalpha()`).
* Removes the text labels in the side bar and converts it to a layout box with tool buttons. The tool buttons have the same style sheets as other tool buttons in the app.
* Takes control over the popup location of the menu on the Settings button. It will now always pop up to the right of the button, growing upwards from the bottom of the button.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
