### PR TITLE
Make sure dialogs close when project closes

### DIFF
--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -26,21 +26,21 @@ from __future__ import annotations
 
 import logging
 
+from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, TypeVar
-from pathlib import Path
 
 from PyQt5.QtCore import QObject, QRunnable, QThreadPool, QTimer, pyqtSignal
 from PyQt5.QtWidgets import QFileDialog, QMessageBox, QWidget
-from novelwriter.common import formatFileFilter
 
+from novelwriter.common import formatFileFilter
 from novelwriter.constants import nwFiles
 from novelwriter.core.spellcheck import NWSpellEnchant
 
 if TYPE_CHECKING:  # pragma: no cover
-    from novelwriter.guimain import GuiMain
-    from novelwriter.gui.theme import GuiTheme
     from novelwriter.core.project import NWProject
+    from novelwriter.gui.theme import GuiTheme
+    from novelwriter.guimain import GuiMain
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +198,7 @@ class SharedData(QObject):
 
     def closeProject(self) -> None:
         """Close the current project."""
+        self._closeDialogs()
         self.project.closeProject(self._idleTime)
         self._resetProject()
         self._resetIdleTimer()
@@ -354,6 +355,17 @@ class SharedData(QObject):
         """Reset the timer data for the idle timer."""
         self._idleRefTime = time()
         self._idleTime = 0.0
+        return
+
+    def _closeDialogs(self) -> None:
+        """Close non-modal dialogs."""
+        from novelwriter.tools.manuscript import GuiManuscript
+        from novelwriter.tools.writingstats import GuiWritingStats
+
+        for widget in self.mainGui.children():
+            if isinstance(widget, (GuiManuscript, GuiWritingStats)):
+                widget.close()
+
         return
 
 # END Class SharedData

--- a/tests/test_tools/test_tools_manuscript.py
+++ b/tests/test_tools/test_tools_manuscript.py
@@ -20,18 +20,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
-import pytest
 import sys
 
 from pathlib import Path
-from pytestqt.qtbot import QtBot
+
+import pytest
 
 from mocked import causeOSError
-from tools import C, buildTestProject
-
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtPrintSupport import QPrintPreviewDialog
 from PyQt5.QtWidgets import QAction, QListWidgetItem
+from pytestqt.qtbot import QtBot
+from tools import C, buildTestProject
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwHeadFmt
@@ -81,7 +81,9 @@ def testManuscript_Init(monkeypatch, qtbot: QtBot, nwGUI: GuiMain, projPath: Pat
         manus.show()
         manus.loadContent()
         assert manus.docPreview.toPlainText().strip() == ""
-        manus.close()
+
+    nwGUI.closeProject()  # This should auto-close the manuscript tool
+    assert manus.isHidden()
 
     # qtbot.stop()
 

--- a/tests/test_tools/test_tools_manuscript.py
+++ b/tests/test_tools/test_tools_manuscript.py
@@ -26,12 +26,10 @@ from pathlib import Path
 
 import pytest
 
-from mocked import causeOSError
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtPrintSupport import QPrintPreviewDialog
 from PyQt5.QtWidgets import QAction, QListWidgetItem
 from pytestqt.qtbot import QtBot
-from tools import C, buildTestProject
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwHeadFmt
@@ -41,6 +39,9 @@ from novelwriter.tools.manusbuild import GuiManuscriptBuild
 from novelwriter.tools.manuscript import GuiManuscript
 from novelwriter.tools.manussettings import GuiBuildSettings
 from novelwriter.types import QtAlignAbsolute, QtAlignJustify, QtDialogApply, QtDialogSave
+
+from tests.mocked import causeOSError
+from tests.tools import C, buildTestProject
 
 
 @pytest.mark.gui


### PR DESCRIPTION
**Summary:**

This PR adds a check that the Manuscript and Writing Stats dialogs are not left open when a project closes.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
