### PR TITLE
Improve state persistence of document search buttons

### DIFF
--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1270,7 +1270,7 @@ class GuiMain(QMainWindow):
     @pyqtSlot()
     def _keyPressEscape(self) -> None:
         """Process an escape keypress in the main window."""
-        if self.docEditor.docSearch.isVisible():
+        if self.docEditor.searchVisible():
             self.docEditor.closeSearch()
         elif SHARED.focusMode:
             SHARED.setFocusMode(False)

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1956,21 +1956,21 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
         mp.setattr(docSearch.searchBox, "hasFocus", lambda: False)
         mp.setattr(docSearch.replaceBox, "hasFocus", lambda: False)
         assert docEditor.focusNextPrevChild(True) is False
-        assert docSearch.cycleFocus(True) is False
+        assert docSearch.cycleFocus() is False
 
     with monkeypatch.context() as mp:
         mp.setattr(docEditor, "hasFocus", lambda: False)
         mp.setattr(docSearch.searchBox, "hasFocus", lambda: True)
         mp.setattr(docSearch.replaceBox, "hasFocus", lambda: False)
         assert docEditor.focusNextPrevChild(True) is True
-        assert docSearch.cycleFocus(True) is True
+        assert docSearch.cycleFocus() is True
 
     with monkeypatch.context() as mp:
         mp.setattr(docEditor, "hasFocus", lambda: False)
         mp.setattr(docSearch.searchBox, "hasFocus", lambda: False)
         mp.setattr(docSearch.replaceBox, "hasFocus", lambda: True)
         assert docEditor.focusNextPrevChild(True) is True
-        assert docSearch.cycleFocus(True) is True
+        assert docSearch.cycleFocus() is True
         docSearch.closeSearch()
         assert docSearch.isVisible() is False
         assert docEditor.focusNextPrevChild(True) is True

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1794,7 +1794,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Activate loop search
     docSearch.toggleLoop.activate(QAction.Trigger)
     assert docSearch.toggleLoop.isChecked()
-    assert docSearch.doLoop is True
+    assert CONFIG.searchLoop is True
 
     # Find next by menu Search > Find Next
     nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
@@ -1819,7 +1819,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Enable RegEx search
     docSearch.toggleRegEx.activate(QAction.Trigger)
     assert docSearch.toggleRegEx.isChecked()
-    assert docSearch.isRegEx is True
+    assert CONFIG.searchRegEx is True
 
     # Set invalid RegEx
     docEditor.setCursorPosition(0)
@@ -1848,7 +1848,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Make RegEx case sensitive
     docSearch.toggleCase.activate(QAction.Trigger)
     assert docSearch.toggleCase.isChecked()
-    assert docSearch.isCaseSense is True
+    assert CONFIG.searchCase is True
 
     # Find next/prev (one result)
     nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
@@ -1865,12 +1865,12 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Disable RegEx case sensitive
     docSearch.toggleCase.activate(QAction.Trigger)
     assert docSearch.toggleCase.isChecked() is False
-    assert docSearch.isCaseSense is False
+    assert CONFIG.searchCase is False
 
     # Toggle replace preserve case
     docSearch.toggleMatchCap.activate(QAction.Trigger)
     assert docSearch.toggleMatchCap.isChecked()
-    assert docSearch.doMatchCap is True
+    assert CONFIG.searchMatchCap is True
 
     # Replace "Sus" with "Foo" via menu
     docEditor.setCursorPosition(605)
@@ -1898,7 +1898,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Disable RegEx search
     docSearch.toggleRegEx.activate(QAction.Trigger)
     assert not docSearch.toggleRegEx.isChecked()
-    assert docSearch.isRegEx is False
+    assert CONFIG.searchRegEx is False
 
     # Close search and select "est" again
     docSearch.cancelSearch.activate(QAction.Trigger)
@@ -1915,7 +1915,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Enable full word search
     docSearch.toggleWord.activate(QAction.Trigger)
     assert docSearch.toggleWord.isChecked()
-    assert docSearch.isWholeWord is True
+    assert CONFIG.searchWord is True
 
     # Only one match
     nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
@@ -1926,7 +1926,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Enable next doc search
     docSearch.toggleProject.activate(QAction.Trigger)
     assert docSearch.toggleProject.isChecked()
-    assert docSearch.doNextFile is True
+    assert CONFIG.searchNextFile is True
 
     # Next match
     nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
@@ -1937,7 +1937,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert abs(docEditor.getCursorPosition() - 1127) < 3
 
     # Next doc, no match
-    assert docSearch.doNextFile is True
+    assert CONFIG.searchNextFile is True
     docSearch.setSearchText("abcdef")
     nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
     assert docEditor.docHandle != "2426c6f0ca922"


### PR DESCRIPTION
**Summary:**

This PR drops the local caching of the document search options in the search widget class and instead relies on the config settings everywhere they're accessed, and lets the toggle buttons set the configs directly.

**Related Issue(s):**

Closes #1794

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
