### PR TITLE
Fix manuscript tool font issue

### DIFF
--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -836,7 +836,7 @@ class _PreviewWidget(QTextBrowser):
             font = QFont()
             font.setFamily(family)
             font.setPointSize(size)
-            self.setFont(font)
+            self.document().setDefaultFont(font)
         return
 
     ##


### PR DESCRIPTION
**Summary:**

The manuscript tool should only use the document font for the document itself, not the header.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
