### PR TITLE
Use Qt localisation for numbers and dates

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -41,7 +41,7 @@ from PyQt5.QtCore import QCoreApplication, QUrl
 
 from novelwriter.enum import nwItemClass, nwItemType, nwItemLayout
 from novelwriter.error import logException
-from novelwriter.constants import nwConst, nwLabels, nwUnicode, trConst
+from novelwriter.constants import nwConst, nwLabels, trConst
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import TypeGuard  # Requires Python 3.10
@@ -200,26 +200,6 @@ def checkIntTuple(value: int, valid: tuple | list | set, default: int) -> int:
 ##
 #  Formatting Functions
 ##
-
-def formatInt(value: int) -> str:
-    """Formats an integer with k, M, G etc."""
-    if not isinstance(value, int):
-        return "ERR"
-
-    fVal = float(value)
-    if fVal > 1000.0:
-        for pF in ["k", "M", "G", "T", "P", "E"]:
-            fVal /= 1000.0
-            if fVal < 1000.0:
-                if fVal < 10.0:
-                    return f"{fVal:4.2f}{nwUnicode.U_THSP}{pF}"
-                elif fVal < 100.0:
-                    return f"{fVal:4.1f}{nwUnicode.U_THSP}{pF}"
-                else:
-                    return f"{fVal:3.0f}{nwUnicode.U_THSP}{pF}"
-
-    return str(value)
-
 
 def formatTimeStamp(value: float, fileSafe: bool = False) -> str:
     """Take a number (on the format returned by time.time()) and convert

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -30,6 +30,7 @@ import logging
 
 from time import time
 from pathlib import Path
+from datetime import datetime
 
 from PyQt5.QtGui import QFontDatabase
 from PyQt5.QtCore import (
@@ -86,6 +87,8 @@ class Config:
 
         wantedLocale = self._nwLangPath / f"nw_{QLocale.system().name()}.qm"
         self._qLocale = QLocale.system() if wantedLocale.exists() else QLocale("en_GB")
+        self._qShortDate = self._qLocale.dateFormat(QLocale.FormatType.ShortFormat)
+        self._qShortDateTime = self._qLocale.dateTimeFormat(QLocale.FormatType.ShortFormat)
         self._qtTrans = {}
 
         # PDF Manual
@@ -414,6 +417,18 @@ class Config:
         self._errData = []
         return message
 
+    def localNumber(self, value: int) -> str:
+        """Return a localised integer format."""
+        return self._qLocale.toString(value)
+
+    def localDate(self, value: datetime) -> str:
+        """Return a localised datetime format."""
+        return self._qLocale.toString(value, self._qShortDate)
+
+    def localDateTime(self, value: datetime) -> str:
+        """Return a localised datetime format."""
+        return self._qLocale.toString(value, self._qShortDateTime)
+
     def listLanguages(self, lngSet: int) -> list[tuple[str, str]]:
         """List localisation files in the i18n folder. The default GUI
         language is British English (en_GB).
@@ -493,6 +508,8 @@ class Config:
     def initLocalisation(self, nwApp: QApplication) -> None:
         """Initialise the localisation of the GUI."""
         self._qLocale = QLocale(self.guiLocale)
+        self._qShortDate = self._qLocale.dateFormat(QLocale.FormatType.ShortFormat)
+        self._qShortDateTime = self._qLocale.dateTimeFormat(QLocale.FormatType.ShortFormat)
         QLocale.setDefault(self._qLocale)
         self._qtTrans = {}
 

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -421,6 +421,27 @@ class Config:
         """Return a localised integer format."""
         return self._qLocale.toString(value)
 
+    def localFloat(self, value: float, precision: int) -> str:
+        """Return a localised integer format."""
+        return self._qLocale.toString(value, "f", precision)
+
+    def localFloatSI(self, value: int | float) -> str:
+        """Return a localised integer format with k, M, G etc."""
+        if not isinstance(value, (int, float)):
+            return "ERR"
+        fVal = float(value)
+        if fVal > 1000.0:
+            for pF in ["k", "M", "G", "T", "P", "E"]:
+                fVal /= 1000.0
+                if fVal < 1000.0:
+                    if fVal < 10.0:
+                        return f"{self.localFloat(fVal, 2)}{nwUnicode.U_THSP}{pF}"
+                    elif fVal < 100.0:
+                        return f"{self.localFloat(fVal, 1)}{nwUnicode.U_THSP}{pF}"
+                    else:
+                        return f"{self.localFloat(fVal, 0)}{nwUnicode.U_THSP}{pF}"
+        return str(value)
+
     def localDate(self, value: datetime) -> str:
         """Return a localised datetime format."""
         return self._qLocale.toString(value, self._qShortDate)

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -47,7 +47,7 @@ from novelwriter.core.sessions import NWSessionLog
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.projectdata import NWProjectData
 from novelwriter.common import (
-    checkStringNone, formatInt, formatTimeStamp, getFileSize, hexToInt, makeFileNameSafe, minmax
+    checkStringNone, formatTimeStamp, getFileSize, hexToInt, makeFileNameSafe, minmax
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -447,7 +447,7 @@ class NWProject:
         archName = baseDir / f"{cleanName} {timeStamp}.zip"
         if self._storage.zipIt(archName, compression=2):
             if doNotify:
-                size = formatInt(getFileSize(archName))
+                size = CONFIG.localFloatSI(getFileSize(archName))
                 SHARED.info(
                     self.tr("Created a backup of your project of size {0}B.").format(size),
                     info=self.tr("Path: {0}").format(str(backupPath))

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -25,23 +25,19 @@ from __future__ import annotations
 
 import logging
 
-from typing import TYPE_CHECKING
 from pathlib import Path
 
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QAbstractItemView, QDialog, QDialogButtonBox, QFileDialog, QHBoxLayout,
-    QLineEdit, QListWidget, QPushButton, QVBoxLayout, qApp
+    QLineEdit, QListWidget, QPushButton, QVBoxLayout, QWidget, qApp
 )
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatFileFilter
 from novelwriter.core.spellcheck import UserDictionary
 from novelwriter.extensions.configlayout import NColourLabel
-
-if TYPE_CHECKING:  # pragma: no cover
-    from novelwriter.guimain import GuiMain
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +46,8 @@ class GuiWordList(QDialog):
 
     newWordListReady = pyqtSignal()
 
-    def __init__(self, mainGui: GuiMain) -> None:
-        super().__init__(parent=mainGui)
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent=parent)
 
         logger.debug("Create: GuiWordList")
         self.setObjectName("GuiWordList")
@@ -64,13 +60,13 @@ class GuiWordList(QDialog):
         self.setMinimumWidth(mS)
         self.setMinimumHeight(mS)
         self.resize(
-            CONFIG.pxInt(SHARED.project.options.getInt("GuiWordList", "winWidth",  wW)),
+            CONFIG.pxInt(SHARED.project.options.getInt("GuiWordList", "winWidth", wW)),
             CONFIG.pxInt(SHARED.project.options.getInt("GuiWordList", "winHeight", wH))
         )
 
         # Header
         self.headLabel = NColourLabel(
-            "Project Word List", SHARED.theme.helpText, parent=self,
+            self.tr("Project Word List"), SHARED.theme.helpText, parent=self,
             scale=NColourLabel.HEADER_SCALE
         )
 

--- a/novelwriter/extensions/circularprogress.py
+++ b/novelwriter/extensions/circularprogress.py
@@ -29,6 +29,8 @@ from PyQt5.QtGui import QBrush, QColor, QPaintEvent, QPainter, QPen
 from PyQt5.QtCore import QRect, Qt
 from PyQt5.QtWidgets import QProgressBar, QSizePolicy, QWidget
 
+from novelwriter import CONFIG
+
 
 class NProgressCircle(QProgressBar):
     """Extension: Circular Progress Widget
@@ -94,7 +96,8 @@ class NProgressCircle(QProgressBar):
         painter.setPen(self._cPen)
         painter.drawArc(self._cRect, 90*16, -angle)
         painter.setPen(self._tColor)
-        painter.drawText(self._cRect, Qt.AlignCenter, self._text or f"{progress:.1f} %")
+        painter.drawText(self._cRect, Qt.AlignCenter,
+                         self._text or f"{CONFIG.localFloat(progress, 1)} %")
         return
 
 # END Class NProgressCircle

--- a/novelwriter/extensions/versioninfo.py
+++ b/novelwriter/extensions/versioninfo.py
@@ -57,7 +57,7 @@ class VersionInfoWidget(QWidget):
         # Labels
         self._lblInfo = QLabel("{0} {1} \u2013 {2} {3} \u2013 {4}".format(
             self.tr("Version"), formatVersion(__version__),
-            self.tr("Released on"), datetime.strptime(__date__, "%Y-%m-%d").strftime("%x"),
+            self.tr("Released on"), CONFIG.localDate(datetime.strptime(__date__, "%Y-%m-%d")),
             "<a href='#notes'>{0}</a>".format(self.tr("Release Notes")),
         ), self)
         self._lblInfo.linkActivated.connect(self._processLink)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -3157,18 +3157,21 @@ class GuiDocEditFooter(QWidget):
         cLine = cursor.blockNumber() + 1
         cCount = max(cursor.document().characterCount(), 1)
         self.linesText.setText(
-            self._trLineCount.format(f"{cLine:n}", f"{100*cPos//cCount:d} %")
+            self._trLineCount.format(CONFIG.localNumber(cLine), f"{100*cPos//cCount:d} %")
         )
         return
 
     def updateWordCount(self, wCount: int, selection: bool) -> None:
         """Update word counter information."""
         if selection and wCount:
-            wText = self._trSelectCount.format(f"{wCount:n}")
+            wText = self._trSelectCount.format(CONFIG.localNumber(wCount))
         elif self._tItem:
             wCount = self._tItem.wordCount
             wDiff = wCount - self._tItem.initCount
-            wText = self._trWordCount.format(f"{wCount:n}", f"{wDiff:+n}")
+            wPre = "+" if wDiff >= 0 else ""
+            wText = self._trWordCount.format(
+                CONFIG.localNumber(wCount), f"{wPre}{CONFIG.localNumber(wDiff)}"
+            )
         else:
             wText = self._trWordCount.format("0", "+0")
         self.wordsText.setText(wText)

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -280,9 +280,9 @@ class GuiItemDetails(QWidget):
         # ======
 
         if nwItem.isFileType():
-            self.cCountData.setText(f"{nwItem.charCount:n}")
-            self.wCountData.setText(f"{nwItem.wordCount:n}")
-            self.pCountData.setText(f"{nwItem.paraCount:n}")
+            self.cCountData.setText(CONFIG.localNumber(nwItem.charCount))
+            self.wCountData.setText(CONFIG.localNumber(nwItem.wordCount))
+            self.pCountData.setText(CONFIG.localNumber(nwItem.paraCount))
         else:
             self.cCountData.setText("–")
             self.wCountData.setText("–")
@@ -296,9 +296,9 @@ class GuiItemDetails(QWidget):
         already showing. Otherwise, do nothing.
         """
         if tHandle == self._itemHandle:
-            self.cCountData.setText(f"{cC:n}")
-            self.wCountData.setText(f"{wC:n}")
-            self.pCountData.setText(f"{pC:n}")
+            self.cCountData.setText(CONFIG.localNumber(cC))
+            self.wCountData.setText(CONFIG.localNumber(wC))
+            self.pCountData.setText(CONFIG.localNumber(pC))
         return
 
 # END Class GuiItemDetails

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -706,7 +706,7 @@ class GuiNovelTree(QTreeWidget):
         trItem.setData(self.C_TITLE, Qt.ItemDataRole.DecorationRole, hDec)
         trItem.setText(self.C_TITLE, idxItem.title)
         trItem.setFont(self.C_TITLE, self._hFonts[iLevel])
-        trItem.setText(self.C_WORDS, f"{idxItem.wordCount:n}")
+        trItem.setText(self.C_WORDS, CONFIG.localNumber(idxItem.wordCount))
         trItem.setData(self.C_MORE, Qt.ItemDataRole.DecorationRole, self._pMore)
 
         # Custom column

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -700,11 +700,11 @@ class GuiOutlineTree(QTreeWidget):
             trItem.setText(self._colIdx[nwOutline.LEVEL], novIdx.level)
             trItem.setIcon(self._colIdx[nwOutline.LABEL], self._dIcon[nwItem.mainHeading])
             trItem.setText(self._colIdx[nwOutline.LABEL], nwItem.itemName)
-            trItem.setText(self._colIdx[nwOutline.LINE], f"{novIdx.line:n}")
+            trItem.setText(self._colIdx[nwOutline.LINE], CONFIG.localNumber(novIdx.line))
             trItem.setText(self._colIdx[nwOutline.SYNOP], novIdx.synopsis)
-            trItem.setText(self._colIdx[nwOutline.CCOUNT], f"{novIdx.charCount:n}")
-            trItem.setText(self._colIdx[nwOutline.WCOUNT], f"{novIdx.wordCount:n}")
-            trItem.setText(self._colIdx[nwOutline.PCOUNT], f"{novIdx.paraCount:n}")
+            trItem.setText(self._colIdx[nwOutline.CCOUNT], CONFIG.localNumber(novIdx.charCount))
+            trItem.setText(self._colIdx[nwOutline.WCOUNT], CONFIG.localNumber(novIdx.wordCount))
+            trItem.setText(self._colIdx[nwOutline.PCOUNT], CONFIG.localNumber(novIdx.paraCount))
             trItem.setTextAlignment(self._colIdx[nwOutline.CCOUNT], Qt.AlignmentFlag.AlignRight)
             trItem.setTextAlignment(self._colIdx[nwOutline.WCOUNT], Qt.AlignmentFlag.AlignRight)
             trItem.setTextAlignment(self._colIdx[nwOutline.PCOUNT], Qt.AlignmentFlag.AlignRight)
@@ -1031,9 +1031,9 @@ class GuiOutlineDetails(QScrollArea):
             self.fileValue.setText(nwItem.itemName)
             self.itemValue.setText(itemStatus)
 
-            self.cCValue.setText(f"{checkInt(novIdx.charCount, 0):n}")
-            self.wCValue.setText(f"{checkInt(novIdx.wordCount, 0):n}")
-            self.pCValue.setText(f"{checkInt(novIdx.paraCount, 0):n}")
+            self.cCValue.setText(CONFIG.localNumber(checkInt(novIdx.charCount, 0)))
+            self.wCValue.setText(CONFIG.localNumber(checkInt(novIdx.wordCount, 0)))
+            self.pCValue.setText(CONFIG.localNumber(checkInt(novIdx.paraCount, 0)))
 
             self.synopValue.setText(novIdx.synopsis)
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1084,7 +1084,7 @@ class GuiProjectTree(QTreeWidget):
             for i in range(tItem.childCount()):
                 newCount += int(tItem.child(i).data(self.C_DATA, self.D_WORDS))
 
-        tItem.setText(self.C_COUNT, f"{newCount:n}")
+        tItem.setText(self.C_COUNT, CONFIG.localNumber(newCount))
         tItem.setData(self.C_DATA, self.D_WORDS, int(newCount))
 
         pItem = tItem.parent()

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -172,7 +172,8 @@ class GuiMainStatus(QStatusBar):
     def setProjectStats(self, pWC: int, sWC: int) -> None:
         """Update the current project statistics."""
         self.statsText.setText(self.tr("Words: {0} ({1})").format(
-            CONFIG.localNumber(pWC), ("+" if sWC >= 0 else "") + CONFIG.localNumber(sWC)))
+            CONFIG.localNumber(pWC), ("+" if sWC >= 0 else "") + CONFIG.localNumber(sWC)
+        ))
         if CONFIG.incNotesWCount:
             self.statsText.setToolTip(self.tr("Project word count (session change)"))
         else:

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -171,7 +171,8 @@ class GuiMainStatus(QStatusBar):
 
     def setProjectStats(self, pWC: int, sWC: int) -> None:
         """Update the current project statistics."""
-        self.statsText.setText(self.tr("Words: {0} ({1})").format(f"{pWC:n}", f"{sWC:+n}"))
+        self.statsText.setText(self.tr("Words: {0} ({1})").format(
+            CONFIG.localNumber(pWC), ("+" if sWC >= 0 else "") + CONFIG.localNumber(sWC)))
         if CONFIG.incNotesWCount:
             self.statsText.setToolTip(self.tr("Project word count (session change)"))
         else:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -777,7 +777,9 @@ class GuiMain(QMainWindow):
 
         tEnd = time()
         self.mainStatus.setStatusMessage(
-            self.tr("Indexing completed in {0} ms").format(f"{(tEnd - tStart)*1000.0:.1f}")
+            self.tr("Indexing completed in {0} ms").format(
+                CONFIG.localFloat((tEnd - tStart)*1000.0, 1)
+            )
         )
         self.docEditor.updateTagHighLighting()
         self._updateStatusWordCount()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -457,7 +457,7 @@ class GuiMain(QMainWindow):
                     "'{0}' ({1} {2}), last active on {3}."
                 ).format(
                     lockStatus[0], lockStatus[1], lockStatus[2],
-                    datetime.fromtimestamp(int(lockStatus[3])).strftime("%x %X")
+                    CONFIG.localDateTime(datetime.fromtimestamp(int(lockStatus[3])))
                 )
             except Exception:
                 lockDetails = ""

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -37,7 +37,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.error import formatException
-from novelwriter.common import formatFileFilter, openExternalPath, formatInt, getFileSize
+from novelwriter.common import formatFileFilter, openExternalPath, getFileSize
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +246,7 @@ class GuiDictionaries(QDialog):
                     size = getFileSize(oPath)
                     self._appendLog(self.tr(
                         "Added: {0} [{1}B]"
-                    ).format(zPath.name, formatInt(size)))
+                    ).format(zPath.name, CONFIG.localFloatSI(size)))
         return nAff, nDic
 
     def _appendLog(self, text: str, err: bool = False) -> None:

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -917,23 +917,23 @@ class _StatsWidget(QWidget):
     def updateStats(self, data: dict[str, int]) -> None:
         """Update the stats values from a Tokenizer stats dict."""
         # Minimal
-        self.minWordCount.setText("{0:n}".format(data.get("allWords", 0)))
-        self.minCharCount.setText("{0:n}".format(data.get("allChars", 0)))
+        self.minWordCount.setText(CONFIG.localNumber(data.get("allWords", 0)))
+        self.minCharCount.setText(CONFIG.localNumber(data.get("allChars", 0)))
 
         # Maximal
-        self.maxTotalWords.setText("{0:n}".format(data.get("allWords", 0)))
-        self.maxHeaderWords.setText("{0:n}".format(data.get("titleWords", 0)))
-        self.maxTextWords.setText("{0:n}".format(data.get("textWords", 0)))
-        self.maxTitleCount.setText("{0:n}".format(data.get("titleCount", 0)))
-        self.maxParCount.setText("{0:n}".format(data.get("paragraphCount", 0)))
+        self.maxTotalWords.setText(CONFIG.localNumber(data.get("allWords", 0)))
+        self.maxHeaderWords.setText(CONFIG.localNumber(data.get("titleWords", 0)))
+        self.maxTextWords.setText(CONFIG.localNumber(data.get("textWords", 0)))
+        self.maxTitleCount.setText(CONFIG.localNumber(data.get("titleCount", 0)))
+        self.maxParCount.setText(CONFIG.localNumber(data.get("paragraphCount", 0)))
 
-        self.maxTotalChars.setText("{0:n}".format(data.get("allChars", 0)))
-        self.maxHeaderChars.setText("{0:n}".format(data.get("titleChars", 0)))
-        self.maxTextChars.setText("{0:n}".format(data.get("textChars", 0)))
+        self.maxTotalChars.setText(CONFIG.localNumber(data.get("allChars", 0)))
+        self.maxHeaderChars.setText(CONFIG.localNumber(data.get("titleChars", 0)))
+        self.maxTextChars.setText(CONFIG.localNumber(data.get("textChars", 0)))
 
-        self.maxTotalWordChars.setText("{0:n}".format(data.get("allWordChars", 0)))
-        self.maxHeaderWordChars.setText("{0:n}".format(data.get("titleWordChars", 0)))
-        self.maxTextWordChars.setText("{0:n}".format(data.get("textWordChars", 0)))
+        self.maxTotalWordChars.setText(CONFIG.localNumber(data.get("allWordChars", 0)))
+        self.maxHeaderWordChars.setText(CONFIG.localNumber(data.get("titleWordChars", 0)))
+        self.maxTextWordChars.setText(CONFIG.localNumber(data.get("textWordChars", 0)))
 
         return
 

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -829,7 +829,7 @@ class _PreviewWidget(QTextBrowser):
         """Update the build time and the fuzzy age."""
         if self._docTime > 0:
             strBuildTime = "%s (%s)" % (
-                datetime.fromtimestamp(self._docTime).strftime("%x %X"),
+                CONFIG.localDateTime(datetime.fromtimestamp(self._docTime)),
                 fuzzyTime(int(time()) - self._docTime)
             )
         else:

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -477,7 +477,7 @@ class _ContentsPage(NFixedPage):
                 cPage = tPages - fstPage
                 pgProg = 100.0*(cPage - 1)/pMax if pMax > 0 else 0.0
                 progPage = CONFIG.localNumber(cPage)
-                progText = f"{pgProg:.1f}{nwUnicode.U_THSP}%"
+                progText = f"{CONFIG.localFloat(pgProg, 1)}{nwUnicode.U_THSP}%"
 
             hDec = SHARED.theme.getHeaderDecoration(tLevel)
             if tTitle.strip() == "":

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -265,11 +265,11 @@ class _OverviewPage(NScrollablePage):
         wcNovel, wcNotes = project.data.currCounts
 
         self.projName.setText(project.data.name)
-        self.projRevisions.setText(f"{project.data.saveCount:n}")
+        self.projRevisions.setText(CONFIG.localNumber(project.data.saveCount))
         self.projEditTime.setText(formatTime(project.currentEditTime))
-        self.projWords.setText(f"{wcNovel + wcNotes:n}")
-        self.projNovels.setText(f"{wcNovel:n}")
-        self.projNotes.setText(f"{wcNotes:n}")
+        self.projWords.setText(CONFIG.localNumber(wcNovel + wcNotes))
+        self.projNovels.setText(CONFIG.localNumber(wcNovel))
+        self.projNotes.setText(CONFIG.localNumber(wcNotes))
         return
 
     ##
@@ -284,11 +284,11 @@ class _OverviewPage(NScrollablePage):
             self.novelName.setText(nwItem.itemName)
 
         nwCount = project.index.getNovelWordCount(rootHandle=tHandle)
-        self.novelWords.setText(f"{nwCount:n}")
+        self.novelWords.setText(CONFIG.localNumber(nwCount))
 
         hCounts = project.index.getNovelTitleCounts(rootHandle=tHandle)
-        self.novelChapters.setText(f"{hCounts[2]:n}")
-        self.novelScenes.setText(f"{hCounts[3]:n}")
+        self.novelChapters.setText(CONFIG.localNumber(hCounts[2]))
+        self.novelScenes.setText(CONFIG.localNumber(hCounts[3]))
 
         return
 
@@ -476,7 +476,7 @@ class _ContentsPage(NFixedPage):
             else:
                 cPage = tPages - fstPage
                 pgProg = 100.0*(cPage - 1)/pMax if pMax > 0 else 0.0
-                progPage = f"{cPage:n}"
+                progPage = CONFIG.localNumber(cPage)
                 progText = f"{pgProg:.1f}{nwUnicode.U_THSP}%"
 
             hDec = SHARED.theme.getHeaderDecoration(tLevel)
@@ -485,8 +485,8 @@ class _ContentsPage(NFixedPage):
 
             newItem.setData(self.C_TITLE, Qt.DecorationRole, hDec)
             newItem.setText(self.C_TITLE, tTitle)
-            newItem.setText(self.C_WORDS, f"{wCount:n}")
-            newItem.setText(self.C_PAGES, f"{pCount:n}")
+            newItem.setText(self.C_WORDS, CONFIG.localNumber(wCount))
+            newItem.setText(self.C_PAGES, CONFIG.localNumber(pCount))
             newItem.setText(self.C_PAGE,  progPage)
             newItem.setText(self.C_PROG,  progText)
 

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -455,7 +455,7 @@ class _ProjectListModel(QAbstractListModel):
         opened = self.tr("Last Opened")
         records = sorted(CONFIG.recentProjects.listEntries(), key=lambda x: x[3], reverse=True)
         for path, title, count, time in records:
-            when = datetime.fromtimestamp(time).strftime("%x")
+            when = CONFIG.localDate(datetime.fromtimestamp(time))
             data.append((title, path, f"{opened}: {when}, {words}: {formatInt(count)}"))
         self._data = data
         return

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -42,7 +42,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.enum import nwItemClass
-from novelwriter.common import formatInt, makeFileNameSafe
+from novelwriter.common import makeFileNameSafe
 from novelwriter.constants import nwFiles
 from novelwriter.core.coretools import ProjectBuilder
 from novelwriter.extensions.switch import NSwitch
@@ -456,7 +456,7 @@ class _ProjectListModel(QAbstractListModel):
         records = sorted(CONFIG.recentProjects.listEntries(), key=lambda x: x[3], reverse=True)
         for path, title, count, time in records:
             when = CONFIG.localDate(datetime.fromtimestamp(time))
-            data.append((title, path, f"{opened}: {when}, {words}: {formatInt(count)}"))
+            data.append((title, path, f"{opened}: {when}, {words}: {CONFIG.localFloatSI(count)}"))
         self._data = data
         return
 

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -479,9 +479,9 @@ class GuiWritingStats(QDialog):
         ttWords = ttNovel + ttNotes
         self.labelTotal.setText(formatTime(round(ttTime)))
         self.labelIdleT.setText(formatTime(round(ttIdle)))
-        self.novelWords.setText(f"{ttNovel:n}")
-        self.notesWords.setText(f"{ttNotes:n}")
-        self.totalWords.setText(f"{ttWords:n}")
+        self.novelWords.setText(CONFIG.localNumber(ttNovel))
+        self.notesWords.setText(CONFIG.localNumber(ttNotes))
+        self.totalWords.setText(CONFIG.localNumber(ttWords))
 
         return
 
@@ -582,7 +582,7 @@ class GuiWritingStats(QDialog):
             newItem.setText(self.C_TIME, sStart)
             newItem.setText(self.C_LENGTH, formatTime(round(sDiff)))
             newItem.setText(self.C_IDLE, idleEntry)
-            newItem.setText(self.C_COUNT, f"{nWords:n}")
+            newItem.setText(self.C_COUNT, CONFIG.localNumber(nWords))
 
             if nWords > 0 and listMax > 0:
                 wBar = self.barImage.scaled(

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -34,11 +34,11 @@ from PyQt5.QtCore import QUrl
 
 from novelwriter.common import (
     checkBool, checkFloat, checkInt, checkIntTuple, checkPath, checkString,
-    checkStringNone, checkUuid, formatFileFilter, formatInt, formatTime,
-    formatTimeStamp, formatVersion, fuzzyTime, getFileSize, hexToInt, isHandle,
-    isItemClass, isItemLayout, isItemType, isTitleTag, jsonEncode,
-    makeFileNameSafe, minmax, numberToRoman, NWConfigParser, openExternalPath,
-    readTextFile, simplified, transferCase, xmlIndent, yesNo
+    checkStringNone, checkUuid, formatFileFilter, formatTime, formatTimeStamp,
+    formatVersion, fuzzyTime, getFileSize, hexToInt, isHandle, isItemClass,
+    isItemLayout, isItemType, isTitleTag, jsonEncode, makeFileNameSafe, minmax,
+    numberToRoman, NWConfigParser, openExternalPath, readTextFile, simplified,
+    transferCase, xmlIndent, yesNo
 )
 
 
@@ -393,29 +393,6 @@ def testBaseCommon_yesNo():
     assert yesNo(2.0) == "yes"  # type: ignore
 
 # END Test testBaseCommon_yesNo
-
-
-@pytest.mark.base
-def testBaseCommon_formatInt():
-    """Test the formatInt function."""
-    # Normal Cases
-    assert formatInt(1) == "1"
-    assert formatInt(12) == "12"
-    assert formatInt(123) == "123"
-    assert formatInt(1234) == "1.23\u2009k"
-    assert formatInt(12345) == "12.3\u2009k"
-    assert formatInt(123456) == "123\u2009k"
-    assert formatInt(1234567) == "1.23\u2009M"
-    assert formatInt(12345678) == "12.3\u2009M"
-    assert formatInt(123456789) == "123\u2009M"
-    assert formatInt(1234567890) == "1.23\u2009G"
-
-    # Exceptions
-    assert formatInt(12.3) == "ERR"  # type: ignore
-    assert formatInt(None) == "ERR"  # type: ignore
-    assert formatInt("42") == "ERR"  # type: ignore
-
-# END Test testBaseCommon_formatInt
 
 
 @pytest.mark.base

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -195,6 +195,35 @@ def testBaseConfig_Localisation(fncPath, tstPaths):
 
 
 @pytest.mark.base
+def testBaseConfig_LocalFloatSI(fncPath):
+    """Test the localFloatSI function."""
+    tstConf = Config()
+    tstConf.initConfig(confPath=fncPath, dataPath=fncPath)
+    tstConf.guiLocale = "en_GB"
+
+    tstApp = MockApp()
+    tstConf.initLocalisation(tstApp)  # type: ignore
+
+    # Normal Cases
+    assert tstConf.localFloatSI(1) == "1"
+    assert tstConf.localFloatSI(12) == "12"
+    assert tstConf.localFloatSI(123) == "123"
+    assert tstConf.localFloatSI(1234) == "1.23\u2009k"
+    assert tstConf.localFloatSI(12345) == "12.3\u2009k"
+    assert tstConf.localFloatSI(123456) == "123\u2009k"
+    assert tstConf.localFloatSI(1234567) == "1.23\u2009M"
+    assert tstConf.localFloatSI(12345678) == "12.3\u2009M"
+    assert tstConf.localFloatSI(123456789) == "123\u2009M"
+    assert tstConf.localFloatSI(1234567890) == "1.23\u2009G"
+
+    # Exceptions
+    assert tstConf.localFloatSI("xx") == "ERR"  # type: ignore
+    assert tstConf.localFloatSI(None) == "ERR"  # type: ignore
+
+# END Test testBaseConfig_LocalPrefixed
+
+
+@pytest.mark.base
 def testBaseConfig_Methods(fncPath):
     """Check class methods."""
     tstConf = Config()

--- a/tests/test_tools/test_tools_noveldetails.py
+++ b/tests/test_tools/test_tools_noveldetails.py
@@ -24,7 +24,7 @@ import pytest
 
 from PyQt5.QtWidgets import QAction
 
-from novelwriter import SHARED
+from novelwriter import CONFIG, SHARED
 from novelwriter.enum import nwItemClass
 from novelwriter.tools.noveldetails import GuiNovelDetails
 
@@ -60,24 +60,24 @@ def testToolNovelDetails_Main(qtbot, nwGUI, prjLipsum, ipsumText):
 
     # Check project data
     assert overview.projName.text() == "Lorem Ipsum"
-    assert overview.projWords.text() == f"{4376:n}"
-    assert overview.projNovels.text() == f"{3638:n}"
-    assert overview.projNotes.text() == f"{738:n}"
+    assert overview.projWords.text() == CONFIG.localNumber(4376)
+    assert overview.projNovels.text() == CONFIG.localNumber(3638)
+    assert overview.projNotes.text() == CONFIG.localNumber(738)
     assert overview.projRevisions.text() != ""
     assert overview.projEditTime.text() != ""
 
     # Check novel data for "Novel"
     assert overview.novelName.text() == "Novel"
-    assert overview.novelWords.text() == f"{3000:n}"
-    assert overview.novelChapters.text() == f"{3:n}"
-    assert overview.novelScenes.text() == f"{5:n}"
+    assert overview.novelWords.text() == CONFIG.localNumber(3000)
+    assert overview.novelChapters.text() == "3"
+    assert overview.novelScenes.text() == "5"
 
     # Check novel data for "Second"
     details.novelSelector.setHandle(sHandle, blockSignal=False)
     assert overview.novelName.text() == "Second"
-    assert overview.novelWords.text() == f"{529:n}"
-    assert overview.novelChapters.text() == f"{0:n}"
-    assert overview.novelScenes.text() == f"{0:n}"
+    assert overview.novelWords.text() == CONFIG.localNumber(529)
+    assert overview.novelChapters.text() == "0"
+    assert overview.novelScenes.text() == "0"
 
     # Contents Page
     # =============
@@ -87,9 +87,9 @@ def testToolNovelDetails_Main(qtbot, nwGUI, prjLipsum, ipsumText):
     contents = details.contentsPage
 
     # Check defaults
-    words = [f"{v:n}" for v in [40, 176, 92, 6, 1071, 1615, 0]]
-    pages = [f"{v:n}" for v in [2, 2, 2, 2, 4, 6, 0]]
-    page = [f"{v:n}" for v in [1, 3, 5, 7, 9, 13, 19]]
+    words = [CONFIG.localNumber(v) for v in [40, 176, 92, 6, 1071, 1615, 0]]
+    pages = [CONFIG.localNumber(v) for v in [2, 2, 2, 2, 4, 6, 0]]
+    page = [CONFIG.localNumber(v) for v in [1, 3, 5, 7, 9, 13, 19]]
     for i in range(6):
         item = contents.tocTree.topLevelItem(i)
         assert item is not None
@@ -100,9 +100,9 @@ def testToolNovelDetails_Main(qtbot, nwGUI, prjLipsum, ipsumText):
     # Change Settings
     contents.poValue.setValue(7)
     contents.wpValue.setValue(50)
-    words = [f"{v:n}" for v in [40, 176, 92, 6, 1071, 1615, 0]]
-    pages = [f"{v:n}" for v in [2, 4, 2, 2, 22, 34, 0]]
-    page = ["i", "iii"] + [f"{v:n}" for v in [1, 3, 5, 27, 61]]
+    words = [CONFIG.localNumber(v) for v in [40, 176, 92, 6, 1071, 1615, 0]]
+    pages = [CONFIG.localNumber(v) for v in [2, 4, 2, 2, 22, 34, 0]]
+    page = ["i", "iii"] + [CONFIG.localNumber(v) for v in [1, 3, 5, 27, 61]]
     for i in range(6):
         item = contents.tocTree.topLevelItem(i)
         assert item is not None
@@ -114,9 +114,9 @@ def testToolNovelDetails_Main(qtbot, nwGUI, prjLipsum, ipsumText):
     contents.dblValue.setChecked(False)
     contents.poValue.setValue(0)
     contents.wpValue.setValue(100)
-    words = [f"{v:n}" for v in [40, 176, 92, 6, 1071, 1615, 0]]
-    pages = [f"{v:n}" for v in [1, 2, 1, 1, 11, 17, 0]]
-    page = [f"{v:n}" for v in [1, 2, 4, 5, 6, 17, 34]]
+    words = [CONFIG.localNumber(v) for v in [40, 176, 92, 6, 1071, 1615, 0]]
+    pages = [CONFIG.localNumber(v) for v in [1, 2, 1, 1, 11, 17, 0]]
+    page = [CONFIG.localNumber(v) for v in [1, 2, 4, 5, 6, 17, 34]]
     for i in range(6):
         item = contents.tocTree.topLevelItem(i)
         assert item is not None

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -75,8 +75,8 @@ def testToolWelcome_Open(qtbot: QtBot, monkeypatch, nwGUI, fncPath):
 
     CONFIG.recentProjects.update("/stuff/project_one", "Project One", 12345, 1690000000)
     CONFIG.recentProjects.update("/stuff/project_two", "Project Two", 54321, 1700000000)
-    dateOne = datetime.fromtimestamp(1700000000).strftime("%x")
-    dateTwo = datetime.fromtimestamp(1690000000).strftime("%x")
+    dateOne = CONFIG.localDate(datetime.fromtimestamp(1700000000))
+    dateTwo = CONFIG.localDate(datetime.fromtimestamp(1690000000))
 
     welcome = GuiWelcome(nwGUI)
     with qtbot.waitExposed(welcome):

--- a/tests/test_tools/test_tools_writingstats.py
+++ b/tests/test_tools/test_tools_writingstats.py
@@ -31,7 +31,7 @@ from mocked import causeOSError
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QAction, QFileDialog
 
-from novelwriter import SHARED
+from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwFiles
 from novelwriter.tools.writingstats import GuiWritingStats
 
@@ -103,18 +103,18 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     monkeypatch.setattr(QFileDialog, "getSaveFileName", lambda ss, tt, pp, options: (pp, ""))
     sessLog.listBox.sortByColumn(sessLog.C_TIME, 0)
 
-    assert sessLog.novelWords.text() == "{:n}".format(600)
-    assert sessLog.notesWords.text() == "{:n}".format(275)
-    assert sessLog.totalWords.text() == "{:n}".format(875)
+    assert sessLog.novelWords.text() == CONFIG.localNumber(600)
+    assert sessLog.notesWords.text() == CONFIG.localNumber(275)
+    assert sessLog.totalWords.text() == CONFIG.localNumber(875)
 
-    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == "{:n}".format(1)
-    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == "{:n}".format(-200)
-    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == "{:n}".format(300)
-    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == "{:n}".format(-120)
-    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == "{:n}".format(-20)
-    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == "{:n}".format(40)
-    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == "{:n}".format(-400)
-    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == "{:n}".format(200)
+    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == CONFIG.localNumber(1)
+    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == CONFIG.localNumber(-200)
+    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == CONFIG.localNumber(300)
+    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == CONFIG.localNumber(-120)
+    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == CONFIG.localNumber(-20)
+    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == CONFIG.localNumber(40)
+    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == CONFIG.localNumber(-400)
+    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == CONFIG.localNumber(200)
 
     assert sessLog._saveData(sessLog.FMT_CSV)
     assert sessLog._saveData(sessLog.FMT_JSON)
@@ -163,14 +163,14 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.loads(inFile.read())
 
-    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == "{:n}".format(1)
-    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == "{:n}".format(-100)
-    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == "{:n}".format(150)
-    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == "{:n}".format(-60)
-    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == "{:n}".format(-10)
-    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == "{:n}".format(20)
-    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == "{:n}".format(-200)
-    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == "{:n}".format(100)
+    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == CONFIG.localNumber(1)
+    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == CONFIG.localNumber(-100)
+    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == CONFIG.localNumber(150)
+    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == CONFIG.localNumber(-60)
+    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == CONFIG.localNumber(-10)
+    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == CONFIG.localNumber(20)
+    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == CONFIG.localNumber(-200)
+    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == CONFIG.localNumber(100)
 
     assert jsonData == [
         {
@@ -209,14 +209,14 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
-    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == "{:n}".format(1)
-    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == "{:n}".format(-100)
-    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == "{:n}".format(150)
-    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == "{:n}".format(-60)
-    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == "{:n}".format(-10)
-    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == "{:n}".format(20)
-    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == "{:n}".format(-200)
-    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == "{:n}".format(100)
+    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == CONFIG.localNumber(1)
+    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == CONFIG.localNumber(-100)
+    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == CONFIG.localNumber(150)
+    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == CONFIG.localNumber(-60)
+    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == CONFIG.localNumber(-10)
+    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == CONFIG.localNumber(20)
+    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == CONFIG.localNumber(-200)
+    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == CONFIG.localNumber(100)
 
     assert jsonData == [
         {
@@ -257,10 +257,10 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
-    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == "{:n}".format(1)
-    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == "{:n}".format(300)
-    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == "{:n}".format(40)
-    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == "{:n}".format(200)
+    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == CONFIG.localNumber(1)
+    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == CONFIG.localNumber(300)
+    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == CONFIG.localNumber(40)
+    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == CONFIG.localNumber(200)
 
     assert jsonData == [
         {
@@ -287,16 +287,16 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
-    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == "{:n}".format(1)
-    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == "{:n}".format(0)
-    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == "{:n}".format(-200)
-    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == "{:n}".format(300)
-    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == "{:n}".format(-120)
-    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == "{:n}".format(-20)
-    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == "{:n}".format(40)
-    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == "{:n}".format(-400)
-    assert sessLog.listBox.topLevelItem(8).text(sessLog.C_COUNT) == "{:n}".format(200)
-    assert sessLog.listBox.topLevelItem(9).text(sessLog.C_COUNT) == "{:n}".format(0)
+    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == CONFIG.localNumber(1)
+    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == CONFIG.localNumber(0)
+    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == CONFIG.localNumber(-200)
+    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == CONFIG.localNumber(300)
+    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == CONFIG.localNumber(-120)
+    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == CONFIG.localNumber(-20)
+    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == CONFIG.localNumber(40)
+    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == CONFIG.localNumber(-400)
+    assert sessLog.listBox.topLevelItem(8).text(sessLog.C_COUNT) == CONFIG.localNumber(200)
+    assert sessLog.listBox.topLevelItem(9).text(sessLog.C_COUNT) == CONFIG.localNumber(0)
 
     assert jsonData == [
         {
@@ -340,14 +340,14 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     with open(jsonStats, mode="r", encoding="utf-8") as inFile:
         jsonData = json.load(inFile)
 
-    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == "{:n}".format(1)
-    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == "{:n}".format(-200)
-    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == "{:n}".format(180)
-    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == "{:n}".format(-20)
-    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == "{:n}".format(40)
-    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == "{:n}".format(-400)
-    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == "{:n}".format(200)
-    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == "{:n}".format(0)
+    assert sessLog.listBox.topLevelItem(0).text(sessLog.C_COUNT) == CONFIG.localNumber(1)
+    assert sessLog.listBox.topLevelItem(1).text(sessLog.C_COUNT) == CONFIG.localNumber(-200)
+    assert sessLog.listBox.topLevelItem(2).text(sessLog.C_COUNT) == CONFIG.localNumber(180)
+    assert sessLog.listBox.topLevelItem(3).text(sessLog.C_COUNT) == CONFIG.localNumber(-20)
+    assert sessLog.listBox.topLevelItem(4).text(sessLog.C_COUNT) == CONFIG.localNumber(40)
+    assert sessLog.listBox.topLevelItem(5).text(sessLog.C_COUNT) == CONFIG.localNumber(-400)
+    assert sessLog.listBox.topLevelItem(6).text(sessLog.C_COUNT) == CONFIG.localNumber(200)
+    assert sessLog.listBox.topLevelItem(7).text(sessLog.C_COUNT) == CONFIG.localNumber(0)
 
     assert jsonData == [
         {


### PR DESCRIPTION
**Summary:**

This PR switches novelWriter from using Python localised formatting of numbers and dates to using the Qt implementation. This means that the format should follow the GUI language setting instead of system setting.

**Related Issue(s):**

Closes #1739

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
