### PR TITLE
Make it possible to re-order build settings

### DIFF
--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -144,6 +144,8 @@ class GuiManuscript(QDialog):
         self.buildList.setIconSize(QSize(iPx, iPx))
         self.buildList.doubleClicked.connect(self._editSelectedBuild)
         self.buildList.currentItemChanged.connect(self._updateBuildDetails)
+        self.buildList.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.buildList.setDragDropMode(QAbstractItemView.InternalMove)
 
         self.buildDetails = _DetailsWidget(self)
         self.buildDetails.setColumnWidth(
@@ -417,9 +419,15 @@ class GuiManuscript(QDialog):
         """Save the user GUI settings."""
         logger.debug("Saving GuiManuscript settings")
 
+        buildOrder = []
+        for i in range(self.buildList.count()):
+            if item := self.buildList.item(i):
+                buildOrder.append(item.data(self.D_KEY))
+
         current = self.buildList.currentItem()
-        if isinstance(current, QListWidgetItem):
-            self._builds.setLastBuild(current.data(self.D_KEY))
+        lastBuild = current.data(self.D_KEY) if isinstance(current, QListWidgetItem) else ""
+
+        self._builds.setBuildsState(lastBuild, buildOrder)
 
         winWidth  = CONFIG.rpxInt(self.width())
         winHeight = CONFIG.rpxInt(self.height())

--- a/tests/test_core/test_core_buildsettings.py
+++ b/tests/test_core/test_core_buildsettings.py
@@ -435,7 +435,7 @@ def testCoreBuildSettings_Collection(monkeypatch, mockGUI, fncPath: Path, mockRn
         (buildIDTwo, "Build Two"),
         (buildIDOne, "Build One"),
     ]
-    builds.setLastBuild(buildIDOne)
+    builds.setBuildsState(buildIDOne, [buildIDTwo, buildIDOne])
     builds.setDefaultBuild(buildIDTwo)
 
     # Check errors: No valid path


### PR DESCRIPTION
**Summary:**

This PR makes build settings definitions drag-and-drop-able in the Manuscript Build window. This required a bit of rewriting in the underlying data class.

Now, all builds are loaded as BuildSettings objects, rather than as Python dicts and unpacked in a BuildSettings object when requested by the user. Preserving them as dicts meant changes in added/deprecated values were not propagated unless they were actively edited, so this approach means they will be cleaned up by the unpack validation. The change was needed in order to save the order field for the numerical order in which each build settings definition appears on the GUI.

**Related Issue(s):**

Closes #1542

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
