### PR TITLE
Convert theme colours to Qt objects

### DIFF
--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -220,23 +220,25 @@ class GuiAbout(QDialog):
 
     def _setStyleSheet(self) -> None:
         """Set stylesheet for all browser tabs."""
+        colHead = SHARED.theme.colHead
+        colKey = SHARED.theme.colKey
         styleSheet = (
             "h1, h2, h3, h4 {{"
-            "  color: rgb({hColR},{hColG},{hColB});"
+            "  color: rgb({hColR}, {hColG}, {hColB});"
             "}}\n"
             "a {{"
-            "  color: rgb({hColR},{hColG},{hColB});"
+            "  color: rgb({hColR}, {hColG}, {hColB});"
             "}}\n"
             ".alt {{"
-            "  color: rgb({kColR},{kColG},{kColB});"
+            "  color: rgb({kColR}, {kColG}, {kColB});"
             "}}\n"
         ).format(
-            hColR=SHARED.theme.colHead[0],
-            hColG=SHARED.theme.colHead[1],
-            hColB=SHARED.theme.colHead[2],
-            kColR=SHARED.theme.colKey[0],
-            kColG=SHARED.theme.colKey[1],
-            kColB=SHARED.theme.colKey[2],
+            hColR=colHead.red(),
+            hColG=colHead.green(),
+            hColB=colHead.blue(),
+            kColR=colKey.red(),
+            kColG=colKey.green(),
+            kColB=colKey.blue(),
         )
         self.pageAbout.document().setDefaultStyleSheet(styleSheet)
         self.pageNotes.document().setDefaultStyleSheet(styleSheet)

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 
-from PyQt5.QtGui import QCloseEvent, QColor, QFont, QKeyEvent, QKeySequence, QPalette
+from PyQt5.QtGui import QCloseEvent, QFont, QKeyEvent, QKeySequence, QPalette
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QAbstractButton, QComboBox, QCompleter, QDialog, QDialogButtonBox,
@@ -62,7 +62,7 @@ class GuiPreferences(QDialog):
         font.setPointSizeF(1.25*SHARED.theme.fontPointSize)
 
         palette = self.palette()
-        palette.setColor(QPalette.ColorRole.WindowText, QColor(*SHARED.theme.helpText))
+        palette.setColor(QPalette.ColorRole.WindowText, SHARED.theme.helpText)
 
         self.titleLabel = QLabel(self.tr("Preferences"), self)
         self.titleLabel.setFont(font)

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -76,9 +76,9 @@ class NScrollableForm(QScrollArea):
     #  Setters
     ##
 
-    def setHelpTextStyle(self, color: QColor | list | tuple, scale: float = FONT_SCALE) -> None:
+    def setHelpTextStyle(self, color: QColor, scale: float = FONT_SCALE) -> None:
         """Set the text color for the help text."""
-        self._helpCol = color if isinstance(color, QColor) else QColor(*color)
+        self._helpCol = color
         self._fontScale = scale
         return
 
@@ -187,7 +187,7 @@ class NConfigLayout(QGridLayout):
     #  Getters and Setters
     ##
 
-    def setHelpTextStyle(self, color: QColor | list | tuple, scale: float = FONT_SCALE) -> None:
+    def setHelpTextStyle(self, color: QColor, scale: float = FONT_SCALE) -> None:
         """Set the text color for the help text."""
         self._helpCol = color if isinstance(color, QColor) else QColor(*color)
         self._fontScale = scale
@@ -328,18 +328,15 @@ class NSimpleLayout(QGridLayout):
 
 class NHelpLabel(QLabel):
 
-    def __init__(self, text: str, color: QColor | list | tuple,
-                 fontSize: float = FONT_SCALE) -> None:
+    def __init__(self, text: str, color: QColor, scale: float = FONT_SCALE) -> None:
         super().__init__(text)
 
-        qCol = color if isinstance(color, QColor) else QColor(*color)
-
         lblCol = self.palette()
-        lblCol.setColor(QPalette.WindowText, qCol)
+        lblCol.setColor(QPalette.WindowText, color)
         self.setPalette(lblCol)
 
         lblFont = self.font()
-        lblFont.setPointSizeF(fontSize*lblFont.pointSizeF())
+        lblFont.setPointSizeF(scale*lblFont.pointSizeF())
         self.setFont(lblFont)
 
         self.setWordWrap(True)

--- a/novelwriter/extensions/pagedsidebar.py
+++ b/novelwriter/extensions/pagedsidebar.py
@@ -67,9 +67,9 @@ class NPagedSideBar(QToolBar):
         """Return a specific button."""
         return self._buttons[buttonId]
 
-    def setLabelColor(self, color: list | QColor) -> None:
+    def setLabelColor(self, color: QColor) -> None:
         """Set the text color for the labels."""
-        self._labelCol = color if isinstance(color, QColor) else QColor(*color)
+        self._labelCol = color
         return
 
     def addSeparator(self) -> None:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -276,14 +276,14 @@ class GuiDocEditor(QPlainTextEdit):
     def updateSyntaxColours(self) -> None:
         """Update the syntax highlighting theme."""
         mainPalette = self.palette()
-        mainPalette.setColor(QPalette.ColorRole.Window, QColor(*SHARED.theme.colBack))
-        mainPalette.setColor(QPalette.ColorRole.Base, QColor(*SHARED.theme.colBack))
-        mainPalette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        mainPalette.setColor(QPalette.ColorRole.Window, SHARED.theme.colBack)
+        mainPalette.setColor(QPalette.ColorRole.Base, SHARED.theme.colBack)
+        mainPalette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
         self.setPalette(mainPalette)
 
         docPalette = self.viewport().palette()
-        docPalette.setColor(QPalette.ColorRole.Base, QColor(*SHARED.theme.colBack))
-        docPalette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        docPalette.setColor(QPalette.ColorRole.Base, SHARED.theme.colBack)
+        docPalette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
         self.viewport().setPalette(docPalette)
 
         self.docHeader.matchColours()
@@ -2326,9 +2326,9 @@ class GuiDocToolBar(QWidget):
     def updateTheme(self) -> None:
         """Initialise GUI elements that depend on specific settings."""
         palette = QPalette()
-        palette.setColor(QPalette.ColorRole.Window, QColor(*SHARED.theme.colBack))
-        palette.setColor(QPalette.ColorRole.WindowText, QColor(*SHARED.theme.colText))
-        palette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        palette.setColor(QPalette.ColorRole.Window, SHARED.theme.colBack)
+        palette.setColor(QPalette.ColorRole.WindowText, SHARED.theme.colText)
+        palette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
         self.setPalette(palette)
 
         self.tbBoldMD.setIcon(SHARED.theme.getIcon("fmt_bold-md"))
@@ -2866,10 +2866,11 @@ class GuiDocEditHeader(QWidget):
         self.minmaxButton.setIcon(SHARED.theme.getIcon("maximise"))
         self.closeButton.setIcon(SHARED.theme.getIcon("close"))
 
+        colText = SHARED.theme.colText
         buttonStyle = (
             "QToolButton {{border: none; background: transparent;}} "
-            "QToolButton:hover {{border: none; background: rgba({0},{1},{2},0.2);}}"
-        ).format(*SHARED.theme.colText)
+            "QToolButton:hover {{border: none; background: rgba({0}, {1}, {2}, 0.2);}}"
+        ).format(colText.red(), colText.green(), colText.blue())
 
         self.tbButton.setStyleSheet(buttonStyle)
         self.searchButton.setStyleSheet(buttonStyle)
@@ -2885,9 +2886,9 @@ class GuiDocEditHeader(QWidget):
         theme rather than the main GUI.
         """
         palette = QPalette()
-        palette.setColor(QPalette.ColorRole.Window, QColor(*SHARED.theme.colBack))
-        palette.setColor(QPalette.ColorRole.WindowText, QColor(*SHARED.theme.colText))
-        palette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        palette.setColor(QPalette.ColorRole.Window, SHARED.theme.colBack)
+        palette.setColor(QPalette.ColorRole.WindowText, SHARED.theme.colText)
+        palette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
 
         self.setPalette(palette)
         self.itemTitle.setPalette(palette)
@@ -3093,9 +3094,9 @@ class GuiDocEditFooter(QWidget):
         theme rather than the main GUI.
         """
         palette = QPalette()
-        palette.setColor(QPalette.ColorRole.Window, QColor(*SHARED.theme.colBack))
-        palette.setColor(QPalette.ColorRole.WindowText, QColor(*SHARED.theme.colText))
-        palette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        palette.setColor(QPalette.ColorRole.Window, SHARED.theme.colBack)
+        palette.setColor(QPalette.ColorRole.WindowText, SHARED.theme.colText)
+        palette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
 
         self.setPalette(palette)
         self.statusText.setPalette(palette)

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -65,22 +65,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._hRules: list[tuple[str, dict]] = []
         self._hStyles: dict[str, QTextCharFormat] = {}
 
-        self._colHead   = QColor(0, 0, 0)
-        self._colHeadH  = QColor(0, 0, 0)
-        self._colEmph   = QColor(0, 0, 0)
-        self._colDialN  = QColor(0, 0, 0)
-        self._colDialD  = QColor(0, 0, 0)
-        self._colDialS  = QColor(0, 0, 0)
-        self._colHidden = QColor(0, 0, 0)
-        self._colCode   = QColor(0, 0, 0)
-        self._colKey    = QColor(0, 0, 0)
-        self._colVal    = QColor(0, 0, 0)
-        self._colSpell  = QColor(0, 0, 0)
-        self._colError  = QColor(0, 0, 0)
-        self._colRepTag = QColor(0, 0, 0)
-        self._colMod    = QColor(0, 0, 0)
-        self._colBreak  = QColor(0, 0, 0)
-
         self.initHighlighter()
 
         logger.debug("Ready: GuiDocHighlighter")
@@ -93,54 +77,37 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         """
         logger.debug("Setting up highlighting rules")
 
-        self._colHead   = QColor(*SHARED.theme.colHead)
-        self._colHeadH  = QColor(*SHARED.theme.colHeadH)
-        self._colDialN  = QColor(*SHARED.theme.colDialN)
-        self._colDialD  = QColor(*SHARED.theme.colDialD)
-        self._colDialS  = QColor(*SHARED.theme.colDialS)
-        self._colHidden = QColor(*SHARED.theme.colHidden)
-        self._colCode   = QColor(*SHARED.theme.colCode)
-        self._colKey    = QColor(*SHARED.theme.colKey)
-        self._colVal    = QColor(*SHARED.theme.colVal)
-        self._colSpell  = QColor(*SHARED.theme.colSpell)
-        self._colError  = QColor(*SHARED.theme.colError)
-        self._colRepTag = QColor(*SHARED.theme.colRepTag)
-        self._colMod    = QColor(*SHARED.theme.colMod)
-        self._colBreak  = QColor(*SHARED.theme.colEmph)
-        self._colBreak.setAlpha(64)
-
-        self._colEmph = None
-        if CONFIG.highlightEmph:
-            self._colEmph = QColor(*SHARED.theme.colEmph)
-
-        self._hStyles = {
-            "header1":   self._makeFormat(self._colHead, "bold", 1.8),
-            "header2":   self._makeFormat(self._colHead, "bold", 1.6),
-            "header3":   self._makeFormat(self._colHead, "bold", 1.4),
-            "header4":   self._makeFormat(self._colHead, "bold", 1.2),
-            "header1h":  self._makeFormat(self._colHeadH, "bold", 1.8),
-            "header2h":  self._makeFormat(self._colHeadH, "bold", 1.6),
-            "header3h":  self._makeFormat(self._colHeadH, "bold", 1.4),
-            "header4h":  self._makeFormat(self._colHeadH, "bold", 1.2),
-            "bold":      self._makeFormat(self._colEmph, "bold"),
-            "italic":    self._makeFormat(self._colEmph, "italic"),
-            "strike":    self._makeFormat(self._colHidden, "strike"),
-            "mspaces":   self._makeFormat(self._colError, "errline"),
-            "nobreak":   self._makeFormat(self._colBreak, "background"),
-            "dialogue1": self._makeFormat(self._colDialN),
-            "dialogue2": self._makeFormat(self._colDialD),
-            "dialogue3": self._makeFormat(self._colDialS),
-            "replace":   self._makeFormat(self._colRepTag),
-            "hidden":    self._makeFormat(self._colHidden),
-            "code":      self._makeFormat(self._colCode),
-            "keyword":   self._makeFormat(self._colKey),
-            "modifier":  self._makeFormat(self._colMod),
-            "value":     self._makeFormat(self._colVal, "underline"),
-            "codevalue": self._makeFormat(self._colVal),
-            "codeinval": self._makeFormat(None, "errline"),
-        }
+        colEmph = SHARED.theme.colEmph if CONFIG.highlightEmph else None
+        colBreak = QColor(SHARED.theme.colEmph)
+        colBreak.setAlpha(64)
 
         self._hRules = []
+        self._hStyles = {
+            "header1":   self._makeFormat(SHARED.theme.colHead, "bold", 1.8),
+            "header2":   self._makeFormat(SHARED.theme.colHead, "bold", 1.6),
+            "header3":   self._makeFormat(SHARED.theme.colHead, "bold", 1.4),
+            "header4":   self._makeFormat(SHARED.theme.colHead, "bold", 1.2),
+            "header1h":  self._makeFormat(SHARED.theme.colHeadH, "bold", 1.8),
+            "header2h":  self._makeFormat(SHARED.theme.colHeadH, "bold", 1.6),
+            "header3h":  self._makeFormat(SHARED.theme.colHeadH, "bold", 1.4),
+            "header4h":  self._makeFormat(SHARED.theme.colHeadH, "bold", 1.2),
+            "bold":      self._makeFormat(colEmph, "bold"),
+            "italic":    self._makeFormat(colEmph, "italic"),
+            "strike":    self._makeFormat(SHARED.theme.colHidden, "strike"),
+            "mspaces":   self._makeFormat(SHARED.theme.colError, "errline"),
+            "nobreak":   self._makeFormat(colBreak, "background"),
+            "dialogue1": self._makeFormat(SHARED.theme.colDialN),
+            "dialogue2": self._makeFormat(SHARED.theme.colDialD),
+            "dialogue3": self._makeFormat(SHARED.theme.colDialS),
+            "replace":   self._makeFormat(SHARED.theme.colRepTag),
+            "hidden":    self._makeFormat(SHARED.theme.colHidden),
+            "code":      self._makeFormat(SHARED.theme.colCode),
+            "keyword":   self._makeFormat(SHARED.theme.colKey),
+            "modifier":  self._makeFormat(SHARED.theme.colMod),
+            "value":     self._makeFormat(SHARED.theme.colVal, "underline"),
+            "codevalue": self._makeFormat(SHARED.theme.colVal),
+            "codeinval": self._makeFormat(None, "errline"),
+        }
 
         # Multiple or Trailing Spaces
         if CONFIG.showMultiSpaces:
@@ -318,7 +285,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                                 self.setFormat(xPos, xLen, self._hStyles["value"])
                         else:
                             kwFmt = self.format(xPos)
-                            kwFmt.setUnderlineColor(self._colError)
+                            kwFmt.setUnderlineColor(SHARED.theme.colError)
                             kwFmt.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
                             self.setFormat(xPos, xLen, kwFmt)
 
@@ -402,8 +369,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             for xPos, xLen in data.spellCheck(text):
                 for x in range(xPos, xPos+xLen):
                     spFmt = self.format(x)
-                    spFmt.setUnderlineColor(self._colSpell)
-                    spFmt.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
+                    spFmt.merge(self._hStyles["codeinval"])
                     self.setFormat(x, 1, spFmt)
 
         return
@@ -431,7 +397,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             if "strike" in styles:
                 charFormat.setFontStrikeOut(True)
             if "errline" in styles:
-                charFormat.setUnderlineColor(self._colError)
+                charFormat.setUnderlineColor(SHARED.theme.colError)
                 charFormat.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
             if "underline" in styles:
                 charFormat.setFontUnderline(True)

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -48,7 +48,7 @@ SPELLRX.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
 
 class GuiDocHighlighter(QSyntaxHighlighter):
 
-    __slots__ = ("_tItem", "_tHandle", "_spellCheck", "_hRules", "_hStyles", "_spellErr")
+    __slots__ = ("_tItem", "_tHandle", "_spellCheck", "_spellErr", "_hRules", "_hStyles")
 
     BLOCK_NONE  = 0
     BLOCK_TEXT  = 1

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QPoint, QSize, Qt, QUrl
 from PyQt5.QtGui import (
-    QColor, QCursor, QFont, QMouseEvent, QPalette, QResizeEvent, QTextCursor,
+    QCursor, QFont, QMouseEvent, QPalette, QResizeEvent, QTextCursor,
     QTextOption
 )
 from PyQt5.QtWidgets import (
@@ -149,14 +149,14 @@ class GuiDocViewer(QTextBrowser):
 
         # Set the widget colours to match syntax theme
         mainPalette = self.palette()
-        mainPalette.setColor(QPalette.ColorRole.Window, QColor(*SHARED.theme.colBack))
-        mainPalette.setColor(QPalette.ColorRole.Base, QColor(*SHARED.theme.colBack))
-        mainPalette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        mainPalette.setColor(QPalette.ColorRole.Window, SHARED.theme.colBack)
+        mainPalette.setColor(QPalette.ColorRole.Base, SHARED.theme.colBack)
+        mainPalette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
         self.setPalette(mainPalette)
 
         docPalette = self.viewport().palette()
-        docPalette.setColor(QPalette.ColorRole.Base, QColor(*SHARED.theme.colBack))
-        docPalette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        docPalette.setColor(QPalette.ColorRole.Base, SHARED.theme.colBack)
+        docPalette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
         self.viewport().setPalette(docPalette)
 
         self.docHeader.matchColours()
@@ -463,7 +463,13 @@ class GuiDocViewer(QTextBrowser):
         """Generate an appropriate style sheet for the document viewer,
         based on the current syntax highlighter theme,
         """
-        pTheme = SHARED.theme
+        colText = SHARED.theme.colText
+        colHead = SHARED.theme.colHead
+        colVal = SHARED.theme.colVal
+        colEmph = SHARED.theme.colEmph
+        colKey = SHARED.theme.colKey
+        colHidden = SHARED.theme.colHidden
+        colMod = SHARED.theme.colMod
         styleSheet = (
             "body {{"
             "  color: rgb({tColR}, {tColG}, {tColB});"
@@ -490,27 +496,27 @@ class GuiDocViewer(QTextBrowser):
             "  text-align: center;"
             "}}\n"
         ).format(
-            tColR=pTheme.colText[0],
-            tColG=pTheme.colText[1],
-            tColB=pTheme.colText[2],
-            hColR=pTheme.colHead[0],
-            hColG=pTheme.colHead[1],
-            hColB=pTheme.colHead[2],
-            aColR=pTheme.colVal[0],
-            aColG=pTheme.colVal[1],
-            aColB=pTheme.colVal[2],
-            eColR=pTheme.colEmph[0],
-            eColG=pTheme.colEmph[1],
-            eColB=pTheme.colEmph[2],
-            kColR=pTheme.colKey[0],
-            kColG=pTheme.colKey[1],
-            kColB=pTheme.colKey[2],
-            cColR=pTheme.colHidden[0],
-            cColG=pTheme.colHidden[1],
-            cColB=pTheme.colHidden[2],
-            mColR=pTheme.colMod[0],
-            mColG=pTheme.colMod[1],
-            mColB=pTheme.colMod[2],
+            tColR=colText.red(),
+            tColG=colText.green(),
+            tColB=colText.blue(),
+            hColR=colHead.red(),
+            hColG=colHead.green(),
+            hColB=colHead.blue(),
+            aColR=colVal.red(),
+            aColG=colVal.green(),
+            aColB=colVal.blue(),
+            eColR=colEmph.red(),
+            eColG=colEmph.green(),
+            eColB=colEmph.blue(),
+            kColR=colKey.red(),
+            kColG=colKey.green(),
+            kColB=colKey.blue(),
+            cColR=colHidden.red(),
+            cColG=colHidden.green(),
+            cColB=colHidden.blue(),
+            mColR=colMod.red(),
+            mColG=colMod.green(),
+            mColB=colMod.blue(),
         )
         self.document().setDefaultStyleSheet(styleSheet)
 
@@ -744,10 +750,11 @@ class GuiDocViewHeader(QWidget):
         self.refreshButton.setIcon(SHARED.theme.getIcon("refresh"))
         self.closeButton.setIcon(SHARED.theme.getIcon("close"))
 
+        colText = SHARED.theme.colText
         buttonStyle = (
             "QToolButton {{border: none; background: transparent;}} "
-            "QToolButton:hover {{border: none; background: rgba({0},{1},{2},0.2);}}"
-        ).format(*SHARED.theme.colText)
+            "QToolButton:hover {{border: none; background: rgba({0}, {1}, {2}, 0.2);}}"
+        ).format(colText.red(), colText.green(), colText.blue())
 
         self.backButton.setStyleSheet(buttonStyle)
         self.forwardButton.setStyleSheet(buttonStyle)
@@ -763,9 +770,9 @@ class GuiDocViewHeader(QWidget):
         theme rather than the main GUI.
         """
         palette = QPalette()
-        palette.setColor(QPalette.ColorRole.Window, QColor(*SHARED.theme.colBack))
-        palette.setColor(QPalette.ColorRole.WindowText, QColor(*SHARED.theme.colText))
-        palette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        palette.setColor(QPalette.ColorRole.Window, SHARED.theme.colBack)
+        palette.setColor(QPalette.ColorRole.WindowText, SHARED.theme.colText)
+        palette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
         self.setPalette(palette)
         self.docTitle.setPalette(palette)
         return
@@ -937,11 +944,11 @@ class GuiDocViewFooter(QWidget):
         self.showComments.setIcon(bulletIcon)
         self.showSynopsis.setIcon(bulletIcon)
 
-        # StyleSheets
+        colText = SHARED.theme.colText
         buttonStyle = (
             "QToolButton {{border: none; background: transparent;}} "
-            "QToolButton:hover {{border: none; background: rgba({0},{1},{2},0.2);}}"
-        ).format(*SHARED.theme.colText)
+            "QToolButton:hover {{border: none; background: rgba({0}, {1}, {2}, 0.2);}}"
+        ).format(colText.red(), colText.green(), colText.blue())
 
         self.showHide.setStyleSheet(buttonStyle)
         self.showComments.setStyleSheet(buttonStyle)
@@ -956,9 +963,9 @@ class GuiDocViewFooter(QWidget):
         theme rather than the main GUI.
         """
         palette = QPalette()
-        palette.setColor(QPalette.ColorRole.Window, QColor(*SHARED.theme.colBack))
-        palette.setColor(QPalette.ColorRole.WindowText, QColor(*SHARED.theme.colText))
-        palette.setColor(QPalette.ColorRole.Text, QColor(*SHARED.theme.colText))
+        palette.setColor(QPalette.ColorRole.Window, SHARED.theme.colBack)
+        palette.setColor(QPalette.ColorRole.WindowText, SHARED.theme.colText)
+        palette.setColor(QPalette.ColorRole.Text, SHARED.theme.colText)
         self.setPalette(palette)
         return
 

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -29,7 +29,6 @@ from time import time
 from typing import TYPE_CHECKING, Literal
 from datetime import datetime
 
-from PyQt5.QtGui import QColor
 from PyQt5.QtCore import pyqtSlot, QLocale
 from PyQt5.QtWidgets import qApp, QStatusBar, QLabel
 
@@ -55,9 +54,9 @@ class GuiMainStatus(QStatusBar):
         self._userIdle = False
         self._debugInfo = False
 
-        colNone = QColor(*SHARED.theme.statNone)
-        colSaved = QColor(*SHARED.theme.statSaved)
-        colUnsaved = QColor(*SHARED.theme.statUnsaved)
+        colNone = SHARED.theme.statNone
+        colSaved = SHARED.theme.statSaved
+        colUnsaved = SHARED.theme.statUnsaved
 
         iPx = SHARED.theme.baseIconSize
 

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -70,10 +70,10 @@ class GuiTheme:
         self.isLightTheme     = True
 
         # GUI
-        self.statNone    = [120, 120, 120]
-        self.statUnsaved = [200, 15, 39]
-        self.statSaved   = [2, 133, 37]
-        self.helpText    = [0, 0, 0]
+        self.statNone    = QColor(120, 120, 120)
+        self.statUnsaved = QColor(200, 15, 39)
+        self.statSaved   = QColor(2, 133, 37)
+        self.helpText    = QColor(0, 0, 0)
 
         # Loaded Syntax Settings
         # ======================
@@ -88,23 +88,23 @@ class GuiTheme:
         self.syntaxLicenseUrl  = ""
 
         # Colours
-        self.colBack   = [255, 255, 255]
-        self.colText   = [0, 0, 0]
-        self.colLink   = [0, 0, 0]
-        self.colHead   = [0, 0, 0]
-        self.colHeadH  = [0, 0, 0]
-        self.colEmph   = [0, 0, 0]
-        self.colDialN  = [0, 0, 0]
-        self.colDialD  = [0, 0, 0]
-        self.colDialS  = [0, 0, 0]
-        self.colHidden = [0, 0, 0]
-        self.colCode   = [0, 0, 0]
-        self.colKey    = [0, 0, 0]
-        self.colVal    = [0, 0, 0]
-        self.colSpell  = [0, 0, 0]
-        self.colError  = [0, 0, 0]
-        self.colRepTag = [0, 0, 0]
-        self.colMod    = [0, 0, 0]
+        self.colBack   = QColor(255, 255, 255)
+        self.colText   = QColor(0, 0, 0)
+        self.colLink   = QColor(0, 0, 0)
+        self.colHead   = QColor(0, 0, 0)
+        self.colHeadH  = QColor(0, 0, 0)
+        self.colEmph   = QColor(0, 0, 0)
+        self.colDialN  = QColor(0, 0, 0)
+        self.colDialD  = QColor(0, 0, 0)
+        self.colDialS  = QColor(0, 0, 0)
+        self.colHidden = QColor(0, 0, 0)
+        self.colCode   = QColor(0, 0, 0)
+        self.colKey    = QColor(0, 0, 0)
+        self.colVal    = QColor(0, 0, 0)
+        self.colSpell  = QColor(0, 0, 0)
+        self.colError  = QColor(0, 0, 0)
+        self.colRepTag = QColor(0, 0, 0)
+        self.colMod    = QColor(0, 0, 0)
 
         # Class Setup
         # ===========
@@ -256,12 +256,12 @@ class GuiTheme:
         backLNess = backCol.lightnessF()
         textLNess = textCol.lightnessF()
         self.isLightTheme = backLNess > textLNess
-        if self.helpText == [0, 0, 0]:
+        if self.helpText == QColor(0, 0, 0):
             if self.isLightTheme:
                 helpLCol = textLNess + 0.35*(backLNess - textLNess)
             else:
                 helpLCol = backLNess + 0.65*(textLNess - backLNess)
-            self.helpText = [int(255*helpLCol)]*3
+            self.helpText = QColor.fromHsl(0, 0, int(255*helpLCol))
 
         # Icons
         defaultIcons = "typicons_light" if backLNess >= 0.5 else "typicons_dark"
@@ -398,29 +398,14 @@ class GuiTheme:
 
         return True
 
-    def _parseColour(self, parser: NWConfigParser, section: str, name: str) -> list[int]:
+    def _parseColour(self, parser: NWConfigParser, section: str, name: str) -> QColor:
         """Parse a colour value from a config string."""
-        if parser.has_option(section, name):
-            values = parser.get(section, name).split(",")
-            result = []
-            try:
-                result.append(minmax(int(values[0]), 0, 255))
-                result.append(minmax(int(values[1]), 0, 255))
-                result.append(minmax(int(values[2]), 0, 255))
-            except Exception:
-                logger.error("Could not load theme colours for '%s' from config file", name)
-                result = [0, 0, 0]
-        else:
-            logger.warning("Could not find theme colours for '%s' in config file", name)
-            result = [0, 0, 0]
-        return result
+        return QColor(*parser.rdIntList(section, name, [0, 0, 0, 255]))
 
     def _setPalette(self, parser: NWConfigParser, section: str,
                     name: str, value: QPalette.ColorRole) -> None:
         """Set a palette colour value from a config string."""
-        self._guiPalette.setColor(
-            value, QColor(*self._parseColour(parser, section, name))
-        )
+        self._guiPalette.setColor(value, self._parseColour(parser, section, name))
         return
 
 # End Class GuiTheme

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -27,9 +27,7 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from PyQt5.QtGui import (
-    QColor, QFont, QIcon, QSyntaxHighlighter, QTextCharFormat, QTextDocument
-)
+from PyQt5.QtGui import QFont, QIcon, QSyntaxHighlighter, QTextCharFormat, QTextDocument
 from PyQt5.QtCore import QEvent, QSize, Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QAbstractButton, QAbstractItemView, QComboBox, QDialog, QDialogButtonBox,
@@ -862,9 +860,9 @@ class _HeadingSyntaxHighlighter(QSyntaxHighlighter):
     def __init__(self, document: QTextDocument) -> None:
         super().__init__(document)
         self._fmtSymbol = QTextCharFormat()
-        self._fmtSymbol.setForeground(QColor(*SHARED.theme.colHead))
+        self._fmtSymbol.setForeground(SHARED.theme.colHead)
         self._fmtFormat = QTextCharFormat()
-        self._fmtFormat.setForeground(QColor(*SHARED.theme.colEmph))
+        self._fmtFormat.setForeground(SHARED.theme.colEmph)
         return
 
     def highlightBlock(self, text: str) -> None:

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -343,7 +343,7 @@ class _ProjectListItem(QStyledItemDelegate):
 
         self._dFont = qApp.font()
         self._dFont.setPointSizeF(fPt)
-        self._dPen = QPen(QColor(*SHARED.theme.helpText))
+        self._dPen = QPen(SHARED.theme.helpText)
 
         self._icon = SHARED.theme.getPixmap("proj_nwx", (iPx, iPx))
 

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -29,7 +29,7 @@ from tools import (
     C, NWD_IGNORE, cmpFiles, buildTestProject, XML_IGNORE, getGuiItem
 )
 
-from PyQt5.QtGui import QColor, QPalette
+from PyQt5.QtGui import QPalette
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMenu, QInputDialog
 
@@ -170,7 +170,7 @@ def testGuiMain_UpdateTheme(qtbot, nwGUI):
     mainTheme.loadSyntax()
     nwGUI._processConfigChanges(True, True, True, True)
 
-    syntaxBack = QColor(*SHARED.theme.colBack)
+    syntaxBack = SHARED.theme.colBack
 
     assert nwGUI.docEditor.palette().color(QPalette.ColorRole.Window) == syntaxBack
     assert nwGUI.docEditor.docHeader.palette().color(QPalette.ColorRole.Window) == syntaxBack

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -89,11 +89,21 @@ def testGuiTheme_Main(qtbot, nwGUI, tstPaths):
 
     parser = NWConfigParser()
     parser["Palette"] = {
-        "colour1": "100, 150, 200",
-        "colour2": "100, 150, 200, 250",
-        "colour3": "250, 250",
-        "colour4": "-10, 127, 300",
+        "colour1": "100, 150, 200",            # Valid
+        "colour2": "100, 150, 200, 250",       # With alpha
+        "colour3": "100, 150, 200, 250, 300",  # Too many values
+        "colour4": "250, 250",                 # Missing blue
+        "colour5": "-10, 127, 300",            # Invalid red and blue
+        "colour6": "bob, 127, 255",            # Invalid red
     }
+
+    # Test the parser for several valid and invalid values
+    assert mainTheme._parseColour(parser, "Palette", "colour1").getRgb() == (100, 150, 200, 255)
+    assert mainTheme._parseColour(parser, "Palette", "colour2").getRgb() == (100, 150, 200, 250)
+    assert mainTheme._parseColour(parser, "Palette", "colour3").getRgb() == (100, 150, 200, 250)
+    assert mainTheme._parseColour(parser, "Palette", "colour4").getRgb() == (250, 250, 0, 255)
+    assert mainTheme._parseColour(parser, "Palette", "colour5").getRgb() == (0, 0, 0, 0)
+    assert mainTheme._parseColour(parser, "Palette", "colour6").getRgb() == (0, 127, 255, 255)
 
     # The palette should load with the parsed values
     mainTheme._setPalette(parser, "Palette", "colour1", QPalette.Window)
@@ -101,10 +111,16 @@ def testGuiTheme_Main(qtbot, nwGUI, tstPaths):
     mainTheme._setPalette(parser, "Palette", "colour2", QPalette.Window)
     assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (100, 150, 200, 250)
     mainTheme._setPalette(parser, "Palette", "colour3", QPalette.Window)
-    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (250, 250, 0, 255)
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (100, 150, 200, 250)
     mainTheme._setPalette(parser, "Palette", "colour4", QPalette.Window)
-    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 0, 0, 0)
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (250, 250, 0, 255)
     mainTheme._setPalette(parser, "Palette", "colour5", QPalette.Window)
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 0, 0, 0)
+    mainTheme._setPalette(parser, "Palette", "colour6", QPalette.Window)
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 127, 255, 255)
+
+    # Non-existing value should return default colour
+    mainTheme._setPalette(parser, "Palette", "stuff", QPalette.Window)
     assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 0, 0, 255)
 
     # qtbot.stop()

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from mocked import causeOSError
 from tools import writeFile
 
-from PyQt5.QtGui import QIcon, QPalette, QPixmap
+from PyQt5.QtGui import QColor, QIcon, QPalette, QPixmap
 from PyQt5.QtWidgets import QApplication
 
 from novelwriter import CONFIG, SHARED
@@ -95,22 +95,15 @@ def testGuiTheme_Main(qtbot, nwGUI, tstPaths):
         "colour4": "-10, 127, 300",
     }
 
-    # Test the parser for several valid and invalid values
-    assert mainTheme._parseColour(parser, "Palette", "colour1") == [100, 150, 200]
-    assert mainTheme._parseColour(parser, "Palette", "colour2") == [100, 150, 200]
-    assert mainTheme._parseColour(parser, "Palette", "colour3") == [0, 0, 0]
-    assert mainTheme._parseColour(parser, "Palette", "colour4") == [0, 127, 255]
-    assert mainTheme._parseColour(parser, "Palette", "colour5") == [0, 0, 0]
-
     # The palette should load with the parsed values
     mainTheme._setPalette(parser, "Palette", "colour1", QPalette.Window)
     assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (100, 150, 200, 255)
     mainTheme._setPalette(parser, "Palette", "colour2", QPalette.Window)
-    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (100, 150, 200, 255)
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (100, 150, 200, 250)
     mainTheme._setPalette(parser, "Palette", "colour3", QPalette.Window)
-    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 0, 0, 255)
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (250, 250, 0, 255)
     mainTheme._setPalette(parser, "Palette", "colour4", QPalette.Window)
-    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 127, 255, 255)
+    assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 0, 0, 0)
     mainTheme._setPalette(parser, "Palette", "colour5", QPalette.Window)
     assert mainTheme._guiPalette.color(QPalette.Window).getRgb() == (0, 0, 0, 255)
 
@@ -240,9 +233,9 @@ def testGuiTheme_Syntax(qtbot, monkeypatch, nwGUI):
 
     # Check some values
     assert mainTheme.syntaxName == "Default Light"
-    assert mainTheme.colBack == [255, 255, 255]
-    assert mainTheme.colText == [0, 0, 0]
-    assert mainTheme.colLink == [0, 0, 200]
+    assert mainTheme.colBack == QColor(255, 255, 255)
+    assert mainTheme.colText == QColor(0, 0, 0)
+    assert mainTheme.colLink == QColor(0, 0, 200)
 
     # Load Default Dark Theme
     # =======================
@@ -253,9 +246,9 @@ def testGuiTheme_Syntax(qtbot, monkeypatch, nwGUI):
 
     # Check some values
     assert mainTheme.syntaxName == "Default Dark"
-    assert mainTheme.colBack == [54, 54, 54]
-    assert mainTheme.colText == [199, 207, 208]
-    assert mainTheme.colLink == [184, 200, 0]
+    assert mainTheme.colBack == QColor(54, 54, 54)
+    assert mainTheme.colText == QColor(199, 207, 208)
+    assert mainTheme.colLink == QColor(184, 200, 0)
 
     # qtbot.stop()
 


### PR DESCRIPTION
**Summary:**

This PR changes all colours defined in the Theme class to be QColor objects. They are nearly always used as QColor anyway, and this saves a lot of calls the constructor. The few cases where the colour components are used separately can extract them from the object instead.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
