### PR TITLE
Add an auto-completer for editor references

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -621,6 +621,10 @@ class NWIndex:
         sTitle = self._tagsIndex.tagHeading(tagKey)
         return tHandle, sTitle
 
+    def getTags(self, itemClass: nwItemClass) -> list[str]:
+        """Return all tags based on itemClass."""
+        return self._tagsIndex.filterTagNames(itemClass.name)
+
 # END Class NWIndex
 
 
@@ -683,6 +687,12 @@ class TagsIndex:
     def tagClass(self, tagKey: str) -> str | None:
         """Get the class of a given tag."""
         return self._tags.get(tagKey.lower(), {}).get("class", None)
+
+    def filterTagNames(self, className: str) -> list[str]:
+        """Get a list of tag names for a given class."""
+        return [
+            x.get("name", "") for x in self._tags.values() if x.get("class", "") == className
+        ]
 
     ##
     #  Pack/Unpack

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -196,6 +196,16 @@ def testCoreIndex_ScanThis(mockGUI):
     assert theBits == ["@tag", "this", "and this"]
     assert thePos  == [0, 6, 12]
 
+    isValid, theBits, thePos = index.scanThis("@tag: this,, and this")
+    assert isValid is True
+    assert theBits == ["@tag", "this", "", "and this"]
+    assert thePos  == [0, 6, 11, 13]
+
+    isValid, theBits, thePos = index.scanThis("@tag: this, , and this")
+    assert isValid is True
+    assert theBits == ["@tag", "this", "", "and this"]
+    assert thePos  == [0, 6, 12, 14]
+
     project.closeProject()
 
 # END Test testCoreIndex_ScanThis

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -21,15 +21,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 
-from mocked import causeOSError
 from tools import C, buildTestProject
+from mocked import causeOSError
 
 from PyQt5.QtCore import QThreadPool, Qt
 from PyQt5.QtGui import QTextBlock, QTextCursor, QTextOption
 from PyQt5.QtWidgets import QAction, qApp
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.enum import nwDocAction, nwDocInsert, nwItemLayout
+from novelwriter.enum import nwDocAction, nwDocInsert, nwItemLayout, nwWidget
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.core.index import countWords
 from novelwriter.gui.doceditor import GuiDocEditor
@@ -145,10 +145,10 @@ def testGuiEditor_SaveText(qtbot, monkeypatch, caplog, nwGUI, projPath, ipsumTex
         assert "Could not save document." in caplog.text
 
     # Change header level
-    assert SHARED.project.tree[C.hSceneDoc].itemLayout == nwItemLayout.DOCUMENT
+    assert SHARED.project.tree[C.hSceneDoc].itemLayout == nwItemLayout.DOCUMENT  # type: ignore
     nwGUI.docEditor.replaceText(longText[1:])
     assert nwGUI.docEditor.saveText() is True
-    assert SHARED.project.tree[C.hSceneDoc].itemLayout == nwItemLayout.DOCUMENT
+    assert SHARED.project.tree[C.hSceneDoc].itemLayout == nwItemLayout.DOCUMENT  # type: ignore
 
     # Regular save
     assert nwGUI.docEditor.saveText() is True
@@ -184,9 +184,9 @@ def testGuiEditor_MetaData(qtbot, nwGUI, projPath, mockRnd):
     # Cursor Position
     nwGUI.docEditor.setCursorPosition(10)
     assert nwGUI.docEditor.getCursorPosition() == 10
-    assert SHARED.project.tree[C.hSceneDoc].cursorPos != 10
+    assert SHARED.project.tree[C.hSceneDoc].cursorPos != 10  # type: ignore
     nwGUI.docEditor.saveCursorPosition()
-    assert SHARED.project.tree[C.hSceneDoc].cursorPos == 10
+    assert SHARED.project.tree[C.hSceneDoc].cursorPos == 10  # type: ignore
 
     nwGUI.docEditor.setCursorLine(None)
     assert nwGUI.docEditor.getCursorPosition() == 10
@@ -1041,14 +1041,14 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.openDocument(C.hSceneDoc) is True
 
     # Create Scene
-    theText = "### A Scene\n\n@char: Jane, John\n\n" + ipsumText[0] + "\n\n"
-    nwGUI.docEditor.replaceText(theText)
+    text = "### A Scene\n\n@char: Jane, John\n\n" + ipsumText[0] + "\n\n"
+    nwGUI.docEditor.replaceText(text)
 
     # Create Character
-    theText = "### Jane Doe\n\n@tag: Jane\n\n" + ipsumText[1] + "\n\n"
+    text = "### Jane Doe\n\n@tag: Jane\n\n" + ipsumText[1] + "\n\n"
     cHandle = SHARED.project.newFile("Jane Doe", C.hCharRoot)
     assert nwGUI.openDocument(cHandle) is True
-    nwGUI.docEditor.replaceText(theText)
+    nwGUI.docEditor.replaceText(text)
     assert nwGUI.saveDocument() is True
     assert nwGUI.projView.projTree.revealNewTreeItem(cHandle)
     nwGUI.docEditor.updateTagHighLighting()
@@ -1093,6 +1093,107 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
 
 @pytest.mark.gui
+def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
+    """Test the document editor meta completer functionality."""
+    buildTestProject(nwGUI, projPath)
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+
+    # Create Character
+    text = (
+        "# Jane Doe\n\n"
+        "@tag: Jane\n\n"
+        "# John Doe\n\n"
+        "@tag: John\n\n"
+    )
+    cHandle = SHARED.project.newFile("People", C.hCharRoot)
+    assert nwGUI.openDocument(cHandle) is True
+    nwGUI.docEditor.replaceText(text)
+    assert nwGUI.saveDocument() is True
+    assert nwGUI.projView.projTree.revealNewTreeItem(cHandle)
+
+    docEditor = nwGUI.docEditor
+    docEditor.replaceText("")
+    completer = docEditor._completer
+
+    # Create Scene
+    nwGUI.switchFocus(nwWidget.EDITOR)
+    for c in "### Scene One":
+        qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+
+    # Type Keyword @
+    qtbot.keyClick(docEditor, "@", delay=KEY_DELAY)
+    assert len(completer.actions()) == len(nwKeyWords.VALID_KEYS)
+
+    # Type "c" to filer list to 2
+    qtbot.keyClick(docEditor, "c", delay=KEY_DELAY)
+    assert len(completer.actions()) == 2
+
+    # Type "q" to filer list to 0
+    qtbot.keyClick(docEditor, "q", delay=KEY_DELAY)
+    assert len(completer.actions()) == 0
+
+    # Delete character and go select @char
+    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+    assert len(completer.actions()) == 2
+    completer.actions()[0].trigger()
+    assert docEditor.getText() == (
+        "### Scene One\n\n"
+        "@char:"
+    )
+
+    # The list of Characters should show up automatically
+    qtbot.keyClick(docEditor, " ", delay=KEY_DELAY)
+    assert [a.text() for a in completer.actions()] == ["Jane", "John"]
+
+    # Typing "q" should clear the list
+    qtbot.keyClick(docEditor, "q", delay=KEY_DELAY)
+    assert [a.text() for a in completer.actions()] == []
+
+    # Deleting it and typing "a", should leave "Jane"
+    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, "a", delay=KEY_DELAY)
+    assert [a.text() for a in completer.actions()] == ["Jane"]
+
+    # Selecting "Jane" should insert it
+    completer.actions()[0].trigger()
+    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    assert docEditor.getText() == (
+        "### Scene One\n\n"
+        "@char: Jane\n"
+    )
+
+    # Start a new line with a nonsense keyword, which should be handled
+    for c in "@: ":
+        qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+
+    # Send keypresses to the completer object
+    qtbot.keyClick(docEditor, "@", delay=KEY_DELAY)
+    assert len(completer.actions()) == len(nwKeyWords.VALID_KEYS)
+    qtbot.keyClick(completer, "f", delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key_Down, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, " ", delay=KEY_DELAY)
+    qtbot.keyClick(completer, "h", delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key_Down, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key_Escape, delay=KEY_DELAY)
+    assert docEditor.getText() == (
+        "### Scene One\n\n"
+        "@char: Jane\n"
+        "@focus: John"
+    )
+
+    # qtbot.stop()
+
+# END Test testGuiEditor_Completer
+
+
+@pytest.mark.gui
 def testGuiEditor_WordCounters(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd):
     """Test saving text from the editor."""
     class MockThreadPool:
@@ -1125,8 +1226,8 @@ def testGuiEditor_WordCounters(qtbot, monkeypatch, nwGUI, projPath, ipsumText, m
     assert nwGUI.docEditor.docFooter.wordsText.text() == "Words: 0 (+0)"
 
     # Open a document and populate it
-    SHARED.project.tree[C.hSceneDoc]._initCount = 0  # Clear item's count
-    SHARED.project.tree[C.hSceneDoc]._wordCount = 0  # Clear item's count
+    SHARED.project.tree[C.hSceneDoc]._initCount = 0  # type: ignore
+    SHARED.project.tree[C.hSceneDoc]._wordCount = 0  # type: ignore
     assert nwGUI.openDocument(C.hSceneDoc) is True
 
     theText = "\n\n".join(ipsumText)
@@ -1150,9 +1251,9 @@ def testGuiEditor_WordCounters(qtbot, monkeypatch, nwGUI, projPath, ipsumText, m
 
     nwGUI.docEditor.wCounterDoc.run()
     # nwGUI.docEditor._updateDocCounts(cC, wC, pC)
-    assert SHARED.project.tree[C.hSceneDoc]._charCount == cC
-    assert SHARED.project.tree[C.hSceneDoc]._wordCount == wC
-    assert SHARED.project.tree[C.hSceneDoc]._paraCount == pC
+    assert SHARED.project.tree[C.hSceneDoc]._charCount == cC  # type: ignore
+    assert SHARED.project.tree[C.hSceneDoc]._wordCount == wC  # type: ignore
+    assert SHARED.project.tree[C.hSceneDoc]._paraCount == pC  # type: ignore
     assert nwGUI.docEditor.docFooter.wordsText.text() == f"Words: {wC} (+{wC})"
 
     # Select all text


### PR DESCRIPTION
**Summary:**

This PR adds a custom MetaCompleter class, a context menu that is triggered on lines starting with the `@` character. It has the following features:
* On typing `@`, a list of keyword options appear. The list is shortened when more characters are typed. Typing `@c` will list `@char` and `@custom`. Hitting enter on an option will insert it and a `:`.
* Typing anything after a keyword, like a space, will open a list of up to 15 tags in that category. Any further typing will look for the typed characters in the list and filter it down. The lookup needs to be consecutive characters, but it's not case sensitive. So "an" will match "Jane" and "Jannet", but not "John".
* The auto-completer will treat multiple references separated by a comma. It uses the same evaluation function as the syntax highlighter for the parsing.

**Related Issue(s):**

Closes #823

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
