### PR TITLE
Fix illegal drag and drop checks

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1739,9 +1739,7 @@ class GuiProjectTree(QTreeWidget):
         newItem.setData(self.C_DATA, self.D_WORDS, 0)
 
         if pHandle is None and nwItem.isRootType():
-            # newItem.setFlags(newItem.flags() ^ Qt.ItemFlag.ItemIsDragEnabled)
             pItem = self.invisibleRootItem()
-            # pItem.setFlags(pItem.flags() ^ Qt.ItemFlag.ItemIsDropEnabled)
         elif pHandle and pHandle in self._treeMap:
             pItem = self._treeMap[pHandle]
         else:


### PR DESCRIPTION
**Summary:**

Add back in some of the checks for illegal moves on the project tree widget. The flags set on the invisible root item are ignored in at least Qt 5.15.8, although they work in Qt 5.15.2 which is used in most release formats. This change keeps both approaches. This should have no affect on releases with !t 5.15.2 as the checks won't even be reached.

**Related Issue(s):**

Closes #1569

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
