### PR TITLE
Fix syntax highlighter init

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -301,8 +301,6 @@ class GuiDocEditor(QPlainTextEdit):
         self.docHeader.matchColours()
         self.docFooter.matchColours()
 
-        self._qDocument.syntaxHighlighter.initHighlighter()
-
         return
 
     def initEditor(self) -> None:
@@ -335,6 +333,9 @@ class GuiDocEditor(QPlainTextEdit):
         font.setFamily(CONFIG.textFont)
         font.setPointSize(CONFIG.textSize)
         self._qDocument.setDefaultFont(font)
+
+        # Update highlighter settings
+        self._qDocument.syntaxHighlighter.initHighlighter()
 
         # Set default text margins
         # Due to cursor visibility, a part of the margin must be


### PR DESCRIPTION
**Summary:**

Make sure syntax highlighter is initialised when the editor is.

**Related Issue(s):**

Closes #1865

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
