### PR TITLE
Change "Build" to "Complie"

### DIFF
--- a/docs/source/int_howto.rst
+++ b/docs/source/int_howto.rst
@@ -65,7 +65,7 @@ Organising Your Text
    within chapters. Like for instance if you switch point-of-view character often.
 
    In such cases you may want to use the scene heading for hard scene breaks and section headings
-   for soft scene breaks. the :guilabel:`Build Manuscript` tool will let you add separate
+   for soft scene breaks. the :guilabel:`Compile Manuscript` tool will let you add separate
    formatting for the two when you generate your manuscript. You can for instance add the common
    "``* * *``" for hard breaks and select to hide section breaks, which will just insert an empty
    paragraph in their place. See :ref:`a_manuscript_settings` for more details.

--- a/docs/source/int_introduction.rst
+++ b/docs/source/int_introduction.rst
@@ -42,7 +42,7 @@ Below are some key features of novelWriter.
 
 **Organise your documents how you like**
    You can split your novel project up into as many individual documents as you want to. When you
-   build the project into a manuscript, they are all glued together in the top-to-bottom order in
+   compile the project into a manuscript, they are all glued together in the top-to-bottom order in
    which they appear in the project tree. You can use as few text documents as you like, but
    splitting the project up into chapters and scenes means you can easily reorder them using the
    drag-and-drop feature. You can also start out with a few documents and then later split them
@@ -66,13 +66,13 @@ Below are some key features of novelWriter.
    subset of the outline information is also available in the :guilabel:`Novel View` as an
    alternative view to the project tree.
 
-**Building your manuscript**
+**Compiling your manuscript**
    Whether you want to assemble a manuscript, or export all your notes, or generate an outline of
-   your chapters and scenes with a synopsis, you can use the :guilabel:`Build Manuscript` tool to
-   do so. The tool lets you select what information you want to include in the generated document,
-   and how it is formatted. You can send the result to a printer, a PDF, or to an Open Document
-   file that can be opened by most office type word processors. You can also generate the result
-   as HTML, or Markdown, both suitable for further conversion to other formats.
+   your chapters and scenes with a synopsis, you can use the :guilabel:`Settings Manuscript` tool
+   to do so. The tool lets you select what information you want to include in the generated
+   document, and how it is formatted. You can send the result to a printer, a PDF, or to an Open
+   Document file that can be opened by most office type word processors. You can also generate the
+   result as HTML, or Markdown, both suitable for further conversion to other formats.
 
 
 .. _a_intro_screenshots:

--- a/docs/source/int_overview.rst
+++ b/docs/source/int_overview.rst
@@ -88,5 +88,5 @@ meta data for it to extract.
    the application interface.
 
 :ref:`a_manuscript` - Recommended Reading
-   This chapter explains how the :guilabel:`Manuscript Build` tool works, how you can control the
+   This chapter explains how the :guilabel:`Manuscript Compile` tool works, how you can control the
    way chapter titles are formatted, and how scene and section breaks are handled.

--- a/docs/source/project_manuscript.rst
+++ b/docs/source/project_manuscript.rst
@@ -1,45 +1,46 @@
 .. _a_manuscript:
 
-***********************
-Building the Manuscript
-***********************
+************************
+Compiling the Manuscript
+************************
 
-You can at any time build a manuscript, an outline of your notes, or any other type of document
-from the text in your project. All of this is handled by the :guilabel:`Manuscript Build` tool.
-You can activate it from the sidebar, the :guilabel:`Tools` menu, or by pressing :kbd:`F5`.
+You can at any time compile a manuscript, an outline of your notes, or any other type of document
+from the text in your project. All of this is handled by the :guilabel:`Compile ManuscriptBuild`
+tool. You can activate it from the sidebar, the :guilabel:`Tools` menu, or by pressing :kbd:`F5`.
 
 .. versionadded:: 2.1
    This tool is new for version 2.1. A simpler tool was used for earlier versions. The simpler tool
-   only allows you to define a single set of options for the build, but otherwise has much the same
-   functionality.
+   only allowed you to define a single set of options for the manuscript, but otherwise has much
+   the same functionality as the new one.
 
 
 .. _a_manuscript_main:
 
-The Manuscript Build Tool
-=========================
+The Compile Manuscript Tool
+===========================
 
 .. figure:: images/fig_manuscript_build.png
 
-   The :guilabel:`Manuscript Build` tool main window.
+   The :guilabel:`Compile Manuscript` tool main window.
 
-The main window of the :guilabel:`Manuscript Build` tool contains a list of all the builds you have
-defined, a selection of settings, and a few buttons to generate preview, open the print dialog, or
-run the build to create a manuscript document.
+The main window of the :guilabel:`Compile Manuscript` tool contains a list of all the compile
+settings have defined, an overview of some of their settings, and a few buttons to generate
+preview, open the print dialog, or compile a manuscript document.
 
 
 .. _a_manuscript_settings:
 
-Build Settings
-==============
+Manuscript Compile Settings
+===========================
 
-Each build definition can be edited by opening it in the :guilabel:`Manuscript Build Settings`
-dialog, either by double-clicking or by selecting it and pressing the edit button in the toolbar.
+Each compile settings definition can be edited by opening it in the
+:guilabel:`Manuscript Compile Settings` dialog, either by double-clicking or by selecting it and
+pressing the edit button in the toolbar.
 
 .. tip::
-   You can keep the :guilabel:`Manuscript Build Settings` dialog open while testing the different
+   You can keep the :guilabel:`Manuscript Compile Settings` dialog open while testing the different
    options, and just hit the :guilabel:`Apply` button. You can test the result of your settings
-   by pressing the :guilabel:`Preview` button in the main :guilabel:`Manuscript Build` window.
+   by pressing the :guilabel:`Preview` button in the main :guilabel:`Compile Manuscript` window.
    When you're happy with the result, you can close the settings.
 
 
@@ -48,11 +49,11 @@ Document Selection
 
 .. figure:: images/fig_build_settings_selections.png
 
-   The :guilabel:`Selections` page of the :guilabel:`Manuscript Build Settings` dialog.
+   The :guilabel:`Selections` page of the :guilabel:`Manuscript Compile Settings` dialog.
 
-The :guilabel:`Selections` page of the :guilabel:`Manuscript Build Settings` dialog allows you to
-fine tune which documents are included in the build. They are indicated by a green arrow icon in
-the last column. On the right you have some filter options for selecting content of a specific
+The :guilabel:`Selections` page of the :guilabel:`Manuscript Compile Settings` dialog allows you to
+fine tune which documents are included in the manuscript. They are indicated by a green arrow icon
+in the last column. On the right you have some filter options for selecting content of a specific
 type, and a set of switches for which root folders to include.
 
 You can override the result of these filters by marking one or more documents and selecting to
@@ -68,23 +69,24 @@ Formatting Headings
 
 .. figure:: images/fig_build_settings_headings.png
 
-   The :guilabel:`Headings` page of the :guilabel:`Manuscript Build Settings` dialog.
+   The :guilabel:`Headings` page of the :guilabel:`Manuscript Compile Settings` dialog.
 
-The :guilabel:`Headings` page of the :guilabel:`Manuscript Build Settings` dialog allows you to set
-how the headings in your :term:`Novel Documents` are formatted. By default, the title is just
+The :guilabel:`Headings` page of the :guilabel:`Manuscript Compile Settings` dialog allows you to
+set how the headings in your :term:`Novel Documents` are formatted. By default, the title is just
 copied as-is, indicated by the ``{Title}`` format. You can change this to for instance add chapter
 numbers and scene numbers like shown int he figure above.
 
 Clicking the edit button next to a format will copy the formatting string into the edit box where
 it can be modified, and where a syntax highlighter will help indicate which parts are automatically
-generated by the build tool. The :guilabel:`Insert` button is a dropdown list of these formats, and
-selecting one will insert it at the position of the cursor.
+generated by the compile tool. The :guilabel:`Insert` button is a dropdown list of these formats,
+and selecting one will insert it at the position of the cursor.
 
 Any text you add that isn't highlighted in colours will remain in your formatted titles.
 ``{Title}`` will always be replaced by the text in the heading from your documents.
 
 You can preview the result of these format strings by clicking :guilabel:`Apply`, and then clicking
-:guilabel:`Preview` in the :guilabel:`Manuscript Build` tool main window.
+:guilabel:`Preview` in the :guilabel:`Compile Manuscript` tool main window.
+
 
 Scene Separators
 ^^^^^^^^^^^^^^^^
@@ -103,30 +105,30 @@ Output Settings
 ---------------
 
 The :guilabel:`Content`, :guilabel:`Format` and :guilabel:`Output` pages of the
-:guilabel:`Manuscript Build Settings` dialog control a number of other settings for the output.
+:guilabel:`Manuscript Compile Settings` dialog control a number of other settings for the output.
 Some of these only apply to specific output formats, which is indicated by the section headings on
 the settings pages.
 
 
 .. _a_manuscript_build:
 
-Building Manuscript Documents
-=============================
+Compiling Manuscript Documents
+==============================
 
 .. figure:: images/fig_build_build.png
 
-   The :guilabel:`Manuscript Build` dialog used for writing the actual manuscript documents.
+   The :guilabel:`Compile Manuscript` dialog used for writing the actual manuscript documents.
 
-When you press the :guilabel:`Build` button on the :guilabel:`Build Manuscript` tool main window, a
-special file dialog opens up. This is where you pick your desired output format and where to write
-the file.
+When you press the :guilabel:`Compile` button on the :guilabel:`Compile Manuscript` tool main
+window, a special file dialog opens up. This is where you pick your desired output format and where
+to write the file.
 
 On the left side of the dialog is a list of all the available file formats, and on the right, a
-list of the documents which are included based on the build definition you selected. You can choose
+list of the documents which are included based on the compile settings you selected. You can choose
 an output path, and set a base file name as well. The file extension will be added automatically.
 
-To generate the manuscript document, press the :guilabel:`Build` button. A small progress bar will
-show the build progress, but for small projects it may pass very fast.
+To generate the manuscript document, press the :guilabel:`Compile` button. A small progress bar
+will show the progress, but for small projects it may pass very fast.
 
 
 File Formats
@@ -135,7 +137,7 @@ File Formats
 Currently, four document formats are supported.
 
 Open Document Format
-   The Build tool can produce either an ``.odt`` file, or an ``.fodt`` file. The latter is just a
+   The Compile tool can produce either an ``.odt`` file, or an ``.fodt`` file. The latter is just a
    flat version of the document format as a single XML file. Most rich text editors support the
    former, and only a few the latter.
 

--- a/docs/source/project_overview.rst
+++ b/docs/source/project_overview.rst
@@ -119,7 +119,7 @@ deleted accidentally, but still want it out of your main project tree, you can c
 :guilabel:`Archive` root folder and move it there.
 
 You can drag any document to this folder and preserve its settings. The document will always be
-excluded from the :guilabel:`Build Manuscript` tool. It is also removed from the
+excluded from the :guilabel:`Compile Manuscript` tool. It is also removed from the
 :term:`project index`, so the tags and references defined in it will not show up anywhere else.
 
 

--- a/docs/source/project_references.rst
+++ b/docs/source/project_references.rst
@@ -67,7 +67,7 @@ colour that valid tags do.
 The tag is the only part of these notes that the novelWriter uses. The rest of the document content
 is there for the writer to use in whatever way they wish. Of course, the content of the documents
 can be added to the manuscript, or an outline document. If you want to compile a single document of
-all your notes, you can do this from the :guilabel:`Manuscript Build` tool.
+all your notes, you can do this from the :guilabel:`Compile Manuscript` tool.
 
 Example of a heading with a tag for a character of the story:
 
@@ -159,7 +159,7 @@ highlight that two notes are related.
 
 .. tip::
    If you cross-reference between notes and export your project as an HTML document using the
-   :guilabel:`Manuscript Build` tool, the cross-references become clickable links in the exported
+   :guilabel:`Compile Manuscript` tool, the cross-references become clickable links in the exported
    HTML document as well.
 
 Example of a novel document with references to characters and plots:

--- a/docs/source/project_structure.rst
+++ b/docs/source/project_structure.rst
@@ -50,7 +50,7 @@ The syntax for the four basic header types, and the two special header types, is
 
 **Header Level 3: Scene**
    This header level signifies a scene level partition. You must provide a title text, but the
-   title text can be replaced with a scene separator or just skipped entirely when you build your
+   title text can be replaced with a scene separator or just skipped entirely when you compile your
    manuscript.
 
 **Header Level 4: Section**
@@ -59,13 +59,13 @@ The syntax for the four basic header types, and the two special header types, is
    mid-scene, like if you change the point-of-view character. You are free to use sections as you
    wish, and you can filter them out of the final manuscript just like with scene titles.
 
-Page breaks are automatically added before level 1 and 2 headers when you build your project to a
+Page breaks are automatically added before level 1 and 2 headers when you compile your project to a
 format that supports page breaks, or when you print the document directly from the
-:guilabel:`Manuscript Build` tool. If you want page breaks in other places, you have to specify
+:guilabel:`Compile Manuscript` tool. If you want page breaks in other places, you have to specify
 them manually. See :ref:`a_fmt_break`.
 
 .. tip::
-   There are multiple options of how to process novel titles when building the manuscript. For
+   There are multiple options of how to process novel titles when compiling the manuscript. For
    instance, chapter numbers can be applied automatically, and so can scene numbers if you want
    them in a draft manuscript. See the :ref:`a_manuscript` page for more details.
 
@@ -78,7 +78,7 @@ Novel Title and Front Matter
 It is recommended that you add a document at the very top of each Novel root folder with the novel
 title as the first line. You should modify the level 1 header format code with an ``!`` in order to
 render it as a document title that is excluded from any automatic Table of Content in a manuscript
-build document, like so:
+document, like so:
 
 ``#! My Novel``
 
@@ -97,12 +97,12 @@ Unnumbered Chapter Headings
 
 If you use the automatic numbering feature for your chapters, but you want to keep some special
 chapters separate from this, you cam add an ``!`` to the level 2 header formatting code to tell the
-build tool to skip these chapters.
+compile tool to skip these chapters.
 
 ``##! Unnumbered Chapter Title``
 
-There is a separate formatting feature for such chapters in the :guilabel:`Manuscript Build` tool
-as well. See the :ref:`a_manuscript` page for more details. When building a document of a format
+There is a separate formatting feature for such chapters in the :guilabel:`Compile Manuscript` tool
+as well. See the :ref:`a_manuscript` page for more details. When compiling a document of a format
 that supports page breaks, also unnumbered chapters will have a page break added just like for
 normal chapters.
 

--- a/docs/source/tech_storage.rst
+++ b/docs/source/tech_storage.rst
@@ -127,11 +127,11 @@ check somehow fails and novelWriter keeps crashing, you can delete the file manu
 the index. If this too fails, you have likely encountered a bug.
 
 
-Build Definitions
------------------
+Compile Definitions
+-------------------
 
-The build definitions from the :guilabel:`Manuscript Build` tool are kept in the
-``meta/builds.json`` file. If this file is lost, all custom build definitions are lost too.
+The compile definitions from the :guilabel:`Compile Manuscript` tool are kept in the
+``meta/builds.json`` file. If this file is lost, all custom definitions are lost too.
 
 
 Cached GUI Options

--- a/docs/source/usage_breakdown.rst
+++ b/docs/source/usage_breakdown.rst
@@ -33,7 +33,7 @@ them. For reference, a list of all shortcuts can be found in the :ref:`a_kb` cha
    Formatting is limited to headers, emphasis, text alignment, and a few other simple features.
 
 On the left side of the main window, you will find a sidebar. This bar has buttons for the standard
-views you can switch between, a quick link to the :guilabel:`Build Manuscript` tool, and a set of
+views you can switch between, a quick link to the :guilabel:`Compile Manuscript` tool, and a set of
 project-related tools and quick access to settings at the bottom.
 
 
@@ -165,11 +165,11 @@ whatever they want. See :ref:`a_struct` and :ref:`a_references` for more details
 
 .. _a_breakdown_export:
 
-Building the Manuscript
-=======================
+Compiling the Manuscript
+========================
 
 The project can at any time be assembled into a range of different formats through the
-:guilabel:`Build Manuscript` tool. Natively, novelWriter supports `Open Document`_, HTML5, and
+:guilabel:`Compile Manuscript` tool. Natively, novelWriter supports `Open Document`_, HTML5, and
 various flavours of Markdown.
 
 The HTML5 format is suitable for conversion by a number of other tools like Pandoc_, or for
@@ -184,7 +184,7 @@ HTML formatted text, or with the raw text as typed into the novel documents.
 See :ref:`a_manuscript` for more details.
 
 .. versionadded:: 2.1
-   You can now define multiple build definitions in the :guilabel:`Build Manuscript` tool. This
+   You can now define multiple compile settings in the :guilabel:`Compile Manuscript` tool. This
    allows you to define specific settings for various types of draft documents, outline documents,
    and manuscript formats. See :ref:`a_manuscript` for more details.
 

--- a/docs/source/usage_format.rst
+++ b/docs/source/usage_format.rst
@@ -56,29 +56,30 @@ correctly to produce the intended result. See :ref:`a_struct_heads` for more det
 
 ``## Title Text``
    Heading level two. For novel documents, the header level indicates the start of a new chapter.
-   Chapter numbers can be inserted automatically when building the manuscript.
+   Chapter numbers can be inserted automatically when compiling the manuscript.
 
 ``### Title Text``
    Heading level three. For novel documents, the header level indicates the start of a new scene.
-   Scene numbers or scene separators can be inserted automatically when building the manuscript,
+   Scene numbers or scene separators can be inserted automatically when compiling the manuscript,
    so you can use the title field as a working title for your scenes if you wish.
 
 ``#### Title Text``
    Heading level four. For novel documents, the header level indicates the start of a new section.
-   Section titles can be replaced by separators or ignored completely when building the manuscript.
+   Section titles can be replaced by separators or ignored completely when compiling the
+   manuscript.
 
 For headers level one and two, adding a ``!`` modifies the behaviour of the heading:
 
 ``#! Title Text``
-   This tells the build tool that the level one heading is intended to be used for the novel's
-   main title, like for instance on the front page. When building the manuscript, this will use a
-   different styling and will exclude the title from, for instance, a Table of Contents in Libre
-   Office.
+   This tells the :guilabel:`Compile Manuscrip` tool that the level one heading is intended to be
+   used for the novel's main title, like for instance on the front page. When compiling the
+   manuscript, this will use a different styling and will exclude the title from, for instance, a
+   Table of Contents in Libre Office.
 
 ``##! Title Text``
-   This tells the build tool to not assign a chapter number to this chapter title if automatic
-   chapter numbers are being used. Such titles are useful for a prologue for instance. See
-   :ref:`a_struct_heads_unnum` for more details.
+   This tells the :guilabel:`Compile Manuscrip` tool to not assign a chapter number to this chapter
+   title if automatic chapter numbers are being used. Such titles are useful for a prologue for
+   instance. See :ref:`a_struct_heads_unnum` for more details.
 
 .. note::
    The space after the ``#`` or ``!`` character is mandatory. The syntax highlighter will change
@@ -162,7 +163,7 @@ Comments and Synopsis
 
 In addition to these standard Markdown features, novelWriter also allows for comments in documents.
 The text of a comment is ignored by the word counter. The text can also be filtered out when
-building the manuscript or viewing the document.
+compiling the manuscript or viewing the document.
 
 If the first word of a comment is ``Synopsis:`` (with the colon included), the comment is treated
 in a special manner and will show up in the :ref:`a_ui_outline` in a dedicated column. The word
@@ -176,7 +177,7 @@ indicate this by altering the colour of the word.
 ``% Synopsis: text...``
    This is a synopsis comment. It is generally treated in the same way as a regular comment, except
    that it is also captured by the indexing algorithm and displayed in the :ref:`a_ui_outline`. It
-   can also be filtered separately when building the project to for instance generate an outline
+   can also be filtered separately when compiling the project to for instance generate an outline
    document of the whole project.
 
 .. note::
@@ -241,7 +242,7 @@ Examples:
 .. note::
    The text editor will not show the alignment and indentation live. But the viewer will show them
    when you open the document there. It will of course also be reflected in the document generated
-   from the build tool as long as the format supports paragraph alignment.
+   from the :guilabel:`Compile Manuscrip` tool as long as the format supports paragraph alignment.
 
 
 .. _a_fmt_break:
@@ -250,14 +251,16 @@ Vertical Space and Page Breaks
 ==============================
 
 Adding more than one line break between paragraphs will *not* increase the space between those
-paragraphs when building the project. To add additional space between paragraphs, add the text
-``[VSPACE]`` on a line of its own, and the build tool will insert a blank paragraph in its place.
+paragraphs when compiling the project. To add additional space between paragraphs, add the text
+``[VSPACE]`` on a line of its own, and the :guilabel:`Compile Manuscrip` tool will insert a blank
+paragraph in its place.
 
 If you need multiple blank paragraphs just add a colon and a number to the above code. For
 instance, writing ``[VSPACE:3]`` will insert three blank paragraphs.
 
-Normally, the build tool will insert a page break before all headers of level one and for all
-headers of level two for novel documents, i.e. chapters, but not for project notes.
+Normally, the :guilabel:`Compile Manuscrip` tool will insert a page break before all headers of
+level one and for all headers of level two for novel documents, i.e. chapters, but not for project
+notes.
 
 If you need to add a page break somewhere else, put the text ``[NEW PAGE]`` on a line by itself
 before the text you wish to start on a new page.
@@ -282,4 +285,4 @@ If you want page breaks for scenes and sections, you must add them manually.
 
    [NEWPAGE]
 
-   This text will always start on a new page if the build format has pages.
+   This text will always start on a new page if the manuscript documents format has pages.

--- a/docs/source/usage_project.rst
+++ b/docs/source/usage_project.rst
@@ -35,7 +35,7 @@ the project, and has four columns.
 **Column 3**
    The third column indicates whether the document is considered active or inactive in the project.
    You can use this flag to indicate that a document is still in the project, but should not be
-   considered an active part of it. When you run the :guilabel:`Build Manuscript` tool, you can
+   considered an active part of it. When you run the :guilabel:`Compile Manuscript` tool, you can
    include or exclude documents based on this flag. You can change this value from the
    :term:`context menu`.
 
@@ -135,7 +135,7 @@ Project Tree Drag & Drop
 
 The project tree allows drag & drop to a certain extent to allow you to reorder your documents and
 folders. Moving a document in the project tree will affect the text's position when you assemble
-your manuscript in the :guilabel:`Manuscript Build` tool.
+your manuscript in the :guilabel:`Compile Manuscript` tool.
 
 Drag & drop has only limited support for moving documents. In general, bulk actions are not
 allowed. This is deliberate to avoid accidentally messing up your project. If you make a mistake,

--- a/docs/source/usage_shortcuts.rst
+++ b/docs/source/usage_shortcuts.rst
@@ -20,7 +20,7 @@ Main Window Shortcuts
    :header: "Shortcut", "Description"
 
    ":kbd:`F1`",           "Open the online user manual"
-   ":kbd:`F5`",           "Open the :guilabel:`Build Manuscript` tool"
+   ":kbd:`F5`",           "Open the :guilabel:`Compile Manuscript` tool"
    ":kbd:`F6`",           "Open the :guilabel:`Writing Statistics` tool"
    ":kbd:`F8`",           "Toggle :guilabel:`Focus Mode`"
    ":kbd:`F9`",           "Re-build the project index"

--- a/docs/source/usage_typography.rst
+++ b/docs/source/usage_typography.rst
@@ -79,7 +79,7 @@ right single quotation marks, depending on the font. There is a Wikipedia articl
 `Modifier letter apostrophe`_ with more details.
 
 .. note::
-   On export with the :guilabel:`Build Manuscript` tool, these apostrophes will be replaced
+   On export with the :guilabel:`Compile Manuscript` tool, these apostrophes will be replaced
    automatically with the corresponding right hand single quote symbol as is generally recommended.
    Therefore it doesn't really matter if you only use them to correct syntax highlighting.
 

--- a/novelwriter/dialogs/projsettings.py
+++ b/novelwriter/dialogs/projsettings.py
@@ -237,7 +237,7 @@ class GuiProjectEditMain(QWidget):
         self.mainForm.addRow(
             self.tr("Project language"),
             self.projLang,
-            self.tr("Used when building the manuscript.")
+            self.tr("Used when compiling the manuscript.")
         )
 
         langIdx = 0

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -885,8 +885,8 @@ class GuiMainMenu(QMenuBar):
         self.aBackupProject = self.toolsMenu.addAction(self.tr("Backup Project"))
         self.aBackupProject.triggered.connect(lambda: SHARED.project.backupProject(True))
 
-        # Tools > Build Manuscript
-        self.aBuildManuscript = self.toolsMenu.addAction(self.tr("Build Manuscript"))
+        # Tools > Compile Manuscript
+        self.aBuildManuscript = self.toolsMenu.addAction(self.tr("Compile Manuscript"))
         self.aBuildManuscript.setShortcut("F5")
         self.aBuildManuscript.triggered.connect(self.mainGui.showBuildManuscriptDialog)
 

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -72,7 +72,7 @@ class GuiSideBar(QWidget):
         self.tbOutline.clicked.connect(lambda: self.viewChangeRequested.emit(nwView.OUTLINE))
 
         self.tbBuild = QToolButton(self)
-        self.tbBuild.setToolTip("{0} [F5]".format(self.tr("Build Manuscript")))
+        self.tbBuild.setToolTip("{0} [F5]".format(self.tr("Compile Manuscript")))
         self.tbBuild.setIconSize(iconSize)
         self.tbBuild.clicked.connect(self.mainGui.showBuildManuscriptDialog)
 

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI Build Manuscript
-==================================
+novelWriter – GUI Compile Manuscript
+====================================
 
 File History:
 Created: 2023-05-24 [2.1b1] GuiManuscriptBuild
@@ -47,10 +47,10 @@ logger = logging.getLogger(__name__)
 
 
 class GuiManuscriptBuild(QDialog):
-    """GUI Tools: Manuscript Build Dialog
+    """GUI Tools: Manuscript Compile Dialog
 
     This is the tool for running the build itself. It can be accessed
-    independently of the Manuscript Build Tool.
+    independently of the Manuscript Compile Tool.
     """
 
     D_KEY = Qt.ItemDataRole.UserRole
@@ -64,7 +64,7 @@ class GuiManuscriptBuild(QDialog):
         self._parent = parent
         self._build = build
 
-        self.setWindowTitle(self.tr("Build Manuscript"))
+        self.setWindowTitle(self.tr("Compile Manuscript"))
         self.setMinimumWidth(CONFIG.pxInt(500))
         self.setMinimumHeight(CONFIG.pxInt(300))
 
@@ -175,7 +175,7 @@ class GuiManuscriptBuild(QDialog):
         self.buildBox.setVerticalSpacing(sp4)
 
         # Dialog Buttons
-        self.btnBuild = QPushButton(SHARED.theme.getIcon("export"), self.tr("&Build"))
+        self.btnBuild = QPushButton(SHARED.theme.getIcon("export"), self.tr("&Compile"))
         self.dlgButtons = QDialogButtonBox(QDialogButtonBox.Close)
         self.dlgButtons.addButton(self.btnBuild, QDialogButtonBox.ActionRole)
 

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -79,7 +79,7 @@ class GuiManuscript(QDialog):
         self._builds = BuildCollection(SHARED.project)
         self._buildMap: dict[str, QListWidgetItem] = {}
 
-        self.setWindowTitle(self.tr("Build Manuscript"))
+        self.setWindowTitle(self.tr("Compile Manuscript"))
         self.setMinimumWidth(CONFIG.pxInt(600))
         self.setMinimumHeight(CONFIG.pxInt(500))
 
@@ -109,21 +109,21 @@ class GuiManuscript(QDialog):
         self.tbAdd = QToolButton(self)
         self.tbAdd.setIcon(SHARED.theme.getIcon("add"))
         self.tbAdd.setIconSize(QSize(iPx, iPx))
-        self.tbAdd.setToolTip(self.tr("Add New Build"))
+        self.tbAdd.setToolTip(self.tr("Add New Compile Settings"))
         self.tbAdd.setStyleSheet(buttonStyle)
         self.tbAdd.clicked.connect(self._createNewBuild)
 
         self.tbDel = QToolButton(self)
         self.tbDel.setIcon(SHARED.theme.getIcon("remove"))
         self.tbDel.setIconSize(QSize(iPx, iPx))
-        self.tbDel.setToolTip(self.tr("Delete Selected Build"))
+        self.tbDel.setToolTip(self.tr("Delete Selected Compile Settings"))
         self.tbDel.setStyleSheet(buttonStyle)
         self.tbDel.clicked.connect(self._deleteSelectedBuild)
 
         self.tbEdit = QToolButton(self)
         self.tbEdit.setIcon(SHARED.theme.getIcon("edit"))
         self.tbEdit.setIconSize(QSize(iPx, iPx))
-        self.tbEdit.setToolTip(self.tr("Edit Selected Build"))
+        self.tbEdit.setToolTip(self.tr("Edit Selected Compile Settings"))
         self.tbEdit.setStyleSheet(buttonStyle)
         self.tbEdit.clicked.connect(self._editSelectedBuild)
 
@@ -169,7 +169,7 @@ class GuiManuscript(QDialog):
         self.btnPrint = QPushButton(self.tr("Print"))
         self.btnPrint.clicked.connect(self._printDocument)
 
-        self.btnBuild = QPushButton(self.tr("Build"))
+        self.btnBuild = QPushButton(self.tr("Compile"))
         self.btnBuild.clicked.connect(self._buildManuscript)
 
         self.btnClose = QPushButton(self.tr("Close"))

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI Build Settings
-================================
+novelWriter – GUI Compile Settings
+==================================
 
 File History:
 Created: 2023-02-13 [2.1b1] GuiBuildSettings
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 
 class GuiBuildSettings(QDialog):
-    """GUI Tools: Manuscript Build Settings Dialog
+    """GUI Tools: Manuscript Compile Settings Dialog
 
     The main tool for configuring manuscript builds. It's a GUI tool for
     editing JSON build definitions, wrapped as a BuildSettings object.
@@ -78,7 +78,7 @@ class GuiBuildSettings(QDialog):
 
         self._build = build
 
-        self.setWindowTitle(self.tr("Manuscript Build Settings"))
+        self.setWindowTitle(self.tr("Manuscript Compile Settings"))
         self.setMinimumWidth(CONFIG.pxInt(700))
         self.setMinimumHeight(CONFIG.pxInt(400))
 


### PR DESCRIPTION
**Summary:**

This PR renames the "Build Manuscript" to "Compile Manuscript", and all associated labels. Including descriptions in the documentation.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
