### PR TITLE
Fix editor refresh issues

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -359,6 +359,8 @@ class GuiDocEditor(QTextEdit):
             self.clearEditor()
         else:
             self.redrawText()
+            if not self._bigDoc:
+                self.highLight.rehighlight()
 
         return True
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -980,6 +980,7 @@ class GuiMain(QMainWindow):
         if dlgWords.result() == QDialog.Accepted:
             logger.debug("Reloading word list")
             SHARED.updateSpellCheckLanguage(reload=True)
+            self.docEditor.spellCheckDocument()
 
         return True
 


### PR DESCRIPTION
**Summary:**

This PR fixes two issues with refreshing the editor when settings change. One forces a full rehighlight of the editor (unless the document is above the big doc limit) when the syntax theme changes. The mark as dirty feature doesn't seem to work properly for this. The second fix is to re-run the spell checker when the word list has changed.

**Related Issue(s):**

Closes #1559
Closes #1535

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
