### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,7 +14,7 @@ jobs:
   testLinux:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ documentation.
 
 ## Implementation
 
-novelWriter is written with Python 3 (3.8+) using Qt5 and PyQt5 (5.15 only), and is released on
+novelWriter is written with Python 3 (3.9+) using Qt5 and PyQt5 (5.15 only), and is released on
 Linux, Windows and macOS. It can in principle run on any Operating System that also supports Qt,
 PyQt and Python.
 

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -162,9 +162,9 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     # Check Packages and Versions
     errorData = []
     errorCode = 0
-    if sys.hexversion < 0x030800f0:
+    if sys.hexversion < 0x030900f0:
         errorData.append(
-            "At least Python 3.8 is required, found %s" % CONFIG.verPyString
+            "At least Python 3.9 is required, found %s" % CONFIG.verPyString
         )
         errorCode |= 0x04
     if CONFIG.verQtValue < 0x050f00:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = {file = "setup/description_pypi.md", content-type = "text/markdown"}
 license = {text = "GNU General Public License v3"}
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -25,7 +24,7 @@ classifiers = [
     "Natural Language :: English",
     "Topic :: Text Editors",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "pyqt5>=5.15",
     "pyenchant>=3.0.0",

--- a/setup/debian/control
+++ b/setup/debian/control
@@ -2,14 +2,14 @@ Source: novelwriter
 Maintainer: Veronica Berglyd Olsen <code@vkbo.net>
 Section: text
 Priority: optional
-Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.8), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
+Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.9), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
 Standards-Version: 4.5.1
 Homepage: https://novelwriter.io
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.9
 
 Package: novelwriter
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.8), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
+Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.9), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
 Description: A markdown-like text editor for planning and writing novels
  novelWriter is a plain text editor designed for writing novels assembled from
  many smaller text documents. It uses a minimal formatting syntax inspired by

--- a/setup/description_pypi.md
+++ b/setup/description_pypi.md
@@ -10,7 +10,7 @@ synchronisation tools. All text is saved as plain text files with a meta data he
 project structure is stored in a single project XML file, and other meta data is primarily saved as
 JSON files.
 
-The application is written with Python 3 (3.8+) using Qt5 and PyQt5 (5.10+). It is developed on
+The application is written with Python 3 (3.9+) using Qt5 and PyQt5 (5.10+). It is developed on
 Linux, but should in principle work fine on other operating systems as well as long as dependencies
 are met. It is regularly tested on Debian and Ubuntu Linux, Windows, and MacOS.
 

--- a/setup/launchpad_setup.cfg
+++ b/setup/launchpad_setup.cfg
@@ -11,7 +11,6 @@ license_files = LICENSE.md
 license = GNU General Public License v3
 classifiers =
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -30,7 +29,7 @@ project_urls =
 
 [options]
 zip_safe = False
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = True
 packages = find_namespace:
 install_requires =


### PR DESCRIPTION
**Summary:**

Since we're no longer supporting Ubuntu 20.04 with native packages from 2.5 release, due to requiring Qt 5.15, we may as well drop Python 3.8 as well as it is causing issues with type annotations. Ubuntu 20.04 uses Python 3.8, but 22.04 has Python 3.10. We could in principle drop Python 3.9 as well, but at the moment it isn't necessary.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
