### PR TITLE
Fix focus switch bug in project tree

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -680,6 +680,7 @@ class GuiProjectTree(QTreeWidget):
 
         # Add the new item to the project tree
         self.revealNewTreeItem(tHandle, nHandle=nHandle, wordCount=True)
+        self.projView.setTreeFocus()  # See issue #1376
 
         return True
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -41,6 +41,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
+from novelwriter.enum import nwDocMode, nwItemType, nwItemClass, nwItemLayout
 from novelwriter.common import minmax
 from novelwriter.constants import nwHeaders, nwUnicode, trConst, nwLabels
 from novelwriter.core.item import NWItem
@@ -49,9 +50,6 @@ from novelwriter.dialogs.docmerge import GuiDocMerge
 from novelwriter.dialogs.docsplit import GuiDocSplit
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projsettings import GuiProjectSettings
-from novelwriter.enum import (
-    nwDocMode, nwItemType, nwItemClass, nwItemLayout, nwWidget
-)
 
 if TYPE_CHECKING:  # pragma: no cover
     from novelwriter.guimain import GuiMain
@@ -682,7 +680,6 @@ class GuiProjectTree(QTreeWidget):
 
         # Add the new item to the project tree
         self.revealNewTreeItem(tHandle, nHandle=nHandle, wordCount=True)
-        self.mainGui.switchFocus(nwWidget.TREE)
 
         return True
 


### PR DESCRIPTION
**Summary:**

This PR:
* Removes the focus switch call made after creating a new project item.

**Related Issue(s):**

Closes #1648

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
