### PR TITLE
Add project tree option to rename item to first heading

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1785,6 +1785,7 @@ class _TreeContextMenu(QMenu):
         action = self.addAction(self.tr("Rename"))
         action.triggered.connect(lambda: self.projTree.renameTreeItem(self._handle))
         if isFile:
+            self._itemHeader()
             self._itemActive(False)
         self._itemStatusImport(False)
 
@@ -1831,6 +1832,15 @@ class _TreeContextMenu(QMenu):
         menu.addAction(self.projView.projBar.aAddScene)
         menu.addAction(self.projView.projBar.aAddNote)
         menu.addAction(self.projView.projBar.aAddFolder)
+        return
+
+    def _itemHeader(self) -> None:
+        """Check if there is a header that can be used for rename."""
+        if hItem := SHARED.project.index.getItemHeader(self._handle, "T0001"):
+            action = self.addAction(self.tr("Rename to Heading"))
+            action.triggered.connect(
+                lambda: self.projTree.renameTreeItem(self._handle, hItem.title)
+            )
         return
 
     def _itemActive(self, multi: bool) -> None:

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -1223,8 +1223,8 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(True)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Create New ...", "Rename", "Toggle Active",
-        "Set Status to ...", "Transform ...", "Expand All", "Collapse All",
+        "Open Document", "View Document", "Create New ...", "Rename", "Rename to Heading",
+        "Toggle Active", "Set Status to ...", "Transform ...", "Expand All", "Collapse All",
         "Duplicate from Here", "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
@@ -1239,8 +1239,9 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(False)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Create New ...", "Rename", "Toggle Active",
-        "Set Importance to ...", "Transform ...", "Duplicate Document", "Move to Trash",
+        "Open Document", "View Document", "Create New ...", "Rename", "Rename to Heading",
+        "Toggle Active", "Set Importance to ...", "Transform ...", "Duplicate Document",
+        "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Split Document by Headers",
@@ -1253,8 +1254,9 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     ctxMenu.buildSingleSelectMenu(False)
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Open Document", "View Document", "Create New ...", "Rename", "Toggle Active",
-        "Set Status to ...", "Transform ...", "Duplicate Document", "Move to Trash",
+        "Open Document", "View Document", "Create New ...", "Rename", "Rename to Heading",
+        "Toggle Active", "Set Status to ...", "Transform ...", "Duplicate Document",
+        "Move to Trash",
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Convert to Novel Document", "Split Document by Headers",


### PR DESCRIPTION
**Summary:**

This is a simple PR that adds a context menu option "Rename to Heading" under the regular "Rename" option, if the selected item is a document, and there is a heading recorded by the index. When triggered, this option pre-populates the text field of the Edit Label pop-up with the heading text rather than the current item label. It uses entirely pre-existing functionality, so the PR simply adds the option and updates the unit test.

**Related Issue(s):**

Closes #1443

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
