### PR TITLE
Fix stylesheet bug

### DIFF
--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -161,7 +161,7 @@ class GuiProjectSearch(QWidget):
         colBase = cssCol(qPalette.base().color())
         colFocus = cssCol(qPalette.highlight().color())
 
-        self.headerWidget.setStyleSheet(f"background: {colBase};")
+        self.headerWidget.setStyleSheet(f"QWidget {{background: {colBase};}}")
         self.headerWidget.setAutoFillBackground(True)
 
         self.setStyleSheet(


### PR DESCRIPTION
**Summary:**

This PR limits the change of background colour on the search panel toolbar to the widget itself. The old stylesheet setting also affected the tooltip labels.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
