### PR TITLE
Add fast document read

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -122,9 +122,8 @@ class NWIndex:
         self.clearIndex()
         for nwItem in self._project.tree:
             if nwItem.isFileType():
-                tHandle = nwItem.itemHandle
-                doc = self._project.storage.getDocument(tHandle)
-                self.scanText(tHandle, doc.readDocument() or "", blockSignal=True)
+                text = self._project.storage.getDocumentText(nwItem.itemHandle)
+                self.scanText(nwItem.itemHandle, text, blockSignal=True)
         self._indexBroken = False
         SHARED.indexSignalProxy({"event": "buildIndex"})
         return
@@ -142,17 +141,15 @@ class NWIndex:
         })
         return
 
-    def reIndexHandle(self, tHandle: str | None) -> bool:
+    def reIndexHandle(self, tHandle: str | None) -> None:
         """Put a file back into the index. This is used when files are
         moved from the archive or trash folders back into the active
         project.
         """
         if tHandle and self._project.tree.checkType(tHandle, nwItemType.FILE):
             logger.debug("Re-indexing item '%s'", tHandle)
-            doc = self._project.storage.getDocument(tHandle)
-            self.scanText(tHandle, doc.readDocument() or "")
-            return True
-        return False
+            self.scanText(tHandle, self._project.storage.getDocumentText(tHandle))
+        return
 
     def indexChangedSince(self, checkTime: int | float) -> bool:
         """Check if the index has changed since a given time."""

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -175,12 +175,10 @@ class NWProject:
         """Write content to a new document after it is created. This
         will not run if the file exists and is not empty.
         """
-        tItem = self._tree[tHandle]
-        if not (tItem and tItem.isFileType()):
+        if not ((tItem := self._tree[tHandle]) and tItem.isFileType()):
             return False
 
-        newDoc = self._storage.getDocument(tHandle)
-        if (newDoc.readDocument() or "").strip():
+        if self._storage.getDocumentText(tHandle).strip():
             return False
 
         indent = "#"*minmax(hLevel, 1, 4)
@@ -191,7 +189,7 @@ class NWProject:
         else:
             tItem.setLayout(nwItemLayout.NOTE)
 
-        newDoc.writeDocument(text)
+        self._storage.getDocument(tHandle).writeDocument(text)
         self._index.scanText(tHandle, text)
 
         return True
@@ -200,21 +198,18 @@ class NWProject:
         """Copy content to a new document after it is created. This
         will not run if the file exists and is not empty.
         """
-        tItem = self._tree[tHandle]
-        if not (tItem and tItem.isFileType()):
+        if not ((tItem := self._tree[tHandle]) and tItem.isFileType()):
             return False
 
-        sItem = self._tree[sHandle]
-        if not (sItem and sItem.isFileType()):
+        if not ((sItem := self._tree[sHandle]) and sItem.isFileType()):
             return False
 
-        newDoc = self._storage.getDocument(tHandle)
-        if (newDoc.readDocument() or "").strip():
+        if self._storage.getDocumentText(tHandle).strip():
             return False
 
         logger.debug("Populating '%s' with text from '%s'", tHandle, sHandle)
-        text = self._storage.getDocument(sHandle).readDocument() or ""
-        newDoc.writeDocument(text)
+        text = self._storage.getDocumentText(sHandle)
+        self._storage.getDocument(tHandle).writeDocument(text)
         sItem.setLayout(tItem.itemLayout)
         self._index.scanText(tHandle, text)
 

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -289,21 +289,8 @@ class NWStorage:
 
     def getDocumentText(self, tHandle: str) -> str:
         """Return the text of a document in a fast and efficient way."""
-        if (
-            isinstance(self._runtimePath, Path)
-            and (path := self._runtimePath / "content" / f"{tHandle}.nwd").is_file()
-        ):
-            try:
-                with open(path, mode="r", encoding="utf-8") as inFile:
-                    line = ""
-                    for _ in range(10):
-                        if not (line := inFile.readline()).startswith(r"%%~"):
-                            break
-                    return line + inFile.read()
-            except Exception:
-                logger.error("Cannot read document with handle '%s'", tHandle)
-                logException()
-                return ""
+        if isinstance(self._runtimePath, Path):
+            return NWDocument.quickReadText(self._runtimePath / "content", tHandle)
         return ""
 
     def scanContent(self) -> list[str]:

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -429,9 +429,7 @@ class Tokenizer(ABC):
         self._text = ""
         self._handle = None
         if nwItem := self._project.tree[tHandle]:
-            if text is None:
-                text = self._project.storage.getDocument(tHandle).readDocument() or ""
-            self._text = text
+            self._text = text or self._project.storage.getDocumentText(tHandle)
             self._handle = tHandle
             self._isNovel = nwItem.itemLayout == nwItemLayout.DOCUMENT
         return

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -214,8 +214,7 @@ class GuiDocSplit(QDialog):
 
         spLevel = self.splitLevel.currentData()
         if not self._text:
-            inDoc = SHARED.project.storage.getDocument(sHandle)
-            self._text = (inDoc.readDocument() or "").splitlines()
+            self._text = SHARED.project.storage.getDocumentText(sHandle).splitlines()
 
         for lineNo, aLine in enumerate(self._text):
 

--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -423,9 +423,6 @@ def testCoreTools_DocSearch(monkeypatch, mockGUI, fncPath, mockRnd, ipsumText):
     assert result[1] == (C.hChapterDoc, [], False)
     assert result[2] == (C.hSceneDoc, [(8, 5, "Scene")], False)
 
-    # Cache
-    assert list(search._cache.keys()) == [C.hTitlePage, C.hChapterDoc, C.hSceneDoc]
-
     # Patterns
     # ========
 

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -60,9 +60,8 @@ def testCoreIndex_LoadSave(qtbot, monkeypatch, prjLipsum, mockGUI, tstPaths):
         "60bdf227455cc": False,  # World ROOT
     }
     for tItem in project.tree:
-        assert index.reIndexHandle(tItem.itemHandle) is notIndexable.get(tItem.itemHandle, True)
-
-    assert index.reIndexHandle(None) is False
+        index.reIndexHandle(tItem.itemHandle)
+        assert (tItem.itemHandle in index._itemIndex) is notIndexable.get(tItem.itemHandle, True)
 
     # No folder for saving
     with monkeypatch.context() as mp:

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -64,6 +64,7 @@ def testCoreStorage_CreateNewProject(mockGUI, fncPath):
     assert bool(storage.getDocument(C.hSceneDoc)) is False
     assert storage.getMetaFile("file") is None
     assert storage.scanContent() == []
+    assert storage.getDocumentText(C.hSceneDoc) == ""
 
     # Cannot prepare a non-empty folder
     (fncPath / "foobar.txt").touch()
@@ -159,12 +160,6 @@ def testCoreStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
 
     # We can directly access the content of a document
     assert storage.getDocumentText(C.hSceneDoc) == "### New Scene\n\n"
-
-    # Check read text fallback
-    assert storage.getDocumentText(C.hInvalid) == ""
-    with monkeypatch.context() as mp:
-        mp.setattr("builtins.open", causeOSError)
-        assert storage.getDocumentText(C.hSceneDoc) == ""
 
     project.closeProject()
 


### PR DESCRIPTION
**Summary:**

This PR adds an alternative and efficient way to read the text of a document when all that is needed is the text content with the meta data stripped. The reader is added as a static method in the NWDocument class, and a wrapper function is added to the NWStorage class.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
