### PR TITLE
Simplify the ODT header format

### DIFF
--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -325,11 +325,8 @@ class nwHeadFmt:
         CHAR_POV, CHAR_FOCUS
     ]
 
-    # ODT Document Page Header
-    ODT_PROJECT = "{Project}"
-    ODT_AUTHOR = "{Author}"
+    # ODT Document Header Page Counter
     ODT_PAGE = "{Page}"
-    ODT_AUTO = "{Project} / {Author} / {Page}"
 
 # END Class nwHeadFmt
 

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -79,7 +79,7 @@ SETTINGS_TEMPLATE = {
     "format.leftMargin":      (float, 2.0),
     "format.rightMargin":     (float, 2.0),
     "odt.addColours":         (bool, True),
-    "odt.pageHeader":         (str, nwHeadFmt.ODT_AUTO),
+    "odt.pageHeaderText":     (str, nwHeadFmt.ODT_PAGE),
     "odt.pageCountOffset":    (int, 0),
     "html.addStyles":         (bool, True),
 }
@@ -127,7 +127,7 @@ SETTINGS_LABELS = {
 
     "odt":                    QT_TRANSLATE_NOOP("Builds", "Open Document (.odt)"),
     "odt.addColours":         QT_TRANSLATE_NOOP("Builds", "Add Highlight Colours"),
-    "odt.pageHeader":         QT_TRANSLATE_NOOP("Builds", "Page Header"),
+    "odt.pageHeaderText":     QT_TRANSLATE_NOOP("Builds", "Page Header"),
     "odt.pageCountOffset":    QT_TRANSLATE_NOOP("Builds", "Page Counter Offset"),
 
     "html":                   QT_TRANSLATE_NOOP("Builds", "HTML (.html)"),

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -285,7 +285,7 @@ class NWBuildDocument:
             bldObj.setColourHeaders(self._build.getBool("odt.addColours"))
             bldObj.setLanguage(self._project.data.language)
             bldObj.setHeaderFormat(
-                self._build.getStr("odt.pageHeader"), self._build.getInt("odt.pageCountOffset")
+                self._build.getStr("odt.pageHeaderText"), self._build.getInt("odt.pageCountOffset")
             )
 
             scale = nwLabels.UNIT_SCALE.get(self._build.getStr("format.pageUnit"), 1.0)

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -1013,12 +1013,6 @@ class ToOdt(Tokenizer):
         # Standard Page Header
         if self._headerFormat:
             pre, page, post = self._headerFormat.partition(nwHeadFmt.ODT_PAGE)
-
-            pre = pre.replace(nwHeadFmt.ODT_PROJECT, self._project.data.name)
-            pre = pre.replace(nwHeadFmt.ODT_AUTHOR, self._project.data.author)
-            post = post.replace(nwHeadFmt.ODT_PROJECT, self._project.data.name)
-            post = post.replace(nwHeadFmt.ODT_AUTHOR, self._project.data.author)
-
             xHead = ET.SubElement(xPage, _mkTag("style", "header"))
             xPar = ET.SubElement(xHead, _mkTag("text", "p"), attrib={
                 _mkTag("text", "style-name"): "Header"

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1228,8 +1228,8 @@ class _OutputTab(NScrollableForm):
         self.btnPageHeader.setIcon(SHARED.theme.getIcon("revert"))
         self.btnPageHeader.clicked.connect(self._resetPageHeader)
         self.addRow(
-            self._build.getLabel("odt.pageHeader"), self.odtPageHeader,
-            button=self.btnPageHeader, stretch=(1, 1)
+            self._build.getLabel("odt.pageHeaderText"), self.odtPageHeader,
+            button=self.btnPageHeader, stretch=(2, 3)
         )
 
         self.odtPageCountOffset = NSpinBox(self)
@@ -1253,7 +1253,7 @@ class _OutputTab(NScrollableForm):
     def loadContent(self) -> None:
         """Populate the widgets."""
         self.odtAddColours.setChecked(self._build.getBool("odt.addColours"))
-        self.odtPageHeader.setText(self._build.getStr("odt.pageHeader"))
+        self.odtPageHeader.setText(self._build.getStr("odt.pageHeaderText"))
         self.odtPageCountOffset.setValue(self._build.getInt("odt.pageCountOffset"))
         self.htmlAddStyles.setChecked(self._build.getBool("html.addStyles"))
         return
@@ -1261,7 +1261,7 @@ class _OutputTab(NScrollableForm):
     def saveContent(self) -> None:
         """Save choices back into build object."""
         self._build.setValue("odt.addColours", self.odtAddColours.isChecked())
-        self._build.setValue("odt.pageHeader", self.odtPageHeader.text())
+        self._build.setValue("odt.pageHeaderText", self.odtPageHeader.text())
         self._build.setValue("odt.pageCountOffset", self.odtPageCountOffset.value())
         self._build.setValue("html.addStyles", self.htmlAddStyles.isChecked())
         return
@@ -1272,7 +1272,10 @@ class _OutputTab(NScrollableForm):
 
     def _resetPageHeader(self) -> None:
         """Reset the ODT header format to default."""
-        self.odtPageHeader.setText(nwHeadFmt.ODT_AUTO)
+        self.odtPageHeader.setText(" / ".join(filter(bool, [
+            SHARED.project.data.name, SHARED.project.data.author, nwHeadFmt.ODT_PAGE
+        ])))
+        self.odtPageHeader.setCursorPosition(0)
         return
 
 # END Class _OutputTab

--- a/tests/reference/coreToOdt_SaveFlat_document.fodt
+++ b/tests/reference/coreToOdt_SaveFlat_document.fodt
@@ -76,7 +76,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Test Project / Jane Smith / <text:page-number text:page-adjust="-1">2</text:page-number></text:p>
+        <text:p text:style-name="Header"><text:page-number text:page-adjust="-1">2</text:page-number></text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
+++ b/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
@@ -100,7 +100,7 @@
   <office:master-styles>
     <style:master-page style:name="Standard" style:page-layout-name="PM1">
       <style:header>
-        <text:p text:style-name="Header">Lorem Ipsum / lipsum.com / <text:page-number text:select-page="current">2</text:page-number></text:p>
+        <text:p text:style-name="Header"><text:page-number text:select-page="current">2</text:page-number></text:p>
       </style:header>
       <style:header-first>
         <text:p text:style-name="Header" />

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -693,8 +693,8 @@ def testCoreToOdt_SaveFlat(mockGUI, fncPath, tstPaths):
     assert odt._dLanguage == "nb"
     odt.setColourHeaders(True)
     assert odt._colourHead is True
-    odt.setHeaderFormat(nwHeadFmt.ODT_AUTO, 1)
-    assert odt._headerFormat == nwHeadFmt.ODT_AUTO
+    odt.setHeaderFormat(nwHeadFmt.ODT_PAGE, 1)
+    assert odt._headerFormat == nwHeadFmt.ODT_PAGE
 
     odt.setPageLayout(148, 210, 20, 18, 17, 15)
     assert odt._mDocWidth  == "14.800cm"
@@ -741,7 +741,7 @@ def testCoreToOdt_SaveFull(mockGUI, fncPath, tstPaths):
     odt._isNovel = True
 
     # Set a format without page number
-    odt.setHeaderFormat(f"{nwHeadFmt.ODT_PROJECT} - {nwHeadFmt.ODT_AUTHOR}", 0)
+    odt.setHeaderFormat("Test Project - Jane Smith", 0)
 
     odt._text = (
         "## Chapter One\n\n"

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -649,7 +649,7 @@ def testBuildSettings_Output(qtbot: QtBot, nwGUI: GuiMain):
 
     # Check initial values
     assert outTab.odtAddColours.isChecked() is False
-    assert outTab.odtPageHeader.text() == nwHeadFmt.ODT_AUTO
+    assert outTab.odtPageHeader.text() == nwHeadFmt.ODT_PAGE
     assert outTab.htmlAddStyles.isChecked() is False
 
     # Toggle all
@@ -663,12 +663,13 @@ def testBuildSettings_Output(qtbot: QtBot, nwGUI: GuiMain):
     outTab.saveContent()
 
     assert build.getBool("odt.addColours") is True
-    assert build.getStr("odt.pageHeader") == "Stuff"
+    assert build.getStr("odt.pageHeaderText") == "Stuff"
     assert build.getBool("html.addStyles") is True
 
     # Reset header format
+    SHARED.project.data.setName("Test Project")
     outTab.btnPageHeader.click()
-    assert outTab.odtPageHeader.text() == nwHeadFmt.ODT_AUTO
+    assert outTab.odtPageHeader.text() == f"Test Project / {nwHeadFmt.ODT_PAGE}"
 
     # Finish
     bSettings._dialogButtonClicked(bSettings.buttonBox.button(QDialogButtonBox.Close))


### PR DESCRIPTION
**Summary:**

This PR simplifies the ODT header format in the Build Settings tool to just fill in the info instead of using placeholders. The `{Page}` placeholder is still needed.

**Related Issue(s):**

Closes #1757 

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
