### PR TITLE
Fix index error in word counter

### DIFF
--- a/novelwriter/text/counting.py
+++ b/novelwriter/text/counting.py
@@ -57,7 +57,7 @@ def preProcessText(text: str, keepHeaders: bool = True) -> list[str]:
                 continue
             if line[0] == ">":
                 line = line.lstrip(">").lstrip(" ")
-        if line:  # Above check can return empty line (Issue #1816)
+        if line:  # Above block can return empty line (Issue #1816)
             if line[-1] == "<":
                 line = line.rstrip("<").rstrip(" ")
             if "[" in line:

--- a/novelwriter/text/counting.py
+++ b/novelwriter/text/counting.py
@@ -57,6 +57,7 @@ def preProcessText(text: str, keepHeaders: bool = True) -> list[str]:
                 continue
             if line[0] == ">":
                 line = line.lstrip(">").lstrip(" ")
+        if line:  # Above check can return empty line (Issue #1816)
             if line[-1] == "<":
                 line = line.rstrip("<").rstrip(" ")
             if "[" in line:

--- a/tests/test_text/test_core_counting.py
+++ b/tests/test_text/test_core_counting.py
@@ -29,7 +29,7 @@ from novelwriter.text.counting import bodyTextCounter, preProcessText, standardC
 def testTextCounting_preProcessText():
     """Test the text preprocessor for counters."""
     # Not Text
-    assert preProcessText(None) == []
+    assert preProcessText(None) == []  # type: ignore
 
     # No Text
     assert preProcessText("") == []
@@ -80,6 +80,10 @@ def testTextCounting_standardCounter():
     # Non-Text
     assert standardCounter(None) == (0, 0, 0)  # type: ignore
     assert standardCounter(1234) == (0, 0, 0)  # type: ignore
+
+    # Test Corner Cases, Bug #1816
+    assert standardCounter("> ") == (0, 0, 0)
+    assert standardCounter(" <") == (0, 0, 0)
 
     # General Text
     cC, wC, pC = standardCounter((
@@ -182,7 +186,7 @@ def testTextCounting_standardCounter():
 def testTextCounting_bodyTextCounter():
     """Test the body text counter."""
     # Not Text
-    assert bodyTextCounter(None) == (0, 0, 0)
+    assert bodyTextCounter(None) == (0, 0, 0)  # type: ignore
 
     # General Text
     wC, cC, sC = bodyTextCounter((

--- a/tests/test_text/test_core_counting.py
+++ b/tests/test_text/test_core_counting.py
@@ -92,7 +92,8 @@ def testTextCounting_standardCounter():
         "# Heading One\n"
         "## Heading Two\n"
         "### Heading Three\n"
-        "#### Heading Four\n\n"
+        "###! Heading Four\n"
+        "#### Heading Five\n\n"
         "@tag: value\n\n"
         "% A comment that should not be counted.\n\n"
         "The first paragraph.\n\n"
@@ -100,8 +101,8 @@ def testTextCounting_standardCounter():
         "The third paragraph.\n\n"
         "Dashes\u2013and even longer\u2014dashes."
     ))
-    assert cC == 151
-    assert wC == 24
+    assert cC == 163
+    assert wC == 26
     assert pC == 4
 
     # Text Alignment


### PR DESCRIPTION
**Summary:**

This PR fixes a bug in the part of the word counter that strips alignment codes.

**Related Issue(s):**

Closes #1816

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
