### PR TITLE
Improve how formatting is applied in the editor

### DIFF
--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -327,8 +327,7 @@ class nwQuotes:
 
 
 class nwUnicode:
-    """Supported unicode character constants and their HTML equivalents.
-    """
+    """Supported unicode character constants and their HTML equivalents."""
     # Unicode Constants
     # =================
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class SelectAction(Enum):
+class _SelectAction(Enum):
 
     NO_DECISION    = 0
     KEEP_SELECTION = 1
@@ -1423,13 +1423,13 @@ class GuiDocEditor(QPlainTextEdit):
         cursor = self.textCursor()
         posO = cursor.position()
         if cursor.hasSelection():
-            select = SelectAction.KEEP_SELECTION
+            select = _SelectAction.KEEP_SELECTION
         else:
             cursor = self._autoSelect()
             if cursor.hasSelection() and posO == cursor.selectionEnd():
-                select = SelectAction.MOVE_AFTER
+                select = _SelectAction.MOVE_AFTER
             else:
-                select = SelectAction.KEEP_POSITION
+                select = _SelectAction.KEEP_POSITION
 
         posS = cursor.selectionStart()
         posE = cursor.selectionEnd()
@@ -1483,7 +1483,7 @@ class GuiDocEditor(QPlainTextEdit):
         return True
 
     def _wrapSelection(self, before: str, after: str | None = None, pos: int | None = None,
-                       select: SelectAction = SelectAction.NO_DECISION) -> bool:
+                       select: _SelectAction = _SelectAction.NO_DECISION) -> bool:
         """Wrap the selected text in whatever is in tBefore and tAfter.
         If there is no selection, the autoSelect setting decides the
         action. AutoSelect will select the word under the cursor before
@@ -1494,15 +1494,15 @@ class GuiDocEditor(QPlainTextEdit):
 
         cursor = self.textCursor()
         posO = pos if isinstance(pos, int) else cursor.position()
-        if select == SelectAction.NO_DECISION:
+        if select == _SelectAction.NO_DECISION:
             if cursor.hasSelection():
-                select = SelectAction.KEEP_SELECTION
+                select = _SelectAction.KEEP_SELECTION
             else:
                 cursor = self._autoSelect()
                 if cursor.hasSelection() and posO == cursor.selectionEnd():
-                    select = SelectAction.MOVE_AFTER
+                    select = _SelectAction.MOVE_AFTER
                 else:
-                    select = SelectAction.KEEP_POSITION
+                    select = _SelectAction.KEEP_POSITION
 
         posS = cursor.selectionStart()
         posE = cursor.selectionEnd()
@@ -1520,12 +1520,12 @@ class GuiDocEditor(QPlainTextEdit):
         cursor.insertText(before)
         cursor.endEditBlock()
 
-        if select == SelectAction.MOVE_AFTER:
+        if select == _SelectAction.MOVE_AFTER:
             cursor.setPosition(posE + len(before + after))
-        elif select == SelectAction.KEEP_SELECTION:
+        elif select == _SelectAction.KEEP_SELECTION:
             cursor.setPosition(posE + len(before), QTextCursor.MoveMode.MoveAnchor)
             cursor.setPosition(posS + len(before), QTextCursor.MoveMode.KeepAnchor)
-        elif select == SelectAction.KEEP_POSITION:
+        elif select == _SelectAction.KEEP_POSITION:
             cursor.setPosition(posO + len(before))
 
         self.setTextCursor(cursor)
@@ -1957,7 +1957,6 @@ class GuiDocEditor(QPlainTextEdit):
             for i in range(bPos + bLen - cPos):
                 ePos = cPos + i
                 if not self._qDocument.characterAt(ePos).isalnum():
-                    # ePos -= 1
                     break
 
             if ePos - sPos <= 0:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -74,7 +74,7 @@ class _SelectAction(Enum):
     KEEP_POSITION  = 2
     MOVE_AFTER     = 3
 
-# END Class EditorSelectMode
+# END Class _SelectAction
 
 
 class GuiDocEditor(QPlainTextEdit):

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -672,7 +672,7 @@ def testGuiEditor_Insert(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd
 
 
 @pytest.mark.gui
-def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd):
+def testGuiEditor_TextManipulation(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     """Test the text manipulation functions."""
     buildTestProject(nwGUI, projPath)
     assert nwGUI.openDocument(C.hSceneDoc) is True
@@ -680,48 +680,12 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     text = "### A Scene\n\n%s" % "\n\n".join(ipsumText)
     nwGUI.docEditor.replaceText(text)
 
-    # Clear Surrounding
-    # =================
-
-    # No Selection
-    text = "### A Scene\n\n%s" % ipsumText[0]
-    nwGUI.docEditor.replaceText(text)
-    nwGUI.docEditor.setCursorPosition(45)
-
-    cursor = nwGUI.docEditor.textCursor()
-    assert nwGUI.docEditor._clearSurrounding(cursor, 1) is False
-
-    # Clear Characters, 1 Layer
-    repText = text.replace("consectetur", "=consectetur=")
-    nwGUI.docEditor.replaceText(repText)
-    nwGUI.docEditor.setCursorPosition(45)
-
-    cursor = nwGUI.docEditor.textCursor()
-    cursor.select(QTextCursor.WordUnderCursor)
-    assert nwGUI.docEditor._clearSurrounding(cursor, 1) is True
-    assert nwGUI.docEditor.getText() == text
-
-    # Clear Characters, 2 Layers
-    repText = text.replace("consectetur", "==consectetur==")
-    nwGUI.docEditor.replaceText(repText)
-    nwGUI.docEditor.setCursorPosition(45)
-
-    cursor = nwGUI.docEditor.textCursor()
-    cursor.select(QTextCursor.WordUnderCursor)
-    assert nwGUI.docEditor._clearSurrounding(cursor, 2) is True
-    assert nwGUI.docEditor.getText() == text
-
     # Wrap Selection
     # ==============
 
     text = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2])
     nwGUI.docEditor.replaceText(text)
     nwGUI.docEditor.setCursorPosition(45)
-
-    # No Selection
-    with monkeypatch.context() as mp:
-        mp.setattr(nwGUI.docEditor, "_autoSelect", lambda: QTextCursor())
-        assert nwGUI.docEditor._wrapSelection("=", "=") is False
 
     # Wrap Equal
     nwGUI.docEditor.replaceText(text)
@@ -752,13 +716,13 @@ def testGuiEditor_TextManipulation(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # =============
 
     text = "### A Scene\n\n%s" % "\n\n".join(ipsumText[0:2])
-    nwGUI.docEditor.replaceText(text)
-    nwGUI.docEditor.setCursorPosition(45)
 
-    # No Selection
-    with monkeypatch.context() as mp:
-        mp.setattr(nwGUI.docEditor, "_autoSelect", lambda: QTextCursor())
-        assert nwGUI.docEditor._toggleFormat(2, "=") is False
+    # Block format repetition
+    nwGUI.docEditor.replaceText(text)
+    nwGUI.docEditor.setCursorPosition(39)
+    assert nwGUI.docEditor._toggleFormat(1, "=") is True
+    assert nwGUI.docEditor.getText() == text.replace("amet", "=amet=", 1)
+    assert nwGUI.docEditor._toggleFormat(1, "=") is False
 
     # Wrap Single Equal
     nwGUI.docEditor.replaceText(text)


### PR DESCRIPTION
**Summary:**

This PR:
* Rewrites the Auto Select feature to no longer use Qt's "Text Under Cursor" selector. Instead, it will now iterate backwards and forwards from the cursor position until it finds the first character in either direction that isn't considered a Unicode alphanumeric character as per Python's string implementation. This generates more meaningful selections than the Qt implementation which would select the punctuation if you activated it with the cursor between a word and its immediate punctuation.
* Changes the logic when you toggle a bold, italic or strike through Markdown format. When the cursor is at the end of the word, it will be left after the word + markup when the toggle is complete. If the cursor position was at the beginning or inside the word, the cursor remains in the same position after. Applying a shortcode behaves the same way, although they cannot be toggled, only added.
* When an auto select is performed in the process, the word is no longer selected after the change. Before, it would remain selected.
* When no selection is made, and the auto select does not find anything to select, the format is inserted around the cursor itself.

**Related Issue(s):**

Closes #1333
Closes #1598

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
