### PR TITLE
Improve first line indent

### DIFF
--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -25,22 +25,22 @@ from __future__ import annotations
 
 import logging
 
-from pathlib import Path
 from collections.abc import Iterable
+from pathlib import Path
 
 from PyQt5.QtGui import QFont, QFontInfo
 
 from novelwriter import CONFIG
-from novelwriter.enum import nwBuildFmt
-from novelwriter.error import formatException, logException
 from novelwriter.constants import nwLabels
+from novelwriter.core.buildsettings import BuildSettings
 from novelwriter.core.item import NWItem
+from novelwriter.core.project import NWProject
+from novelwriter.core.tohtml import ToHtml
+from novelwriter.core.tokenizer import Tokenizer
 from novelwriter.core.tomd import ToMarkdown
 from novelwriter.core.toodt import ToOdt
-from novelwriter.core.tohtml import ToHtml
-from novelwriter.core.project import NWProject
-from novelwriter.core.tokenizer import Tokenizer
-from novelwriter.core.buildsettings import BuildSettings
+from novelwriter.enum import nwBuildFmt
+from novelwriter.error import formatException, logException
 
 logger = logging.getLogger(__name__)
 
@@ -333,6 +333,11 @@ class NWBuildDocument:
         bldObj.setFont(fontFamily, textSize, textFixed)
         bldObj.setJustify(self._build.getBool("format.justifyText"))
         bldObj.setLineHeight(self._build.getFloat("format.lineHeight"))
+        bldObj.setFirstLineIndent(
+            self._build.getBool("format.firstLineIndent"),
+            self._build.getFloat("format.firstIndentWidth"),
+            self._build.getBool("format.indentFirstPar"),
+        )
 
         bldObj.setBodyText(self._build.getBool("text.includeBodyText"))
         bldObj.setSynopsis(self._build.getBool("text.includeSynopsis"))
@@ -350,7 +355,6 @@ class NWBuildDocument:
             bldObj.setHeaderFormat(
                 self._build.getStr("odt.pageHeader"), self._build.getInt("odt.pageCountOffset")
             )
-            bldObj.setFirstLineIndent(self._build.getBool("odt.firstLineIndent"))
 
             scale = nwLabels.UNIT_SCALE.get(self._build.getStr("format.pageUnit"), 1.0)
             pW, pH = nwLabels.PAPER_SIZE.get(self._build.getStr("format.pageSize"), (-1.0, -1.0))

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -116,6 +116,7 @@ class Tokenizer(ABC):
 
     # Lookups
     L_HEADINGS = [T_TITLE, T_HEAD1, T_HEAD2, T_HEAD3, T_HEAD4]
+    L_SKIP_INDENT = [T_TITLE, T_HEAD1, T_HEAD2, T_HEAD2, T_HEAD3, T_HEAD4, T_SEP, T_SKIP]
 
     def __init__(self, project: NWProject) -> None:
 
@@ -142,7 +143,9 @@ class Tokenizer(ABC):
         self._textFixed    = False    # Fixed width text
         self._lineHeight   = 1.15     # Line height in units of em
         self._blockIndent  = 4.00     # Block indent in units of em
-        self._textIndent   = 1.40     # First line indent in units of em
+        self._firstIndent  = False    # Enable first line indent
+        self._firstWidth   = 1.40     # First line indent in units of em
+        self._indentFirst  = False    # Indent first paragraph
         self._doJustify    = False    # Justify text
         self._doBodyText   = True     # Include body text
         self._doSynopsis   = False    # Also process synopsis comments
@@ -325,6 +328,15 @@ class Tokenizer(ABC):
     def setBlockIndent(self, indent: float) -> None:
         """Set the block indent between 0.0 and 10.0."""
         self._blockIndent = min(max(float(indent), 0.0), 10.0)
+        return
+
+    def setFirstLineIndent(self, state: bool, indent: float, first: bool) -> None:
+        """Set first line indent and whether to also indent first
+        paragraph after a heading.
+        """
+        self._firstIndent = state
+        self._firstWidth = indent
+        self._indentFirst = first
         return
 
     def setJustify(self, state: bool) -> None:

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -141,7 +141,6 @@ class ToOdt(Tokenizer):
         self._textSize     = 12
         self._textFixed    = False
         self._colourHead   = False
-        self._firstIndent  = False
         self._headerFormat = ""
         self._pageOffset   = 0
 
@@ -240,11 +239,6 @@ class ToOdt(Tokenizer):
         self._pageOffset = offset
         return
 
-    def setFirstLineIndent(self, state: bool) -> None:
-        """Enable or disable first line indent."""
-        self._firstIndent = state
-        return
-
     ##
     #  Class Methods
     ##
@@ -301,7 +295,7 @@ class ToOdt(Tokenizer):
 
         self._fLineHeight  = f"{round(100 * self._lineHeight):d}%"
         self._fBlockIndent = self._emToCm(self._blockIndent)
-        self._fTextIndent  = self._emToCm(self._textIndent)
+        self._fTextIndent  = self._emToCm(self._firstWidth)
         self._textAlign    = "justify" if self._doJustify else "left"
 
         # Clear Errors
@@ -447,7 +441,7 @@ class ToOdt(Tokenizer):
                 if tStyle & self.A_IND_R:
                     oStyle.setMarginRight(self._fBlockIndent)
 
-            if tType not in (self.T_EMPTY, self.T_TEXT):
+            if not self._indentFirst and tType in self.L_SKIP_INDENT:
                 pIndent = False
 
             # Process Text Types

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1113,6 +1113,25 @@ class _FormatTab(NScrollableForm):
         self.addRow(self._build.getLabel("format.stripUnicode"), self.stripUnicode)
         self.addRow(self._build.getLabel("format.replaceTabs"), self.replaceTabs)
 
+        # First Line Indent
+        # =================
+
+        self.addGroupLabel(self._build.getLabel("format.grpParIndent"))
+
+        self.firstIndent = NSwitch(self, height=iPx)
+        self.indentFirstPar = NSwitch(self, height=iPx)
+
+        self.indentWidth = NDoubleSpinBox(self)
+        self.indentWidth.setFixedWidth(spW)
+        self.indentWidth.setMinimum(0.1)
+        self.indentWidth.setMaximum(9.9)
+        self.indentWidth.setSingleStep(0.1)
+        self.indentWidth.setDecimals(1)
+
+        self.addRow(self._build.getLabel("format.firstLineIndent"), self.firstIndent)
+        self.addRow(self._build.getLabel("format.firstIndentWidth"), self.indentWidth, unit="em")
+        self.addRow(self._build.getLabel("format.indentFirstPar"), self.indentFirstPar)
+
         # Page Layout
         # ===========
 
@@ -1176,6 +1195,10 @@ class _FormatTab(NScrollableForm):
         self.stripUnicode.setChecked(self._build.getBool("format.stripUnicode"))
         self.replaceTabs.setChecked(self._build.getBool("format.replaceTabs"))
 
+        self.firstIndent.setChecked(self._build.getBool("format.firstLineIndent"))
+        self.indentWidth.setValue(self._build.getFloat("format.firstIndentWidth"))
+        self.indentFirstPar.setChecked(self._build.getBool("format.indentFirstPar"))
+
         pageUnit = self._build.getStr("format.pageUnit")
         index = self.pageUnit.findData(pageUnit)
         if index >= 0:
@@ -1210,6 +1233,10 @@ class _FormatTab(NScrollableForm):
         self._build.setValue("format.justifyText", self.justifyText.isChecked())
         self._build.setValue("format.stripUnicode", self.stripUnicode.isChecked())
         self._build.setValue("format.replaceTabs", self.replaceTabs.isChecked())
+
+        self._build.setValue("format.firstLineIndent", self.firstIndent.isChecked())
+        self._build.setValue("format.firstIndentWidth", self.indentWidth.value())
+        self._build.setValue("format.indentFirstPar", self.indentFirstPar.isChecked())
 
         self._build.setValue("format.pageUnit", str(self.pageUnit.currentData()))
         self._build.setValue("format.pageSize", str(self.pageSize.currentData()))
@@ -1355,9 +1382,6 @@ class _OutputTab(NScrollableForm):
         self.odtPageCountOffset.setMinimumWidth(spW)
         self.addRow(self._build.getLabel("odt.pageCountOffset"), self.odtPageCountOffset)
 
-        self.odtFirstLineIndent = NSwitch(self, height=iPx)
-        self.addRow(self._build.getLabel("odt.firstLineIndent"), self.odtFirstLineIndent)
-
         # HTML Document
         self.addGroupLabel(self._build.getLabel("html"))
 
@@ -1383,7 +1407,6 @@ class _OutputTab(NScrollableForm):
         self.odtAddColours.setChecked(self._build.getBool("odt.addColours"))
         self.odtPageHeader.setText(self._build.getStr("odt.pageHeader"))
         self.odtPageCountOffset.setValue(self._build.getInt("odt.pageCountOffset"))
-        self.odtFirstLineIndent.setChecked(self._build.getBool("odt.firstLineIndent"))
         self.htmlAddStyles.setChecked(self._build.getBool("html.addStyles"))
         self.htmlPreserveTabs.setChecked(self._build.getBool("html.preserveTabs"))
         self.mdPreserveBreaks.setChecked(self._build.getBool("md.preserveBreaks"))
@@ -1395,7 +1418,6 @@ class _OutputTab(NScrollableForm):
         self._build.setValue("odt.addColours", self.odtAddColours.isChecked())
         self._build.setValue("odt.pageHeader", self.odtPageHeader.text())
         self._build.setValue("odt.pageCountOffset", self.odtPageCountOffset.value())
-        self._build.setValue("odt.firstLineIndent", self.odtFirstLineIndent.isChecked())
         self._build.setValue("html.addStyles", self.htmlAddStyles.isChecked())
         self._build.setValue("html.preserveTabs", self.htmlPreserveTabs.isChecked())
         self._build.setValue("md.preserveBreaks", self.mdPreserveBreaks.isChecked())

--- a/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
+++ b/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2024-04-27T16:43:44</meta:creation-date>
-    <meta:generator>novelWriter/2.5a2</meta:generator>
+    <meta:creation-date>2024-05-10T15:23:56</meta:creation-date>
+    <meta:generator>novelWriter/2.5a3</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
     <meta:editing-cycles>45</meta:editing-cycles>
     <meta:editing-duration>P0DT0H36M8S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2024-04-27T16:43:44</dc:date>
+    <dc:date>2024-05-10T15:23:56</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -121,7 +121,7 @@
       <text:p text:style-name="P1">“Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit…”</text:p>
       <text:p text:style-name="P1">“There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain…”</text:p>
       <text:p text:style-name="P2"><text:span text:style-name="T1">Comment:</text:span> Exctracted from the lipsum.com website.</text:p>
-      <text:p text:style-name="Text_20_body">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of “de Finibus Bonorum et Malorum” (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, “Lorem ipsum dolor sit amet..”, comes from a line in section 1.10.32.</text:p>
+      <text:p text:style-name="First_20_line_20_indent">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of “de Finibus Bonorum et Malorum” (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, “Lorem ipsum dolor sit amet..”, comes from a line in section 1.10.32.</text:p>
       <text:p text:style-name="First_20_line_20_indent">The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from “de Finibus Bonorum et Malorum” by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.</text:p>
       <text:h text:style-name="P3" text:outline-level="2">Prologue</text:h>
       <text:p text:style-name="Text_20_Meta"><text:span text:style-name="T1">Synopsis:</text:span> Explanation from the lipsum.com website.</text:p>

--- a/tests/test_core/test_core_docbuild.py
+++ b/tests/test_core/test_core_docbuild.py
@@ -21,21 +21,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
 import json
+
+from pathlib import Path
+from shutil import copyfile
+
 import pytest
 
-from shutil import copyfile
-from pathlib import Path
-
-from tools import C, ODT_IGNORE, buildTestProject, cmpFiles
-from mocked import causeException, causeOSError
-
-from novelwriter.enum import nwBuildFmt
+from novelwriter.core.buildsettings import BuildSettings
+from novelwriter.core.docbuild import NWBuildDocument
+from novelwriter.core.project import NWProject
+from novelwriter.core.tohtml import ToHtml
 from novelwriter.core.tomd import ToMarkdown
 from novelwriter.core.toodt import ToOdt
-from novelwriter.core.tohtml import ToHtml
-from novelwriter.core.project import NWProject
-from novelwriter.core.docbuild import NWBuildDocument
-from novelwriter.core.buildsettings import BuildSettings
+from novelwriter.enum import nwBuildFmt
+
+from tests.mocked import causeException, causeOSError
+from tests.tools import ODT_IGNORE, C, buildTestProject, cmpFiles
 
 BUILD_CONF = {
     "name": "Test Build",
@@ -63,8 +64,8 @@ BUILD_CONF = {
         "format.justifyText": True,
         "format.stripUnicode": False,
         "format.replaceTabs": True,
+        "format.firstLineIndent": True,
         "odt.addColours": True,
-        "odt.firstLineIndent": True,
         "html.addStyles": True,
     },
     "content": {

--- a/tests/test_core/test_core_toodt.py
+++ b/tests/test_core/test_core_toodt.py
@@ -753,8 +753,10 @@ def testCoreToOdt_SaveFlat(mockGUI, fncPath, tstPaths):
     assert odt._colourHead is True
     odt.setHeaderFormat(nwHeadFmt.ODT_AUTO, 1)
     assert odt._headerFormat == nwHeadFmt.ODT_AUTO
-    odt.setFirstLineIndent(True)
+    odt.setFirstLineIndent(True, 1.4, False)
     assert odt._firstIndent is True
+    assert odt._fTextIndent == "0.499cm"
+    assert odt._indentFirst is False
 
     odt.setPageLayout(148, 210, 20, 18, 17, 15)
     assert odt._mDocWidth  == "14.800cm"


### PR DESCRIPTION
**Summary:**

This PR:
* Fixes an issue with first line indent after comments.
* Adds settings to customise how the first line indent works,
* Moves the first line indent settings to the Format tab so it can be applied to more than just ODT documents.

**Related Issue(s):**

Closes #1852

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
