### PR TITLE
Add customisation option for ODT build document header

### DIFF
--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -309,7 +309,13 @@ class nwHeadFmt:
     SC_NUM  = "{Scene}"
     SC_ABS  = "{Scene:Abs}"
 
-    ALL = [TITLE, CH_NUM, CH_WORD, CH_ROMU, CH_ROML, SC_NUM, SC_ABS]
+    PAGE_HEADERS = [TITLE, CH_NUM, CH_WORD, CH_ROMU, CH_ROML, SC_NUM, SC_ABS]
+
+    # ODT Document Page Header
+    ODT_PROJECT = "{Project}"
+    ODT_AUTHOR = "{Author}"
+    ODT_PAGE = "{Page}"
+    ODT_AUTO = "{Project} / {Author} / {Page}"
 
 # END Class nwHeadFmt
 

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -80,6 +80,7 @@ SETTINGS_TEMPLATE = {
     "format.rightMargin":     (float, 2.0),
     "odt.addColours":         (bool, True),
     "odt.pageHeader":         (str, nwHeadFmt.ODT_AUTO),
+    "odt.pageCountOffset":    (int, 0),
     "html.addStyles":         (bool, True),
 }
 
@@ -127,6 +128,7 @@ SETTINGS_LABELS = {
     "odt":                    QT_TRANSLATE_NOOP("Builds", "Open Document (.odt)"),
     "odt.addColours":         QT_TRANSLATE_NOOP("Builds", "Add Highlight Colours"),
     "odt.pageHeader":         QT_TRANSLATE_NOOP("Builds", "Page Header"),
+    "odt.pageCountOffset":    QT_TRANSLATE_NOOP("Builds", "Page Counter Offset"),
 
     "html":                   QT_TRANSLATE_NOOP("Builds", "HTML (.html)"),
     "html.addStyles":         QT_TRANSLATE_NOOP("Builds", "Add CSS Styles"),

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -79,6 +79,7 @@ SETTINGS_TEMPLATE = {
     "format.leftMargin":      (float, 2.0),
     "format.rightMargin":     (float, 2.0),
     "odt.addColours":         (bool, True),
+    "odt.pageHeader":         (str, nwHeadFmt.ODT_AUTO),
     "html.addStyles":         (bool, True),
 }
 
@@ -125,6 +126,7 @@ SETTINGS_LABELS = {
 
     "odt":                    QT_TRANSLATE_NOOP("Builds", "Open Document (.odt)"),
     "odt.addColours":         QT_TRANSLATE_NOOP("Builds", "Add Highlight Colours"),
+    "odt.pageHeader":         QT_TRANSLATE_NOOP("Builds", "Page Header"),
 
     "html":                   QT_TRANSLATE_NOOP("Builds", "HTML (.html)"),
     "html.addStyles":         QT_TRANSLATE_NOOP("Builds", "Add CSS Styles"),

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -284,7 +284,9 @@ class NWBuildDocument:
         if isinstance(bldObj, ToOdt):
             bldObj.setColourHeaders(self._build.getBool("odt.addColours"))
             bldObj.setLanguage(self._project.data.language)
-            bldObj.setHeaderFormat(self._build.getStr("odt.pageHeader"))
+            bldObj.setHeaderFormat(
+                self._build.getStr("odt.pageHeader"), self._build.getInt("odt.pageCountOffset")
+            )
 
             scale = nwLabels.UNIT_SCALE.get(self._build.getStr("format.pageUnit"), 1.0)
             pW, pH = nwLabels.PAPER_SIZE.get(self._build.getStr("format.pageSize"), (-1.0, -1.0))

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -284,6 +284,7 @@ class NWBuildDocument:
         if isinstance(bldObj, ToOdt):
             bldObj.setColourHeaders(self._build.getBool("odt.addColours"))
             bldObj.setLanguage(self._project.data.language)
+            bldObj.setHeaderFormat(self._build.getStr("odt.pageHeader"))
 
             scale = nwLabels.UNIT_SCALE.get(self._build.getStr("format.pageUnit"), 1.0)
             pW, pH = nwLabels.PAPER_SIZE.get(self._build.getStr("format.pageSize"), (-1.0, -1.0))

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -34,11 +34,11 @@ from pathlib import Path
 from functools import partial
 
 from PyQt5.QtCore import QCoreApplication, QRegularExpression
-from novelwriter.core.index import processComment
 
 from novelwriter.enum import nwComment, nwItemLayout
 from novelwriter.common import formatTimeStamp, numberToRoman, checkInt
 from novelwriter.constants import nwHeadFmt, nwRegEx, nwShortcode, nwUnicode
+from novelwriter.core.index import processComment
 from novelwriter.core.project import NWProject
 
 logger = logging.getLogger(__name__)

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -137,6 +137,7 @@ class ToOdt(Tokenizer):
         self._textFixed    = False
         self._colourHead   = False
         self._headerFormat = ""
+        self._pageOffset   = 0
 
         # Internal
         self._fontFamily   = "&apos;Liberation Serif&apos;"
@@ -222,9 +223,10 @@ class ToOdt(Tokenizer):
         self._mDocRight  = f"{right/10.0:.3f}cm"
         return
 
-    def setHeaderFormat(self, format: str) -> None:
+    def setHeaderFormat(self, format: str, offset: int) -> None:
         """Set the document header format."""
         self._headerFormat = format.strip()
+        self._pageOffset = offset
         return
 
     ##
@@ -1023,9 +1025,10 @@ class ToOdt(Tokenizer):
             })
             xPar.text = pre
             if page:
-                xTail = ET.SubElement(xPar, _mkTag("text", "page-number"), attrib={
-                    _mkTag("text", "select-page"): "current"
-                })
+                attrib = {_mkTag("text", "select-page"): "current"}
+                if self._pageOffset > 0:
+                    attrib = {_mkTag("text", "page-adjust"): str(0 - self._pageOffset)}
+                xTail = ET.SubElement(xPar, _mkTag("text", "page-number"), attrib=attrib)
                 xTail.text = "2"
                 xTail.tail = post
             else:

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -132,11 +132,11 @@ class ToOdt(Tokenizer):
         self._errData = []  # List of errors encountered
 
         # Properties
-        self._textFont   = "Liberation Serif"
-        self._textSize   = 12
-        self._textFixed  = False
-        self._colourHead = False
-        self._headerText = ""
+        self._textFont     = "Liberation Serif"
+        self._textSize     = 12
+        self._textFixed    = False
+        self._colourHead   = False
+        self._headerFormat = ""
 
         # Internal
         self._fontFamily   = "&apos;Liberation Serif&apos;"
@@ -222,6 +222,11 @@ class ToOdt(Tokenizer):
         self._mDocRight  = f"{right/10.0:.3f}cm"
         return
 
+    def setHeaderFormat(self, format: str) -> None:
+        """Set the document header format."""
+        self._headerFormat = format.strip()
+        return
+
     ##
     #  Class Methods
     ##
@@ -278,12 +283,6 @@ class ToOdt(Tokenizer):
 
         # Clear Errors
         self._errData = []
-
-        # Document Header
-        # ===============
-
-        if self._headerText == "":
-            self._headerText = f"{self._project.data.name} / {self._project.data.author} /"
 
         # Create Roots
         # ============
@@ -1010,17 +1009,27 @@ class ToOdt(Tokenizer):
         xPage = ET.SubElement(self._xMast, _mkTag("style", "master-page"), attrib=tAttr)
 
         # Standard Page Header
-        xHead = ET.SubElement(xPage, _mkTag("style", "header"))
-        xPar = ET.SubElement(xHead, _mkTag("text", "p"), attrib={
-            _mkTag("text", "style-name"): "Header"
-        })
-        xPar.text = self._headerText.strip() + " "
+        if self._headerFormat:
+            pre, page, post = self._headerFormat.partition(nwHeadFmt.ODT_PAGE)
 
-        xTail = ET.SubElement(xPar, _mkTag("text", "page-number"), attrib={
-            _mkTag("text", "select-page"): "current"
-        })
-        xTail.text = "2"
-        xTail.tail = ""  # Prevent line break in indented XML
+            pre = pre.replace(nwHeadFmt.ODT_PROJECT, self._project.data.name)
+            pre = pre.replace(nwHeadFmt.ODT_AUTHOR, self._project.data.author)
+            post = post.replace(nwHeadFmt.ODT_PROJECT, self._project.data.name)
+            post = post.replace(nwHeadFmt.ODT_AUTHOR, self._project.data.author)
+
+            xHead = ET.SubElement(xPage, _mkTag("style", "header"))
+            xPar = ET.SubElement(xHead, _mkTag("text", "p"), attrib={
+                _mkTag("text", "style-name"): "Header"
+            })
+            xPar.text = pre
+            if page:
+                xTail = ET.SubElement(xPar, _mkTag("text", "page-number"), attrib={
+                    _mkTag("text", "select-page"): "current"
+                })
+                xTail.text = "2"
+                xTail.tail = post
+            else:
+                xPar.text += post
 
         # First Page Header
         xHead = ET.SubElement(xPage, _mkTag("style", "header-first"))

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1210,6 +1210,7 @@ class _OutputTab(NScrollableForm):
         self._build = build
 
         iPx = SHARED.theme.baseIconSize
+        spW = 6*SHARED.theme.textNWidth
 
         # Open Document
         self.addGroupLabel(self._build.getLabel("odt"))
@@ -1227,6 +1228,13 @@ class _OutputTab(NScrollableForm):
             button=self.btnPageHeader, stretch=(1, 1)
         )
 
+        self.odtPageCountOffset = QSpinBox(self)
+        self.odtPageCountOffset.setMinimum(0)
+        self.odtPageCountOffset.setMaximum(999)
+        self.odtPageCountOffset.setSingleStep(1)
+        self.odtPageCountOffset.setMinimumWidth(spW)
+        self.addRow(self._build.getLabel("odt.pageCountOffset"), self.odtPageCountOffset)
+
         # HTML Document
         self.addGroupLabel(self._build.getLabel("html"))
 
@@ -1242,6 +1250,7 @@ class _OutputTab(NScrollableForm):
         """Populate the widgets."""
         self.odtAddColours.setChecked(self._build.getBool("odt.addColours"))
         self.odtPageHeader.setText(self._build.getStr("odt.pageHeader"))
+        self.odtPageCountOffset.setValue(self._build.getInt("odt.pageCountOffset"))
         self.htmlAddStyles.setChecked(self._build.getBool("html.addStyles"))
         return
 
@@ -1249,6 +1258,7 @@ class _OutputTab(NScrollableForm):
         """Save choices back into build object."""
         self._build.setValue("odt.addColours", self.odtAddColours.isChecked())
         self._build.setValue("odt.pageHeader", self.odtPageHeader.text())
+        self._build.setValue("odt.pageCountOffset", self.odtPageCountOffset.value())
         self._build.setValue("html.addStyles", self.htmlAddStyles.isChecked())
         return
 

--- a/tests/reference/coreToOdt_SaveFlat_document.fodt
+++ b/tests/reference/coreToOdt_SaveFlat_document.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2023-10-20T22:51:30</meta:creation-date>
-    <meta:generator>novelWriter/2.2-alpha1</meta:generator>
+    <meta:creation-date>2024-01-28T15:48:36</meta:creation-date>
+    <meta:generator>novelWriter/2.3a3</meta:generator>
     <meta:initial-creator>Jane Smith</meta:initial-creator>
     <meta:editing-cycles>1234</meta:editing-cycles>
     <meta:editing-duration>P42DT12H34M56S</meta:editing-duration>
     <dc:title>Test Project</dc:title>
-    <dc:date>2023-10-20T22:51:30</dc:date>
+    <dc:date>2024-01-28T15:48:36</dc:date>
     <dc:creator>Jane Smith</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -76,7 +76,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number></text:p>
+        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:page-adjust="-1">2</text:page-number></text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/reference/coreToOdt_SaveFull_styles.xml
+++ b/tests/reference/coreToOdt_SaveFull_styles.xml
@@ -63,8 +63,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:select-page="current">2</text:page-number>
-        </text:p>
+        <text:p text:style-name="Header">Test Project - Jane Smith</text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -25,11 +25,11 @@ import zipfile
 import xml.etree.ElementTree as ET
 
 from shutil import copyfile
-from novelwriter.constants import nwHeadFmt
 
 from tools import ODT_IGNORE, cmpFiles
 
 from novelwriter.common import xmlIndent
+from novelwriter.constants import nwHeadFmt
 from novelwriter.core.toodt import ToOdt, ODTParagraphStyle, ODTTextStyle, XMLParagraph, _mkTag
 from novelwriter.core.project import NWProject
 

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -25,6 +25,7 @@ import zipfile
 import xml.etree.ElementTree as ET
 
 from shutil import copyfile
+from novelwriter.constants import nwHeadFmt
 
 from tools import ODT_IGNORE, cmpFiles
 
@@ -691,6 +692,9 @@ def testCoreToOdt_SaveFlat(mockGUI, fncPath, tstPaths):
     odt.setLanguage("nb_NO")
     assert odt._dLanguage == "nb"
     odt.setColourHeaders(True)
+    assert odt._colourHead is True
+    odt.setHeaderFormat(nwHeadFmt.ODT_AUTO)
+    assert odt._headerFormat == nwHeadFmt.ODT_AUTO
 
     odt.setPageLayout(148, 210, 20, 18, 17, 15)
     assert odt._mDocWidth  == "14.800cm"
@@ -735,6 +739,9 @@ def testCoreToOdt_SaveFull(mockGUI, fncPath, tstPaths):
 
     odt = ToOdt(project, isFlat=False)
     odt._isNovel = True
+
+    # Set a format without page number
+    odt.setHeaderFormat(f"{nwHeadFmt.ODT_PROJECT} - {nwHeadFmt.ODT_AUTHOR}")
 
     odt._text = (
         "## Chapter One\n\n"

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -693,7 +693,7 @@ def testCoreToOdt_SaveFlat(mockGUI, fncPath, tstPaths):
     assert odt._dLanguage == "nb"
     odt.setColourHeaders(True)
     assert odt._colourHead is True
-    odt.setHeaderFormat(nwHeadFmt.ODT_AUTO)
+    odt.setHeaderFormat(nwHeadFmt.ODT_AUTO, 1)
     assert odt._headerFormat == nwHeadFmt.ODT_AUTO
 
     odt.setPageLayout(148, 210, 20, 18, 17, 15)
@@ -741,7 +741,7 @@ def testCoreToOdt_SaveFull(mockGUI, fncPath, tstPaths):
     odt._isNovel = True
 
     # Set a format without page number
-    odt.setHeaderFormat(f"{nwHeadFmt.ODT_PROJECT} - {nwHeadFmt.ODT_AUTHOR}")
+    odt.setHeaderFormat(f"{nwHeadFmt.ODT_PROJECT} - {nwHeadFmt.ODT_AUTHOR}", 0)
 
     odt._text = (
         "## Chapter One\n\n"

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -649,17 +649,26 @@ def testBuildSettings_Output(qtbot: QtBot, nwGUI: GuiMain):
 
     # Check initial values
     assert outTab.odtAddColours.isChecked() is False
+    assert outTab.odtPageHeader.text() == nwHeadFmt.ODT_AUTO
     assert outTab.htmlAddStyles.isChecked() is False
 
     # Toggle all
     outTab.odtAddColours.setChecked(True)
     outTab.htmlAddStyles.setChecked(True)
 
+    # Change header format
+    outTab.odtPageHeader.setText("Stuff")
+
     # Save values
     outTab.saveContent()
 
     assert build.getBool("odt.addColours") is True
+    assert build.getStr("odt.pageHeader") == "Stuff"
     assert build.getBool("html.addStyles") is True
+
+    # Reset header format
+    outTab.btnPageHeader.click()
+    assert outTab.odtPageHeader.text() == nwHeadFmt.ODT_AUTO
 
     # Finish
     bSettings._dialogButtonClicked(bSettings.buttonBox.button(QDialogButtonBox.Close))


### PR DESCRIPTION
**Summary:**

This PR adds a field in the Manuscript Build Settings tool to customise the page header for ODT documents. It defaults to the current standard format.

**Related Issue(s):**

Closes #1505

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
