### PR TITLE
Add a button to open manuscript build folder

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -33,8 +33,11 @@ from typing import Any, Literal
 from pathlib import Path
 from datetime import datetime
 from configparser import ConfigParser
+from urllib.parse import urljoin
+from urllib.request import pathname2url
 
-from PyQt5.QtCore import QCoreApplication
+from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtCore import QCoreApplication, QUrl
 from PyQt5.QtWidgets import QWidget, qApp
 
 from novelwriter.enum import nwItemClass, nwItemType, nwItemLayout
@@ -493,6 +496,16 @@ def getFileSize(path: Path) -> int:
         return path.stat().st_size
     except Exception:
         return -1
+
+
+def openExternalPath(path: Path) -> bool:
+    """Open a path by passing it to the desktop environment."""
+    if Path(path).exists():
+        QDesktopServices.openUrl(
+            QUrl(urljoin("file:", pathname2url(str(path))))
+        )
+        return True
+    return False
 
 
 # =============================================================================================== #

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -45,7 +45,7 @@ from novelwriter.core.sessions import NWSessionLog
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.projectdata import NWProjectData
 from novelwriter.common import (
-    checkStringNone, formatInt, formatTimeStamp, hexToInt, makeFileNameSafe, minmax
+    checkStringNone, formatInt, formatTimeStamp, getFileSize, hexToInt, makeFileNameSafe, minmax
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -420,7 +420,7 @@ class NWProject:
         timeStamp = formatTimeStamp(time(), fileSafe=True)
         archName = baseDir / f"{cleanName} {timeStamp}.zip"
         if self._storage.zipIt(archName, compression=2):
-            size = formatInt(archName.stat().st_size)
+            size = formatInt(getFileSize(archName))
             if doNotify:
                 SHARED.info(
                     self.tr("Created a backup of your project of size {0}B.").format(size),

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -27,15 +27,14 @@ import logging
 
 from typing import TYPE_CHECKING
 from pathlib import Path
-from urllib.parse import urljoin
-from urllib.request import pathname2url
 
-from PyQt5.QtCore import QUrl, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtCore import QUrl, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QMenuBar, QAction
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.enum import nwDocAction, nwDocInsert, nwWidget
+from novelwriter.common import openExternalPath
 from novelwriter.constants import nwConst, trConst, nwKeyWords, nwLabels, nwUnicode
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -111,9 +110,7 @@ class GuiMainMenu(QMenuBar):
     def _openUserManualFile(self) -> None:
         """Open the documentation in PDF format."""
         if isinstance(CONFIG.pdfDocs, Path):
-            QDesktopServices.openUrl(
-                QUrl(urljoin("file:", pathname2url(str(CONFIG.pdfDocs))))
-            )
+            openExternalPath(CONFIG.pdfDocs)
         return
 
     @pyqtSlot(str)

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -27,19 +27,17 @@ import logging
 
 from pathlib import Path
 from zipfile import ZipFile
-from urllib.parse import urljoin
-from urllib.request import pathname2url
 
-from PyQt5.QtGui import QCloseEvent, QDesktopServices, QTextCursor
-from PyQt5.QtCore import QUrl, pyqtSlot
+from PyQt5.QtGui import QCloseEvent, QTextCursor
+from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import (
     QDialog, QDialogButtonBox, QFileDialog, QFrame, QHBoxLayout, QLabel,
     QLineEdit, QPlainTextEdit, QPushButton, QVBoxLayout, QWidget, qApp
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import formatInt, getFileSize
 from novelwriter.error import formatException
+from novelwriter.common import openExternalPath, formatInt, getFileSize
 
 logger = logging.getLogger(__name__)
 
@@ -217,12 +215,7 @@ class GuiDictionaries(QDialog):
     @pyqtSlot()
     def _doOpenInstallLocation(self) -> None:
         """Open the dictionary folder."""
-        path = self.inPath.text()
-        if Path(path).is_dir():
-            QDesktopServices.openUrl(
-                QUrl(urljoin("file:", pathname2url(path)))
-            )
-        else:
+        if not openExternalPath(Path(self.inPath.text())):
             SHARED.error("Path not found.")
         return
 

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -37,7 +37,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.enum import nwBuildFmt
-from novelwriter.common import makeFileNameSafe
+from novelwriter.common import makeFileNameSafe, openExternalPath
 from novelwriter.constants import nwLabels
 from novelwriter.core.item import NWItem
 from novelwriter.core.docbuild import NWBuildDocument
@@ -176,9 +176,11 @@ class GuiManuscriptBuild(QDialog):
         self.buildBox.setVerticalSpacing(sp4)
 
         # Dialog Buttons
+        self.btnOpen = QPushButton(SHARED.theme.getIcon("browse"), self.tr("Open Folder"))
         self.btnBuild = QPushButton(SHARED.theme.getIcon("export"), self.tr("&Build"))
-        self.dlgButtons = QDialogButtonBox(QDialogButtonBox.Close)
-        self.dlgButtons.addButton(self.btnBuild, QDialogButtonBox.ActionRole)
+        self.dlgButtons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        self.dlgButtons.addButton(self.btnOpen, QDialogButtonBox.ButtonRole.ActionRole)
+        self.dlgButtons.addButton(self.btnBuild, QDialogButtonBox.ButtonRole.ActionRole)
 
         # Assemble GUI
         # ============
@@ -254,7 +256,10 @@ class GuiManuscriptBuild(QDialog):
         """Handle button clicks from the dialog button box."""
         role = self.dlgButtons.buttonRole(button)
         if role == QDialogButtonBox.ActionRole:
-            self._runBuild()
+            if button == self.btnBuild:
+                self._runBuild()
+            elif button == self.btnOpen:
+                self._openOutputFolder()
         elif role == QDialogButtonBox.RejectRole:
             self.close()
         return
@@ -384,6 +389,11 @@ class GuiManuscriptBuild(QDialog):
                 item.setIcon(itemIcon)
                 self.listContent.addItem(item)
 
+        return
+
+    def _openOutputFolder(self):
+        """Open the build folder in the system's file explorer."""
+        openExternalPath(Path(self.buildPath.text()))
         return
 
 # END Class GuiManuscriptBuild

--- a/tests/test_tools/test_tools_manusbuild.py
+++ b/tests/test_tools/test_tools_manusbuild.py
@@ -19,6 +19,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+from PyQt5.QtCore import QUrl
+from PyQt5.QtGui import QDesktopServices
 import pytest
 
 from pathlib import Path
@@ -131,6 +133,19 @@ def testManuscriptBuild_Main(
     with monkeypatch.context() as mp:
         mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
         assert manus._runBuild() is False
+
+    # Test that the open button works
+    lastUrl = ""
+
+    def mockOpenUrl(url: QUrl) -> None:
+        nonlocal lastUrl
+        lastUrl = url.toString()
+        return
+
+    with monkeypatch.context() as mp:
+        mp.setattr(QDesktopServices, "openUrl", mockOpenUrl)
+        manus.btnOpen.click()
+        assert lastUrl.startswith("file://")
 
     # Finish
     manus._dialogButtonClicked(manus.dlgButtons.button(QDialogButtonBox.Close))


### PR DESCRIPTION
**Summary:**

This PR adds a button to the Manuscript Build dialog that will open the output folder.

**Related Issue(s):**

Closes #1554

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
