### PR TITLE
Fix scene separators and chapter and scene counters

### DIFF
--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -89,7 +89,7 @@ class Tokenizer(ABC):
     T_UNNUM    = 7   # Unnumbered
     T_HEAD1    = 8   # Header 1
     T_HEAD2    = 9   # Header 2
-    T_HEAD3    = 10   # Header 3
+    T_HEAD3    = 10  # Header 3
     T_HEAD4    = 11  # Header 4
     T_TEXT     = 12  # Text line
     T_SEP      = 13  # Scene separator

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -671,16 +671,18 @@ class Tokenizer(ABC):
             if tToken[0] == self.T_TEXT:
                 self._firstScene = False
 
-            elif tToken[0] == self.T_HEAD1:
-                # Partition
+            elif tToken[0] == self.T_HEAD1:  # Partition
 
                 tTemp = self._hFormatter.apply(self._fmtTitle, tToken[2], tToken[1])
                 self._tokens[n] = (
                     tToken[0], tToken[1], tTemp, [], tToken[4]
                 )
 
-            elif tToken[0] in (self.T_HEAD2, self.T_UNNUM):
-                # Chapter
+                # Set scene variables
+                # self._firstScene = True
+                # self._hFormatter.resetScene()
+
+            elif tToken[0] in (self.T_HEAD2, self.T_UNNUM):  # Chapter
 
                 # Numbered or Unnumbered
                 if tToken[0] == self.T_UNNUM:
@@ -698,8 +700,7 @@ class Tokenizer(ABC):
                 self._firstScene = True
                 self._hFormatter.resetScene()
 
-            elif tToken[0] == self.T_HEAD3:
-                # Scene
+            elif tToken[0] == self.T_HEAD3:  # Scene
 
                 self._hFormatter.incScene()
 
@@ -709,23 +710,14 @@ class Tokenizer(ABC):
                         self.T_EMPTY, tToken[1], "", [], self.A_NONE
                     )
                 elif tTemp == "" and not self._hideScene:
-                    if self._firstScene:
-                        self._tokens[n] = (
-                            self.T_EMPTY, tToken[1], "", [], self.A_NONE
-                        )
-                    else:
-                        self._tokens[n] = (
-                            self.T_SKIP, tToken[1], "", [], tToken[4]
-                        )
+                    t1 = self.T_EMPTY if self._firstScene else self.T_SKIP
+                    t4 = self.A_NONE if self._firstScene else tToken[4]
+                    self._tokens[n] = (t1, tToken[1], "", [], t4)
                 elif tTemp == self._fmtScene:
-                    if self._firstScene:
-                        self._tokens[n] = (
-                            self.T_EMPTY, tToken[1], "", [], self.A_NONE
-                        )
-                    else:
-                        self._tokens[n] = (
-                            self.T_SEP, tToken[1], tTemp, [], tToken[4] | self.A_CENTRE
-                        )
+                    t1 = self.T_EMPTY if self._firstScene else self.T_SEP
+                    t2 = "" if self._firstScene else tTemp
+                    t4 = self.A_NONE if self._firstScene else (tToken[4] | self.A_CENTRE)
+                    self._tokens[n] = (t1, tToken[1], t2, [], t4)
                 else:
                     self._tokens[n] = (
                         tToken[0], tToken[1], tTemp, [], tToken[4]
@@ -733,8 +725,7 @@ class Tokenizer(ABC):
 
                 self._firstScene = False
 
-            elif tToken[0] == self.T_HEAD4:
-                # Section
+            elif tToken[0] == self.T_HEAD4:  # Section
 
                 tTemp = self._hFormatter.apply(self._fmtSection, tToken[2], tToken[1])
                 if tTemp == "" and self._hideSection:

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -713,17 +713,15 @@ class Tokenizer(ABC):
                         self.T_EMPTY, token[1], "", [], self.A_NONE
                     )
                 elif tTemp == "" and not self._hideScene:
-                    t1 = self.T_EMPTY if self._allowSeparator else self.T_SKIP
-                    t4 = self.A_NONE if self._allowSeparator else token[4]
                     self._tokens[n] = (
-                        t1, token[1], "", [], t4
+                        self.T_EMPTY if self._allowSeparator else self.T_SKIP, token[1],
+                        "", [], self.A_NONE if self._allowSeparator else token[4]
                     )
                 elif tTemp == self._fmtScene:
-                    t1 = self.T_EMPTY if self._allowSeparator else self.T_SEP
-                    t2 = "" if self._allowSeparator else tTemp
-                    t4 = self.A_NONE if self._allowSeparator else (token[4] | self.A_CENTRE)
                     self._tokens[n] = (
-                        t1, token[1], t2, [], t4
+                        self.T_EMPTY if self._allowSeparator else self.T_SEP, token[1],
+                        "" if self._allowSeparator else tTemp, [],
+                        self.A_NONE if self._allowSeparator else (token[4] | self.A_CENTRE)
                     )
                 else:
                     self._tokens[n] = (

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -1122,7 +1122,7 @@ def testCoreToken_ProcessHeaders(mockGUI):
     # H3: Scene wo/Format, first
     tokens._text = "### Scene One\n"
     tokens.setSceneFormat("", False)
-    tokens._firstScene = True
+    tokens._allowSeparator = True
     tokens.tokenizeText()
     tokens.doHeaders()
     assert tokens._tokens == [
@@ -1133,7 +1133,7 @@ def testCoreToken_ProcessHeaders(mockGUI):
     # H3: Scene wo/Format, not first
     tokens._text = "### Scene One\n"
     tokens.setSceneFormat("", False)
-    tokens._firstScene = False
+    tokens._allowSeparator = False
     tokens.tokenizeText()
     tokens.doHeaders()
     assert tokens._tokens == [
@@ -1144,7 +1144,7 @@ def testCoreToken_ProcessHeaders(mockGUI):
     # H3: Scene Separator, first
     tokens._text = "### Scene One\n"
     tokens.setSceneFormat("* * *", False)
-    tokens._firstScene = True
+    tokens._allowSeparator = True
     tokens.tokenizeText()
     tokens.doHeaders()
     assert tokens._tokens == [
@@ -1155,7 +1155,7 @@ def testCoreToken_ProcessHeaders(mockGUI):
     # H3: Scene Separator, not first
     tokens._text = "### Scene One\n"
     tokens.setSceneFormat("* * *", False)
-    tokens._firstScene = False
+    tokens._allowSeparator = False
     tokens.tokenizeText()
     tokens.doHeaders()
     assert tokens._tokens == [
@@ -1231,12 +1231,12 @@ def testCoreToken_ProcessHeaders(mockGUI):
     ]
 
     # Check the first scene detector
-    assert tokens._firstScene is False
-    tokens._firstScene = True
+    assert tokens._allowSeparator is False
+    tokens._allowSeparator = True
     tokens._text = "Some text ...\n"
     tokens.tokenizeText()
     tokens.doHeaders()
-    assert tokens._firstScene is False
+    assert tokens._allowSeparator is False
 
 # END Test testCoreToken_ProcessHeaders
 

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -26,6 +26,7 @@ import pytest
 from tools import C, buildTestProject, readFile
 
 from novelwriter.constants import nwHeadFmt
+from novelwriter.core.tomd import ToMarkdown
 from novelwriter.core.project import NWProject
 from novelwriter.core.tokenizer import HeadingFormatter, Tokenizer, stripEscape
 
@@ -1010,7 +1011,7 @@ def testCoreToken_ProcessHeaders(mockGUI):
     tokens._isNote = False
 
     ##
-    #  Story FIles
+    #  Story Files
     ##
 
     tokens._isNone  = False
@@ -1192,7 +1193,7 @@ def testCoreToken_ProcessHeaders(mockGUI):
 
     # H4: Section Hidden wo/Format
     tokens._text = "#### A Section\n"
-    tokens.setSectionFormat(r"", True)
+    tokens.setSectionFormat("", True)
     tokens.tokenizeText()
     tokens.doHeaders()
     assert tokens._tokens == [
@@ -1239,6 +1240,193 @@ def testCoreToken_ProcessHeaders(mockGUI):
     assert tokens._allowSeparator is False
 
 # END Test testCoreToken_ProcessHeaders
+
+
+@pytest.mark.core
+def testCoreToken_HeaderCounterAndVisibility(mockGUI):
+    """Test the header counter and visibility of the Tokenizer class.
+    This is a special test to cover issue #1704.
+    """
+    project = NWProject()
+    project.data.setLanguage("en")
+    project._loadProjectLocalisation()
+    md = ToMarkdown(project)
+    md._isNone = False
+    md._isNote = False
+    md._isNovel = True
+
+    # Separator Handling, Titles
+    # ==========================
+
+    md._text = (
+        "# Title One\n\n"
+        "### Scene One\n\n"
+        "Text\n\n"
+        "### Scene Two\n\n"
+        "Text\n\n"
+        "# Title Two\n\n"
+        "### Scene Three\n\n"
+        "Text\n\n"
+        "### Scene Four\n\n"
+        "Text\n\n"
+    )
+    md.setTitleFormat(f"T: {nwHeadFmt.TITLE}")
+    md.setChapterFormat(f"C: {nwHeadFmt.TITLE}")
+    md.setSectionFormat("", True)
+
+    # Static Separator
+    md.setSceneFormat("* * *", False)
+    md.tokenizeText()
+    md.doHeaders()
+    md.doConvert()
+    assert md.result == (
+        "# T: Title One\n\n"
+        "Text\n\n"
+        "* * *\n\n"
+        "Text\n\n"
+        "# T: Title Two\n\n"
+        "Text\n\n"
+        "* * *\n\n"
+        "Text\n\n"
+    )
+
+    # Scene Title Formatted
+    md.setSceneFormat(f"S: {nwHeadFmt.TITLE}", False)
+    md.tokenizeText()
+    md.doHeaders()
+    md.doConvert()
+    assert md.result == (
+        "# T: Title One\n\n"
+        "### S: Scene One\n\n"
+        "Text\n\n"
+        "### S: Scene Two\n\n"
+        "Text\n\n"
+        "# T: Title Two\n\n"
+        "### S: Scene Three\n\n"
+        "Text\n\n"
+        "### S: Scene Four\n\n"
+        "Text\n\n"
+    )
+
+    # Separator Handling, Chapters
+    # ============================
+
+    md._text = (
+        "# Title One\n\n"
+        "## Chapter One\n\n"
+        "### Scene One\n\n"
+        "Text\n\n"
+        "### Scene Two\n\n"
+        "Text\n\n"
+        "## Chapter Two\n\n"
+        "### Scene Three\n\n"
+        "Text\n\n"
+        "### Scene Four\n\n"
+        "Text\n\n"
+    )
+    md.setTitleFormat(f"T: {nwHeadFmt.TITLE}")
+    md.setChapterFormat(f"C: {nwHeadFmt.TITLE}")
+    md.setSectionFormat("", True)
+
+    # Static Separator
+    md.setSceneFormat("* * *", False)
+    md.tokenizeText()
+    md.doHeaders()
+    md.doConvert()
+    assert md.result == (
+        "# T: Title One\n\n"
+        "## C: Chapter One\n\n"
+        "Text\n\n"
+        "* * *\n\n"
+        "Text\n\n"
+        "## C: Chapter Two\n\n"
+        "Text\n\n"
+        "* * *\n\n"
+        "Text\n\n"
+    )
+
+    # Scene Title Formatted
+    md.setSceneFormat(f"S: {nwHeadFmt.TITLE}", False)
+    md.tokenizeText()
+    md.doHeaders()
+    md.doConvert()
+    assert md.result == (
+        "# T: Title One\n\n"
+        "## C: Chapter One\n\n"
+        "### S: Scene One\n\n"
+        "Text\n\n"
+        "### S: Scene Two\n\n"
+        "Text\n\n"
+        "## C: Chapter Two\n\n"
+        "### S: Scene Three\n\n"
+        "Text\n\n"
+        "### S: Scene Four\n\n"
+        "Text\n\n"
+    )
+
+    # Counter Handling, Novel Titles
+    # ==============================
+
+    md._text = (
+        "#! Novel One\n\n"
+        "## Chapter One\n\n"
+        "### Scene One\n\n"
+        "Text\n\n"
+        "### Scene Two\n\n"
+        "Text\n\n"
+        "## Chapter Two\n\n"
+        "### Scene Three\n\n"
+        "Text\n\n"
+        "### Scene Four\n\n"
+        "Text\n\n"
+        "#! Novel Two\n\n"
+        "## Chapter One\n\n"
+        "### Scene One\n\n"
+        "Text\n\n"
+        "### Scene Two\n\n"
+        "Text\n\n"
+        "## Chapter Two\n\n"
+        "### Scene Three\n\n"
+        "Text\n\n"
+        "### Scene Four\n\n"
+        "Text\n\n"
+    )
+    md.setTitleFormat(f"T: {nwHeadFmt.TITLE}")
+    md.setChapterFormat(f"C {nwHeadFmt.CH_NUM}: {nwHeadFmt.TITLE}")
+    md.setSceneFormat(f"S {nwHeadFmt.CH_NUM}.{nwHeadFmt.SC_NUM} ({nwHeadFmt.SC_ABS}): "
+                      f"{nwHeadFmt.TITLE}", False)
+    md.setSectionFormat("", True)
+
+    # Two Novel Format
+    md.tokenizeText()
+    md.doHeaders()
+    md.doConvert()
+    assert md.result == (
+        "# Novel One\n\n"
+        "## C 1: Chapter One\n\n"
+        "### S 1.1 (1): Scene One\n\n"
+        "Text\n\n"
+        "### S 1.2 (2): Scene Two\n\n"
+        "Text\n\n"
+        "## C 2: Chapter Two\n\n"
+        "### S 2.1 (3): Scene Three\n\n"
+        "Text\n\n"
+        "### S 2.2 (4): Scene Four\n\n"
+        "Text\n\n"
+        "# Novel Two\n\n"
+        "## C 1: Chapter One\n\n"
+        "### S 1.1 (1): Scene One\n\n"
+        "Text\n\n"
+        "### S 1.2 (2): Scene Two\n\n"
+        "Text\n\n"
+        "## C 2: Chapter Two\n\n"
+        "### S 2.1 (3): Scene Three\n\n"
+        "Text\n\n"
+        "### S 2.2 (4): Scene Four\n\n"
+        "Text\n\n"
+    )
+
+# END Test testCoreToken_HeaderCounterAndVisibility
 
 
 @pytest.mark.core
@@ -1305,6 +1493,12 @@ def testCoreIndex_HeadingFormatter(fncPath, mockRnd):
     formatter.resetScene()
     formatter.incScene()
     assert formatter.apply(cFormat, "Hi Bob", 1) == "Chapter 2.1 - Scene 5 - Hi Bob"
+
+    # New Main Title
+    formatter.resetAll()
+    formatter.incChapter()
+    formatter.incScene()
+    assert formatter.apply(cFormat, "Hi Bob", 1) == "Chapter 1.1 - Scene 1 - Hi Bob"
 
     # Special Formats
     # ===============


### PR DESCRIPTION
**Summary:**

This PR fixes two issues:
* Scene separators being inserted directly after level one headers.
* Chapter and scene counters not being reset after a new novel title is introduced, including for multiple novel folders.

**Related Issue(s):**

Closes #1704

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
