### PR TITLE
Prefer GUI locale for date format

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -30,6 +30,7 @@ import logging
 
 from time import time
 from pathlib import Path
+from datetime import datetime
 
 from PyQt5.QtGui import QFontDatabase
 from PyQt5.QtCore import (
@@ -84,8 +85,11 @@ class Config:
         self._nwLangPath = self._appPath / "assets" / "i18n"
         self._qtLangPath = QLibraryInfo.location(QLibraryInfo.TranslationsPath)
 
-        wantedLocale = self._nwLangPath / f"nw_{QLocale.system().name()}.qm"
-        self._qLocale = QLocale.system() if wantedLocale.exists() else QLocale("en_GB")
+        hasLocale = (self._nwLangPath / f"nw_{QLocale.system().name()}.qm").exists()
+        self._qLocale = QLocale.system() if hasLocale else QLocale("en_GB")
+        self._dLocale = QLocale.system()
+        self._dShortDate = self._dLocale.dateFormat(QLocale.FormatType.ShortFormat)
+        self._dShortDateTime = self._dLocale.dateTimeFormat(QLocale.FormatType.ShortFormat)
         self._qtTrans = {}
 
         # PDF Manual
@@ -414,6 +418,14 @@ class Config:
         self._errData = []
         return message
 
+    def localDate(self, value: datetime) -> str:
+        """Return a localised date format."""
+        return self._dLocale.toString(value, self._dShortDate)
+
+    def localDateTime(self, value: datetime) -> str:
+        """Return a localised datetime format."""
+        return self._dLocale.toString(value, self._dShortDateTime)
+
     def listLanguages(self, lngSet: int) -> list[tuple[str, str]]:
         """List localisation files in the i18n folder. The default GUI
         language is British English (en_GB).
@@ -495,6 +507,11 @@ class Config:
         self._qLocale = QLocale(self.guiLocale)
         QLocale.setDefault(self._qLocale)
         self._qtTrans = {}
+
+        hasLocale = (self._nwLangPath / f"nw_{self._qLocale.name()}.qm").exists()
+        self._dLocale = self._qLocale if hasLocale else QLocale.system()
+        self._dShortDate = self._dLocale.dateFormat(QLocale.FormatType.ShortFormat)
+        self._dShortDateTime = self._dLocale.dateTimeFormat(QLocale.FormatType.ShortFormat)
 
         langList = [
             (self._qtLangPath, "qtbase"),   # Qt 5.x

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -151,8 +151,7 @@ class GuiPreferences(QDialog):
         self.guiLocale.setMinimumWidth(minWidth)
         for lang, name in CONFIG.listLanguages(CONFIG.LANG_NW):
             self.guiLocale.addItem(name, lang)
-        if (idx := self.guiLocale.findData(CONFIG.guiLocale)) != -1:
-            self.guiLocale.setCurrentIndex(idx)
+        self.guiLocale.setCurrentData(CONFIG.guiLocale, "en_GB")
 
         self.mainForm.addRow(
             self.tr("Display language"), self.guiLocale,
@@ -164,8 +163,7 @@ class GuiPreferences(QDialog):
         self.guiTheme.setMinimumWidth(minWidth)
         for theme, name in SHARED.theme.listThemes():
             self.guiTheme.addItem(name, theme)
-        if (idx := self.guiTheme.findData(CONFIG.guiTheme)) != -1:
-            self.guiTheme.setCurrentIndex(idx)
+        self.guiTheme.setCurrentData(CONFIG.guiTheme, "default")
 
         self.mainForm.addRow(
             self.tr("Colour theme"), self.guiTheme,
@@ -226,8 +224,7 @@ class GuiPreferences(QDialog):
         self.guiSyntax.setMinimumWidth(CONFIG.pxInt(200))
         for syntax, name in SHARED.theme.listSyntax():
             self.guiSyntax.addItem(name, syntax)
-        if (idx := self.guiSyntax.findData(CONFIG.guiSyntax)) != -1:
-            self.guiSyntax.setCurrentIndex(idx)
+        self.guiSyntax.setCurrentData(CONFIG.guiSyntax, "default_light")
 
         self.mainForm.addRow(
             self.tr("Document colour theme"), self.guiSyntax,

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -44,6 +44,12 @@ class NComboBox(QComboBox):
             event.ignore()
         return
 
+    def setCurrentData(self, data: str, default: str) -> None:
+        """Set the current index from data, with a fallback."""
+        idx = self.findData(data)
+        self.setCurrentIndex(self.findData(default) if idx < 0 else idx)
+        return
+
 # END Class NComboBox
 
 

--- a/novelwriter/extensions/versioninfo.py
+++ b/novelwriter/extensions/versioninfo.py
@@ -57,7 +57,7 @@ class VersionInfoWidget(QWidget):
         # Labels
         self._lblInfo = QLabel("{0} {1} \u2013 {2} {3} \u2013 {4}".format(
             self.tr("Version"), formatVersion(__version__),
-            self.tr("Released on"), datetime.strptime(__date__, "%Y-%m-%d").strftime("%x"),
+            self.tr("Released on"), CONFIG.localDate(datetime.strptime(__date__, "%Y-%m-%d")),
             "<a href='#notes'>{0}</a>".format(self.tr("Release Notes")),
         ), self)
         self._lblInfo.linkActivated.connect(self._processLink)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -457,7 +457,7 @@ class GuiMain(QMainWindow):
                     "'{0}' ({1} {2}), last active on {3}."
                 ).format(
                     lockStatus[0], lockStatus[1], lockStatus[2],
-                    datetime.fromtimestamp(int(lockStatus[3])).strftime("%x %X")
+                    CONFIG.localDateTime(datetime.fromtimestamp(int(lockStatus[3])))
                 )
             except Exception:
                 lockDetails = ""

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -829,7 +829,7 @@ class _PreviewWidget(QTextBrowser):
         """Update the build time and the fuzzy age."""
         if self._docTime > 0:
             strBuildTime = "%s (%s)" % (
-                datetime.fromtimestamp(self._docTime).strftime("%x %X"),
+                CONFIG.localDateTime(datetime.fromtimestamp(self._docTime)),
                 fuzzyTime(int(time()) - self._docTime)
             )
         else:

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -456,7 +456,7 @@ class _ProjectListModel(QAbstractListModel):
         opened = self.tr("Last Opened")
         records = sorted(CONFIG.recentProjects.listEntries(), key=lambda x: x[3], reverse=True)
         for path, title, count, time in records:
-            when = datetime.fromtimestamp(time).strftime("%x")
+            when = CONFIG.localDate(datetime.fromtimestamp(time))
             data.append((title, path, f"{opened}: {when}, {words}: {formatInt(count)}"))
         self._data = data
         return

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -75,8 +75,8 @@ def testToolWelcome_Open(qtbot: QtBot, monkeypatch, nwGUI, fncPath):
 
     CONFIG.recentProjects.update("/stuff/project_one", "Project One", 12345, 1690000000)
     CONFIG.recentProjects.update("/stuff/project_two", "Project Two", 54321, 1700000000)
-    dateOne = datetime.fromtimestamp(1700000000).strftime("%x")
-    dateTwo = datetime.fromtimestamp(1690000000).strftime("%x")
+    dateOne = CONFIG.localDate(datetime.fromtimestamp(1700000000))
+    dateTwo = CONFIG.localDate(datetime.fromtimestamp(1690000000))
 
     welcome = GuiWelcome(nwGUI)
     with qtbot.waitExposed(welcome):


### PR DESCRIPTION
**Summary:**

A second attempt at fixing date formats. This PR sets up the Config class to generate short date and date time formats from GUI locale if selected GUI locale file exists. If not, it will generate these formats from the system locale.

The dates are now used for the Welcome dialog, the About dialog, the Manuscript tool and on the lock file warning. These are the only places using formatted dates at the moment.

A small issue with displaying fallback settings for GUI locale in Preferences has been fixed as well.

**Related Issue(s):**

Closes #1739

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
