### PR TITLE
Add a 'Create New' menu for documents in project tree context menu

### DIFF
--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -79,7 +79,6 @@ class GuiProjectSettings(QDialog):
         self.sidebar.addButton(self.tr("Status"), self.PAGE_STATUS)
         self.sidebar.addButton(self.tr("Importance"), self.PAGE_IMPORT)
         self.sidebar.addButton(self.tr("Auto-Replace"), self.PAGE_REPLACE)
-        self.sidebar.setSelected(gotoPage)
         self.sidebar.buttonClicked.connect(self._sidebarClicked)
 
         # Buttons
@@ -121,6 +120,10 @@ class GuiProjectSettings(QDialog):
 
         self.setLayout(self.outerBox)
         self.setSizeGripEnabled(True)
+
+        # Jump to Specified Page
+        self.sidebar.setSelected(gotoPage)
+        self._sidebarClicked(gotoPage)
 
         logger.debug("Ready: GuiProjectSettings")
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1674,9 +1674,13 @@ class _TreeContextMenu(QMenu):
             self._docActions()
             self.addSeparator()
 
+        # Create New Items
+        self._itemCreation()
+        self.addSeparator()
+
         # Edit Item Settings
-        aLabel = self.addAction(self.tr("Rename"))
-        aLabel.triggered.connect(lambda: self.projTree.renameTreeItem(self._handle))
+        action = self.addAction(self.tr("Rename"))
+        action.triggered.connect(lambda: self.projTree.renameTreeItem(self._handle))
         if isFile:
             self._itemActive(False)
         self._itemStatusImport(False)
@@ -1714,6 +1718,16 @@ class _TreeContextMenu(QMenu):
         action.triggered.connect(
             lambda: self.projView.openDocumentRequest.emit(self._handle, nwDocMode.VIEW, "", False)
         )
+        return
+
+    def _itemCreation(self) -> None:
+        """Add create item actions."""
+        menu = self.addMenu(self.tr("Create New ..."))
+        menu.addAction(self.projView.projBar.aAddEmpty)
+        menu.addAction(self.projView.projBar.aAddChap)
+        menu.addAction(self.projView.projBar.aAddScene)
+        menu.addAction(self.projView.projBar.aAddNote)
+        menu.addAction(self.projView.projBar.aAddFolder)
         return
 
     def _itemActive(self, multi: bool) -> None:

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1783,7 +1783,7 @@ class _TreeContextMenu(QMenu):
 
     def _itemTransform(self, isFile: bool, isFolder: bool, hasChild: bool) -> None:
         """Add actions for the Transform menu."""
-        menu = self.addMenu(self.tr("Transform"))
+        menu = self.addMenu(self.tr("Transform ..."))
 
         tree = self.projTree
         tHandle = self._handle

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -1182,8 +1182,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(True)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Rename", "Set Status to ...", "Expand All", "Collapse All",
-        "Duplicate from Here", "Delete Permanently",
+        "Create New", "Rename", "Set Status to ...", "Expand All",
+        "Collapse All", "Duplicate from Here", "Delete Permanently",
     ]
 
     # Context Menu on Folder Item
@@ -1193,8 +1193,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(True)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Rename", "Set Status to ...", "Transform", "Expand All", "Collapse All",
-        "Duplicate from Here", "Move to Trash",
+        "Create New", "Rename", "Set Status to ...", "Transform", "Expand All",
+        "Collapse All", "Duplicate from Here", "Move to Trash",
     ]
 
     def getTransformSubMenu(menu: QMenu) -> list[str]:
@@ -1210,8 +1210,9 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(True)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Rename", "Toggle Active", "Set Status to ...",
-        "Transform", "Expand All", "Collapse All", "Duplicate from Here", "Move to Trash",
+        "Open Document", "View Document", "Create New", "Rename", "Toggle Active",
+        "Set Status to ...", "Transform", "Expand All", "Collapse All",
+        "Duplicate from Here", "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Convert to Project Note", "Merge Child Items into Self",
@@ -1225,8 +1226,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(False)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Rename", "Toggle Active", "Set Importance to ...",
-        "Transform", "Duplicate Document", "Move to Trash",
+        "Open Document", "View Document", "Create New", "Rename", "Toggle Active",
+        "Set Importance to ...", "Transform", "Duplicate Document", "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Split Document by Headers",
@@ -1239,8 +1240,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(False)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Rename", "Toggle Active", "Set Status to ...",
-        "Transform", "Duplicate Document", "Move to Trash",
+        "Open Document", "View Document", "Create New", "Rename", "Toggle Active",
+        "Set Status to ...", "Transform", "Duplicate Document", "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Convert to Novel Document", "Split Document by Headers",

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -1182,7 +1182,7 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(True)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Create New", "Rename", "Set Status to ...", "Expand All",
+        "Create New ...", "Rename", "Set Status to ...", "Expand All",
         "Collapse All", "Duplicate from Here", "Delete Permanently",
     ]
 
@@ -1193,13 +1193,13 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(True)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Create New", "Rename", "Set Status to ...", "Transform", "Expand All",
+        "Create New ...", "Rename", "Set Status to ...", "Transform ...", "Expand All",
         "Collapse All", "Duplicate from Here", "Move to Trash",
     ]
 
     def getTransformSubMenu(menu: QMenu) -> list[str]:
         for action in menu.actions():
-            if action.text() == "Transform":
+            if action.text() == "Transform ...":
                 return [x.text() for x in action.menu().actions() if x.text()]
         return []
 
@@ -1210,8 +1210,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(True)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Create New", "Rename", "Toggle Active",
-        "Set Status to ...", "Transform", "Expand All", "Collapse All",
+        "Open Document", "View Document", "Create New ...", "Rename", "Toggle Active",
+        "Set Status to ...", "Transform ...", "Expand All", "Collapse All",
         "Duplicate from Here", "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
@@ -1226,8 +1226,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(False)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Create New", "Rename", "Toggle Active",
-        "Set Importance to ...", "Transform", "Duplicate Document", "Move to Trash",
+        "Open Document", "View Document", "Create New ...", "Rename", "Toggle Active",
+        "Set Importance to ...", "Transform ...", "Duplicate Document", "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Split Document by Headers",
@@ -1240,8 +1240,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(False)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Create New", "Rename", "Toggle Active",
-        "Set Status to ...", "Transform", "Duplicate Document", "Move to Trash",
+        "Open Document", "View Document", "Create New ...", "Rename", "Toggle Active",
+        "Set Status to ...", "Transform ...", "Duplicate Document", "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Convert to Novel Document", "Split Document by Headers",


### PR DESCRIPTION
**Summary:**

This PR:
* Connects the already existing create document/folder actions in the "Add Item" menu of the Project Tree to a new submenu "Create New ..." in the context menu. No other code is needed, since the actions are already defined.
* Changes the label of the context menu "Transform" submenu to the same format as the other submenus.
* Fixes an issue with switching tab in Project Settings when opening it from the Project Tree context menu.

**Related Issue(s):**

Closes #1519

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
