### PR TITLE
Allow creating project from other project (copy)

### DIFF
--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -425,7 +425,7 @@ def testCoreTools_ProjectBuilderWrapper(monkeypatch, caplog, fncPath, mockGUI):
     # Creating the project once more should fail
     caplog.clear()
     assert builder.buildProject({"path": fncPath}) is False
-    assert "A project already exists" in caplog.text
+    assert "The target folder is not empty." in caplog.text
 
 # END Test testCoreTools_ProjectBuilderWrapper
 


### PR DESCRIPTION
**Summary:**

This PR completes the feature added to the new Welcome dialog that allows selecting a different project as the source for creating a new project. The missing piece was the implementation in the `ProjectBuilder` class, and this PR adds that.

It takes the path to an existing `nwProject.nwx` file and copies it, and everything under the `content` folder into the destination folder, opens this project, and sets the values defined in the New Project form on the Welcome dialog. Some other counter meta data is set to 0, like `saveCount`, `autoCount`, and `editTime`, and some other settings are reset to defaults. 

**Related Issue(s):**

Resolves #841

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
