### PR TITLE
Add a document outline dropdown

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -519,10 +519,15 @@ class NWIndex:
 
     def getItemHeading(self, tHandle: str, sTitle: str) -> IndexHeading | None:
         """Get the heading entry for a specific item and heading."""
-        tItem = self._itemIndex[tHandle]
-        if isinstance(tItem, IndexItem):
+        if tItem := self._itemIndex[tHandle]:
             return tItem[sTitle]
         return None
+
+    def iterItemHeadings(self, tHandle: str) -> Iterator[str, IndexHeading]:
+        """Get all headings for a specific item."""
+        if tItem := self._itemIndex[tHandle]:
+            yield from tItem.items()
+        return []
 
     def novelStructure(
         self, rootHandle: str | None = None, activeOnly: bool = True
@@ -900,13 +905,11 @@ class ItemIndex:
 
             if rHandle is None:
                 for sTitle in self._items[tHandle].headings():
-                    hItem = self._items[tHandle][sTitle]
-                    if hItem:
+                    if hItem := self._items[tHandle][sTitle]:
                         yield tHandle, sTitle, hItem
             elif tItem.itemRoot == rHandle:
                 for sTitle in self._items[tHandle].headings():
-                    hItem = self._items[tHandle][sTitle]
-                    if hItem:
+                    if hItem := self._items[tHandle][sTitle]:
                         yield tHandle, sTitle, hItem
 
         return

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -259,7 +259,7 @@ class GuiDocEditor(QPlainTextEdit):
         self._doReplace  = False
 
         self.setDocumentChanged(False)
-        self.docHeader.setTitleFromHandle(self._docHandle)
+        self.docHeader.clearHeader()
         self.docFooter.setHandle(self._docHandle)
         self.docToolBar.setVisible(False)
 
@@ -363,7 +363,7 @@ class GuiDocEditor(QPlainTextEdit):
         # which makes it read only.
         if self._docHandle:
             self._qDocument.syntaxHighlighter.rehighlight()
-            self.docHeader.setTitleFromHandle(self._docHandle)
+            self.docHeader.setHandle(self._docHandle)
         else:
             self.clearEditor()
 
@@ -408,8 +408,8 @@ class GuiDocEditor(QPlainTextEdit):
         elif isinstance(tLine, int):
             self.setCursorLine(tLine)
 
-        self.docHeader.setTitleFromHandle(self._docHandle)
-        self.docFooter.setHandle(self._docHandle)
+        self.docHeader.setHandle(tHandle)
+        self.docFooter.setHandle(tHandle)
 
         # This is a hack to fix invisible cursor on an empty document
         if self._qDocument.characterCount() <= 1:
@@ -991,8 +991,8 @@ class GuiDocEditor(QPlainTextEdit):
         """Called when an item label is changed to check if the document
         title bar needs updating,
         """
-        if tHandle == self._docHandle:
-            self.docHeader.setTitleFromHandle(self._docHandle)
+        if tHandle and tHandle == self._docHandle:
+            self.docHeader.setHandle(tHandle)
             self.docFooter.updateInfo()
             self.updateDocMargins()
         return
@@ -2909,6 +2909,20 @@ class GuiDocEditHeader(QWidget):
     #  Methods
     ##
 
+    def clearHeader(self) -> None:
+        """Clear the header."""
+        self._docHandle = None
+        self._docOutline = {}
+
+        self.itemTitle.setText("")
+        self.outlineMenu.clear()
+        self.tbButton.setVisible(False)
+        self.searchButton.setVisible(False)
+        self.outlineButton.setVisible(False)
+        self.closeButton.setVisible(False)
+        self.minmaxButton.setVisible(False)
+        return
+
     def setOutline(self, data: dict[int, str]) -> None:
         """Set the document outline dataset."""
         if data != self._docOutline:
@@ -2962,21 +2976,11 @@ class GuiDocEditHeader(QWidget):
 
         return
 
-    def setTitleFromHandle(self, tHandle: str | None) -> None:
+    def setHandle(self, tHandle: str) -> None:
         """Set the document title from the handle, or alternatively, set
         the whole document path within the project.
         """
         self._docHandle = tHandle
-        if tHandle is None:
-            self.itemTitle.setText("")
-            self.tbButton.setVisible(False)
-            self.searchButton.setVisible(False)
-            self.outlineButton.setVisible(False)
-            self.closeButton.setVisible(False)
-            self.minmaxButton.setVisible(False)
-            self.outlineMenu.clear()
-            self._docOutline = {}
-            return
 
         if CONFIG.showFullPath:
             self.itemTitle.setText(f"  {nwUnicode.U_RSAQUO}  ".join(reversed(
@@ -3011,14 +3015,8 @@ class GuiDocEditHeader(QWidget):
     @pyqtSlot()
     def _closeDocument(self) -> None:
         """Trigger the close editor on the main window."""
+        self.clearHeader()
         self.closeDocumentRequest.emit()
-        self.tbButton.setVisible(False)
-        self.searchButton.setVisible(False)
-        self.outlineButton.setVisible(False)
-        self.closeButton.setVisible(False)
-        self.minmaxButton.setVisible(False)
-        self.outlineMenu.clear()
-        self._docOutline = {}
         return
 
     @pyqtSlot(int)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -548,8 +548,8 @@ class GuiDocEditor(QPlainTextEdit):
         sH = hBar.height() if hBar.isVisible() else 0
 
         tM = self._vpMargin
-        if CONFIG.textWidth > 0 or self.mainGui.isFocusMode:
-            tW = CONFIG.getTextWidth(self.mainGui.isFocusMode)
+        if CONFIG.textWidth > 0 or SHARED.focusMode:
+            tW = CONFIG.getTextWidth(SHARED.focusMode)
             tM = max((wW - sW - tW)//2, self._vpMargin)
 
         tB = self.frameWidth()
@@ -2894,6 +2894,9 @@ class GuiDocEditHeader(QWidget):
 
         self.setLayout(self.outerBox)
 
+        # Other Signals
+        SHARED.focusModeChanged.connect(self._focusModeChanged)
+
         # Fix Margins and Size
         # This is needed for high DPI systems. See issue #499.
         self.setContentsMargins(0, 0, 0, 0)
@@ -2997,17 +3000,6 @@ class GuiDocEditHeader(QWidget):
 
         return
 
-    def updateFocusMode(self) -> None:
-        """Update the minimise/maximise icon of the Focus Mode button.
-        This function is called by the GuiMain class via the
-        toggleFocusMode function and should not be activated directly.
-        """
-        if self.mainGui.isFocusMode:
-            self.minmaxButton.setIcon(SHARED.theme.getIcon("minimise"))
-        else:
-            self.minmaxButton.setIcon(SHARED.theme.getIcon("maximise"))
-        return
-
     ##
     #  Private Slots
     ##
@@ -3023,6 +3015,12 @@ class GuiDocEditHeader(QWidget):
     def _gotoBlock(self, blockNumber: int) -> None:
         """Move cursor to a specific heading."""
         self.docEditor.setCursorLine(blockNumber + 1)
+        return
+
+    @pyqtSlot(bool)
+    def _focusModeChanged(self, focusMode: bool) -> None:
+        """Update minimise/maximise icon of the Focus Mode button."""
+        self.minmaxButton.setIcon(SHARED.theme.getIcon("minimise" if focusMode else "maximise"))
         return
 
     ##

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -2974,6 +2974,8 @@ class GuiDocEditHeader(QWidget):
             self.outlineButton.setVisible(False)
             self.closeButton.setVisible(False)
             self.minmaxButton.setVisible(False)
+            self.outlineMenu.clear()
+            self._docOutline = {}
             return
 
         if CONFIG.showFullPath:
@@ -3012,8 +3014,11 @@ class GuiDocEditHeader(QWidget):
         self.closeDocumentRequest.emit()
         self.tbButton.setVisible(False)
         self.searchButton.setVisible(False)
+        self.outlineButton.setVisible(False)
         self.closeButton.setVisible(False)
         self.minmaxButton.setVisible(False)
+        self.outlineMenu.clear()
+        self._docOutline = {}
         return
 
     @pyqtSlot(int)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -2837,15 +2837,6 @@ class GuiDocEditHeader(QWidget):
         self.tbButton.setToolTip(self.tr("Toggle Tool Bar"))
         self.tbButton.clicked.connect(lambda: self.toggleToolBarRequest.emit())
 
-        self.searchButton = QToolButton(self)
-        self.searchButton.setContentsMargins(0, 0, 0, 0)
-        self.searchButton.setIconSize(iconSize)
-        self.searchButton.setFixedSize(fPx, fPx)
-        self.searchButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
-        self.searchButton.setVisible(False)
-        self.searchButton.setToolTip(self.tr("Search"))
-        self.searchButton.clicked.connect(self.docEditor.toggleSearch)
-
         self.outlineButton = QToolButton(self)
         self.outlineButton.setContentsMargins(0, 0, 0, 0)
         self.outlineButton.setIconSize(iconSize)
@@ -2855,6 +2846,15 @@ class GuiDocEditHeader(QWidget):
         self.outlineButton.setToolTip(self.tr("Outline"))
         self.outlineButton.setMenu(self.outlineMenu)
         self.outlineButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+
+        self.searchButton = QToolButton(self)
+        self.searchButton.setContentsMargins(0, 0, 0, 0)
+        self.searchButton.setIconSize(iconSize)
+        self.searchButton.setFixedSize(fPx, fPx)
+        self.searchButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.searchButton.setVisible(False)
+        self.searchButton.setToolTip(self.tr("Search"))
+        self.searchButton.clicked.connect(self.docEditor.toggleSearch)
 
         self.minmaxButton = QToolButton(self)
         self.minmaxButton.setContentsMargins(0, 0, 0, 0)
@@ -2878,8 +2878,8 @@ class GuiDocEditHeader(QWidget):
         self.outerBox = QHBoxLayout()
         self.outerBox.setSpacing(hSp)
         self.outerBox.addWidget(self.tbButton, 0)
-        self.outerBox.addWidget(self.searchButton, 0)
         self.outerBox.addWidget(self.outlineButton, 0)
+        self.outerBox.addWidget(self.searchButton, 0)
         self.outerBox.addWidget(self.itemTitle, 1)
         self.outerBox.addSpacing(fPx + hSp)
         self.outerBox.addWidget(self.minmaxButton, 0)
@@ -2914,8 +2914,8 @@ class GuiDocEditHeader(QWidget):
         self.itemTitle.setText("")
         self.outlineMenu.clear()
         self.tbButton.setVisible(False)
-        self.searchButton.setVisible(False)
         self.outlineButton.setVisible(False)
+        self.searchButton.setVisible(False)
         self.closeButton.setVisible(False)
         self.minmaxButton.setVisible(False)
         return
@@ -2937,8 +2937,8 @@ class GuiDocEditHeader(QWidget):
     def updateTheme(self) -> None:
         """Update theme elements."""
         self.tbButton.setIcon(SHARED.theme.getIcon("menu"))
-        self.searchButton.setIcon(SHARED.theme.getIcon("search"))
         self.outlineButton.setIcon(SHARED.theme.getIcon("list"))
+        self.searchButton.setIcon(SHARED.theme.getIcon("search"))
         self.minmaxButton.setIcon(SHARED.theme.getIcon("maximise"))
         self.closeButton.setIcon(SHARED.theme.getIcon("close"))
 
@@ -2950,8 +2950,8 @@ class GuiDocEditHeader(QWidget):
         buttonStyleMenu = f"{buttonStyle} QToolButton::menu-indicator {{image: none;}}"
 
         self.tbButton.setStyleSheet(buttonStyle)
-        self.searchButton.setStyleSheet(buttonStyle)
         self.outlineButton.setStyleSheet(buttonStyleMenu)
+        self.searchButton.setStyleSheet(buttonStyle)
         self.minmaxButton.setStyleSheet(buttonStyle)
         self.closeButton.setStyleSheet(buttonStyle)
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1194,7 +1194,7 @@ class GuiDocEditor(QPlainTextEdit):
             SHARED.runInThreadPool(self.wCounterDoc)
             self.docHeader.setOutline({
                 block.blockNumber(): block.text()
-                for block in self._qDocument.iterBlockByType(BLOCK_TITLE)
+                for block in self._qDocument.iterBlockByType(BLOCK_TITLE, maxCount=30)
             })
 
         return
@@ -1306,6 +1306,7 @@ class GuiDocEditor(QPlainTextEdit):
                     self._docHandle, wrapAround=self.docSearch.doLoop
                 )
                 self.beginSearch()
+                self.setFocus()
             return
 
         cursor = self.textCursor()
@@ -1326,6 +1327,7 @@ class GuiDocEditor(QPlainTextEdit):
                     self._docHandle, wrapAround=self.docSearch.doLoop
                 )
                 self.beginSearch()
+                self.setFocus()
                 return
             else:
                 resIdx = 0 if doLoop else maxIdx

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1192,7 +1192,10 @@ class GuiDocEditor(QPlainTextEdit):
         if time() - self._lastEdit < 25.0:
             logger.debug("Running word counter")
             SHARED.runInThreadPool(self.wCounterDoc)
-            self._updateOutline()
+            self.docHeader.setOutline({
+                block.blockNumber(): block.text()
+                for block in self._qDocument.iterBlockByType(BLOCK_TITLE)
+            })
 
         return
 
@@ -1836,14 +1839,6 @@ class GuiDocEditor(QPlainTextEdit):
     ##
     #  Internal Functions
     ##
-
-    def _updateOutline(self) -> None:
-        """Scan the text for headings and update the outline."""
-        self.docHeader.setOutline({
-            block.blockNumber(): block.text()
-            for block in self._qDocument.iterBlockByType(BLOCK_TITLE)
-        })
-        return
 
     def _processTag(self, cursor: QTextCursor | None = None,
                     follow: bool = True, create: bool = False) -> nwTrinary:

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -45,15 +45,15 @@ logger = logging.getLogger(__name__)
 SPELLRX = QRegularExpression(r"\b[^\s\-\+\/–—\[\]:]+\b")
 SPELLRX.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
 
+BLOCK_NONE  = 0
+BLOCK_TEXT  = 1
+BLOCK_META  = 2
+BLOCK_TITLE = 4
+
 
 class GuiDocHighlighter(QSyntaxHighlighter):
 
     __slots__ = ("_tItem", "_tHandle", "_spellCheck", "_spellErr", "_hRules", "_hStyles")
-
-    BLOCK_NONE  = 0
-    BLOCK_TEXT  = 1
-    BLOCK_META  = 2
-    BLOCK_TITLE = 4
 
     def __init__(self, document: QTextDocument) -> None:
         super().__init__(document)
@@ -272,12 +272,12 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         is significantly faster than running the regex checks used for
         text paragraphs.
         """
-        self.setCurrentBlockState(self.BLOCK_NONE)
+        self.setCurrentBlockState(BLOCK_NONE)
         if self._tHandle is None or not text:
             return
 
         if text.startswith("@"):  # Keywords and commands
-            self.setCurrentBlockState(self.BLOCK_META)
+            self.setCurrentBlockState(BLOCK_META)
             index = SHARED.project.index
             isValid, bits, pos = index.scanThis(text)
             isGood = index.checkThese(bits, self._tHandle)
@@ -301,7 +301,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             return
 
         elif text.startswith(("# ", "#! ", "## ", "##! ", "### ", "###! ", "#### ")):
-            self.setCurrentBlockState(self.BLOCK_TITLE)
+            self.setCurrentBlockState(BLOCK_TITLE)
 
             if text.startswith("# "):  # Heading 1
                 self.setFormat(0, 1, self._hStyles["head1h"])
@@ -332,7 +332,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 self.setFormat(4, len(text), self._hStyles["header3"])
 
         elif text.startswith("%"):  # Comments
-            self.setCurrentBlockState(self.BLOCK_TEXT)
+            self.setCurrentBlockState(BLOCK_TEXT)
             cStyle, _, cPos = processComment(text)
             if cStyle == nwComment.PLAIN:
                 self.setFormat(0, len(text), self._hStyles["hidden"])
@@ -357,7 +357,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                     return
 
             # Regular Text
-            self.setCurrentBlockState(self.BLOCK_TEXT)
+            self.setCurrentBlockState(BLOCK_TEXT)
             for rX, xFmt in self.rxRules:
                 rxItt = rX.globalMatch(text, 0)
                 while rxItt.hasNext():

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -756,7 +756,7 @@ class GuiDocViewHeader(QWidget):
                 if title != "T0000":
                     entries.append((title, text, level))
                     minLevel = min(minLevel, level)
-            for title, text, level in entries:
+            for title, text, level in entries[:30]:
                 indent = "    "*(level - minLevel)
                 action = self.outlineMenu.addAction(f"{indent}{text}")
                 action.triggered.connect(

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -23,11 +23,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
+from collections.abc import Generator
 import logging
 
 from time import time
 
-from PyQt5.QtGui import QTextCursor, QTextDocument
+from PyQt5.QtGui import QTextBlock, QTextCursor, QTextDocument
 from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import QPlainTextDocumentLayout, qApp
 from novelwriter import SHARED
@@ -112,6 +113,14 @@ class GuiTextDocument(QTextDocument):
                         word = text[cPos:cEnd]
                         return word, cPos, cLen, SHARED.spelling.suggestWords(word)
         return "", -1, -1, []
+
+    def iterBlockByType(self, cType: int) -> Generator[QTextBlock]:
+        """Iterate over all text blocks of a given type."""
+        for i in range(self.blockCount()):
+            block = self.findBlockByNumber(i)
+            if block.isValid() and block.userState() & cType > 0:
+                yield block
+        return None
 
     ##
     #  Public Slots

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -114,11 +114,13 @@ class GuiTextDocument(QTextDocument):
                         return word, cPos, cLen, SHARED.spelling.suggestWords(word)
         return "", -1, -1, []
 
-    def iterBlockByType(self, cType: int) -> Generator[QTextBlock]:
+    def iterBlockByType(self, cType: int, maxCount: int = 1000) -> Generator[QTextBlock]:
         """Iterate over all text blocks of a given type."""
+        count = 0
         for i in range(self.blockCount()):
             block = self.findBlockByNumber(i)
-            if block.isValid() and block.userState() & cType > 0:
+            if count < maxCount and block.isValid() and block.userState() & cType > 0:
+                count += 1
                 yield block
         return None
 

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -196,12 +196,12 @@ class GuiMainMenu(QMenuBar):
         # Document > Open
         self.aOpenDoc = self.docuMenu.addAction(self.tr("Open Document"))
         self.aOpenDoc.setShortcut("Ctrl+O")
-        self.aOpenDoc.triggered.connect(lambda: self.mainGui.openSelectedItem())
+        self.aOpenDoc.triggered.connect(self.mainGui.openSelectedItem)
 
         # Document > Save
         self.aSaveDoc = self.docuMenu.addAction(self.tr("Save Document"))
         self.aSaveDoc.setShortcut("Ctrl+S")
-        self.aSaveDoc.triggered.connect(lambda: self.mainGui.saveDocument())
+        self.aSaveDoc.triggered.connect(self.mainGui.saveDocument)
 
         # Document > Close
         self.aCloseDoc = self.docuMenu.addAction(self.tr("Close Document"))
@@ -219,7 +219,7 @@ class GuiMainMenu(QMenuBar):
         # Document > Close Preview
         self.aCloseView = self.docuMenu.addAction(self.tr("Close Document View"))
         self.aCloseView.setShortcut("Ctrl+Shift+R")
-        self.aCloseView.triggered.connect(lambda: self.mainGui.closeDocViewer())
+        self.aCloseView.triggered.connect(self.mainGui.closeDocViewer)
 
         # Document > Separator
         self.docuMenu.addSeparator()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -273,6 +273,7 @@ class GuiMain(QMainWindow):
         self.docEditor.toggleFocusModeRequest.connect(self.toggleFocusMode)
         self.docEditor.requestProjectItemSelected.connect(self.projView.setSelectedHandle)
         self.docEditor.requestProjectItemRenamed.connect(self.projView.renameTreeItem)
+        self.docEditor.requestNewNoteCreation.connect(self.projView.createNewNote)
 
         self.docViewer.documentLoaded.connect(self.docViewerPanel.updateHandle)
         self.docViewer.loadDocumentTagRequest.connect(self._followTag)

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -57,6 +57,7 @@ class SharedData(QObject):
     projectStatusChanged = pyqtSignal(bool)
     projectStatusMessage = pyqtSignal(str)
     spellLanguageChanged = pyqtSignal(str, str)
+    focusModeChanged = pyqtSignal(bool)
     indexScannedText = pyqtSignal(str)
     indexChangedTags = pyqtSignal(list, list)
     indexCleared = pyqtSignal()
@@ -76,6 +77,7 @@ class SharedData(QObject):
         self._lastAlert = ""
         self._idleTime = 0.0
         self._idleRefTime = time()
+        self._focusMode = False
 
         return
 
@@ -112,6 +114,11 @@ class SharedData(QObject):
         return self._spelling
 
     @property
+    def focusMode(self) -> bool:
+        """Return the Focus Mode state."""
+        return self._focusMode
+
+    @property
     def hasProject(self) -> bool:
         """Return True if the project instance is populated."""
         return self.project.isValid
@@ -130,6 +137,17 @@ class SharedData(QObject):
     def lastAlert(self) -> str:
         """Return the last alert message."""
         return self._lastAlert
+
+    ##
+    #  Setters
+    ##
+
+    def setFocusMode(self, state: bool) -> None:
+        """Set focus mode on or off."""
+        if state is not self._focusMode:
+            self._focusMode = state
+            self.focusModeChanged.emit(state)
+        return
 
     ##
     #  Methods
@@ -323,6 +341,7 @@ class SharedData(QObject):
         self._project = NWProject()
         self._spelling = NWSpellEnchant(self._project)
         self.updateSpellCheckLanguage()
+        self._focusMode = False
         return
 
     def _resetIdleTimer(self) -> None:

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -705,6 +705,16 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
         index.getItemHeading(dHandle, "T0001")
     )]
 
+    # getItemHeading
+    # ==============
+    assert list(index.iterItemHeadings(cHandle)) == [
+        ("T0001", index.getItemHeading(cHandle, "T0001"))
+    ]
+    assert list(index.iterItemHeadings(dHandle)) == [
+        ("T0001", index.getItemHeading(dHandle, "T0001"))
+    ]
+    assert list(index.iterItemHeadings(C.hInvalid)) == []
+
     # getSingleTag
     # ============
     assert index.getSingleTag("jane") == (

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -125,7 +125,7 @@ def testGuiEditor_LoadText(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     longText = "### Lorem Ipsum\n\n%s" % "\n\n".join(ipsumText*20)
     nwGUI.docEditor.replaceText(longText)
     nwGUI.saveDocument()
-    assert nwGUI.closeDocument() is True
+    nwGUI.closeDocument()
 
     # Invalid handle
     assert nwGUI.docEditor.loadText("abcdefghijklm") is False

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -30,7 +30,9 @@ from PyQt5.QtCore import QThreadPool, Qt
 from PyQt5.QtWidgets import QAction, QMenu, qApp
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.enum import nwDocAction, nwDocInsert, nwItemLayout, nwTrinary, nwWidget
+from novelwriter.enum import (
+    nwDocAction, nwDocInsert, nwItemClass, nwItemLayout, nwTrinary, nwWidget
+)
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.gui.doceditor import GuiDocEditor, GuiDocToolBar
 from novelwriter.text.counting import standardCounter
@@ -1527,7 +1529,12 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert "0000000000012" not in SHARED.project.tree
     nwGUI.docEditor.setCursorPosition(42)
     assert nwGUI.docEditor._processTag(create=True) is nwTrinary.NEGATIVE
-    assert "0000000000012" not in SHARED.project.tree
+    oHandle = SHARED.project.tree.findRoot(nwItemClass.OBJECT)
+    assert oHandle == "0000000000012"
+
+    oItem = SHARED.project.tree["0000000000013"]
+    assert oItem is not None
+    assert oItem.itemParent == "0000000000012"
 
     nwGUI.docEditor.setCursorPosition(47)
     assert nwGUI.docEditor._processTag() is nwTrinary.NEUTRAL

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -47,7 +47,7 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.openDocument(C.hSceneDoc)
 
     nwGUI.docEditor.setPlainText("### Lorem Ipsum\n\n%s" % ipsumText[0])
-    assert nwGUI.saveDocument()
+    nwGUI.saveDocument()
 
     # Check Defaults
     qDoc = nwGUI.docEditor.document()
@@ -122,7 +122,7 @@ def testGuiEditor_LoadText(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     longText = "### Lorem Ipsum\n\n%s" % "\n\n".join(ipsumText*20)
     nwGUI.docEditor.replaceText(longText)
-    assert nwGUI.saveDocument() is True
+    nwGUI.saveDocument()
     assert nwGUI.closeDocument() is True
 
     # Invalid handle
@@ -138,7 +138,7 @@ def testGuiEditor_LoadText(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     # Load empty document
     nwGUI.docEditor.replaceText("")
-    assert nwGUI.saveDocument() is True
+    nwGUI.saveDocument()
     assert nwGUI.docEditor.loadText(C.hSceneDoc) is True
     assert nwGUI.docEditor.toPlainText() == ""
 
@@ -1484,7 +1484,7 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     cHandle = SHARED.project.newFile("Jane Doe", C.hCharRoot)
     assert nwGUI.openDocument(cHandle) is True
     nwGUI.docEditor.replaceText(text)
-    assert nwGUI.saveDocument() is True
+    nwGUI.saveDocument()
     assert nwGUI.projView.projTree.revealNewTreeItem(cHandle)
     nwGUI.docEditor.updateTagHighLighting()
 
@@ -1514,7 +1514,7 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert nwGUI.docViewer._docHandle is None
     assert nwGUI.docEditor._processTag(follow=True) is nwTrinary.POSITIVE
     assert nwGUI.docViewer._docHandle == cHandle
-    assert nwGUI.closeDocViewer() is True
+    assert nwGUI.closeViewerPanel() is True
     assert nwGUI.docViewer._docHandle is None
 
     # On Unknown Tag, Create It
@@ -1553,7 +1553,7 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     cHandle = SHARED.project.newFile("People", C.hCharRoot)
     assert nwGUI.openDocument(cHandle) is True
     nwGUI.docEditor.replaceText(text)
-    assert nwGUI.saveDocument() is True
+    nwGUI.saveDocument()
     assert nwGUI.projView.projTree.revealNewTreeItem(cHandle)
 
     docEditor = nwGUI.docEditor

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -185,12 +185,12 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwItem.setName("Test Title")  # type: ignore
     assert nwItem.itemName == "Test Title"  # type: ignore
     docViewer.updateDocInfo("4c4f28287af27")
-    assert docViewer.docHeader.docTitle.text() == "Characters  \u203a  Test Title"
+    assert docViewer.docHeader.itemTitle.text() == "Characters  \u203a  Test Title"
 
     # Title without full path
     CONFIG.showFullPath = False
     docViewer.updateDocInfo("4c4f28287af27")
-    assert docViewer.docHeader.docTitle.text() == "Test Title"
+    assert docViewer.docHeader.itemTitle.text() == "Test Title"
     CONFIG.showFullPath = True
 
     # Document footer show/hide synopsis

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -574,7 +574,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 def testGuiMain_Features(qtbot, nwGUI, projPath, mockRnd):
     """Test various features of the main window."""
     buildTestProject(nwGUI, projPath)
-    assert nwGUI.isFocusMode is False
+    assert SHARED.focusMode is False
 
     # Focus Mode
     # ==========

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -52,10 +52,8 @@ def testGuiMain_ProjectBlocker(nwGUI):
     assert nwGUI.closeDocument() is False
     assert nwGUI.openDocument(None) is False
     assert nwGUI.openNextDocument(None) is False
-    assert nwGUI.saveDocument() is False
     assert nwGUI.viewDocument(None) is False
     assert nwGUI.importDocument() is False
-    assert nwGUI.openSelectedItem() is False
     assert nwGUI.editItemLabel() is False
     assert nwGUI.rebuildIndex() is False
 
@@ -109,7 +107,8 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     buildTestProject(nwGUI, projPath)
 
     sHandle = "000000000000f"
-    assert nwGUI.openSelectedItem() is False
+    nwGUI.openSelectedItem()
+    assert nwGUI.docEditor.docHandle is None
 
     # Project Tree has focus
     nwGUI._changeView(nwView.PROJECT)
@@ -238,7 +237,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     nwGUI.projView.projTree.clearSelection()
     nwGUI.projView.projTree._getTreeItem(C.hCharRoot).setSelected(True)
     nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
-    assert nwGUI.openSelectedItem()
+    nwGUI.openSelectedItem()
 
     # Text Editor
     # ===========
@@ -265,7 +264,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     nwGUI.projView.projTree.clearSelection()
     nwGUI.projView.projTree._getTreeItem(C.hPlotRoot).setSelected(True)
     nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
-    assert nwGUI.openSelectedItem()
+    nwGUI.openSelectedItem()
 
     # Type something into the document
     nwGUI.switchFocus(nwWidget.EDITOR)
@@ -287,7 +286,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     nwGUI.projView.projTree.clearSelection()
     nwGUI.projView.projTree._getTreeItem(C.hWorldRoot).setSelected(True)
     nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, None, isNote=True)
-    assert nwGUI.openSelectedItem()
+    nwGUI.openSelectedItem()
 
     # Add Some Text
     docEditor.replaceText("Hello World!")
@@ -319,7 +318,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     nwGUI.projView.projTree._getTreeItem(C.hNovelRoot).setExpanded(True)
     nwGUI.projView.projTree._getTreeItem(C.hChapterDir).setExpanded(True)
     nwGUI.projView.projTree._getTreeItem(C.hSceneDoc).setSelected(True)
-    assert nwGUI.openSelectedItem()
+    nwGUI.openSelectedItem()
 
     # Type something into the document
     nwGUI.switchFocus(nwWidget.EDITOR)
@@ -524,8 +523,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     # Save the document
     assert docEditor.docChanged
-    assert nwGUI.saveDocument()
-    assert not docEditor.docChanged
+    nwGUI.saveDocument()
+    assert docEditor.docChanged is False
     nwGUI.rebuildIndex()
 
     # Open and view the edited document
@@ -533,7 +532,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     assert nwGUI.openDocument(C.hSceneDoc)
     assert nwGUI.viewDocument(C.hSceneDoc)
     assert nwGUI.saveProject()
-    assert nwGUI.closeDocViewer()
+    assert nwGUI.closeViewerPanel()
 
     # Check the files
     projFile = projPath / "nwProject.nwx"

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -49,13 +49,10 @@ def testGuiMain_ProjectBlocker(nwGUI):
     # Test no-project blocking
     assert nwGUI.closeProject() is True
     assert nwGUI.saveProject() is False
-    assert nwGUI.closeDocument() is False
     assert nwGUI.openDocument(None) is False
     assert nwGUI.openNextDocument(None) is False
     assert nwGUI.viewDocument(None) is False
     assert nwGUI.importDocument() is False
-    assert nwGUI.editItemLabel() is False
-    assert nwGUI.rebuildIndex() is False
 
 # END Test testGuiMain_ProjectBlocker
 
@@ -120,7 +117,7 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
         nwGUI.projView.projTree._getTreeItem(sHandle).setSelected(True)
         nwGUI._keyPressReturn()
         assert nwGUI.docEditor.docHandle == sHandle
-        assert nwGUI.closeDocument() is True
+        nwGUI.closeDocument()
 
     # Novel Tree has focus
     nwGUI._changeView(nwView.NOVEL)
@@ -132,7 +129,7 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
         nwGUI.novelView.novelTree.setCurrentItem(selItem)
         nwGUI._keyPressReturn()
         assert nwGUI.docEditor.docHandle == sHandle
-        assert nwGUI.closeDocument() is True
+        nwGUI.closeDocument()
 
     # Project Outline has focus
     nwGUI._changeView(nwView.OUTLINE)
@@ -144,7 +141,7 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
         nwGUI.outlineView.outlineTree.setCurrentItem(selItem)
         nwGUI._keyPressReturn()
         assert nwGUI.docEditor.docHandle == sHandle
-        assert nwGUI.closeDocument() is True
+        nwGUI.closeDocument()
 
     # qtbot.stop()
 


### PR DESCRIPTION
**Summary:**

This PR adds a dropdown menu in the header of both the document editor and viewer for quick navigation to any heading defined in it. The PR also cleans refactor a lot of the calls from the editor and viewer to other parts of the GUI to use signals and slots instead of direct calls.

**Related Issue(s):**

Closes #1059

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
