### PR TITLE
Set menu parents

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1121,7 +1121,7 @@ class GuiDocEditor(QTextEdit):
         userSelection = userCursor.hasSelection()
         posCursor = self.cursorForPosition(thePos)
 
-        mnuContext = QMenu()
+        mnuContext = QMenu(self)
 
         # Follow, Cut, Copy and Paste
         # ===========================

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -381,7 +381,7 @@ class GuiDocViewer(QTextBrowser):
         userCursor = self.textCursor()
         userSelection = userCursor.hasSelection()
 
-        mnuContext = QMenu()
+        mnuContext = QMenu(self)
 
         # Cut, Copy and Paste
         # ===================

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -228,7 +228,7 @@ class GuiNovelToolBar(QWidget):
         self.tbRefresh.clicked.connect(self._refreshNovelTree)
 
         # More Options Menu
-        self.mMore = QMenu()
+        self.mMore = QMenu(self)
 
         self.mLastCol = self.mMore.addMenu(self.tr("Last Column"))
         self.gLastCol = QActionGroup(self.mMore)

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -248,7 +248,7 @@ class GuiProjectToolBar(QWidget):
         self.viewLabel.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         # Quick Links
-        self.mQuick = QMenu()
+        self.mQuick = QMenu(self)
 
         self.tbQuick = QToolButton(self)
         self.tbQuick.setToolTip("%s [Ctrl+L]" % self.tr("Quick Links"))
@@ -269,7 +269,7 @@ class GuiProjectToolBar(QWidget):
         self.tbMoveD.clicked.connect(lambda: self.projTree.moveTreeItem(1))
 
         # Add Item Menu
-        self.mAdd = QMenu()
+        self.mAdd = QMenu(self)
 
         self.aAddEmpty = self.mAdd.addAction(trConst(nwLabels.ITEM_DESCRIPTION["document"]))
         self.aAddEmpty.triggered.connect(
@@ -307,7 +307,7 @@ class GuiProjectToolBar(QWidget):
         self.tbAdd.setPopupMode(QToolButton.InstantPopup)
 
         # More Options Menu
-        self.mMore = QMenu()
+        self.mMore = QMenu(self)
 
         self.aExpand = self.mMore.addAction(self.tr("Expand All"))
         self.aExpand.triggered.connect(lambda: self.projTree.setExpandedFromHandle(None, True))
@@ -1210,7 +1210,7 @@ class GuiProjectTree(QTreeWidget):
             logger.debug("No item found")
             return False
 
-        ctxMenu = QMenu()
+        ctxMenu = QMenu(self)
 
         # Trash Folder
         # ============

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -95,7 +95,7 @@ class GuiSideBar(QToolBar):
         self.aStats.triggered.connect(lambda: self.mainGui.showWritingStatsDialog())
 
         # Settings Menu
-        self.mSettings = QMenu()
+        self.mSettings = QMenu(self)
 
         self.mSettings.addAction(self.mainGui.mainMenu.aEditWordList)
         self.mSettings.addAction(self.mainGui.mainMenu.aProjectSettings)

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -720,7 +720,7 @@ class _HeadingsTab(QWidget):
 
         self.formSyntax = _HeadingSyntaxHighlighter(self.editTextBox.document())
 
-        self.menuInsert = QMenu()
+        self.menuInsert = QMenu(self)
         self.aInsTitle = self.menuInsert.addAction(self.tr("Title"))
         self.aInsChNum = self.menuInsert.addAction(self.tr("Chapter Number"))
         self.aInsChWord = self.menuInsert.addAction(self.tr("Chapter Number (Word)"))


### PR DESCRIPTION
**Summary:**

This PR adds a parent item to all `QMenu` constructors. This can help with the positioning issue according to [QTBUG-68636](https://bugreports.qt.io/browse/QTBUG-68636).

The remaining issue is a know issue with Qt5 on Wayland, and is not likely to be fixed. Moving to Qt6 (#1142) is the more likely solution, which will have to wait.

**Related Issue(s):**

Closes #1536

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
