### PR TITLE
Add isort and clean up flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E133,E221,E226,E228,E241,W503,ANN101,ANN102,ANN401
-per-file-ignores=tests/*:ANN
-max-line-length = 99
-exclude = docs/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,17 +32,36 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.setuptools.dynamic]
-version = {attr = "novelwriter.__version__"}
-
 [project.urls]
 Homepage = "https://novelwriter.io"
 Documentation = "https://docs.novelwriter.io"
 Repository = "https://github.com/vkbo/novelWriter"
 Issues = "https://github.com/vkbo/novelWriter/issues"
 
+[project.gui-scripts]
+novelwriter = "novelwriter:main"
+
+[tool.setuptools.dynamic]
+version = {attr = "novelwriter.__version__"}
+
 [tool.setuptools.packages.find]
 include = ["novelwriter*"]
 
-[project.gui-scripts]
-novelwriter = "novelwriter:main"
+[tool.isort]
+py_version="38"
+line_length = 99
+wrap_length = 79
+multi_line_output = 5
+force_grid_wrap = 0
+lines_between_types = 1
+forced_separate = ["tests.*"]
+
+[tool.flake8]
+max-line-length = 99
+ignore = ["E133", "E221", "E226", "E228", "E241", "W503", "ANN101", "ANN102", "ANN401"]
+per-file-ignores = ["tests/*:ANN"]
+exclude = ["docs/*"]
+
+[tool.autopep8]
+max_line_length = 99
+ignore = ["E133", "E221", "E226", "E228", "E241", "W503"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8
 flake8-pep585
+flake8-pyproject
 flake8-annotations


### PR DESCRIPTION
**Summary:**

This PR:
* Adds an isort config that matches the current practice in the source code. It is not applied yet to the code, so its implementation will be gradual to avoid merge conflicts everywhere.
* Moves the flake8 config into pyproject.toml.
* Adds config for autopep8.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
