### PR TITLE
Fix Build Settings icon column size issue

### DIFF
--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -332,14 +332,16 @@ class _FilterTab(QWidget):
 
         treeHeader = self.optTree.header()
         treeHeader.setStretchLastSection(False)
+        treeHeader.setMinimumSectionSize(iPx + cMg)  # See Issue #1551
         treeHeader.setSectionResizeMode(self.C_NAME, QHeaderView.Stretch)
         treeHeader.setSectionResizeMode(self.C_ACTIVE, QHeaderView.Fixed)
         treeHeader.setSectionResizeMode(self.C_STATUS, QHeaderView.Fixed)
         treeHeader.resizeSection(self.C_ACTIVE, iPx + cMg)
         treeHeader.resizeSection(self.C_STATUS, iPx + cMg)
 
-        self.optTree.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.optTree.setDragDropMode(QAbstractItemView.NoDragDrop)
+        self.optTree.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.optTree.setSelectionBehavior(QAbstractItemView.SelectRows)
 
         # Filters
         # =======
@@ -390,11 +392,11 @@ class _FilterTab(QWidget):
         self.mainSplit.addWidget(self.filterOpt)
         self.mainSplit.setCollapsible(0, False)
         self.mainSplit.setCollapsible(1, False)
-        self.mainSplit.setStretchFactor(0, 0)
-        self.mainSplit.setStretchFactor(1, 1)
+        self.mainSplit.setStretchFactor(0, 1)
+        self.mainSplit.setStretchFactor(1, 0)
         self.mainSplit.setSizes([
-            CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "treeWidth", 1)),
-            CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "filterWidth", 1))
+            CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "treeWidth", 300)),
+            CONFIG.pxInt(pOptions.getInt("GuiBuildSettings", "filterWidth", 300))
         ])
 
         self.outerBox = QHBoxLayout()


### PR DESCRIPTION
**Summary:**

This PR:
* Sets the minimum column width for the icon columns on the Build Settings tool. On Windows, the default value is far too wide.
* Assigns the additional space when the Build Settings dialog is resized to the middle section on the Selection page.
* Set the initial splitter widths on the Selection page to 300/300.

**Related Issue(s):**

Closes #1551

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
