### PR TITLE
Add formatter helper for file extensions filters

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -41,7 +41,7 @@ from PyQt5.QtCore import QCoreApplication, QUrl
 
 from novelwriter.enum import nwItemClass, nwItemType, nwItemLayout
 from novelwriter.error import logException
-from novelwriter.constants import nwConst, nwUnicode
+from novelwriter.constants import nwConst, nwLabels, nwUnicode, trConst
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import TypeGuard  # Requires Python 3.10
@@ -246,6 +246,19 @@ def formatTime(t: int) -> str:
 def formatVersion(value: str) -> str:
     """Format a version number into a more human readable form."""
     return value.lower().replace("a", " Alpha ").replace("b", " Beta ").replace("rc", " RC ")
+
+
+def formatFileFilter(extensions: list[str | tuple[str, str]]) -> str:
+    """Format a list of extensions, or extension + label pairs into a
+    QFileDialog extensions filter.
+    """
+    result = []
+    for ext in extensions:
+        if isinstance(ext, str):
+            result.append(f"{trConst(nwLabels.FILE_FILTERS.get(ext))} ({ext})")
+        elif isinstance(ext, tuple) and len(ext) == 2:
+            result.append(f"{ext[0]} ({ext[1]})")
+    return ";;".join(result)
 
 
 ##

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -270,6 +270,12 @@ class nwLabels:
         nwBuildFmt.J_HTML: ".json",
         nwBuildFmt.J_NWD:  ".json",
     }
+    FILE_FILTERS = {
+        "*.txt": QT_TRANSLATE_NOOP("Constant", "Text files"),
+        "*.md":  QT_TRANSLATE_NOOP("Constant", "Markdown files"),
+        "*.nwd": QT_TRANSLATE_NOOP("Constant", "novelWriter files"),
+        "*":     QT_TRANSLATE_NOOP("Constant", "All files"),
+    }
     UNIT_NAME = {
         "mm": QT_TRANSLATE_NOOP("Constant", "Millimetres"),
         "cm": QT_TRANSLATE_NOOP("Constant", "Centimetres"),

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -36,6 +36,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
+from novelwriter.common import formatFileFilter
 from novelwriter.core.spellcheck import UserDictionary
 from novelwriter.extensions.configlayout import NColourLabel
 
@@ -184,12 +185,9 @@ class GuiWordList(QDialog):
         SHARED.info(self.tr(
             "Note: The import file must be a plain text file with UTF-8 or ASCII encoding."
         ))
-        extFilter = [
-            "{0} (*.txt)".format(self.tr("Text files")),
-            "{0} (*)".format(self.tr("All files")),
-        ]
+        ffilter = formatFileFilter(["*.txt", "*"])
         path, _ = QFileDialog.getOpenFileName(
-            self, self.tr("Import File"), str(Path.home()), filter=";;".join(extFilter)
+            self, self.tr("Import File"), str(Path.home()), filter=ffilter
         )
         if path:
             try:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -63,7 +63,7 @@ from novelwriter.tools.writingstats import GuiWritingStats
 from novelwriter.enum import (
     nwDocAction, nwDocInsert, nwDocMode, nwItemType, nwWidget, nwView
 )
-from novelwriter.common import hexToInt
+from novelwriter.common import formatFileFilter, hexToInt
 
 logger = logging.getLogger(__name__)
 
@@ -664,14 +664,9 @@ class GuiMain(QMainWindow):
             return False
 
         lastPath = CONFIG.lastPath()
-        extFilter = [
-            "{0} (*.txt)".format(self.tr("Text files")),
-            "{0} (*.md)".format(self.tr("Markdown files")),
-            "{0} (*.nwd)".format(self.tr("novelWriter files")),
-            "{0} (*)".format(self.tr("All files")),
-        ]
+        ffilter = formatFileFilter(["*.txt", "*.md", "*.nwd", "*"])
         loadFile, _ = QFileDialog.getOpenFileName(
-            self, self.tr("Import File"), str(lastPath), filter=";;".join(extFilter)
+            self, self.tr("Import File"), str(lastPath), filter=ffilter
         )
         if not loadFile:
             return False

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from PyQt5.QtCore import QObject, QRunnable, QThreadPool, pyqtSignal
 from PyQt5.QtWidgets import QFileDialog, QMessageBox, QWidget
+from novelwriter.common import formatFileFilter
 
 from novelwriter.constants import nwFiles
 from novelwriter.core.spellcheck import NWSpellEnchant
@@ -221,13 +222,12 @@ class SharedData(QObject):
     def getProjectPath(self, parent: QWidget, path: str | Path | None = None,
                        allowZip: bool = False) -> Path | None:
         """Open the file dialog and select a novelWriter project file."""
-        label = (self.tr("novelWriter Project File or Zip")
+        label = (self.tr("novelWriter Project File or Zip File")
                  if allowZip else self.tr("novelWriter Project File"))
         ext = f"{nwFiles.PROJ_FILE} *.zip" if allowZip else nwFiles.PROJ_FILE
+        ffilter = formatFileFilter([(label, ext), "*"])
         selected, _ = QFileDialog.getOpenFileName(
-            parent, self.tr("Open Project"), str(path or ""), filter=";;".join(
-                [f"{label} ({ext})", "{0} (*)".format(self.tr("All Files"))]
-            )
+            parent, self.tr("Open Project"), str(path or ""), filter=ffilter
         )
         return Path(selected) if selected else None
 

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -37,7 +37,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.error import formatException
-from novelwriter.common import openExternalPath, formatInt, getFileSize
+from novelwriter.common import formatFileFilter, openExternalPath, formatInt, getFileSize
 
 logger = logging.getLogger(__name__)
 
@@ -180,12 +180,11 @@ class GuiDictionaries(QDialog):
     @pyqtSlot()
     def _doBrowseHunspell(self):
         """Browse for a Free/Libre Office dictionary."""
-        extFilter = [
-            self.tr("Free or Libre Office extension ({0})").format("*.sox *.oxt"),
-            self.tr("All files ({0})").format("*"),
-        ]
+        ffilter = formatFileFilter([
+            (self.tr("Free or Libre Office extension"), "*.sox *.oxt"), "*"
+        ])
         soxFile, _ = QFileDialog.getOpenFileName(
-            self, self.tr("Browse Files"), "", filter=";;".join(extFilter)
+            self, self.tr("Browse Files"), "", filter=ffilter
         )
         if soxFile:
             path = Path(soxFile).absolute()

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -381,7 +381,7 @@ class GuiWritingStats(QDialog):
         # Generate the file name
         savePath = CONFIG.lastPath() / f"sessionStats.{fileExt}"
         savePath, _ = QFileDialog.getSaveFileName(
-            self, self.tr("Save Data As"), str(savePath), "%s (*.%s)" % (textFmt, fileExt)
+            self, self.tr("Save Data As"), str(savePath), f"{textFmt} (*.{fileExt})"
         )
         if not savePath:
             return False

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -34,11 +34,11 @@ from PyQt5.QtCore import QUrl
 
 from novelwriter.common import (
     checkBool, checkFloat, checkInt, checkIntTuple, checkPath, checkString,
-    checkStringNone, checkUuid, formatInt, formatTime, formatTimeStamp,
-    formatVersion, fuzzyTime, getFileSize, hexToInt, isHandle, isItemClass,
-    isItemLayout, isItemType, isTitleTag, jsonEncode, makeFileNameSafe, minmax,
-    numberToRoman, NWConfigParser, openExternalPath, readTextFile, simplified,
-    transferCase, xmlIndent, yesNo
+    checkStringNone, checkUuid, formatFileFilter, formatInt, formatTime,
+    formatTimeStamp, formatVersion, fuzzyTime, getFileSize, hexToInt, isHandle,
+    isItemClass, isItemLayout, isItemType, isTitleTag, jsonEncode,
+    makeFileNameSafe, minmax, numberToRoman, NWConfigParser, openExternalPath,
+    readTextFile, simplified, transferCase, xmlIndent, yesNo
 )
 
 
@@ -344,6 +344,18 @@ def testBaseCommon_formatVersion():
     assert formatVersion("1.2rc3") == "1.2 RC 3"
 
 # END Test testBaseCommon_formatVersion
+
+
+@pytest.mark.base
+def testBaseCommon_formatFileFilter():
+    """Test the formatFileFilter function."""
+    assert formatFileFilter(["*.txt"]) == "Text files (*.txt)"
+    assert formatFileFilter(["*.txt", "*"]) == "Text files (*.txt);;All files (*)"
+    assert formatFileFilter([("Stuff", "*.stuff"), "*.txt", "*"]) == (
+        "Stuff (*.stuff);;Text files (*.txt);;All files (*)"
+    )
+
+# END Test testBaseCommon_formatFileFilter
 
 
 @pytest.mark.base


### PR DESCRIPTION
**Summary:**

This PR adds a helper function for building file extension filters for file dialogs. Aside from not having to generated this special format in multiple places in the code, it also combines the translation strings for the ones used multiple places into a single lookup dictionary, preventing duplicate translation entries.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
