### PR TITLE
Updates to the build tool

### DIFF
--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -44,9 +44,7 @@ from novelwriter.core.item import NWItem
 from novelwriter.enum import nwBuildFmt
 from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.extensions.simpleprogress import NProgressSimple
-from novelwriter.types import (
-    QtAlignCenter, QtDialogClose, QtRoleAction, QtRoleReject, QtUserRole
-)
+from novelwriter.types import QtAlignCenter, QtDialogClose, QtRoleAction, QtRoleReject, QtUserRole
 
 logger = logging.getLogger(__name__)
 
@@ -327,6 +325,9 @@ class GuiManuscriptBuild(QDialog):
                 self.tr("The file already exists. Do you want to overwrite it?")
             ):
                 return False
+
+        # Make sure editor content is saved before we start
+        SHARED.mainGui.saveDocument()
 
         docBuild = NWBuildDocument(SHARED.project, self._build)
         docBuild.queueAll()

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -342,6 +342,9 @@ class GuiManuscript(QDialog):
         if not (build := self._getSelectedBuild()):
             return
 
+        # Make sure editor content is saved before we start
+        SHARED.mainGui.saveDocument()
+
         docBuild = NWBuildDocument(SHARED.project, build)
         docBuild.setPreviewMode(True)
         docBuild.queueAll()

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -752,6 +752,7 @@ class _PreviewWidget(QTextBrowser):
 
         self._docTime = 0
         self._buildName = ""
+        self._scrollPos = 0
 
         # Document Setup
         dPalette = self.palette()
@@ -848,6 +849,7 @@ class _PreviewWidget(QTextBrowser):
         self.buildProgress.setValue(0)
         self.buildProgress.setCentreText(None)
         self.buildProgress.setVisible(True)
+        self._scrollPos = self.verticalScrollBar().value()
         self.setPlaceholderText("")
         self.clear()
         return
@@ -860,7 +862,6 @@ class _PreviewWidget(QTextBrowser):
 
     def setContent(self, data: dict) -> None:
         """Set the content of the preview widget."""
-        sPos = self.verticalScrollBar().value()
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         self.buildProgress.setCentreText(self.tr("Processing ..."))
@@ -877,7 +878,6 @@ class _PreviewWidget(QTextBrowser):
             cursor = self.textCursor()
             cursor.insertText("\t")
 
-        self.verticalScrollBar().setValue(sPos)
         self._docTime = checkInt(data.get("time"), 0)
         self._updateBuildAge()
 
@@ -888,7 +888,7 @@ class _PreviewWidget(QTextBrowser):
         self.buildProgress.setCentreText(self.tr("Done"))
         QApplication.restoreOverrideCursor()
         QApplication.processEvents()
-        QTimer.singleShot(300, self._hideProgress)
+        QTimer.singleShot(300, self._postUpdate)
 
         return
 
@@ -943,9 +943,10 @@ class _PreviewWidget(QTextBrowser):
         return
 
     @pyqtSlot()
-    def _hideProgress(self) -> None:
-        """Clean up the build progress bar."""
+    def _postUpdate(self) -> None:
+        """Run tasks after content update."""
         self.buildProgress.setVisible(False)
+        self.verticalScrollBar().setValue(self._scrollPos)
         return
 
     ##

--- a/tests/test_tools/test_tools_manuscript.py
+++ b/tests/test_tools/test_tools_manuscript.py
@@ -270,7 +270,7 @@ def testManuscript_Features(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert manus.docPreview.document().defaultTextOption().alignment() == QtAlignAbsolute
 
     # Tests are too fast to trigger this one, so we trigger it manually to ensure it isn't failing
-    manus.docPreview._hideProgress()
+    manus.docPreview._postUpdate()
 
     # Builds
     # ======


### PR DESCRIPTION
**Summary:**

This PR:
* Adds a save document call before generating a build document or a preview.
* Restores the scroll bar position if a build preview is updated.

**Related Issue(s):**

Closes #1835
Closes #1837

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
