### PR TITLE
Open Project error handling

### DIFF
--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -183,11 +183,15 @@ class NWStorage:
         # 2. A full path to an nwProject.nwx file
         if inPath.is_dir() and inPath != Path.home().resolve():
             nwxFile = inPath / nwFiles.PROJ_FILE
-        elif inPath.is_file() and inPath.name == nwFiles.PROJ_FILE:
-            nwxFile = inPath
+        elif inPath.is_file():
+            if inPath.name == nwFiles.PROJ_FILE:
+                nwxFile = inPath
+            else:
+                logger.error("Not a novelWriter project")
+                return NWStorageOpen.UNKOWN
         else:
-            logger.error("Not a novelWriter project")
-            return NWStorageOpen.UNKOWN
+            logger.error("Not found: %s", inPath)
+            return NWStorageOpen.NOT_FOUND
 
         if not nwxFile.exists():
             # The .nwx file must exist to continue

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -796,7 +796,7 @@ class GuiMain(QMainWindow):
     def showWelcomeDialog(self) -> None:
         """Open the welcome dialog."""
         dialog = GuiWelcome(self)
-        dialog.openProjectRequest.connect(self._openProject)
+        dialog.openProjectRequest.connect(self._openProjectFromWelcome)
         dialog.exec_()
         return
 
@@ -1132,10 +1132,12 @@ class GuiMain(QMainWindow):
         return
 
     @pyqtSlot(Path)
-    def _openProject(self, path: Path) -> None:
-        """Handle an open project request."""
+    def _openProjectFromWelcome(self, path: Path) -> None:
+        """Handle an open project request from the welcome dialog."""
         qApp.processEvents()
         self.openProject(path)
+        if not SHARED.hasProject:
+            self.showWelcomeDialog()
         return
 
     @pyqtSlot(str, nwDocMode, str, bool)

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -111,12 +111,15 @@ def testCoreStorage_InitProjectStorage(mockGUI, fncPath, mockRnd):
     buildTestProject(project, fncPath)
 
     # Init with the wrong file
+    foo = fncPath / "foobar.txt"
+    foo.touch()
     assert storage.initProjectStorage(fncPath / "foobar.txt") == NWStorageOpen.UNKOWN
+    foo.unlink()
     storage._clearLockFile()
     storage.clear()
 
     # Init with the user's home dir
-    assert storage.initProjectStorage(Path.home()) == NWStorageOpen.UNKOWN
+    assert storage.initProjectStorage(Path.home()) == NWStorageOpen.NOT_FOUND
     storage._clearLockFile()
     storage.clear()
 


### PR DESCRIPTION
**Summary:**

This PR:
* Changes the error on missing (deleted) projects reported by the storage class to NOT_FOUND instead of UNKNOWN, which produces a more accurate error message for the user.
* Adds a check after the Welcome dialog has returned and an open project request has been processed. The check will pop open the Welcome dialog again if the previous process did not result in an open project. This will not trigger if there already was a project open before the Welcome dialog was opened. Only when the process results in a blank UI.

**Related Issue(s):**

Closes #1737

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
