### PR TITLE
Fix bug in dictionaries install tool

### DIFF
--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -36,7 +36,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import formatFileFilter, openExternalPath, formatInt, getFileSize
+from novelwriter.common import formatFileFilter, formatInt, getFileSize, openExternalPath
 from novelwriter.error import formatException
 from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.types import QtDialogClose
@@ -143,11 +143,12 @@ class GuiDictionaries(QDialog):
         try:
             import enchant
             path = Path(enchant.get_user_config_dir())
+            self._installPath = Path(path).resolve()
+            self._installPath.mkdir(exist_ok=True, parents=True)
         except Exception:
             logger.error("Could not get enchant path")
             return False
 
-        self._installPath = Path(path).resolve()
         if path.is_dir():
             self.inPath.setText(str(path))
             hunspell = path / "hunspell"
@@ -199,9 +200,9 @@ class GuiDictionaries(QDialog):
         if self._installPath:
             temp = self.huInput.text()
             if temp and (path := Path(temp)).is_file():
-                hunspell = self._installPath / "hunspell"
-                hunspell.mkdir(exist_ok=True)
                 try:
+                    hunspell = self._installPath / "hunspell"
+                    hunspell.mkdir(exist_ok=True)
                     nAff, nDic = self._extractDicts(path, hunspell)
                     if nAff == 0 or nDic == 0:
                         self._appendLog(procErr, err=True)

--- a/tests/test_tools/test_tools_dictionaries.py
+++ b/tests/test_tools/test_tools_dictionaries.py
@@ -20,12 +20,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
-import pytest
-import enchant
-
 from zipfile import ZipFile
 
-from mocked import causeException
+import enchant
+import pytest
 
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import QFileDialog
@@ -33,11 +31,15 @@ from PyQt5.QtWidgets import QFileDialog
 from novelwriter import SHARED
 from novelwriter.tools.dictionaries import GuiDictionaries
 
+from tests.mocked import causeException
+
 
 @pytest.mark.gui
 def testToolDictionaries_Main(qtbot, monkeypatch, nwGUI, fncPath):
     """Test the Dictionaries downloader tool."""
-    monkeypatch.setattr(enchant, "get_user_config_dir", lambda *a: str(fncPath))
+    # Must also create the enchant folder, see issue #1874
+    enchPath = fncPath / "enchant"
+    monkeypatch.setattr(enchant, "get_user_config_dir", lambda *a: str(enchPath))
 
     # Fail to open
     with monkeypatch.context() as mp:
@@ -52,7 +54,7 @@ def testToolDictionaries_Main(qtbot, monkeypatch, nwGUI, fncPath):
     nwDicts = SHARED.findTopLevelWidget(GuiDictionaries)
     assert isinstance(nwDicts, GuiDictionaries)
     assert nwDicts.isVisible()
-    assert nwDicts.inPath.text() == str(fncPath)
+    assert nwDicts.inPath.text() == str(enchPath)
 
     # Allow Open Dir
     SHARED._lastAlert = ""
@@ -98,9 +100,9 @@ def testToolDictionaries_Main(qtbot, monkeypatch, nwGUI, fncPath):
         nwDicts._doBrowseHunspell()
         assert nwDicts.huInput.text() == str(foDict)
         nwDicts._doImportHunspell()
-        assert (fncPath / "hunspell").is_dir()
-        assert (fncPath / "hunspell" / "en_GB.aff").is_file()
-        assert (fncPath / "hunspell" / "en_GB.dic").is_file()
+        assert (enchPath / "hunspell").is_dir()
+        assert (enchPath / "hunspell" / "en_GB.aff").is_file()
+        assert (enchPath / "hunspell" / "en_GB.dic").is_file()
         assert nwDicts.infoBox.blockCount() == 3
 
     # Import Libre Office Dictionary
@@ -109,9 +111,9 @@ def testToolDictionaries_Main(qtbot, monkeypatch, nwGUI, fncPath):
         nwDicts._doBrowseHunspell()
         assert nwDicts.huInput.text() == str(loDict)
         nwDicts._doImportHunspell()
-        assert (fncPath / "hunspell").is_dir()
-        assert (fncPath / "hunspell" / "en_US.aff").is_file()
-        assert (fncPath / "hunspell" / "en_US.dic").is_file()
+        assert (enchPath / "hunspell").is_dir()
+        assert (enchPath / "hunspell" / "en_US.aff").is_file()
+        assert (enchPath / "hunspell" / "en_US.dic").is_file()
         assert nwDicts.infoBox.blockCount() == 5
 
     # Handle Unreadable File


### PR DESCRIPTION
**Summary:**

This PR fixes a bug where the enchant config dir returned by the enchant package does not exist by default, causing a crash when trying to install additional spell check dictionaries.

**Related Issue(s):**

Closes #1874

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
