### PR TITLE
Fix i18n issues

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -81,10 +81,12 @@ class Config:
 
         # Localisation
         # Note that these paths must be strings
-        self._qLocale    = QLocale.system()
-        self._qtTrans    = {}
+        self._nwLangPath = self._appPath / "assets" / "i18n"
         self._qtLangPath = QLibraryInfo.location(QLibraryInfo.TranslationsPath)
-        self._nwLangPath = str(self._appPath / "assets" / "i18n")
+
+        wantedLocale = self._nwLangPath / f"nw_{QLocale.system().name()}.qm"
+        self._qLocale = QLocale.system() if wantedLocale.exists() else QLocale("en_GB")
+        self._qtTrans = {}
 
         # PDF Manual
         pdfDocs = self._appPath / "assets" / "manual.pdf"
@@ -427,7 +429,7 @@ class Config:
         else:
             return []
 
-        for qmFile in Path(self._nwLangPath).iterdir():
+        for qmFile in self._nwLangPath.iterdir():
             qmName = qmFile.name
             if not (qmFile.is_file() and qmName.startswith(fPre) and qmName.endswith(fExt)):
                 continue
@@ -495,8 +497,8 @@ class Config:
         self._qtTrans = {}
 
         langList = [
-            (self._qtLangPath, "qtbase"),  # Qt 5.x
-            (self._nwLangPath, "nw"),      # novelWriter
+            (self._qtLangPath, "qtbase"),   # Qt 5.x
+            (str(self._nwLangPath), "nw"),  # novelWriter
         ]
         for lngPath, lngBase in langList:
             for lngCode in self._qLocale.uiLanguages():

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -32,7 +32,7 @@ from enum import Enum
 from typing import Iterable
 from pathlib import Path
 
-from PyQt5.QtCore import QT_TRANSLATE_NOOP
+from PyQt5.QtCore import QT_TRANSLATE_NOOP, QCoreApplication
 
 from novelwriter import CONFIG
 from novelwriter.enum import nwBuildFmt
@@ -209,7 +209,7 @@ class BuildSettings:
     @staticmethod
     def getLabel(key: str) -> str:
         """Extract the GUI label for a specific setting."""
-        return SETTINGS_LABELS.get(key, "ERROR")
+        return QCoreApplication.translate("Builds", SETTINGS_LABELS.get(key, "ERROR"))
 
     def getStr(self, key: str) -> str:
         """Type safe value access for strings."""

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -176,6 +176,8 @@ class GuiPreferencesGeneral(QWidget):
         for lang, langName in theLangs:
             self.guiLocale.addItem(langName, lang)
         langIdx = self.guiLocale.findData(CONFIG.guiLocale)
+        if langIdx < 0:
+            langIdx = self.guiLocale.findData("en_GB")
         if langIdx != -1:
             self.guiLocale.setCurrentIndex(langIdx)
 

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -166,21 +166,21 @@ def testBaseConfig_Localisation(fncPath, tstPaths):
 
     i18nDir = fncPath / "i18n"
     i18nDir.mkdir()
-    tstConf._nwLangPath = str(i18nDir)
+    tstConf._nwLangPath = i18nDir
 
     copyfile(tstPaths.filesDir / "nw_en_GB.qm", i18nDir / "nw_en_GB.qm")
     writeFile(i18nDir / "nw_en_GB.ts", "")
     writeFile(i18nDir / "nw_abcd.qm", "")
 
     tstApp = MockApp()
-    tstConf.initLocalisation(tstApp)
+    tstConf.initLocalisation(tstApp)  # type: ignore
 
     # Check Lists
     theList = tstConf.listLanguages(tstConf.LANG_NW)
     assert theList == [("en_GB", "British English")]
     theList = tstConf.listLanguages(tstConf.LANG_PROJ)
     assert theList == [("en_GB", "British English")]
-    theList = tstConf.listLanguages(None)
+    theList = tstConf.listLanguages(None)  # type: ignore
     assert theList == []
 
     # Add Language


### PR DESCRIPTION
**Summary:**

This PR solves two issues:
* All strings defined in the build settings core class were sent to the GUI untranslated even when translations exist.
* When no GUI language is set, novelWriter defaults to the system locale. However, if that is not available in novelWriter, the Preferences dialog would just leave the dropbox on the first option, which is currently "Deutch". The config class now only defaults to system locale if there is a translation file for it available. Otherwise it defaults to "British English". The Preferences will also default to "British English" if the language setting in config is invalid or has become unavailable.

**Related Issue(s):**

Closes #1563
Closes #1564

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
