### PR TITLE
Add html text-indent option for docbuild.

### DIFF
--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -97,6 +97,7 @@ SETTINGS_TEMPLATE = {
     "md.preserveBreaks":       (bool, True),
     "html.addStyles":          (bool, True),
     "html.preserveTabs":       (bool, False),
+    "html.textIndent":         (float, 0.0),
 }
 
 SETTINGS_LABELS = {
@@ -152,6 +153,7 @@ SETTINGS_LABELS = {
     "html":                   QT_TRANSLATE_NOOP("Builds", "HTML (.html)"),
     "html.addStyles":         QT_TRANSLATE_NOOP("Builds", "Add CSS Styles"),
     "html.preserveTabs":      QT_TRANSLATE_NOOP("Builds", "Preserve Tab Characters"),
+    "html.textIndent":        QT_TRANSLATE_NOOP("Builds", "Frist Line Indent"),
 }
 
 

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -342,6 +342,7 @@ class NWBuildDocument:
 
         if isinstance(bldObj, ToHtml):
             bldObj.setStyles(self._build.getBool("html.addStyles"))
+            bldObj.setTextIndent(self._build.getFloat("html.textIndent"))
             bldObj.setReplaceUnicode(self._build.getBool("format.stripUnicode"))
 
         if isinstance(bldObj, ToOdt):

--- a/novelwriter/core/tohtml.py
+++ b/novelwriter/core/tohtml.py
@@ -123,6 +123,12 @@ class ToHtml(Tokenizer):
         self._cssStyles = cssStyles
         return
 
+    def setTextIndent(self, textIndent: float) -> None:
+        """Set css text-indent value."""
+
+        self._textIndent = textIndent
+        return
+
     def setReplaceUnicode(self, doReplace: bool) -> None:
         """Set the translation map to either minimal or full unicode for
         html entities replacement.
@@ -396,13 +402,15 @@ class ToHtml(Tokenizer):
         styles.append((
             "p {{"
             "text-align: {0}; line-height: {1:d}%; "
-            "margin-top: {2:.2f}em; margin-bottom: {3:.2f}em;"
+            "margin-top: {2:.2f}em; margin-bottom: {3:.2f}em; "
+            "text-indent: {4:.1f}em;"
             "}}"
         ).format(
             "justify" if self._doJustify else "left",
             round(100 * self._lineHeight),
             mScale * self._marginText[0],
             mScale * self._marginText[1],
+            self._textIndent
         ))
         styles.append((
             "h1 {{"

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1364,6 +1364,14 @@ class _OutputTab(NScrollableForm):
         self.htmlAddStyles = NSwitch(self, height=iPx)
         self.addRow(self._build.getLabel("html.addStyles"), self.htmlAddStyles)
 
+        self.htmlTextIndent = NDoubleSpinBox(self)
+        self.htmlTextIndent.setFixedWidth(spW)
+        self.htmlTextIndent.setMinimum(0.0)
+        self.htmlTextIndent.setMaximum(8.0)
+        self.htmlTextIndent.setSingleStep(0.5)
+        self.htmlTextIndent.setDecimals(1)
+        self.addRow(self._build.getLabel("html.textIndent"), self.htmlTextIndent, unit="em")
+
         self.htmlPreserveTabs = NSwitch(self, height=iPx)
         self.addRow(self._build.getLabel("html.preserveTabs"), self.htmlPreserveTabs)
 
@@ -1386,6 +1394,7 @@ class _OutputTab(NScrollableForm):
         self.odtFirstLineIndent.setChecked(self._build.getBool("odt.firstLineIndent"))
         self.htmlAddStyles.setChecked(self._build.getBool("html.addStyles"))
         self.htmlPreserveTabs.setChecked(self._build.getBool("html.preserveTabs"))
+        self.htmlTextIndent.setValue(self._build.getFloat("html.textIndent"))
         self.mdPreserveBreaks.setChecked(self._build.getBool("md.preserveBreaks"))
         self.odtPageHeader.setCursorPosition(0)
         return
@@ -1398,6 +1407,7 @@ class _OutputTab(NScrollableForm):
         self._build.setValue("odt.firstLineIndent", self.odtFirstLineIndent.isChecked())
         self._build.setValue("html.addStyles", self.htmlAddStyles.isChecked())
         self._build.setValue("html.preserveTabs", self.htmlPreserveTabs.isChecked())
+        self._build.setValue("html.textIndent", self.htmlTextIndent.value())
         self._build.setValue("md.preserveBreaks", self.mdPreserveBreaks.isChecked())
         return
 


### PR DESCRIPTION
Just an initial PoC PR to get your opinions on.

## Rationale

- `text-indent` for 1 or 2em is the proper typesetting spec for some languages, eg. CJK. 
- This seems not easily achievable via Pandoc.

There is already an `Indent First Line` feature for odt. I'm not sure in your opinion:
1. Is this worth adding?
2. If the UI here confusing in some UX related way? (eg. Maybe this should be some sub-option for `Add Css Styles`?)

If you like the direction, we can discuss and refine the implementation a bit if necessary, then I can add tests/i18n stuff to make this a proper PR.

Cheers,
Alex 

<!--
Please check the following before you make a pull request:

* The branch you are making the pull request from (in your own fork) has a unique and descriptive
  name. Do not make a pull request directly from your copy of `main`.
* If you are submitting translation files, only submit the files that you have added translations
  to, not the other .ts files that may have been updated in the process.
* Make sure your contribution follows the style guide and other requirements mentioned in the
  CONTRIBUTING.md file in the repository.
* Fill in the Summary section below, and if relevant, mention the issue numbers related to the PR.
-->

**Summary:**

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
