### PR TITLE
Use selected text for project search

### DIFF
--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -382,8 +382,7 @@ class DocSearch:
                         escaped += f"\\{c}"
                 search = escaped
         if self._words:
-            search = search if search.startswith("\\b") else f"\\b{search}"
-            search = search if search.endswith("\\b") else f"{search}\\b"
+            search = f"(?:^|\\b){search}(?:$|\\b)"
         return search
 
 # END Class DocSearch

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -192,10 +192,13 @@ class GuiProjectSearch(QWidget):
             )
         return
 
-    def beginSearch(self) -> None:
+    def beginSearch(self, text: str = "") -> None:
         """Focus the search box and select its text, if any."""
         self.searchText.setFocus()
         self.searchText.selectAll()
+        if text:
+            self.searchText.setText(text.partition("\n")[0])
+            self.searchText.selectAll()
         return
 
     def closeProjectTasks(self) -> None:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1168,7 +1168,9 @@ class GuiMain(QMainWindow):
         elif view == nwView.SEARCH:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.projSearch)
-            self.projSearch.beginSearch()
+            self.projSearch.beginSearch(
+                self.docEditor.getSelectedText() if self.docEditor.anyFocus() else ""
+            )
         elif view == nwView.OUTLINE:
             self.mainStack.setCurrentWidget(self.outlineView)
         return

--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -439,10 +439,7 @@ def testCoreTools_DocSearch(monkeypatch, mockGUI, fncPath, mockRnd, ipsumText):
     # Whole Words
     search.setWholeWords(True)
     search.setUserRegEx(True)
-    assert search._buildPattern("Hi") == r"\bHi\b"
-    assert search._buildPattern(r"\bHi") == r"\bHi\b"
-    assert search._buildPattern(r"Hi\b") == r"\bHi\b"
-    assert search._buildPattern(r"\bHi\b") == r"\bHi\b"
+    assert search._buildPattern("Hi") == r"(?:^|\b)Hi(?:$|\b)"
     search.setWholeWords(False)
     search.setUserRegEx(False)
 

--- a/tests/test_gui/test_gui_search.py
+++ b/tests/test_gui/test_gui_search.py
@@ -117,7 +117,7 @@ def testGuiDocSearch_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     # RegEx
     search.toggleRegEx.setChecked(True)
-    search.searchText.setText("(dolor|dolorem)")
+    search.beginSearch("(dolor|dolorem)")
     search.searchAction.activate(QAction.ActionEvent.Trigger)
     assert search.searchResult.topLevelItemCount() == 10
     assert totalCount() == 34


### PR DESCRIPTION
**Summary:**

This PR changes the begin search function for the project search panel to use selected text from the editor if the editor has focus when the search is activated.

**Related Issue(s):**

Closes #1789

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
