### PR TITLE
Make the editor actually Plain Text

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -149,7 +149,6 @@ class Config:
         self.autoScrollPos   = 30     # Start point for typewriter-like scrolling
 
         self.wordCountTimer  = 5.0    # Interval for word count update in seconds
-        self.bigDocLimit     = 800    # Size threshold for heavy editor features in kilobytes
         self.incNotesWCount  = True   # The status bar word count includes notes
 
         self.highlightQuotes = True   # Highlight text in quotes
@@ -588,7 +587,6 @@ class Config:
         self.showLineEndings = conf.rdBool(sec, "showlineendings", self.showLineEndings)
         self.showMultiSpaces = conf.rdBool(sec, "showmultispaces", self.showMultiSpaces)
         self.wordCountTimer  = conf.rdFlt(sec, "wordcounttimer", self.wordCountTimer)
-        self.bigDocLimit     = conf.rdInt(sec, "bigdoclimit", self.bigDocLimit)
         self.incNotesWCount  = conf.rdBool(sec, "incnoteswcount", self.incNotesWCount)
         self.showFullPath    = conf.rdBool(sec, "showfullpath", self.showFullPath)
         self.highlightQuotes = conf.rdBool(sec, "highlightquotes", self.highlightQuotes)
@@ -712,7 +710,6 @@ class Config:
             "showlineendings": str(self.showLineEndings),
             "showmultispaces": str(self.showMultiSpaces),
             "wordcounttimer":  str(self.wordCountTimer),
-            "bigdoclimit":     str(self.bigDocLimit),
             "incnoteswcount":  str(self.incNotesWCount),
             "showfullpath":    str(self.showFullPath),
             "highlightquotes": str(self.highlightQuotes),

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -144,7 +144,6 @@ class Config:
         self.doReplaceDash   = True   # Replace multiple hyphens with dashes
         self.doReplaceDots   = True   # Replace three dots with ellipsis
 
-        self.scrollPastEnd   = 25     # Number of lines to scroll past end of document
         self.autoScroll      = False  # Typewriter-like scrolling
         self.autoScrollPos   = 30     # Start point for typewriter-like scrolling
 
@@ -572,7 +571,6 @@ class Config:
         self.doReplaceDQuote = conf.rdBool(sec, "repdquotes", self.doReplaceDQuote)
         self.doReplaceDash   = conf.rdBool(sec, "repdash", self.doReplaceDash)
         self.doReplaceDots   = conf.rdBool(sec, "repdots", self.doReplaceDots)
-        self.scrollPastEnd   = conf.rdInt(sec, "scrollpastend", self.scrollPastEnd)
         self.autoScroll      = conf.rdBool(sec, "autoscroll", self.autoScroll)
         self.autoScrollPos   = conf.rdInt(sec, "autoscrollpos", self.autoScrollPos)
         self.fmtSQuoteOpen   = conf.rdStr(sec, "fmtsquoteopen", self.fmtSQuoteOpen)
@@ -695,7 +693,6 @@ class Config:
             "repdquotes":      str(self.doReplaceDQuote),
             "repdash":         str(self.doReplaceDash),
             "repdots":         str(self.doReplaceDots),
-            "scrollpastend":   str(self.scrollPastEnd),
             "autoscroll":      str(self.autoScroll),
             "autoscrollpos":   str(self.autoScrollPos),
             "fmtsquoteopen":   str(self.fmtSQuoteOpen),

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -40,10 +40,6 @@ class nwConst:
     FMT_FSTAMP = "%Y-%m-%d %H.%M.%S"  # FileName safe format
     FMT_DSTAMP = "%Y-%m-%d"           # Date only format
 
-    # Various Hard Limits
-    MAX_DOCSIZE   = 5000000   # Maximum size of a single document
-    MAX_BUILDSIZE = 10000000  # Maximum size of a project build
-
     # URLs
     URL_WEB     = "https://novelwriter.io"
     URL_DOCS    = "https://docs.novelwriter.io"

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -38,7 +38,7 @@ from PyQt5.QtCore import QCoreApplication, QRegularExpression
 
 from novelwriter.enum import nwItemLayout
 from novelwriter.common import formatTimeStamp, numberToRoman, checkInt
-from novelwriter.constants import nwConst, nwHeadFmt, nwRegEx, nwUnicode
+from novelwriter.constants import nwHeadFmt, nwRegEx, nwUnicode
 from novelwriter.core.project import NWProject
 
 logger = logging.getLogger(__name__)
@@ -348,14 +348,6 @@ class Tokenizer(ABC):
             text = self._project.storage.getDocument(tHandle).readDocument() or ""
 
         self._text = text
-
-        docSize = len(self._text)
-        if docSize > nwConst.MAX_DOCSIZE:
-            errVal = self.tr("Document '{0}' is too big ({1} MB). Skipping.").format(
-                self._nwItem.itemName, f"{docSize/1.0e6:.2f}"
-            )
-            self._text = "# {0}\n\n{1}\n\n".format(self.tr("ERROR"), errVal)
-            self._errData.append(errVal)
 
         self._isNone  = self._nwItem.itemLayout == nwItemLayout.NO_LAYOUT
         self._isNovel = self._nwItem.itemLayout == nwItemLayout.DOCUMENT

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -675,19 +675,6 @@ class GuiPreferencesEditor(QWidget):
             self.tr("Available languages are determined by your system.")
         )
 
-        # Big Document Size Limit
-        self.bigDocLimit = QSpinBox(self)
-        self.bigDocLimit.setMinimum(10)
-        self.bigDocLimit.setMaximum(10000)
-        self.bigDocLimit.setSingleStep(10)
-        self.bigDocLimit.setValue(CONFIG.bigDocLimit)
-        self.mainForm.addRow(
-            self.tr("Big document limit"),
-            self.bigDocLimit,
-            self.tr("Full spell checking is disabled above this limit."),
-            unit=self.tr("kB")
-        )
-
         # Word Count
         # ==========
         self.mainForm.addGroupLabel(self.tr("Word Count"))
@@ -775,11 +762,9 @@ class GuiPreferencesEditor(QWidget):
         return
 
     def saveValues(self):
-        """Save the values set for this tab.
-        """
+        """Save the values set for this tab."""
         # Spell Checking
         CONFIG.spellLanguage = self.spellLanguage.currentData()
-        CONFIG.bigDocLimit   = self.bigDocLimit.value()
 
         # Word Count
         CONFIG.wordCountTimer = self.wordCountTimer.value()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -724,19 +724,6 @@ class GuiPreferencesEditor(QWidget):
         # ================
         self.mainForm.addGroupLabel(self.tr("Scroll Behaviour"))
 
-        # Scroll Past End
-        self.scrollPastEnd = QSpinBox(self)
-        self.scrollPastEnd.setMinimum(0)
-        self.scrollPastEnd.setMaximum(100)
-        self.scrollPastEnd.setSingleStep(1)
-        self.scrollPastEnd.setValue(int(CONFIG.scrollPastEnd))
-        self.mainForm.addRow(
-            self.tr("Scroll past end of the document"),
-            self.scrollPastEnd,
-            self.tr("Set to 0 to disable this feature."),
-            unit=self.tr("lines")
-        )
-
         # Typewriter Scrolling
         self.autoScroll = NSwitch()
         self.autoScroll.setChecked(CONFIG.autoScroll)
@@ -775,7 +762,6 @@ class GuiPreferencesEditor(QWidget):
         CONFIG.showLineEndings = self.showLineEndings.isChecked()
 
         # Scroll Behaviour
-        CONFIG.scrollPastEnd = self.scrollPastEnd.value()
         CONFIG.autoScroll    = self.autoScroll.isChecked()
         CONFIG.autoScrollPos = self.autoScrollPos.value()
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -42,11 +42,13 @@ from PyQt5.QtCore import (
 )
 from PyQt5.QtGui import (
     QColor, QCursor, QFont, QFontMetrics, QKeyEvent, QKeySequence, QMouseEvent,
-    QPalette, QPixmap, QResizeEvent, QTextBlock, QTextCursor, QTextDocument, QTextOption
+    QPalette, QPixmap, QResizeEvent, QTextBlock, QTextCursor, QTextDocument,
+    QTextOption
 )
 from PyQt5.QtWidgets import (
-    QAction, qApp, QFrame, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QMenu,
-    QPushButton, QShortcut, QTextEdit, QToolBar, QToolButton, QWidget
+    QAction, QFrame, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QMenu,
+    QPlainTextEdit, QPushButton, QShortcut, QToolBar, QToolButton, QWidget,
+    qApp
 )
 
 from novelwriter import CONFIG, SHARED
@@ -63,7 +65,7 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class GuiDocEditor(QTextEdit):
+class GuiDocEditor(QPlainTextEdit):
     """Gui Widget: Main Document Editor"""
 
     MOVE_KEYS = (
@@ -141,7 +143,6 @@ class GuiDocEditor(QTextEdit):
 
         # Editor Settings
         self.setMinimumWidth(CONFIG.pxInt(300))
-        self.setAcceptRichText(False)
         self.setAutoFillBackground(True)
         self.setFrameStyle(QFrame.NoFrame)
 
@@ -678,9 +679,9 @@ class GuiDocEditor(QTextEdit):
 
         lineIdx = line - 1  # Block index is 0 offset, lineNo is 1 offset
         if lineIdx >= 0:
-            theBlock = self.document().findBlockByLineNumber(lineIdx)
-            if theBlock:
-                self.setCursorPosition(theBlock.position())
+            block = self.document().findBlockByNumber(lineIdx)
+            if block:
+                self.setCursorPosition(block.position())
                 logger.debug("Cursor moved to line %d", line)
 
         return True

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -340,6 +340,7 @@ class GuiMain(QMainWindow):
     def postLaunchTasks(self, cmdOpen: str | None) -> None:
         """Process tasks after the main window has been created."""
         if cmdOpen:
+            qApp.processEvents()
             logger.info("Command line path: %s", cmdOpen)
             self.openProject(cmdOpen)
 
@@ -513,10 +514,12 @@ class GuiMain(QMainWindow):
                     break
 
         if lastEdited is not None:
+            qApp.processEvents()
             self.openDocument(lastEdited, doScroll=True)
 
         lastViewed = SHARED.project.data.getLastHandle("viewer")
         if lastViewed is not None:
+            qApp.processEvents()
             self.viewDocument(lastViewed)
 
         # Check if we need to rebuild the index

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -58,7 +58,6 @@ showtabsnspaces = False
 showlineendings = False
 showmultispaces = True
 wordcounttimer = 5.0
-bigdoclimit = 800
 incnoteswcount = True
 showfullpath = True
 highlightquotes = True

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -43,7 +43,6 @@ repsquotes = True
 repdquotes = True
 repdash = True
 repdots = True
-scrollpastend = 25
 autoscroll = False
 autoscrollpos = 30
 fmtsquoteopen = ‘

--- a/tests/reference/guiPreferences_novelwriter.conf
+++ b/tests/reference/guiPreferences_novelwriter.conf
@@ -58,7 +58,6 @@ showtabsnspaces = True
 showlineendings = True
 showmultispaces = True
 wordcounttimer = 5.0
-bigdoclimit = 500
 incnoteswcount = True
 showfullpath = False
 highlightquotes = False

--- a/tests/reference/guiPreferences_novelwriter.conf
+++ b/tests/reference/guiPreferences_novelwriter.conf
@@ -43,7 +43,6 @@ repsquotes = True
 repdquotes = True
 repdash = True
 repdots = True
-scrollpastend = 0
 autoscroll = True
 autoscrollpos = 30
 fmtsquoteopen = ‘

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -183,14 +183,6 @@ def testCoreToken_TextOps(monkeypatch, mockGUI, mockRnd, fncPath):
     assert theToken.setText(C.hSceneDoc) is True
     assert theToken._text == docText
 
-    with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.constants.nwConst.MAX_DOCSIZE", 100)
-        assert theToken.setText(C.hSceneDoc, docText) is True
-        assert theToken._text == (
-            "# ERROR\n\n"
-            "Document 'New Scene' is too big (0.00 MB). Skipping.\n\n"
-        )
-
     assert theToken.setText(C.hSceneDoc, docText) is True
     assert theToken._text == docText
 

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -159,9 +159,6 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     qtbot.wait(KEY_DELAY)
     tabEditor.scrollPastEnd.setValue(0)
 
-    qtbot.wait(KEY_DELAY)
-    tabEditor.bigDocLimit.setValue(500)
-
     # Syntax Settings
     qtbot.wait(KEY_DELAY)
     tabSyntax = nwPrefs.tabSyntax

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -156,9 +156,6 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     qtbot.mouseClick(tabEditor.autoScroll, Qt.LeftButton)
     assert tabEditor.autoScroll.isChecked()
 
-    qtbot.wait(KEY_DELAY)
-    tabEditor.scrollPastEnd.setValue(0)
-
     # Syntax Settings
     qtbot.wait(KEY_DELAY)
     tabSyntax = nwPrefs.tabSyntax

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -104,18 +104,12 @@ def testGuiEditor_LoadText(qtbot, monkeypatch, caplog, nwGUI, projPath, ipsumTex
 
     # Regular open
     assert nwGUI.docEditor.loadText(C.hSceneDoc) is True
-    assert nwGUI.docEditor._bigDoc is False
 
     # Reload too big text
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.constants.nwConst.MAX_DOCSIZE", 100)
         assert nwGUI.docEditor.replaceText(longText) is False
         assert "The document you are trying to open is too big." in caplog.text
-
-    # Big doc handling
-    CONFIG.bigDocLimit = 50
-    assert nwGUI.docEditor.loadText(C.hSceneDoc) is True
-    assert nwGUI.docEditor._bigDoc is True
 
     # Regular open, with line number (1 indexed)
     assert nwGUI.docEditor.loadText(C.hSceneDoc, tLine=4) is True

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -200,8 +200,9 @@ def testGuiEditor_MetaData(qtbot, nwGUI, projPath, mockRnd):
     nwGUI.docEditor.saveCursorPosition()
     assert SHARED.project.tree[C.hSceneDoc].cursorPos == 10
 
-    assert nwGUI.docEditor.setCursorLine(None) is False
-    assert nwGUI.docEditor.setCursorLine(3) is True
+    nwGUI.docEditor.setCursorLine(None)
+    assert nwGUI.docEditor.getCursorPosition() == 10
+    nwGUI.docEditor.setCursorLine(3)
     assert nwGUI.docEditor.getCursorPosition() == 15
 
     # Document Changed Signal
@@ -499,7 +500,7 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
 
     theText = "### A Scene\n\n\n%s" % ipsumText[0]
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorLine(3)
+    nwGUI.docEditor.setCursorLine(3)
 
     # Invalid Keyword
     assert nwGUI.docEditor.insertKeyWord("stuff") is False
@@ -1039,7 +1040,7 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     # Third Line
     # This also needs to add a new block
     assert nwGUI.docEditor.replaceText("#### Title\n\nThe Text\n\n") is True
-    assert nwGUI.docEditor.setCursorLine(3) is True
+    nwGUI.docEditor.setCursorLine(3)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "#### Title\n\n% The Text\n\n"
 
@@ -1072,11 +1073,11 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.openDocument(C.hSceneDoc) is True
 
     # Empty Block
-    assert nwGUI.docEditor.setCursorLine(2) is True
+    nwGUI.docEditor.setCursorLine(2)
     assert nwGUI.docEditor._followTag() is False
 
     # Not On Tag
-    assert nwGUI.docEditor.setCursorLine(1) is True
+    nwGUI.docEditor.setCursorLine(1)
     assert nwGUI.docEditor._followTag() is False
 
     # On Tag Keyword

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -96,20 +96,8 @@ def testGuiEditor_LoadText(qtbot, monkeypatch, caplog, nwGUI, projPath, ipsumTex
     # Invalid handle
     assert nwGUI.docEditor.loadText("abcdefghijklm") is False
 
-    # Document too big
-    with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.constants.nwConst.MAX_DOCSIZE", 100)
-        assert nwGUI.docEditor.loadText(C.hSceneDoc) is False
-        assert "The document you are trying to open is too big." in caplog.text
-
     # Regular open
     assert nwGUI.docEditor.loadText(C.hSceneDoc) is True
-
-    # Reload too big text
-    with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.constants.nwConst.MAX_DOCSIZE", 100)
-        assert nwGUI.docEditor.replaceText(longText) is False
-        assert "The document you are trying to open is too big." in caplog.text
 
     # Regular open, with line number (1 indexed)
     assert nwGUI.docEditor.loadText(C.hSceneDoc, tLine=4) is True
@@ -184,7 +172,7 @@ def testGuiEditor_MetaData(qtbot, nwGUI, projPath, mockRnd):
         "Some\u2028text.\u2029"
         "More\u00a0text.\u2029"
     )
-    assert nwGUI.docEditor.replaceText(newText)
+    nwGUI.docEditor.replaceText(newText)
     assert nwGUI.docEditor.getText() == "### New Scene\n\nSome\ntext.\nMore\u00a0text.\n"
 
     # Check Propertoes
@@ -227,7 +215,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.openDocument(C.hSceneDoc) is True
 
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText)
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     theDoc = nwGUI.docEditor.document()
 
@@ -251,7 +239,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert theCursor.selectedText() == ipsumText[1]
 
     # Cut Selected Text
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(1000)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_PARA) is True
     assert nwGUI.docEditor.docAction(nwDocAction.CUT) is True
@@ -269,7 +257,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.docEditor.getText() == theText
 
     # Copy Next Paragraph
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(1500)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_PARA) is True
     assert nwGUI.docEditor.docAction(nwDocAction.COPY) is True
@@ -292,7 +280,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     # ==================
 
     theText = "### A Scene\n\n%s" % ipsumText[0]
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Emphasis
     nwGUI.docEditor.setCursorPosition(50)
@@ -325,7 +313,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     # ======
 
     theText = "### A Scene\n\n%s" % ipsumText[0]
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Add Single Quotes
     nwGUI.docEditor.setCursorPosition(50)
@@ -343,14 +331,14 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     # Replace Single Quotes
     repText = theText.replace("consectetur", "'consectetur'")
-    assert nwGUI.docEditor.replaceText(repText) is True
+    nwGUI.docEditor.replaceText(repText)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_ALL) is True
     assert nwGUI.docEditor.docAction(nwDocAction.REPL_SNG) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "\u2018consectetur\u2019")
 
     # Replace Double Quotes
     repText = theText.replace("consectetur", "\"consectetur\"")
-    assert nwGUI.docEditor.replaceText(repText) is True
+    nwGUI.docEditor.replaceText(repText)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_ALL) is True
     assert nwGUI.docEditor.docAction(nwDocAction.REPL_DBL) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "\u201cconsectetur\u201d")
@@ -360,7 +348,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     theText = "### A Scene\n\n%s" % ipsumText[0]
     repText = theText[:100] + theText[100:].replace(" ", "\n", 3)
-    assert nwGUI.docEditor.replaceText(repText) is True
+    nwGUI.docEditor.replaceText(repText)
     assert nwGUI.docEditor.docAction(nwDocAction.RM_BREAKS) is True
     assert nwGUI.docEditor.getText().strip() == theText.strip()
 
@@ -368,7 +356,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     # ============
 
     theText = "## Scene Title\n\nScene text.\n\n"
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Header 1
     nwGUI.docEditor.setCursorPosition(0)
@@ -456,13 +444,13 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
     assert nwGUI.openDocument(C.hSceneDoc) is True
 
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText)
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Insert Text
     # ===========
 
     theText = "### A Scene\n\n%s" % ipsumText[0]
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # No Document Handle
     nwGUI.docEditor._docHandle = None
@@ -476,7 +464,7 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
     assert nwGUI.docEditor.getText() == theText[:24] + ", ipsumer," + theText[24:]
 
     # Single Quotes
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(41)
     assert nwGUI.docEditor.insertText(nwDocInsert.QUOTE_LS) is True
     nwGUI.docEditor.setCursorPosition(53)
@@ -484,7 +472,7 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "\u2018consectetur\u2019")
 
     # Double Quotes
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(41)
     assert nwGUI.docEditor.insertText(nwDocInsert.QUOTE_LD) is True
     nwGUI.docEditor.setCursorPosition(53)
@@ -499,7 +487,7 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
     # ===============
 
     theText = "### A Scene\n\n\n%s" % ipsumText[0]
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorLine(3)
 
     # Invalid Keyword
@@ -538,14 +526,14 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     assert nwGUI.openDocument(C.hSceneDoc) is True
 
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText)
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Clear Surrounding
     # =================
 
     # No Selection
     theText = "### A Scene\n\n%s" % ipsumText[0]
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
 
     theCursor = nwGUI.docEditor.textCursor()
@@ -553,7 +541,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Clear Characters, 1 Layer
     repText = theText.replace("consectetur", "=consectetur=")
-    assert nwGUI.docEditor.replaceText(repText) is True
+    nwGUI.docEditor.replaceText(repText)
     nwGUI.docEditor.setCursorPosition(45)
 
     theCursor = nwGUI.docEditor.textCursor()
@@ -563,7 +551,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Clear Characters, 2 Layers
     repText = theText.replace("consectetur", "==consectetur==")
-    assert nwGUI.docEditor.replaceText(repText) is True
+    nwGUI.docEditor.replaceText(repText)
     nwGUI.docEditor.setCursorPosition(45)
 
     theCursor = nwGUI.docEditor.textCursor()
@@ -575,7 +563,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # ==============
 
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2])
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
 
     # No Selection
@@ -584,19 +572,19 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
         assert nwGUI.docEditor._wrapSelection("=", "=") is False
 
     # Wrap Equal
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._wrapSelection("=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "=consectetur=")
 
     # Wrap Unequal
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._wrapSelection("=", "*") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "=consectetur*")
 
     # Past Paragraph
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     theCursor = nwGUI.docEditor.textCursor()
     theCursor.setPosition(13, QTextCursor.MoveAnchor)
     theCursor.setPosition(1000, QTextCursor.KeepAnchor)
@@ -612,7 +600,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # =============
 
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2])
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
 
     # No Selection
@@ -621,13 +609,13 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
         assert nwGUI.docEditor._toggleFormat(2, "=") is False
 
     # Wrap Single Equal
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(1, "=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "=consectetur=")
 
     # Past Paragraph
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     theCursor = nwGUI.docEditor.textCursor()
     theCursor.setPosition(13, QTextCursor.MoveAnchor)
     theCursor.setPosition(1000, QTextCursor.KeepAnchor)
@@ -640,20 +628,20 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     assert newPara[2] == ipsumText[1]
 
     # Wrap Double Equal
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "==consectetur==")
 
     # Toggle Double Equal
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
     assert nwGUI.docEditor.getText() == theText
 
     # Toggle Triple+Double Equal
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(3, "=") is True
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
@@ -661,7 +649,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Toggle Unequal
     repText = theText.replace("consectetur", "=consectetur==")
-    assert nwGUI.docEditor.replaceText(repText) is True
+    nwGUI.docEditor.replaceText(repText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(1, "=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "consectetur=")
@@ -673,14 +661,14 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # No Selection
     theText = "### A Scene\n\n%s" % ipsumText[0].replace("consectetur", "=consectetur=")
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._replaceQuotes("=", "<", ">") is False
 
     # First Paragraph Selected
     # This should not replace anything in second paragraph
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2]).replace("ipsum", "=ipsum=")
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_PARA)
     assert nwGUI.docEditor._replaceQuotes("=", "<", ">") is True
@@ -692,7 +680,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Edge of Document
     theText = ipsumText[0].replace("Lorem", "=Lorem=")
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_ALL)
     assert nwGUI.docEditor._replaceQuotes("=", "<", ">") is True
@@ -706,7 +694,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Remove All
     theText = "### A Scene\n\n%s\n\n%s" % (parOne, parTwo)
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     nwGUI.docEditor.setCursorPosition(45)
     nwGUI.docEditor._removeInParLineBreaks()
     assert nwGUI.docEditor.getText() == "### A Scene\n\n%s\n" % "\n\n".join(ipsumText[0:2])
@@ -714,7 +702,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # Remove First Paragraph
     # Second paragraphs should remain unchanged
     theText = "### A Scene\n\n%s\n\n%s" % (parOne, parTwo)
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     theCursor = nwGUI.docEditor.textCursor()
     theCursor.setPosition(16, QTextCursor.MoveAnchor)
     theCursor.setPosition(680, QTextCursor.KeepAnchor)
@@ -743,14 +731,11 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     buildTestProject(nwGUI, projPath)
     assert nwGUI.openDocument(C.hSceneDoc) is True
 
-    theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText)
-    assert nwGUI.docEditor.replaceText(theText) is True
-
     # Invalid and Generic
     # ===================
 
     theText = "### A Scene\n\n%s" % ipsumText[0]
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Invalid Block
     nwGUI.docEditor.setCursorPosition(0)
@@ -759,14 +744,14 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
         assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is False
 
     # Keyword
-    assert nwGUI.docEditor.replaceText("@pov: Jane\n\n") is True
+    nwGUI.docEditor.replaceText("@pov: Jane\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is False
     assert nwGUI.docEditor.getText() == "@pov: Jane\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Unsupported Format
-    assert nwGUI.docEditor.replaceText("% Comment\n\n") is True
+    nwGUI.docEditor.replaceText("% Comment\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.NO_ACTION) is False
 
@@ -774,91 +759,91 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     # ===========================
 
     # Strip Comment w/Space
-    assert nwGUI.docEditor.replaceText("% Comment\n\n") is True
+    nwGUI.docEditor.replaceText("% Comment\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Comment\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Comment wo/Space
-    assert nwGUI.docEditor.replaceText("%Comment\n\n") is True
+    nwGUI.docEditor.replaceText("%Comment\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Comment\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 4
 
     # Strip Header 1
-    assert nwGUI.docEditor.replaceText("# Title\n\n") is True
+    nwGUI.docEditor.replaceText("# Title\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Header 2
-    assert nwGUI.docEditor.replaceText("## Title\n\n") is True
+    nwGUI.docEditor.replaceText("## Title\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 2
 
     # Strip Header 3
-    assert nwGUI.docEditor.replaceText("### Title\n\n") is True
+    nwGUI.docEditor.replaceText("### Title\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 1
 
     # Strip Header 4
-    assert nwGUI.docEditor.replaceText("#### Title\n\n") is True
+    nwGUI.docEditor.replaceText("#### Title\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 0
 
     # Strip Novel Title
-    assert nwGUI.docEditor.replaceText("#! Title\n\n") is True
+    nwGUI.docEditor.replaceText("#! Title\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 2
 
     # Strip Unnumbered CHapter
-    assert nwGUI.docEditor.replaceText("##! Title\n\n") is True
+    nwGUI.docEditor.replaceText("##! Title\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 1
 
     # Strip Text
-    assert nwGUI.docEditor.replaceText("Generic text\n\n") is True
+    nwGUI.docEditor.replaceText("Generic text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Generic text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Left Angle Brackets : Double w/Space
-    assert nwGUI.docEditor.replaceText(">> Some text\n\n") is True
+    nwGUI.docEditor.replaceText(">> Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 2
 
     # Strip Left Angle Brackets : Single w/Space
-    assert nwGUI.docEditor.replaceText("> Some text\n\n") is True
+    nwGUI.docEditor.replaceText("> Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Left Angle Brackets : Double wo/Space
-    assert nwGUI.docEditor.replaceText(">>Some text\n\n") is True
+    nwGUI.docEditor.replaceText(">>Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Left Angle Brackets : Single wo/Space
-    assert nwGUI.docEditor.replaceText(">Some text\n\n") is True
+    nwGUI.docEditor.replaceText(">Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
@@ -868,28 +853,28 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     # ============================
 
     # Strip Right Angle Brackets : Double w/Space
-    assert nwGUI.docEditor.replaceText("Some text <<\n\n") is True
+    nwGUI.docEditor.replaceText("Some text <<\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Right Angle Brackets : Single w/Space
-    assert nwGUI.docEditor.replaceText("Some text <\n\n") is True
+    nwGUI.docEditor.replaceText("Some text <\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Right Angle Brackets : Double wo/Space
-    assert nwGUI.docEditor.replaceText("Some text<<\n\n") is True
+    nwGUI.docEditor.replaceText("Some text<<\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Right Angle Brackets : Single wo/Space
-    assert nwGUI.docEditor.replaceText("Some text<\n\n") is True
+    nwGUI.docEditor.replaceText("Some text<\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
@@ -898,15 +883,15 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     # Block Stripping : Both Sides
     # ============================
 
-    assert nwGUI.docEditor.replaceText(">> Some text <<\n\n") is True
+    nwGUI.docEditor.replaceText(">> Some text <<\n\n")
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
 
-    assert nwGUI.docEditor.replaceText(">Some text <<\n\n") is True
+    nwGUI.docEditor.replaceText(">Some text <<\n\n")
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
 
-    assert nwGUI.docEditor.replaceText(">Some text<\n\n") is True
+    nwGUI.docEditor.replaceText(">Some text<\n\n")
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
 
@@ -914,84 +899,84 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     # ===========
 
     # Comment
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "% Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 7
 
     # Toggle Comment w/Space
-    assert nwGUI.docEditor.replaceText("% Some text\n\n") is True
+    nwGUI.docEditor.replaceText("% Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Toggle Comment wo/Space
-    assert nwGUI.docEditor.replaceText("%Some text\n\n") is True
+    nwGUI.docEditor.replaceText("%Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 4
 
     # Header 1
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H1) is True
     assert nwGUI.docEditor.getText() == "# Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 7
 
     # Header 2
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H2) is True
     assert nwGUI.docEditor.getText() == "## Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Header 3
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H3) is True
     assert nwGUI.docEditor.getText() == "### Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 9
 
     # Header 4
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H4) is True
     assert nwGUI.docEditor.getText() == "#### Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 10
 
     # Novel Title
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TTL) is True
     assert nwGUI.docEditor.getText() == "#! Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Unnumbered Chapter
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_UNN) is True
     assert nwGUI.docEditor.getText() == "##! Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 9
 
     # Left Indent
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_L) is True
     assert nwGUI.docEditor.getText() == "> Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 7
 
     # Right Indent
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_R) is True
     assert nwGUI.docEditor.getText() == "Some text <\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Right/Left Indent
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_L) is True
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_R) is True
@@ -999,28 +984,28 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     assert nwGUI.docEditor.getCursorPosition() == 7
 
     # Left Align
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_L) is True
     assert nwGUI.docEditor.getText() == "Some text <<\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Right Align
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_R) is True
     assert nwGUI.docEditor.getText() == ">> Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Centre Align
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_C) is True
     assert nwGUI.docEditor.getText() == ">> Some text <<\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Left/Right Align (Overrides)
-    assert nwGUI.docEditor.replaceText("Some text\n\n") is True
+    nwGUI.docEditor.replaceText("Some text\n\n")
     nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_L) is True
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_R) is True
@@ -1031,7 +1016,7 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     # ============
 
     # Final Cursor Position Out of Range
-    assert nwGUI.docEditor.replaceText("#### Title\n\n") is True
+    nwGUI.docEditor.replaceText("#### Title\n\n")
     nwGUI.docEditor.setCursorPosition(3)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
@@ -1039,7 +1024,7 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
 
     # Third Line
     # This also needs to add a new block
-    assert nwGUI.docEditor.replaceText("#### Title\n\nThe Text\n\n") is True
+    nwGUI.docEditor.replaceText("#### Title\n\nThe Text\n\n")
     nwGUI.docEditor.setCursorLine(3)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "#### Title\n\n% The Text\n\n"
@@ -1057,13 +1042,13 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     # Create Scene
     theText = "### A Scene\n\n@char: Jane, John\n\n" + ipsumText[0] + "\n\n"
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Create Character
     theText = "### Jane Doe\n\n@tag: Jane\n\n" + ipsumText[1] + "\n\n"
     cHandle = SHARED.project.newFile("Jane Doe", C.hCharRoot)
     assert nwGUI.openDocument(cHandle) is True
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
     assert nwGUI.saveDocument() is True
     assert nwGUI.projView.projTree.revealNewTreeItem(cHandle)
     nwGUI.docEditor.updateTagHighLighting()
@@ -1145,7 +1130,7 @@ def testGuiEditor_WordCounters(qtbot, monkeypatch, nwGUI, projPath, ipsumText, m
 
     theText = "\n\n".join(ipsumText)
     cC, wC, pC = countWords(theText)
-    assert nwGUI.docEditor.replaceText(theText) is True
+    nwGUI.docEditor.replaceText(theText)
 
     # Check that a busy counter is blocked
     with monkeypatch.context() as mp:

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -44,7 +44,7 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     buildTestProject(nwGUI, projPath)
     assert nwGUI.openDocument(C.hSceneDoc)
 
-    nwGUI.docEditor.setText("### Lorem Ipsum\n\n%s" % ipsumText[0])
+    nwGUI.docEditor.setPlainText("### Lorem Ipsum\n\n%s" % ipsumText[0])
     assert nwGUI.saveDocument()
 
     # Check Defaults

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -194,8 +194,7 @@ def testGuiEditor_MetaData(qtbot, nwGUI, projPath, mockRnd):
     assert nwGUI.docEditor.isEmpty is False
 
     # Cursor Position
-    assert nwGUI.docEditor.setCursorPosition(None) is False
-    assert nwGUI.docEditor.setCursorPosition(10) is True
+    nwGUI.docEditor.setCursorPosition(10)
     assert nwGUI.docEditor.getCursorPosition() == 10
     assert SHARED.project.tree[C.hSceneDoc].cursorPos != 10
     nwGUI.docEditor.saveCursorPosition()
@@ -244,7 +243,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     theCursor.clearSelection()
 
     # Select Paragraph
-    assert nwGUI.docEditor.setCursorPosition(1000) is True
+    nwGUI.docEditor.setCursorPosition(1000)
     assert nwGUI.docEditor.getCursorPosition() == 1000
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_PARA) is True
     theCursor = nwGUI.docEditor.textCursor()
@@ -252,7 +251,7 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     # Cut Selected Text
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(1000) is True
+    nwGUI.docEditor.setCursorPosition(1000)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_PARA) is True
     assert nwGUI.docEditor.docAction(nwDocAction.CUT) is True
 
@@ -270,12 +269,12 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     # Copy Next Paragraph
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(1500) is True
+    nwGUI.docEditor.setCursorPosition(1500)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_PARA) is True
     assert nwGUI.docEditor.docAction(nwDocAction.COPY) is True
 
     # Paste at End
-    assert nwGUI.docEditor.setCursorPosition(theDoc.characterCount()) is True
+    nwGUI.docEditor.setCursorPosition(theDoc.characterCount())
     theCursor = nwGUI.docEditor.textCursor()
     theCursor.insertBlock()
     theCursor.insertBlock()
@@ -295,21 +294,21 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.docEditor.replaceText(theText) is True
 
     # Emphasis
-    assert nwGUI.docEditor.setCursorPosition(50) is True
+    nwGUI.docEditor.setCursorPosition(50)
     assert nwGUI.docEditor.docAction(nwDocAction.EMPH) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "_consectetur_")
     assert nwGUI.docEditor.docAction(nwDocAction.UNDO) is True
     assert nwGUI.docEditor.getText() == theText
 
     # Strong
-    assert nwGUI.docEditor.setCursorPosition(50) is True
+    nwGUI.docEditor.setCursorPosition(50)
     assert nwGUI.docEditor.docAction(nwDocAction.STRONG) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "**consectetur**")
     assert nwGUI.docEditor.docAction(nwDocAction.UNDO) is True
     assert nwGUI.docEditor.getText() == theText
 
     # Strikeout
-    assert nwGUI.docEditor.setCursorPosition(50) is True
+    nwGUI.docEditor.setCursorPosition(50)
     assert nwGUI.docEditor.docAction(nwDocAction.STRIKE) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "~~consectetur~~")
     assert nwGUI.docEditor.docAction(nwDocAction.UNDO) is True
@@ -328,14 +327,14 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.docEditor.replaceText(theText) is True
 
     # Add Single Quotes
-    assert nwGUI.docEditor.setCursorPosition(50) is True
+    nwGUI.docEditor.setCursorPosition(50)
     assert nwGUI.docEditor.docAction(nwDocAction.S_QUOTE) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "\u2018consectetur\u2019")
     assert nwGUI.docEditor.docAction(nwDocAction.UNDO) is True
     assert nwGUI.docEditor.getText() == theText
 
     # Add Double Quotes
-    assert nwGUI.docEditor.setCursorPosition(50) is True
+    nwGUI.docEditor.setCursorPosition(50)
     assert nwGUI.docEditor.docAction(nwDocAction.D_QUOTE) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "\u201cconsectetur\u201d")
     assert nwGUI.docEditor.docAction(nwDocAction.UNDO) is True
@@ -371,62 +370,62 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.docEditor.replaceText(theText) is True
 
     # Header 1
-    assert nwGUI.docEditor.setCursorPosition(0) is True
+    nwGUI.docEditor.setCursorPosition(0)
     assert nwGUI.docEditor.docAction(nwDocAction.BLOCK_H1) is True
     assert nwGUI.docEditor.getText() == "# Scene Title\n\nScene text.\n\n"
 
     # Header 2
-    assert nwGUI.docEditor.setCursorPosition(0) is True
+    nwGUI.docEditor.setCursorPosition(0)
     assert nwGUI.docEditor.docAction(nwDocAction.BLOCK_H2) is True
     assert nwGUI.docEditor.getText() == "## Scene Title\n\nScene text.\n\n"
 
     # Header 3
-    assert nwGUI.docEditor.setCursorPosition(0) is True
+    nwGUI.docEditor.setCursorPosition(0)
     assert nwGUI.docEditor.docAction(nwDocAction.BLOCK_H3) is True
     assert nwGUI.docEditor.getText() == "### Scene Title\n\nScene text.\n\n"
 
     # Header 4
-    assert nwGUI.docEditor.setCursorPosition(0) is True
+    nwGUI.docEditor.setCursorPosition(0)
     assert nwGUI.docEditor.docAction(nwDocAction.BLOCK_H4) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\nScene text.\n\n"
 
     # Comment
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\n% Scene text.\n\n"
 
     # Text
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\nScene text.\n\n"
 
     # Align Left
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.ALIGN_L) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\nScene text. <<\n\n"
 
     # Align Right
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.ALIGN_R) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\n>> Scene text.\n\n"
 
     # Align Centre
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.ALIGN_C) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\n>> Scene text. <<\n\n"
 
     # Indent Left
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.INDENT_L) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\n> Scene text.\n\n"
 
     # Indent Right
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.INDENT_R) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\n> Scene text. <\n\n"
 
     # Text (Reset)
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.docAction(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "#### Scene Title\n\nScene text.\n\n"
 
@@ -466,28 +465,28 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
 
     # No Document Handle
     nwGUI.docEditor._docHandle = None
-    assert nwGUI.docEditor.setCursorPosition(24) is True
+    nwGUI.docEditor.setCursorPosition(24)
     assert nwGUI.docEditor.insertText("Stuff") is False
     nwGUI.docEditor._docHandle = C.hSceneDoc
 
     # Insert String
-    assert nwGUI.docEditor.setCursorPosition(24) is True
+    nwGUI.docEditor.setCursorPosition(24)
     assert nwGUI.docEditor.insertText(", ipsumer,") is True
     assert nwGUI.docEditor.getText() == theText[:24] + ", ipsumer," + theText[24:]
 
     # Single Quotes
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(41) is True
+    nwGUI.docEditor.setCursorPosition(41)
     assert nwGUI.docEditor.insertText(nwDocInsert.QUOTE_LS) is True
-    assert nwGUI.docEditor.setCursorPosition(53) is True
+    nwGUI.docEditor.setCursorPosition(53)
     assert nwGUI.docEditor.insertText(nwDocInsert.QUOTE_RS) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "\u2018consectetur\u2019")
 
     # Double Quotes
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(41) is True
+    nwGUI.docEditor.setCursorPosition(41)
     assert nwGUI.docEditor.insertText(nwDocInsert.QUOTE_LD) is True
-    assert nwGUI.docEditor.setCursorPosition(53) is True
+    nwGUI.docEditor.setCursorPosition(53)
     assert nwGUI.docEditor.insertText(nwDocInsert.QUOTE_RD) is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "\u201cconsectetur\u201d")
 
@@ -519,7 +518,7 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
         assert nwGUI.docEditor.insertKeyWord(nwKeyWords.POV_KEY) is False
 
     # Insert In-Block
-    assert nwGUI.docEditor.setCursorPosition(20) is True
+    nwGUI.docEditor.setCursorPosition(20)
     assert nwGUI.docEditor.insertKeyWord(nwKeyWords.CHAR_KEY) is True
     assert nwGUI.docEditor.insertText("John")
     assert nwGUI.docEditor.getText() == theText.replace(
@@ -546,7 +545,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # No Selection
     theText = "### A Scene\n\n%s" % ipsumText[0]
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
 
     theCursor = nwGUI.docEditor.textCursor()
     assert nwGUI.docEditor._clearSurrounding(theCursor, 1) is False
@@ -554,7 +553,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # Clear Characters, 1 Layer
     repText = theText.replace("consectetur", "=consectetur=")
     assert nwGUI.docEditor.replaceText(repText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
 
     theCursor = nwGUI.docEditor.textCursor()
     theCursor.select(QTextCursor.WordUnderCursor)
@@ -564,7 +563,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # Clear Characters, 2 Layers
     repText = theText.replace("consectetur", "==consectetur==")
     assert nwGUI.docEditor.replaceText(repText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
 
     theCursor = nwGUI.docEditor.textCursor()
     theCursor.select(QTextCursor.WordUnderCursor)
@@ -576,7 +575,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2])
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
 
     # No Selection
     with monkeypatch.context() as mp:
@@ -585,13 +584,13 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Wrap Equal
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._wrapSelection("=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "=consectetur=")
 
     # Wrap Unequal
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._wrapSelection("=", "*") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "=consectetur*")
 
@@ -613,7 +612,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2])
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
 
     # No Selection
     with monkeypatch.context() as mp:
@@ -622,7 +621,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Wrap Single Equal
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(1, "=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "=consectetur=")
 
@@ -641,20 +640,20 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Wrap Double Equal
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "==consectetur==")
 
     # Toggle Double Equal
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
     assert nwGUI.docEditor.getText() == theText
 
     # Toggle Triple+Double Equal
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(3, "=") is True
     assert nwGUI.docEditor._toggleFormat(2, "=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "=consectetur=")
@@ -662,7 +661,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # Toggle Unequal
     repText = theText.replace("consectetur", "=consectetur==")
     assert nwGUI.docEditor.replaceText(repText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._toggleFormat(1, "=") is True
     assert nwGUI.docEditor.getText() == theText.replace("consectetur", "consectetur=")
     assert nwGUI.docEditor._toggleFormat(1, "=") is True
@@ -674,14 +673,14 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # No Selection
     theText = "### A Scene\n\n%s" % ipsumText[0].replace("consectetur", "=consectetur=")
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor._replaceQuotes("=", "<", ">") is False
 
     # First Paragraph Selected
     # This should not replace anything in second paragraph
     theText = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2]).replace("ipsum", "=ipsum=")
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_PARA)
     assert nwGUI.docEditor._replaceQuotes("=", "<", ">") is True
 
@@ -693,7 +692,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # Edge of Document
     theText = ipsumText[0].replace("Lorem", "=Lorem=")
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     assert nwGUI.docEditor.docAction(nwDocAction.SEL_ALL)
     assert nwGUI.docEditor._replaceQuotes("=", "<", ">") is True
     assert nwGUI.docEditor.getText() == theText.replace("=Lorem=", "<Lorem>")
@@ -707,7 +706,7 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # Remove All
     theText = "### A Scene\n\n%s\n\n%s" % (parOne, parTwo)
     assert nwGUI.docEditor.replaceText(theText) is True
-    assert nwGUI.docEditor.setCursorPosition(45) is True
+    nwGUI.docEditor.setCursorPosition(45)
     nwGUI.docEditor._removeInParLineBreaks()
     assert nwGUI.docEditor.getText() == "### A Scene\n\n%s\n" % "\n\n".join(ipsumText[0:2])
 
@@ -753,21 +752,21 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     assert nwGUI.docEditor.replaceText(theText) is True
 
     # Invalid Block
-    assert nwGUI.docEditor.setCursorPosition(0) is True
+    nwGUI.docEditor.setCursorPosition(0)
     with monkeypatch.context() as mp:
         mp.setattr(QTextBlock, "isValid", lambda *a, **k: False)
         assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is False
 
     # Keyword
     assert nwGUI.docEditor.replaceText("@pov: Jane\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is False
     assert nwGUI.docEditor.getText() == "@pov: Jane\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Unsupported Format
     assert nwGUI.docEditor.replaceText("% Comment\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.NO_ACTION) is False
 
     # Block Stripping : Left Side
@@ -775,91 +774,91 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
 
     # Strip Comment w/Space
     assert nwGUI.docEditor.replaceText("% Comment\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Comment\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Comment wo/Space
     assert nwGUI.docEditor.replaceText("%Comment\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Comment\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 4
 
     # Strip Header 1
     assert nwGUI.docEditor.replaceText("# Title\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Header 2
     assert nwGUI.docEditor.replaceText("## Title\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 2
 
     # Strip Header 3
     assert nwGUI.docEditor.replaceText("### Title\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 1
 
     # Strip Header 4
     assert nwGUI.docEditor.replaceText("#### Title\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 0
 
     # Strip Novel Title
     assert nwGUI.docEditor.replaceText("#! Title\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 2
 
     # Strip Unnumbered CHapter
     assert nwGUI.docEditor.replaceText("##! Title\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 1
 
     # Strip Text
     assert nwGUI.docEditor.replaceText("Generic text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Generic text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Left Angle Brackets : Double w/Space
     assert nwGUI.docEditor.replaceText(">> Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 2
 
     # Strip Left Angle Brackets : Single w/Space
     assert nwGUI.docEditor.replaceText("> Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Left Angle Brackets : Double wo/Space
     assert nwGUI.docEditor.replaceText(">>Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Strip Left Angle Brackets : Single wo/Space
     assert nwGUI.docEditor.replaceText(">Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 4
@@ -869,28 +868,28 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
 
     # Strip Right Angle Brackets : Double w/Space
     assert nwGUI.docEditor.replaceText("Some text <<\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Right Angle Brackets : Single w/Space
     assert nwGUI.docEditor.replaceText("Some text <\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Right Angle Brackets : Double wo/Space
     assert nwGUI.docEditor.replaceText("Some text<<\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Strip Right Angle Brackets : Single wo/Space
     assert nwGUI.docEditor.replaceText("Some text<\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
@@ -915,84 +914,84 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
 
     # Comment
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "% Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 7
 
     # Toggle Comment w/Space
     assert nwGUI.docEditor.replaceText("% Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 3
 
     # Toggle Comment wo/Space
     assert nwGUI.docEditor.replaceText("%Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_COM) is True
     assert nwGUI.docEditor.getText() == "Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 4
 
     # Header 1
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H1) is True
     assert nwGUI.docEditor.getText() == "# Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 7
 
     # Header 2
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H2) is True
     assert nwGUI.docEditor.getText() == "## Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Header 3
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H3) is True
     assert nwGUI.docEditor.getText() == "### Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 9
 
     # Header 4
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_H4) is True
     assert nwGUI.docEditor.getText() == "#### Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 10
 
     # Novel Title
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TTL) is True
     assert nwGUI.docEditor.getText() == "#! Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Unnumbered Chapter
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_UNN) is True
     assert nwGUI.docEditor.getText() == "##! Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 9
 
     # Left Indent
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_L) is True
     assert nwGUI.docEditor.getText() == "> Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 7
 
     # Right Indent
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_R) is True
     assert nwGUI.docEditor.getText() == "Some text <\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Right/Left Indent
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_L) is True
     assert nwGUI.docEditor._formatBlock(nwDocAction.INDENT_R) is True
     assert nwGUI.docEditor.getText() == "> Some text <\n\n"
@@ -1000,28 +999,28 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
 
     # Left Align
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_L) is True
     assert nwGUI.docEditor.getText() == "Some text <<\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
 
     # Right Align
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_R) is True
     assert nwGUI.docEditor.getText() == ">> Some text\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Centre Align
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_C) is True
     assert nwGUI.docEditor.getText() == ">> Some text <<\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 8
 
     # Left/Right Align (Overrides)
     assert nwGUI.docEditor.replaceText("Some text\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(5) is True
+    nwGUI.docEditor.setCursorPosition(5)
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_L) is True
     assert nwGUI.docEditor._formatBlock(nwDocAction.ALIGN_R) is True
     assert nwGUI.docEditor.getText() == ">> Some text\n\n"
@@ -1032,7 +1031,7 @@ def testGuiEditor_BlockFormatting(qtbot, monkeypatch, nwGUI, projPath, ipsumText
 
     # Final Cursor Position Out of Range
     assert nwGUI.docEditor.replaceText("#### Title\n\n") is True
-    assert nwGUI.docEditor.setCursorPosition(3) is True
+    nwGUI.docEditor.setCursorPosition(3)
     assert nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT) is True
     assert nwGUI.docEditor.getText() == "Title\n\n"
     assert nwGUI.docEditor.getCursorPosition() == 5
@@ -1081,21 +1080,21 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.docEditor._followTag() is False
 
     # On Tag Keyword
-    assert nwGUI.docEditor.setCursorPosition(15) is True
+    nwGUI.docEditor.setCursorPosition(15)
     assert nwGUI.docEditor._followTag() is False
 
     # On Unknown Tag
-    assert nwGUI.docEditor.setCursorPosition(28) is True
+    nwGUI.docEditor.setCursorPosition(28)
     assert nwGUI.docEditor._followTag() is True
     assert nwGUI.docViewer._docHandle is None
 
     # On Known Tag, No Follow
-    assert nwGUI.docEditor.setCursorPosition(22) is True
+    nwGUI.docEditor.setCursorPosition(22)
     assert nwGUI.docEditor._followTag(loadTag=False) is True
     assert nwGUI.docViewer._docHandle is None
 
     # On Known Tag, Follow
-    assert nwGUI.docEditor.setCursorPosition(22) is True
+    nwGUI.docEditor.setCursorPosition(22)
     assert nwGUI.docViewer._docHandle is None
     assert nwGUI.docEditor._followTag(loadTag=True) is True
     assert nwGUI.docViewer._docHandle == cHandle
@@ -1228,7 +1227,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Close search
     nwGUI.docEditor.docSearch.cancelSearch.activate(QAction.Trigger)
     assert nwGUI.docEditor.docSearch.isVisible() is False
-    assert nwGUI.docEditor.setCursorPosition(15)
+    nwGUI.docEditor.setCursorPosition(15)
 
     # Toggle search again with header button
     qtbot.mouseClick(nwGUI.docEditor.docHeader.searchButton, Qt.LeftButton, delay=KEY_DELAY)
@@ -1298,7 +1297,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert nwGUI.docEditor.docSearch.doMatchCap is True
 
     # Replace "Sus" with "Foo" via menu
-    assert nwGUI.docEditor.setCursorPosition(590)
+    nwGUI.docEditor.setCursorPosition(590)
     nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
     nwGUI.mainMenu.aReplaceNext.activate(QAction.Trigger)
     assert nwGUI.docEditor.getText()[608:619] == "Foopendisse"
@@ -1327,7 +1326,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     # Close search and select "est" again
     nwGUI.docEditor.docSearch.cancelSearch.activate(QAction.Trigger)
-    assert nwGUI.docEditor.setCursorPosition(630)
+    nwGUI.docEditor.setCursorPosition(630)
     nwGUI.docEditor._makeSelection(QTextCursor.WordUnderCursor)
     theCursor = nwGUI.docEditor.textCursor()
     assert theCursor.selectedText() == "est"

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -46,8 +46,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     # Split By Chapter
     assert nwGUI.openDocument("4c4f28287af27") is True
-    assert nwGUI.docEditor.setCursorPosition(42) is True
-
+    nwGUI.docEditor.setCursorPosition(42)
     cleanText = nwGUI.docEditor.getText()[39:86]
 
     # Bold
@@ -95,7 +94,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Block Formats
     # =============
     # cSpell:ignore Pellentesque erat nulla posuere commodo
-    assert nwGUI.docEditor.setCursorPosition(42)
+    nwGUI.docEditor.setCursorPosition(42)
 
     # Header 1
     nwGUI.mainMenu.aFmtHead1.activate(QAction.Trigger)
@@ -141,7 +140,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert nwGUI.docEditor.getText()[39:86] == cleanText
 
     # Check comment with no space before text
-    assert nwGUI.docEditor.setCursorPosition(39)
+    nwGUI.docEditor.setCursorPosition(39)
     assert nwGUI.docEditor.insertText("%")
     fmtStr = "%Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[39:87] == fmtStr
@@ -157,7 +156,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert nwGUI.docEditor.getText()[39:86] == cleanText
 
     # Cut, Copy and Paste
-    assert nwGUI.docEditor.setCursorPosition(39)
+    nwGUI.docEditor.setCursorPosition(39)
     nwGUI.docEditor._makeSelection(QTextCursor.WordUnderCursor)
 
     nwGUI.mainMenu.aEditCut.activate(QAction.Trigger)
@@ -170,7 +169,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
         "Pellentesque nec erat ut nulla posuere commodo. Cu"
     )
 
-    assert nwGUI.docEditor.setCursorPosition(39)
+    nwGUI.docEditor.setCursorPosition(39)
     nwGUI.docEditor._makeSelection(QTextCursor.WordUnderCursor)
 
     nwGUI.mainMenu.aEditCopy.activate(QAction.Trigger)
@@ -178,7 +177,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
         "Pellentesque nec erat ut nulla posuere commodo. Cu"
     )
 
-    assert nwGUI.docEditor.setCursorPosition(39)
+    nwGUI.docEditor.setCursorPosition(39)
     nwGUI.mainMenu.aEditPaste.activate(QAction.Trigger)
     assert nwGUI.docEditor.getText()[39:89] == (
         "PellentesquePellentesque nec erat ut nulla posuere"
@@ -186,7 +185,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwGUI.mainMenu.aEditUndo.activate(QAction.Trigger)
 
     # Select Paragraph/All
-    assert nwGUI.docEditor.setCursorPosition(42)
+    nwGUI.docEditor.setCursorPosition(42)
     nwGUI.mainMenu.aSelectPar.activate(QAction.Trigger)
     theCursor = nwGUI.docEditor.textCursor()
     assert theCursor.selectedText() == (
@@ -199,7 +198,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
         "nunc lacus, imperdiet nec posuere ac, interdum non lectus."
     )
 
-    assert nwGUI.docEditor.setCursorPosition(42)
+    nwGUI.docEditor.setCursorPosition(42)
     nwGUI.mainMenu.aSelectAll.activate(QAction.Trigger)
     theCursor = nwGUI.docEditor.textCursor()
     assert len(theCursor.selectedText()) == 1895
@@ -213,7 +212,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     cleanText = "A single, short paragraph.\n\n"
     nwGUI.docEditor.setPlainText(cleanText)
-    assert nwGUI.docEditor.setCursorPosition(0)
+    nwGUI.docEditor.setCursorPosition(0)
 
     # Left Align
     nwGUI.mainMenu.aFmtAlignLeft.activate(QAction.Trigger)
@@ -322,11 +321,11 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     ))
 
     # Cannot Format Tag
-    assert nwGUI.docEditor.setCursorPosition(17)
+    nwGUI.docEditor.setCursorPosition(17)
     assert not nwGUI.docEditor._formatBlock(nwDocAction.BLOCK_TXT)
 
     # Invalid Action
-    assert nwGUI.docEditor.setCursorPosition(30)
+    nwGUI.docEditor.setCursorPosition(30)
     assert not nwGUI.docEditor._formatBlock(nwDocAction.NO_ACTION)
 
     # Ensure No Changes

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -212,7 +212,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     # ==================
 
     cleanText = "A single, short paragraph.\n\n"
-    nwGUI.docEditor.setText(cleanText)
+    nwGUI.docEditor.setPlainText(cleanText)
     assert nwGUI.docEditor.setCursorPosition(0)
 
     # Left Align
@@ -247,7 +247,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Other Checks
 
     # Replace Quotes
-    nwGUI.docEditor.setText((
+    nwGUI.docEditor.setPlainText((
         "### New Text\n\n"
         "Text with 'single' quotes and 'tricky stuff's'.\n\n"
         "Also text with \"double\" quotes which are \"less tricky\".\n\n"
@@ -270,7 +270,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     )
 
     # Remove in-paragraph line breaks
-    nwGUI.docEditor.setText((
+    nwGUI.docEditor.setPlainText((
         "### New Text\n\n"
         "@char: Someone\n"
         "@location: Somewhere\n\n"
@@ -288,7 +288,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
         "With another paragraph here.\n"
     )
 
-    nwGUI.docEditor.setText((
+    nwGUI.docEditor.setPlainText((
         "### New Text\n\n"
         "@char: Someone\n"
         "@location: Somewhere\n\n"
@@ -314,7 +314,7 @@ def testGuiMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert not nwGUI.docEditor.docAction(nwDocAction.NO_ACTION)
 
     # Test Invalid Formats
-    nwGUI.docEditor.setText((
+    nwGUI.docEditor.setPlainText((
         "### New Text\n\n"
         "@tag: Bod\n\n"
         "Text with 'single' quotes and 'tricky stuff's'.\n\n"
@@ -541,43 +541,43 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
     # Insert Keywords
     # ===============
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.TAG_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.TAG_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.POV_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.POV_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.FOCUS_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.FOCUS_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.CHAR_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.CHAR_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.PLOT_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.PLOT_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.TIME_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.TIME_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.WORLD_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.WORLD_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.OBJECT_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.OBJECT_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.ENTITY_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.ENTITY_KEY
 
-    nwGUI.docEditor.setText("Stuff")
+    nwGUI.docEditor.setPlainText("Stuff")
     nwGUI.mainMenu.mInsKWItems[nwKeyWords.CUSTOM_KEY][0].activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.CUSTOM_KEY
 
@@ -592,22 +592,22 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
     # Insert Special Comments
     # =======================
 
-    nwGUI.docEditor.setText("Stuff\n")
+    nwGUI.docEditor.setPlainText("Stuff\n")
     nwGUI.mainMenu.aInsSynopsis.activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n% Synopsis: \n"
 
     # Insert Break or Space
     # =====================
 
-    nwGUI.docEditor.setText("### Stuff\n")
+    nwGUI.docEditor.setPlainText("### Stuff\n")
     nwGUI.mainMenu.aInsNewPage.activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "[NEW PAGE]\n### Stuff\n"
 
-    nwGUI.docEditor.setText("### Stuff\n")
+    nwGUI.docEditor.setPlainText("### Stuff\n")
     nwGUI.mainMenu.aInsVSpaceS.activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "[VSPACE]\n### Stuff\n"
 
-    nwGUI.docEditor.setText("### Stuff\n")
+    nwGUI.docEditor.setPlainText("### Stuff\n")
     nwGUI.mainMenu.aInsVSpaceM.activate(QAction.Trigger)
     assert nwGUI.docEditor.getText() == "[VSPACE:2]\n### Stuff\n"
 
@@ -637,7 +637,7 @@ def testGuiMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
 
     # Open the document from before, and add some text to it
     nwGUI.openDocument(C.hSceneDoc)
-    nwGUI.docEditor.setText("Bar")
+    nwGUI.docEditor.setPlainText("Bar")
     assert nwGUI.docEditor.getText() == "Bar"
 
     # The document isn't empty, so the message box should pop


### PR DESCRIPTION
**Summary:**

This PR makes the text editor in novelWriter actually plain text. So far, it's been a rich text editor with rich text editing disabled. At some point, there was a reason for this. There are still some drawbacks, but the benefits outweigh them.

**Pros**

* It loads a lot faster since it doesn't have to take into account special text content like lists, images and tables. Which we don't support anyway.
* The syntax highlighter works a lot more smoothly since it is designed and optimised for the plain text view.
* Re-running the highlighter is no longer a performance bottleneck, so we can now rerun it for spell checking purposes even for large documents.
* Scrolling past the end of the document is supported out of the box.
* Centring the cursor when skipping to a specific line is natively supported.
* There is no longer a need for the big doc limit setting, and no need to cap the max size of a text document. Performance when loading will suffer when a document reaches the 10MB range, but the editor still works, and works smoothly once the document is loaded.

**Cons**

* The document now scrolls a single line at a time, so there is no smooth scrolling anymore.
* The feature to keep the current line fixed is not as smooth anymore due to the above reason, but it does still work.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
