### PR TITLE
Emit clear index signal when project is closed

### DIFF
--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -410,6 +410,7 @@ class NWProject:
     def closeProject(self, idleTime: float = 0.0) -> None:
         """Close the project."""
         logger.info("Closing project")
+        self._index.clearIndex()  # Triggers clear signal, see #1718
         self._options.saveSettings()
         self._tree.writeToCFile()
         self._session.appendSession(idleTime)

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -25,13 +25,13 @@ import pytest
 
 from shutil import copyfile
 
-from mocked import causeException
-from novelwriter import SHARED
-from novelwriter.core.item import NWItem
 from tools import C, buildTestProject, cmpFiles, writeFile
+from mocked import causeException
 
+from novelwriter import SHARED
 from novelwriter.enum import nwComment, nwItemClass, nwItemLayout
 from novelwriter.constants import nwFiles
+from novelwriter.core.item import NWItem
 from novelwriter.core.index import IndexItem, NWIndex, countWords, TagsIndex, processComment
 from novelwriter.core.project import NWProject
 

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -26,6 +26,7 @@ import pytest
 from shutil import copyfile
 
 from mocked import causeException
+from novelwriter import SHARED
 from novelwriter.core.item import NWItem
 from tools import C, buildTestProject, cmpFiles, writeFile
 
@@ -36,7 +37,7 @@ from novelwriter.core.project import NWProject
 
 
 @pytest.mark.core
-def testCoreIndex_LoadSave(monkeypatch, prjLipsum, mockGUI, tstPaths):
+def testCoreIndex_LoadSave(qtbot, monkeypatch, prjLipsum, mockGUI, tstPaths):
     """Test core functionality of scanning, saving, loading and checking
     the index cache file.
     """
@@ -148,8 +149,10 @@ def testCoreIndex_LoadSave(monkeypatch, prjLipsum, mockGUI, tstPaths):
     assert "fb609cd8319dc" in index._itemIndex
     assert "7a992350f3eb6" in index._itemIndex
 
-    # Finalise
-    project.closeProject()
+    # Close Project
+    with qtbot.waitSignal(SHARED.indexCleared, timeout=1000):
+        # Regression test for issue #1718
+        project.closeProject()
 
 # END Test testCoreIndex_LoadSave
 


### PR DESCRIPTION
**Summary:**

This PR adds a call to clear the index when a project is closed so a indexCleared signal is emitted. This clears the reference panel. The panel is anyway rebuilt when a new index is loaded, but *only* if there are any tags defined, which leaves data behind if the next project opened doesn't have any.

**Related Issue(s):**

Closes #1718

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
