### PR TITLE
Fix viewer navigation

### DIFF
--- a/novelwriter/core/tohtml.py
+++ b/novelwriter/core/tohtml.py
@@ -164,7 +164,7 @@ class ToHtml(Tokenizer):
         parStyle = None
         tmpResult = []
 
-        for tType, tLine, tText, tFormat, tStyle in self._tokens:
+        for tType, nHead, tText, tFormat, tStyle in self._tokens:
 
             # Replace < and > with HTML entities
             if tFormat:
@@ -225,7 +225,7 @@ class ToHtml(Tokenizer):
                 hStyle = ""
 
             if self._linkHeaders:
-                aNm = f"<a name='T{tLine:06d}'></a>"
+                aNm = f"<a name='T{nHead:04d}'></a>"
             else:
                 aNm = ""
 

--- a/tests/test_core/test_core_tohtml.py
+++ b/tests/test_core/test_core_tohtml.py
@@ -29,177 +29,176 @@ from novelwriter.core.project import NWProject
 
 @pytest.mark.core
 def testCoreToHtml_ConvertFormat(mockGUI):
-    """Test the tokenizer and converter chain using the ToHtml class.
-    """
-    theProject = NWProject()
-    theHtml = ToHtml(theProject)
+    """Test the tokenizer and converter chain using the ToHtml class."""
+    project = NWProject()
+    html = ToHtml(project)
 
     # Novel Files Headers
     # ===================
 
-    theHtml._isNovel = True
-    theHtml._isNote = False
-    theHtml._isFirst = True
+    html._isNovel = True
+    html._isNote = False
+    html._isFirst = True
 
     # Header 1
-    theHtml._text = "# Partition\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "# Partition\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' style='text-align: center;'>Partition</h1>\n"
     )
 
     # Header 2
-    theHtml._text = "## Chapter Title\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "## Chapter Title\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<h1 style='page-break-before: always;'>Chapter Title</h1>\n"
     )
 
     # Header 3
-    theHtml._text = "### Scene Title\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h2>Scene Title</h2>\n"
+    html._text = "### Scene Title\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h2>Scene Title</h2>\n"
 
     # Header 4
-    theHtml._text = "#### Section Title\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h3>Section Title</h3>\n"
+    html._text = "#### Section Title\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h3>Section Title</h3>\n"
 
     # Title
-    theHtml._text = "#! Title\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "#! Title\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' style='text-align: center;'>Title</h1>\n"
     )
 
     # Unnumbered
-    theHtml._text = "##! Prologue\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h1 style='page-break-before: always;'>Prologue</h1>\n"
+    html._text = "##! Prologue\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h1 style='page-break-before: always;'>Prologue</h1>\n"
 
     # Note Files Headers
     # ==================
 
-    theHtml._isNovel = False
-    theHtml._isNote = True
-    theHtml._isFirst = True
-    theHtml.setLinkHeaders(True)
+    html._isNovel = False
+    html._isNote = True
+    html._isFirst = True
+    html.setLinkHeaders(True)
 
     # Header 1
-    theHtml._text = "# Heading One\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h1><a name='T000001'></a>Heading One</h1>\n"
+    html._text = "# Heading One\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h1><a name='T0001'></a>Heading One</h1>\n"
 
     # Header 2
-    theHtml._text = "## Heading Two\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h2><a name='T000001'></a>Heading Two</h2>\n"
+    html._text = "## Heading Two\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h2><a name='T0001'></a>Heading Two</h2>\n"
 
     # Header 3
-    theHtml._text = "### Heading Three\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h3><a name='T000001'></a>Heading Three</h3>\n"
+    html._text = "### Heading Three\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h3><a name='T0001'></a>Heading Three</h3>\n"
 
     # Header 4
-    theHtml._text = "#### Heading Four\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h4><a name='T000001'></a>Heading Four</h4>\n"
+    html._text = "#### Heading Four\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h4><a name='T0001'></a>Heading Four</h4>\n"
 
     # Title
-    theHtml._text = "#! Heading One\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
-        "<h1 style='text-align: center;'><a name='T000001'></a>Heading One</h1>\n"
+    html._text = "#! Heading One\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
+        "<h1 style='text-align: center;'><a name='T0001'></a>Heading One</h1>\n"
     )
 
     # Unnumbered
-    theHtml._text = "##! Heading Two\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == "<h2><a name='T000001'></a>Heading Two</h2>\n"
+    html._text = "##! Heading Two\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == "<h2><a name='T0001'></a>Heading Two</h2>\n"
 
     # Paragraphs
     # ==========
 
     # Text
-    theHtml._text = "Some **nested bold and _italic_ and ~~strikethrough~~ text** here\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Some **nested bold and _italic_ and ~~strikethrough~~ text** here\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Some <strong>nested bold and <em>italic</em> and "
         "<del>strikethrough</del> text</strong> here</p>\n"
     )
 
     # Text w/Hard Break
-    theHtml._text = "Line one  \nLine two  \nLine three\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Line one  \nLine two  \nLine three\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p class='break'>Line one<br/>Line two<br/>Line three</p>\n"
     )
 
     # Synopsis
-    theHtml._text = "%synopsis: The synopsis ...\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == ""
+    html._text = "%synopsis: The synopsis ...\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == ""
 
-    theHtml.setSynopsis(True)
-    theHtml._text = "%synopsis: The synopsis ...\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.setSynopsis(True)
+    html._text = "%synopsis: The synopsis ...\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p class='synopsis'><strong>Synopsis:</strong> The synopsis ...</p>\n"
     )
 
     # Comment
-    theHtml._text = "% A comment ...\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == ""
+    html._text = "% A comment ...\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == ""
 
-    theHtml.setComments(True)
-    theHtml._text = "% A comment ...\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.setComments(True)
+    html._text = "% A comment ...\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p class='comment'><strong>Comment:</strong> A comment ...</p>\n"
     )
 
     # Keywords
-    theHtml._text = "@char: Bod, Jane\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == ""
+    html._text = "@char: Bod, Jane\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == ""
 
-    theHtml.setKeywords(True)
-    theHtml._text = "@char: Bod, Jane\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.setKeywords(True)
+    html._text = "@char: Bod, Jane\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p><span class='tags'>Characters:</span> "
         "<a href='#tag_Bod'>Bod</a>, <a href='#tag_Jane'>Jane</a></p>\n"
     )
 
     # Multiple Keywords
-    theHtml.setKeywords(True)
-    theHtml._text = "## Chapter\n\n@pov: Bod\n@plot: Main\n@location: Europe\n\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.setKeywords(True)
+    html._text = "## Chapter\n\n@pov: Bod\n@plot: Main\n@location: Europe\n\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<h2>"
-        "<a name='T000001'></a>Chapter</h2>\n"
+        "<a name='T0001'></a>Chapter</h2>\n"
         "<p style='margin-bottom: 0;'>"
         "<span class='tags'>Point of View:</span> <a href='#tag_Bod'>Bod</a>"
         "</p>\n"
@@ -214,13 +213,13 @@ def testCoreToHtml_ConvertFormat(mockGUI):
     # Preview Mode
     # ============
 
-    theHtml.setPreview(True, True)
+    html.setPreview(True, True)
 
     # Text (HTML4)
-    theHtml._text = "Some **nested bold and _italic_ and ~~strikethrough~~ text** here\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Some **nested bold and _italic_ and ~~strikethrough~~ text** here\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Some <b>nested bold and <i>italic</i> and "
         "<span style='text-decoration: line-through;'>strikethrough</span> "
         "text</b> here</p>\n"
@@ -231,109 +230,108 @@ def testCoreToHtml_ConvertFormat(mockGUI):
 
 @pytest.mark.core
 def testCoreToHtml_ConvertDirect(mockGUI):
-    """Test the converter directly using the ToHtml class.
-    """
-    theProject = NWProject()
-    theHtml = ToHtml(theProject)
+    """Test the converter directly using the ToHtml class."""
+    project = NWProject()
+    html = ToHtml(project)
 
-    theHtml._isNovel = True
-    theHtml._isNote = False
-    theHtml.setLinkHeaders(True)
+    html._isNovel = True
+    html._isNote = False
+    html.setLinkHeaders(True)
 
     # Special Titles
     # ==============
 
     # Title
-    theHtml._tokens = [
-        (theHtml.T_TITLE, 1, "A Title", None, theHtml.A_PBB | theHtml.A_CENTRE),
-        (theHtml.T_EMPTY, 1, "", None, theHtml.A_NONE),
+    html._tokens = [
+        (html.T_TITLE, 1, "A Title", None, html.A_PBB | html.A_CENTRE),
+        (html.T_EMPTY, 1, "", None, html.A_NONE),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' style='text-align: center; page-break-before: always;'>"
-        "<a name='T000001'></a>A Title</h1>\n"
+        "<a name='T0001'></a>A Title</h1>\n"
     )
 
     # Unnumbered
-    theHtml._tokens = [
-        (theHtml.T_UNNUM, 1, "Prologue", None, theHtml.A_PBB),
-        (theHtml.T_EMPTY, 1, "", None, theHtml.A_NONE),
+    html._tokens = [
+        (html.T_UNNUM, 1, "Prologue", None, html.A_PBB),
+        (html.T_EMPTY, 1, "", None, html.A_NONE),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 style='page-break-before: always;'>"
-        "<a name='T000001'></a>Prologue</h1>\n"
+        "<a name='T0001'></a>Prologue</h1>\n"
     )
 
     # Separators
     # ==========
 
     # Separator
-    theHtml._tokens = [
-        (theHtml.T_SEP, 1, "* * *", None, theHtml.A_CENTRE),
-        (theHtml.T_EMPTY, 1, "", None, theHtml.A_NONE),
+    html._tokens = [
+        (html.T_SEP, 1, "* * *", None, html.A_CENTRE),
+        (html.T_EMPTY, 1, "", None, html.A_NONE),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == "<p class='sep' style='text-align: center;'>* * *</p>\n"
+    html.doConvert()
+    assert html.theResult == "<p class='sep' style='text-align: center;'>* * *</p>\n"
 
     # Skip
-    theHtml._tokens = [
-        (theHtml.T_SKIP, 1, "", None, theHtml.A_NONE),
-        (theHtml.T_EMPTY, 1, "", None, theHtml.A_NONE),
+    html._tokens = [
+        (html.T_SKIP, 1, "", None, html.A_NONE),
+        (html.T_EMPTY, 1, "", None, html.A_NONE),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == "<p class='skip'>&nbsp;</p>\n"
+    html.doConvert()
+    assert html.theResult == "<p class='skip'>&nbsp;</p>\n"
 
     # Alignment
     # =========
 
-    theHtml.setLinkHeaders(False)
+    html.setLinkHeaders(False)
 
     # Align Left
-    theHtml.setStyles(False)
-    theHtml._tokens = [
-        (theHtml.T_HEAD1, 1, "A Title", None, theHtml.A_LEFT),
+    html.setStyles(False)
+    html._tokens = [
+        (html.T_HEAD1, 1, "A Title", None, html.A_LEFT),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title'>A Title</h1>\n"
     )
 
-    theHtml.setStyles(True)
+    html.setStyles(True)
 
     # Align Left
-    theHtml._tokens = [
-        (theHtml.T_HEAD1, 1, "A Title", None, theHtml.A_LEFT),
+    html._tokens = [
+        (html.T_HEAD1, 1, "A Title", None, html.A_LEFT),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' style='text-align: left;'>A Title</h1>\n"
     )
 
     # Align Right
-    theHtml._tokens = [
-        (theHtml.T_HEAD1, 1, "A Title", None, theHtml.A_RIGHT),
+    html._tokens = [
+        (html.T_HEAD1, 1, "A Title", None, html.A_RIGHT),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' style='text-align: right;'>A Title</h1>\n"
     )
 
     # Align Centre
-    theHtml._tokens = [
-        (theHtml.T_HEAD1, 1, "A Title", None, theHtml.A_CENTRE),
+    html._tokens = [
+        (html.T_HEAD1, 1, "A Title", None, html.A_CENTRE),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' style='text-align: center;'>A Title</h1>\n"
     )
 
     # Align Justify
-    theHtml._tokens = [
-        (theHtml.T_HEAD1, 1, "A Title", None, theHtml.A_JUSTIFY),
+    html._tokens = [
+        (html.T_HEAD1, 1, "A Title", None, html.A_JUSTIFY),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' style='text-align: justify;'>A Title</h1>\n"
     )
 
@@ -341,11 +339,11 @@ def testCoreToHtml_ConvertDirect(mockGUI):
     # ==========
 
     # Page Break Always
-    theHtml._tokens = [
-        (theHtml.T_HEAD1, 1, "A Title", None, theHtml.A_PBB | theHtml.A_PBA),
+    html._tokens = [
+        (html.T_HEAD1, 1, "A Title", None, html.A_PBB | html.A_PBA),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<h1 class='title' "
         "style='page-break-before: always; page-break-after: always;'>A Title</h1>\n"
     )
@@ -354,22 +352,22 @@ def testCoreToHtml_ConvertDirect(mockGUI):
     # ======
 
     # Indent Left
-    theHtml._tokens = [
-        (theHtml.T_TEXT,  1, "Some text ...", [], theHtml.A_IND_L),
-        (theHtml.T_EMPTY, 2, "", None, theHtml.A_NONE),
+    html._tokens = [
+        (html.T_TEXT,  1, "Some text ...", [], html.A_IND_L),
+        (html.T_EMPTY, 2, "", None, html.A_NONE),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<p style='margin-left: 40px;'>Some text ...</p>\n"
     )
 
     # Indent Right
-    theHtml._tokens = [
-        (theHtml.T_TEXT,  1, "Some text ...", [], theHtml.A_IND_R),
-        (theHtml.T_EMPTY, 2, "", None, theHtml.A_NONE),
+    html._tokens = [
+        (html.T_TEXT,  1, "Some text ...", [], html.A_IND_R),
+        (html.T_EMPTY, 2, "", None, html.A_NONE),
     ]
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.doConvert()
+    assert html.theResult == (
         "<p style='margin-right: 40px;'>Some text ...</p>\n"
     )
 
@@ -378,40 +376,39 @@ def testCoreToHtml_ConvertDirect(mockGUI):
 
 @pytest.mark.core
 def testCoreToHtml_SpecialCases(mockGUI):
-    """Test some special cases that have caused errors in the past.
-    """
-    theProject = NWProject()
-    theHtml = ToHtml(theProject)
-    theHtml._isNovel = True
+    """Test some special cases that have caused errors in the past."""
+    project = NWProject()
+    html = ToHtml(project)
+    html._isNovel = True
 
     # Greater/Lesser than symbols
     # ===========================
 
-    theHtml._text = "Text with > and < with some **bold text** in it.\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Text with > and < with some **bold text** in it.\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Text with &gt; and &lt; with some <strong>bold text</strong> in it.</p>\n"
     )
 
-    theHtml._text = "Text with some <**bold text**> in it.\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Text with some <**bold text**> in it.\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Text with some &lt;<strong>bold text</strong>&gt; in it.</p>\n"
     )
 
-    theHtml._text = "Let's > be > _difficult **shall** > we_?\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Let's > be > _difficult **shall** > we_?\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Let's &gt; be &gt; <em>difficult <strong>shall</strong> &gt; we</em>?</p>\n"
     )
 
-    theHtml._text = "Test > text _<**bold**>_ and more.\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Test > text _<**bold**>_ and more.\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Test &gt; text <em>&lt;<strong>bold</strong>&gt;</em> and more.</p>\n"
     )
 
@@ -419,20 +416,20 @@ def testCoreToHtml_SpecialCases(mockGUI):
     # ===================
     # See: https://github.com/vkbo/novelWriter/issues/950
 
-    theHtml.setComments(True)
-    theHtml._text = "% Test > text _<**bold**>_ and more.\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html.setComments(True)
+    html._text = "% Test > text _<**bold**>_ and more.\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p class='comment'>"
         "<strong>Comment:</strong> Test &gt; text _&lt;**bold**&gt;_ and more."
         "</p>\n"
     )
 
-    theHtml._text = "## Heading <1>\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "## Heading <1>\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<h1 style='page-break-before: always;'>Heading &lt;1&gt;</h1>\n"
     )
 
@@ -440,10 +437,10 @@ def testCoreToHtml_SpecialCases(mockGUI):
     # ====================
     # See: https://github.com/vkbo/novelWriter/issues/1412
 
-    theHtml._text = "Test text \\**_bold_** and more.\n"
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = "Test text \\**_bold_** and more.\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Test text **<em>bold</em>** and more.</p>\n"
     )
 
@@ -452,11 +449,10 @@ def testCoreToHtml_SpecialCases(mockGUI):
 
 @pytest.mark.core
 def testCoreToHtml_Complex(mockGUI, fncPath):
-    """Test the save method of the ToHtml class.
-    """
-    theProject = NWProject()
-    theHtml = ToHtml(theProject)
-    theHtml._isNovel = True
+    """Test the save method of the ToHtml class."""
+    project = NWProject()
+    html = ToHtml(project)
+    html._isNovel = True
 
     # Build Project
     # =============
@@ -502,21 +498,21 @@ def testCoreToHtml_Complex(mockGUI, fncPath):
     ]
 
     for i in range(len(docText)):
-        theHtml._text = docText[i]
-        theHtml.doPreProcessing()
-        theHtml.tokenizeText()
-        theHtml.doConvert()
-        assert theHtml.theResult == resText[i]
+        html._text = docText[i]
+        html.doPreProcessing()
+        html.tokenizeText()
+        html.doConvert()
+        assert html.theResult == resText[i]
 
-    assert theHtml.fullHTML == resText
+    assert html.fullHTML == resText
 
-    theHtml.replaceTabs(nSpaces=2, spaceChar="&nbsp;")
+    html.replaceTabs(nSpaces=2, spaceChar="&nbsp;")
     resText[6] = "<h3>A Section</h3>\n<p>&nbsp;&nbsp;More text in scene two.</p>\n"
 
     # Check File
     # ==========
 
-    theStyle = theHtml.getStyleSheet()
+    theStyle = html.getStyleSheet()
     htmlDoc = (
         "<!DOCTYPE html>\n"
         "<html>\n"
@@ -539,7 +535,7 @@ def testCoreToHtml_Complex(mockGUI, fncPath):
     )
 
     saveFile = fncPath / "outFile.htm"
-    theHtml.saveHtml5(saveFile)
+    html.saveHtml5(saveFile)
     assert readFile(saveFile) == htmlDoc
 
 # END Test testCoreToHtml_Complex
@@ -547,86 +543,84 @@ def testCoreToHtml_Complex(mockGUI, fncPath):
 
 @pytest.mark.core
 def testCoreToHtml_Methods(mockGUI):
-    """Test all the other methods of the ToHtml class.
-    """
-    theProject = NWProject()
-    theHtml = ToHtml(theProject)
-    theHtml.setKeepMarkdown(True)
+    """Test all the other methods of the ToHtml class."""
+    project = NWProject()
+    html = ToHtml(project)
+    html.setKeepMarkdown(True)
 
     # Auto-Replace, keep Unicode
     docText = "Text with <brackets> & short–dash, long—dash …\n"
-    theHtml._text = docText
-    theHtml.setReplaceUnicode(False)
-    theHtml.doPreProcessing()
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = docText
+    html.setReplaceUnicode(False)
+    html.doPreProcessing()
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Text with &lt;brackets&gt; &amp; short–dash, long—dash …</p>\n"
     )
 
     # Auto-Replace, replace Unicode
     docText = "Text with <brackets> & short–dash, long—dash …\n"
-    theHtml._text = docText
-    theHtml.setReplaceUnicode(True)
-    theHtml.doPreProcessing()
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theResult == (
+    html._text = docText
+    html.setReplaceUnicode(True)
+    html.doPreProcessing()
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theResult == (
         "<p>Text with &lt;brackets&gt; &amp; short&ndash;dash, long&mdash;dash &hellip;</p>\n"
     )
 
     # With Preview
-    theHtml.setPreview(True, True)
-    theHtml._text = docText
-    theHtml.doPreProcessing()
-    theHtml.tokenizeText()
-    theHtml.doConvert()
-    assert theHtml.theMarkdown[-1] == (
+    html.setPreview(True, True)
+    html._text = docText
+    html.doPreProcessing()
+    html.tokenizeText()
+    html.doConvert()
+    assert html.theMarkdown[-1] == (
         "Text with <brackets> &amp; short&ndash;dash, long&mdash;dash &hellip;\n\n"
     )
 
     # Result Size
-    assert theHtml.getFullResultSize() == 147
+    assert html.getFullResultSize() == 147
 
     # CSS
     # ===
 
-    assert len(theHtml.getStyleSheet()) > 1
-    assert "p {text-align: left;" in " ".join(theHtml.getStyleSheet())
-    assert "p {text-align: justify;" not in " ".join(theHtml.getStyleSheet())
+    assert len(html.getStyleSheet()) > 1
+    assert "p {text-align: left;" in " ".join(html.getStyleSheet())
+    assert "p {text-align: justify;" not in " ".join(html.getStyleSheet())
 
-    theHtml.setJustify(True)
-    assert "p {text-align: left;" not in " ".join(theHtml.getStyleSheet())
-    assert "p {text-align: justify;" in " ".join(theHtml.getStyleSheet())
+    html.setJustify(True)
+    assert "p {text-align: left;" not in " ".join(html.getStyleSheet())
+    assert "p {text-align: justify;" in " ".join(html.getStyleSheet())
 
-    theHtml.setStyles(False)
-    assert theHtml.getStyleSheet() == []
+    html.setStyles(False)
+    assert html.getStyleSheet() == []
 
 # END Test testCoreToHtml_Methods
 
 
 @pytest.mark.core
 def testCoreToHtml_Format(mockGUI):
-    """Test all the formatters for the ToHtml class.
-    """
-    theProject = NWProject()
-    theHtml = ToHtml(theProject)
+    """Test all the formatters for the ToHtml class."""
+    project = NWProject()
+    html = ToHtml(project)
 
     # Export Mode
     # ===========
 
-    assert theHtml._formatSynopsis("synopsis text") == (
+    assert html._formatSynopsis("synopsis text") == (
         "<p class='synopsis'><strong>Synopsis:</strong> synopsis text</p>\n"
     )
-    assert theHtml._formatComments("comment text") == (
+    assert html._formatComments("comment text") == (
         "<p class='comment'><strong>Comment:</strong> comment text</p>\n"
     )
 
-    assert theHtml._formatKeywords("") == ""
-    assert theHtml._formatKeywords("tag: Jane") == (
+    assert html._formatKeywords("") == ""
+    assert html._formatKeywords("tag: Jane") == (
         "<span class='tags'>Tag:</span> <a name='tag_Jane'>Jane</a>"
     )
-    assert theHtml._formatKeywords("char: Bod, Jane") == (
+    assert html._formatKeywords("char: Bod, Jane") == (
         "<span class='tags'>Characters:</span> "
         "<a href='#tag_Bod'>Bod</a>, "
         "<a href='#tag_Jane'>Jane</a>"
@@ -635,20 +629,20 @@ def testCoreToHtml_Format(mockGUI):
     # Preview Mode
     # ============
 
-    theHtml.setPreview(True, True)
+    html.setPreview(True, True)
 
-    assert theHtml._formatSynopsis("synopsis text") == (
+    assert html._formatSynopsis("synopsis text") == (
         "<p class='comment'><span class='synopsis'>Synopsis:</span> synopsis text</p>\n"
     )
-    assert theHtml._formatComments("comment text") == (
+    assert html._formatComments("comment text") == (
         "<p class='comment'>comment text</p>\n"
     )
 
-    assert theHtml._formatKeywords("") == ""
-    assert theHtml._formatKeywords("tag: Jane") == (
+    assert html._formatKeywords("") == ""
+    assert html._formatKeywords("tag: Jane") == (
         "<span class='tags'>Tag:</span> <a name='tag_Jane'>Jane</a>"
     )
-    assert theHtml._formatKeywords("char: Bod, Jane") == (
+    assert html._formatKeywords("char: Bod, Jane") == (
         "<span class='tags'>Characters:</span> "
         "<a href='#char=Bod'>Bod</a>, "
         "<a href='#char=Jane'>Jane</a>"

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -442,8 +442,8 @@ def testCoreToken_MetaFormat(mockGUI):
     theToken._text = "% A comment\n"
     theToken.tokenizeText()
     assert theToken._tokens == [
-        (Tokenizer.T_COMMENT, 1, "A comment", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_COMMENT, 0, "A comment", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "\n"
 
@@ -455,14 +455,14 @@ def testCoreToken_MetaFormat(mockGUI):
     theToken._text = "%synopsis: The synopsis\n"
     theToken.tokenizeText()
     assert theToken._tokens == [
-        (Tokenizer.T_SYNOPSIS, 1, "The synopsis", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SYNOPSIS, 0, "The synopsis", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     theToken._text = "% synopsis: The synopsis\n"
     theToken.tokenizeText()
     assert theToken._tokens == [
-        (Tokenizer.T_SYNOPSIS, 1, "The synopsis", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SYNOPSIS, 0, "The synopsis", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "\n"
 
@@ -474,8 +474,8 @@ def testCoreToken_MetaFormat(mockGUI):
     theToken._text = "@char: Bod\n"
     theToken.tokenizeText()
     assert theToken._tokens == [
-        (Tokenizer.T_KEYWORD, 1, "char: Bod", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_KEYWORD, 0, "char: Bod", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "\n"
 
@@ -489,10 +489,10 @@ def testCoreToken_MetaFormat(mockGUI):
     styMid = Tokenizer.A_NONE | Tokenizer.A_Z_BTMMRG | Tokenizer.A_Z_TOPMRG
     styBtm = Tokenizer.A_NONE | Tokenizer.A_Z_TOPMRG
     assert theToken._tokens == [
-        (Tokenizer.T_KEYWORD, 1, "pov: Bod", None, styTop),
-        (Tokenizer.T_KEYWORD, 2, "plot: Main", None, styMid),
-        (Tokenizer.T_KEYWORD, 3, "location: Europe", None, styBtm),
-        (Tokenizer.T_EMPTY, 3, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_KEYWORD, 0, "pov: Bod", None, styTop),
+        (Tokenizer.T_KEYWORD, 0, "plot: Main", None, styMid),
+        (Tokenizer.T_KEYWORD, 0, "location: Europe", None, styBtm),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "@pov: Bod\n@plot: Main\n@location: Europe\n\n"
 
@@ -521,23 +521,23 @@ def testCoreToken_MarginFormat(mockGUI):
     )
     theToken.tokenizeText()
     assert theToken._tokens == [
-        (Tokenizer.T_TEXT,  1, "Some regular text", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  3, "Some left-aligned text", [], Tokenizer.A_LEFT),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  5, "Some right-aligned text", [], Tokenizer.A_RIGHT),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  7, "Some centered text", [], Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 8, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  9, "Left-indented block", [], Tokenizer.A_IND_L),
-        (Tokenizer.T_EMPTY, 10, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  11, "Right-indented block", [], Tokenizer.A_IND_R),
-        (Tokenizer.T_EMPTY, 12, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  13, "Double-indented block", [], dblIndent),
-        (Tokenizer.T_EMPTY, 14, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  15, "Right-indent, right-aligned", [], rIndAlign),
-        (Tokenizer.T_EMPTY, 16, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 16, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Some regular text", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Some left-aligned text", [], Tokenizer.A_LEFT),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Some right-aligned text", [], Tokenizer.A_RIGHT),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Some centered text", [], Tokenizer.A_CENTRE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Left-indented block", [], Tokenizer.A_IND_L),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Right-indented block", [], Tokenizer.A_IND_R),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Double-indented block", [], dblIndent),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  0, "Right-indent, right-aligned", [], rIndAlign),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == (
         "Some regular text\n\n"
@@ -564,20 +564,20 @@ def testCoreToken_TextFormat(mockGUI):
     theToken._text = "Some plain text\non two lines\n\n\n"
     theToken.tokenizeText()
     assert theToken._tokens == [
-        (Tokenizer.T_TEXT, 1, "Some plain text", [], Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT, 2, "on two lines", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 3, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT, 0, "Some plain text", [], Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT, 0, "on two lines", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "Some plain text\non two lines\n\n\n\n"
 
     theToken.setBodyText(False)
     theToken.tokenizeText()
     assert theToken._tokens == [
-        (Tokenizer.T_EMPTY, 3, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "\n\n\n"
     theToken.setBodyText(True)
@@ -587,7 +587,7 @@ def testCoreToken_TextFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (
-            Tokenizer.T_TEXT, 1,
+            Tokenizer.T_TEXT, 0,
             "Some **bolded text** on this lines",
             [
                 [5,  2, Tokenizer.FMT_B_B],
@@ -595,7 +595,7 @@ def testCoreToken_TextFormat(mockGUI):
             ],
             Tokenizer.A_NONE
         ),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "Some **bolded text** on this lines\n\n"
 
@@ -603,7 +603,7 @@ def testCoreToken_TextFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (
-            Tokenizer.T_TEXT, 1,
+            Tokenizer.T_TEXT, 0,
             "Some _italic text_ on this lines",
             [
                 [5,  1, Tokenizer.FMT_I_B],
@@ -611,7 +611,7 @@ def testCoreToken_TextFormat(mockGUI):
             ],
             Tokenizer.A_NONE
         ),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "Some _italic text_ on this lines\n\n"
 
@@ -619,7 +619,7 @@ def testCoreToken_TextFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (
-            Tokenizer.T_TEXT, 1,
+            Tokenizer.T_TEXT, 0,
             "Some **_bold italic text_** on this lines",
             [
                 [5,  2, Tokenizer.FMT_B_B],
@@ -629,7 +629,7 @@ def testCoreToken_TextFormat(mockGUI):
             ],
             Tokenizer.A_NONE
         ),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "Some **_bold italic text_** on this lines\n\n"
 
@@ -637,7 +637,7 @@ def testCoreToken_TextFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (
-            Tokenizer.T_TEXT, 1,
+            Tokenizer.T_TEXT, 0,
             "Some ~~strikethrough text~~ on this lines",
             [
                 [5,  2, Tokenizer.FMT_D_B],
@@ -645,7 +645,7 @@ def testCoreToken_TextFormat(mockGUI):
             ],
             Tokenizer.A_NONE
         ),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == "Some ~~strikethrough text~~ on this lines\n\n"
 
@@ -653,7 +653,7 @@ def testCoreToken_TextFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (
-            Tokenizer.T_TEXT, 1,
+            Tokenizer.T_TEXT, 0,
             "Some **nested bold and _italic_ and ~~strikethrough~~ text** here",
             [
                 [5,  2, Tokenizer.FMT_B_B],
@@ -665,7 +665,7 @@ def testCoreToken_TextFormat(mockGUI):
             ],
             Tokenizer.A_NONE
         ),
-        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 0, "", None, Tokenizer.A_NONE),
     ]
     assert theToken.theMarkdown[-1] == (
         "Some **nested bold and _italic_ and ~~strikethrough~~ text** here\n\n"
@@ -687,11 +687,11 @@ def testCoreToken_SpecialFormat(mockGUI):
 
     correctResp = [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_CENTRE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_HEAD1, 2, "Title Two", None, Tokenizer.A_CENTRE | Tokenizer.A_PBB),
         (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_HEAD1, 5, "Title Two", None, Tokenizer.A_CENTRE | Tokenizer.A_PBB),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
     ]
 
     # Command wo/Space
@@ -735,12 +735,12 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  3, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  5, "Some text to go here ...", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
     # Multiple Empty Paragraphs
@@ -755,12 +755,12 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  3, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  5, "Some text to go here ...", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
     # Three Skips
@@ -772,14 +772,14 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  3, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  3, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  3, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  5, "Some text to go here ...", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
     # Malformed Command, Case 1
@@ -791,11 +791,11 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  5, "Some text to go here ...", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
     # Malformed Command, Case 2
@@ -807,11 +807,11 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  5, "Some text to go here ...", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
     # Malformed Command, Case 3
@@ -823,11 +823,11 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  5, "Some text to go here ...", [], Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
     # Empty Paragraph and Page Break
@@ -843,13 +843,13 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  5, "", None, Tokenizer.A_PBB),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  7, "Some text to go here ...", [], 0),
-        (Tokenizer.T_EMPTY, 8, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 8, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_PBB),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], 0),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
     # Multiple Skip
@@ -862,15 +862,15 @@ def testCoreToken_SpecialFormat(mockGUI):
     theToken.tokenizeText()
     assert theToken._tokens == [
         (Tokenizer.T_HEAD1, 1, "Title One", None, Tokenizer.A_PBB | Tokenizer.A_CENTRE),
-        (Tokenizer.T_EMPTY, 2, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 4, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  5, "", None, Tokenizer.A_PBB),
-        (Tokenizer.T_SKIP,  5, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_SKIP,  5, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 6, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_TEXT,  7, "Some text to go here ...", [], 0),
-        (Tokenizer.T_EMPTY, 8, "", None, Tokenizer.A_NONE),
-        (Tokenizer.T_EMPTY, 8, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_PBB),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_SKIP,  1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_TEXT,  1, "Some text to go here ...", [], 0),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
+        (Tokenizer.T_EMPTY, 1, "", None, Tokenizer.A_NONE),
     ]
 
 # END Test testCoreToken_SpecialFormat


### PR DESCRIPTION
**Summary:**

The anchor tags were still generated based on line numbers instead of heading number, so following a link to a heading didn't work in the viewer.

**Related Issue(s):**

Closes #1566

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
