### PR TITLE
Fix deprecated typing

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v4
       - name: Install flake8
-        run: pip install flake8
+        run: pip install flake8 flake8-pep585
       - name: Syntax Check
         run: |
           flake8 --version

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -29,8 +29,8 @@ import uuid
 import logging
 
 from enum import Enum
-from typing import Iterable
 from pathlib import Path
+from collections.abc import Iterable
 
 from PyQt5.QtCore import QT_TRANSLATE_NOOP, QCoreApplication
 

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -29,10 +29,10 @@ from __future__ import annotations
 import shutil
 import logging
 
-from typing import Iterable
 from pathlib import Path
 from functools import partial
 from zipfile import ZipFile, is_zipfile
+from collections.abc import Iterable
 
 from PyQt5.QtCore import QCoreApplication
 

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 
 import logging
 
-from typing import Iterable
 from pathlib import Path
+from collections.abc import Iterable
 
 from PyQt5.QtGui import QFont, QFontInfo
 

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -32,8 +32,9 @@ import json
 import logging
 
 from time import time
-from typing import TYPE_CHECKING, ItemsView, Iterable, Iterator
+from typing import TYPE_CHECKING
 from pathlib import Path
+from collections.abc import ItemsView, Iterable, Iterator
 
 from novelwriter import SHARED
 from novelwriter.enum import nwComment, nwItemClass, nwItemType, nwItemLayout

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -28,9 +28,10 @@ import logging
 
 from enum import Enum
 from time import time
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 from pathlib import Path
 from functools import partial
+from collections.abc import Iterator
 
 from PyQt5.QtCore import QCoreApplication
 

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -27,8 +27,9 @@ import json
 import logging
 
 from time import time
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 from pathlib import Path
+from collections.abc import Iterator
 
 from novelwriter.error import logException
 from novelwriter.common import formatTimeStamp

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -27,8 +27,9 @@ from __future__ import annotations
 import json
 import logging
 
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 from pathlib import Path
+from collections.abc import Iterator
 
 from PyQt5.QtCore import QLocale
 

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -27,7 +27,8 @@ from __future__ import annotations
 import random
 import logging
 
-from typing import TYPE_CHECKING, ItemsView, Iterator, KeysView, Literal, ValuesView
+from typing import TYPE_CHECKING, Literal
+from collections.abc import ItemsView, Iterator, KeysView, ValuesView
 
 from PyQt5.QtGui import QIcon, QPainter, QPainterPath, QPixmap, QColor
 from PyQt5.QtCore import QRectF, Qt

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -29,11 +29,11 @@ from __future__ import annotations
 import logging
 import xml.etree.ElementTree as ET
 
-from typing import Sequence
 from hashlib import sha256
 from pathlib import Path
 from zipfile import ZipFile
 from datetime import datetime
+from collections.abc import Sequence
 
 from novelwriter import __version__
 from novelwriter.common import xmlIndent

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -26,8 +26,9 @@ from __future__ import annotations
 import random
 import logging
 
-from typing import TYPE_CHECKING, Iterator, Literal, overload
+from typing import TYPE_CHECKING, Literal, overload
 from pathlib import Path
+from collections.abc import Iterator
 
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 from novelwriter.error import logException


### PR DESCRIPTION
**Summary:**

Don't allow PEP585 deprecated typing.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
