### PR TITLE
Bump version to 2.2 Beta 1, and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,82 @@
 # novelWriter Changelog
 
+## Version 2.2 Beta 1 [2023-11-11]
+
+### Release Notes
+
+This is a beta release of the next release version, and is intended for testing purposes. Please be
+careful when using this version on live writing projects, and make sure you take frequent backups.
+
+Please check the changelog for an overview of changes. The full release notes will be added to the
+final release.
+
+### Detailed Changelog
+
+**Features**
+
+* novelWriter has a new logo and icon. PR #1593.
+* The Document Editor is now a true plain text editor. This has a number of benefits and a couple
+  of drawbacks. The most important benefits is that the editor responds a lot faster, and can hold
+  much larger text documents. The big document limit has therefore been removed. It mostly affected
+  automatic spell checking. The syntax highlighter and spell checker are also more efficient, which
+  allows for needed improvements to these. The drawbacks are mainly that the editor now scrolls one
+  line at a time, instead of scrolling pixel by pixel like before. PRs #1521 and #1525.
+* Tags and References are now case insensitive. Their display name on the user interface remains
+  the same as the value set for the `@tag` entry. Issue #1313. PRs #1522 and #1578.
+* Keywords for Tags and References, and the References themselves, now have an auto-complete menu
+  that pops up in the editor on lines starting with the `@` character. It will first suggest what
+  keyword you want to use, and when it has been added, use that keyword to look up suggestions for
+  references to add. The suggestions improve as you type by looking for the characters you've
+  already typed in the tags you've previously defined. Issue #823. PR #1581.
+* You can now right-click an undefined tag, and a context menu option to create a Project Note for
+  that tag will appear in the menu. On selection, it will create a note in the first root folder of
+  the correct kind, and set the title and tag to match the undefined reference, making it instantly
+  defined. Issues #1580 and #823. PR #1582.
+* Shortcodes have been added to the Document Editor. Shorcodes are HTML-like syntax, but uses
+  square brackets instead of angular brackets. So `[b]text[/b]` will make the word "text" appear as
+  bold. Shortcodes currently support bold, italic, striketrough, underline, superscript and
+  subscript text. The first three are complimentary to the Markdown-like syntax that. The benefit
+  of the shortcode emphasis syntax, however, is that it does not care about word boundaries, and
+  can therefore be used any place in the text. Including in the middle of words. Issues #1337 and
+  #1444. PRs #1540 and #1583.
+* A show/hide toolbar has been added to the editor where toolbuttons for formatting options are
+  available. The toolbar is hidden by default, but can be activated from a three dots icon in the
+  top left corner of the editor. Issue #1585. PR #1584.
+* Build Definitions in the Manuscript Build tool can now be re-ordered, and the order is preserved
+  when the tool is closed and re-opened. Issue #1542. PR #1591.
+
+**Usability**
+
+* The Settings menu in the sidebar now always pops out to the right and upwards from the bottom of
+  the icon. The previous behaviour was not guaranteed to stay in the vissible area of the screen.
+  PR #1520.
+* The right click action on a misspelled word now uses the actual spell checker data for lookup.
+  Previously, the spell checker would underline a word that was misspelled, but the right click
+  action actually had no way of reading where the error line was, so it had to guess again what
+  word the user was clicking. Since these two parts of the code used different logic, they
+  sometimes produced different results. The spell checker now saves the location of each spell
+  check error, and the right click action retrieves this data when genrating suggestions, which
+  should eliminate the problem of picking the correct word boundaries. Issue #1532. PR #1525.
+* The language of a project is not set in the New Project Wizard and in Project Settings. It is no
+  longer defined in the Build Settings panel. Issue #1588. PR #1589.
+* The way switching focus and view in the main GUi has changed. Pressing `Ctrl+T` will now switch
+  focus to the Project or Novel Tree if focus is elsewhere, or if either have focus already, it
+  will switch view to the other tree. Pressing `Ctrl+E` will switch focus and view to the Document
+  Editor. Pressing `Ctrl+Shift+T` will do the same for the Outline View. The old Alt-based shorcuts
+  have been removed. Issues #1310 and #1291. PR #1590.
+
+**User Interface**
+
+* The labels under the sidebar buttons have been removed. The tooltips have the necessary
+  information. PR #1520.
+
+**Other Improvements**
+
+* Also the Tags and References keywords are now translated into the project language when these are
+  included in Manuscript builds. As long as the phrases have been translated. PR #1586.
+
+----
+
 ## Version 2.1.1 [2023-11-05]
 
 ### Release Notes

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -33,26 +33,8 @@ from novelwriter.error import exceptionHandler, logException
 from novelwriter.config import Config
 from novelwriter.shared import SharedData
 
-##
-#  Version Scheme
-# ================
-#  Generally follows PEP 440
-#  Hex Version:
-#  - Digit 1,2 : Major Version (01-ff)
-#  - Digit 3,4 : Minor Version (01-ff)
-#  - Digit 5,6 : Patch Version (01-ff)
-#  - Digit 7   : Release Type (a: alpha, b: beta, c: candidate, f: final)
-#  - Digit 8   : Release Number (0-f)
-#
-#  Example    : Full        Short   Description
-# --------------------------------------------------------------------
-#  0x010200a0 : 1.2-alpha0  1.2a0   Use while developing next release
-#  0x010200a1 : 1.2-alpha1  1.2a1   First alpha release
-#  0x010200b1 : 1.2-beta1   1.2b1   First beta release
-#  0x010200c1 : 1.2-rc1     1.2rc1  First release candidate
-#  0x010200f0 : 1.2.0       1.2.0   Final release
-#  0x010201f0 : 1.2.1       1.2.1   Patch release
-##
+# Package Meta
+# ============
 
 __package__    = "novelwriter"
 __copyright__  = "Copyright 2018–2023, Veronica Berglyd Olsen"
@@ -60,9 +42,9 @@ __license__    = "GPLv3"
 __author__     = "Veronica Berglyd Olsen"
 __maintainer__ = "Veronica Berglyd Olsen"
 __email__      = "code@vkbo.net"
-__version__    = "2.2-alpha1"
-__hexversion__ = "0x020200a1"
-__date__       = "2023-09-01"
+__version__    = "2.2-beta1"
+__hexversion__ = "0x020200b1"
+__date__       = "2023-11-12"
 __status__     = "Stable"
 __domain__     = "novelwriter.io"
 

--- a/novelwriter/assets/text/release_notes.htm
+++ b/novelwriter/assets/text/release_notes.htm
@@ -2,46 +2,16 @@
 <html>
 <body>
 
-<h2>Release Notes for 2.1</h2>
-<p><i>Released on 17 October 2023</i></p>
+<h2>Release Notes for 2.2 Beta 1</h2>
+<p><i>Released on 11 November 2023</i></p>
 
-<p>Scroll down for <a href="#patch">Patch Notes</a></p>
-
-<p>The primary focus of this release has been a complete redesign of the Build Tool, that is, the
-tool that assembles your project into a manuscript document. The new tool, called the "Manuscript
-Build Tool" allows you to define multiple build definitions for your project. The build definitions
-are edited in a new Manuscript Build Settings dialog, with a lot more options than the old tool.</p>
-<p>The reason for this redesign is a long list of feature requests that could not easily be
-accommodated in the old, much simpler tool. Far from all the features have been added yet, but now
-that the new tool is in place, they will be gradually added in the coming releases.</p>
-<p>The key feature added in this release is the extended control you now have for selecting exactly
-what part of your project is included in a given build definition. You have the same filters for
-selecting documents and notes, and turning on or off root folders as before, but you can now easily
-override on a per-document basis what is included or excluded in addition to the filter.</p>
-<p>A second major improvement is a better tool to format your manuscript headings. You no longer
-have to look up formatting codes and add them manually. Instead, there is now a heading format
-editor in the Build Settings dialog for creating the header format, with syntax highlighting
-included.</p>
-
-<h3>Other Changes</h3>
-<p>Among other features is a new option to duplicate documents and folders in the project tree. The
-duplicate feature is available from the right-click menu. A proper light colour theme has also been
-added. In most cases it will be the same as the default theme, depending on your platform.</p>
-<p>There are other, minor improvements as well, and a lot of code improvements under the hood. For
-a full list of changes, see the detailed changelogs.</p>
+<p>This is a beta release of the next release version, and is intended for testing purposes. Please
+be careful when using this version on live writing projects, and make sure you take frequent
+backups.</p>
+<p>Please check the changelog for an overview of changes. The full release notes will be added to
+the final release.</p>
 
 <p><i>See also the <a href="https://github.com/vkbo/novelWriter/releases">Releases</a> page.</i></p>
-
-<a name="patch"></a><h2>Patch Notes</h2>
-
-<h3>Patch 2.2.1 &ndash; 5 November 2023</h3>
-
-<p>This is a patch release that fixes a layout issue and internationalisation issues with the new
-Manuscript Build tool. It also fixes a number of issues related to bugs in the underlying Qt
-framework that affects drag and drop functionality in the project tree. These issues were mostly
-only affecting Debian Linux package releases.</p>
-<p>Other, minor issues related to updating the editor on colour theme change and project word list
-changes have been fixed as well. See the full changelog for more details.</p>
 
 </body>
 </html>

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.2-alpha1" hexVersion="0x020200a1" fileVersion="1.5" fileRevision="1" timeStamp="2023-11-06 11:44:21">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1609" autoCount="255" editTime="81165">
+<novelWriterXML appVersion="2.2-beta1" hexVersion="0x020200b1" fileVersion="1.5" fileRevision="1" timeStamp="2023-11-11 22:48:30">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="1611" autoCount="255" editTime="81193">
     <name>Sample Project</name>
     <title>Sample Project</title>
     <author>Jane Smith</author>
@@ -36,7 +36,7 @@
       <entry key="i56be10" count="1" red="117" green="0" blue="175">Main</entry>
     </importance>
   </settings>
-  <content items="27" novelWords="989" notesWords="409">
+  <content items="27" novelWords="987" notesWords="409">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
       <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
@@ -46,7 +46,7 @@
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H0" charCount="269" wordCount="51" paraCount="3" cursorPos="275" />
+      <meta expanded="no" heading="H0" charCount="250" wordCount="49" paraCount="2" cursorPos="275" />
       <name status="sf12341" import="ia857f0" active="yes">Page</name>
     </item>
     <item handle="edca4be2fcaf8" parent="7031beac91f75" root="7031beac91f75" order="2" type="FILE" class="NOVEL" layout="DOCUMENT">
@@ -58,7 +58,7 @@
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2901" wordCount="513" paraCount="15" cursorPos="749" />
+      <meta expanded="no" heading="H3" charCount="2901" wordCount="513" paraCount="15" cursorPos="48" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">


### PR DESCRIPTION
**Summary:**

Scheduled for 12 November 2023.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
