### PR TITLE
Fix shortcode spellcheck

### DIFF
--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -44,6 +44,10 @@ logger = logging.getLogger(__name__)
 
 SPELLRX = QRegularExpression(r"\b[^\s\-\+\/–—\[\]:]+\b")
 SPELLRX.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
+SPELLSC = QRegularExpression(nwRegEx.FMT_SC)
+SPELLSC.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
+SPELLSV = QRegularExpression(nwRegEx.FMT_SV)
+SPELLSV.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
 
 BLOCK_NONE  = 0
 BLOCK_TEXT  = 1
@@ -439,6 +443,17 @@ class TextBlockData(QTextBlockUserData):
         """Run the spell checker and cache the result, and return the
         list of spell check errors.
         """
+        if "[" in text:
+            # Strip shortcodes
+            for rX in [SPELLSC, SPELLSV]:
+                rxItt = rX.globalMatch(text, 0)
+                while rxItt.hasNext():
+                    rxMatch = rxItt.next()
+                    xPos = rxMatch.capturedStart(0)
+                    xLen = rxMatch.capturedLength(0)
+                    xEnd = rxMatch.capturedEnd(0)
+                    text = text[:xPos] + " "*xLen + text[xEnd:]
+
         self._spellErrors = []
         rxSpell = SPELLRX.globalMatch(text.replace("_", " "), 0)
         while rxSpell.hasNext():

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -57,7 +57,8 @@ BLOCK_TITLE = 4
 
 class GuiDocHighlighter(QSyntaxHighlighter):
 
-    __slots__ = ("_tItem", "_tHandle", "_spellCheck", "_spellErr", "_hRules", "_hStyles")
+    __slots__ = ("_tHandle", "_isInactive", "_spellCheck", "_spellErr",
+                 "_hRules", "_hStyles", "_rxRules")
 
     def __init__(self, document: QTextDocument) -> None:
         super().__init__(document)
@@ -71,6 +72,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         self._hRules: list[tuple[str, dict]] = []
         self._hStyles: dict[str, QTextCharFormat] = {}
+        self._rxRules: list[tuple[QRegularExpression, dict[str, QTextCharFormat]]] = []
 
         self.initHighlighter()
 
@@ -222,11 +224,11 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         ))
 
         # Build a QRegExp for each highlight pattern
-        self.rxRules = []
+        self._rxRules = []
         for regEx, regRules in self._hRules:
             hReg = QRegularExpression(regEx)
             hReg.setPatternOptions(QRegularExpression.UseUnicodePropertiesOption)
-            self.rxRules.append((hReg, regRules))
+            self._rxRules.append((hReg, regRules))
 
         return
 
@@ -362,7 +364,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
             # Regular Text
             self.setCurrentBlockState(BLOCK_TEXT)
-            for rX, xFmt in self.rxRules:
+            for rX, xFmt in self._rxRules:
                 rxItt = rX.globalMatch(text, 0)
                 while rxItt.hasNext():
                     rxMatch = rxItt.next()

--- a/tests/reference/guiEditor_Main_Final_0000000000011.nwd
+++ b/tests/reference/guiEditor_Main_Final_0000000000011.nwd
@@ -1,10 +1,10 @@
 %%~name: New Note
 %%~path: 0000000000009/0000000000011
 %%~kind: PLOT/NOTE
-%%~hash: 8ff26f8a18ad6390c2ce725c441ab0c792a125cf
-%%~date: 2023-08-25 18:15:35/2023-08-25 18:15:35
+%%~hash: 3d3697638a70fc86cc023df6d42202a262d93905
+%%~date: 2024-04-14 23:46:49/2024-04-14 23:46:49
 # Main Plot
 
 @tag: MainPlot
 
-This is a file detailing the main plot.
+This is a file [i]detailing[/i] the main plot.

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.3a1" hexVersion="0x020300a1" fileVersion="1.5" fileRevision="2" timeStamp="2024-01-26 22:48:13">
+<novelWriterXML appVersion="2.4rc1" hexVersion="0x020400c1" fileVersion="1.5" fileRevision="3" timeStamp="2024-04-14 23:46:11">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="3">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -54,7 +54,7 @@
       <name status="s000000" import="i000004">Plot</name>
     </item>
     <item handle="0000000000011" parent="0000000000009" root="0000000000009" order="0" type="FILE" class="PLOT" layout="NOTE">
-      <meta expanded="no" heading="H1" charCount="48" wordCount="10" paraCount="1" cursorPos="69" />
+      <meta expanded="no" heading="H1" charCount="48" wordCount="10" paraCount="1" cursorPos="76" />
       <name status="s000000" import="i000004" active="yes">New Note</name>
     </item>
     <item handle="000000000000a" parent="None" root="000000000000a" order="2" type="ROOT" class="CHARACTER">

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -274,7 +274,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    for c in "This is a file detailing the main plot.":
+    for c in "This is a file [i]detailing[/i] the main plot.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
 


### PR DESCRIPTION
**Summary:**

This PR adds a filter that strips shortcodes before the spell checker is run. At the moment, only "sup" and "sub" codes are long enough to get spell checked at all, and in English they pass, but that may not be true for other languages. This PR replaces shortcodes with spaces on the copy of the text that is used for spell checking.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
