### PR TITLE
Add error text colur setting to theme

### DIFF
--- a/docs/source/more_customise.rst
+++ b/docs/source/more_customise.rst
@@ -131,9 +131,11 @@ A GUI theme ``.conf`` file consists of the following settings:
    linkvisited     = 100, 100, 100
 
    [GUI]
-   statusnone      = 100, 100, 100
-   statussaved     = 100, 100, 100
-   statusunsaved   = 100, 100, 100
+   helptext        =   0,   0,   0
+   errortext       = 255,   0,   0
+   statusnone      = 120, 120, 120
+   statussaved     =   2, 133,  37
+   statusunsaved   = 200,  15,  39
 
 In the Main section you must at least define the ``name`` and ``icontheme`` settings. The
 ``icontheme`` settings should correspond to one of the internal icon themes, either
@@ -143,7 +145,11 @@ setting must match the icon theme's folder name.
 The Palette values correspond to the Qt enum values for ``QPalette::ColorRole``, see the
 `Qt documentation <https://doc.qt.io/qt-5.15/qpalette.html#ColorRole-enum>`_ for more details. The
 colour values are RGB numbers on the format ``r, g, b`` where each is an integer from ``0`` to
-``255``. Omitted values are not loaded and will use default values.
+``255``. Omitted values are not loaded and will use default values. If the ``helptext`` colour is
+not defined, it is computed as a colour between the ``window`` and ``windowtext`` colour.
+
+.. versionadded:: 2.5
+   The ``errortext`` theme colour entry was added.
 
 
 Custom Syntax Theme

--- a/novelwriter/assets/themes/cyberpunk_night.conf
+++ b/novelwriter/assets/themes/cyberpunk_night.conf
@@ -24,6 +24,8 @@ link            =  77,  77, 255
 linkvisited     =  50,   0,  80
 
 [GUI]
+helptext        =  97,  97,  97
+errortext       = 255,  77,  77
 statusnone      =  50,  50,  50
 statussaved     =  77, 255,  77
 statusunsaved   = 255,  77,  77

--- a/novelwriter/assets/themes/default_dark.conf
+++ b/novelwriter/assets/themes/default_dark.conf
@@ -26,6 +26,7 @@ linkvisited     = 102, 153, 204
 
 [GUI]
 helptext        = 164, 164, 164
+errortext       = 255, 164, 164
 statusnone      = 150, 152, 150
 statussaved     =  39, 135,  78
 statusunsaved   = 138,  32,  32

--- a/novelwriter/assets/themes/default_light.conf
+++ b/novelwriter/assets/themes/default_light.conf
@@ -26,6 +26,7 @@ linkvisited     =  66, 113, 174
 
 [GUI]
 helptext        =  92,  92,  92
+errortext       = 255,  92,  92
 statusnone      = 120, 120, 120
 statussaved     = 200,  15,  39
 statusunsaved   =   2, 133,  37

--- a/novelwriter/assets/themes/dracula.conf
+++ b/novelwriter/assets/themes/dracula.conf
@@ -41,6 +41,7 @@ linkvisited     = 139, 233, 253
 
 [GUI]
 helptext        = 204, 172, 249
+errortext       = 255,  85,  85
 statusnone      =  98, 114, 164
 statussaved     =  80, 250, 123
 statusunsaved   = 255,  85,  85

--- a/novelwriter/assets/themes/solarized_dark.conf
+++ b/novelwriter/assets/themes/solarized_dark.conf
@@ -25,6 +25,7 @@ linkvisited     =  38, 139, 210
 
 [GUI]
 helptext        = 166, 161, 149
+errortext       = 255, 161, 149
 statusnone      =  88, 110, 117
 statussaved     =  42, 161, 152
 statusunsaved   = 203,  75,  22

--- a/novelwriter/assets/themes/solarized_light.conf
+++ b/novelwriter/assets/themes/solarized_light.conf
@@ -25,6 +25,7 @@ linkvisited     =  38, 139, 210
 
 [GUI]
 helptext        =  78,  91,  95
+errortext       = 255,  91,  95
 statusnone      =  88, 110, 117
 statussaved     =  42, 161, 152
 statusunsaved   = 203,  75,  22

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -284,6 +284,10 @@ class GuiTheme:
             else:
                 helpLCol = backLNess + 0.65*(textLNess - backLNess)
             self.helpText = QColor.fromHsl(0, 0, int(255*helpLCol))
+            logger.debug(
+                "Computed help text colour: rgb(%d, %d, %d)",
+                self.helpText.red(), self.helpText.green(), self.helpText.blue()
+            )
 
         # Icons
         defaultIcons = "typicons_light" if backLNess >= 0.5 else "typicons_dark"

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -75,6 +75,7 @@ class GuiTheme:
         self.statUnsaved = QColor(0, 0, 0)
         self.statSaved   = QColor(0, 0, 0)
         self.helpText    = QColor(0, 0, 0)
+        self.errorText   = QColor(255, 0, 0)
 
         # Loaded Syntax Settings
         # ======================
@@ -265,6 +266,7 @@ class GuiTheme:
         sec = "GUI"
         if parser.has_section(sec):
             self.helpText    = self._parseColour(parser, sec, "helptext")
+            self.errorText   = self._parseColour(parser, sec, "errortext")
             self.statNone    = self._parseColour(parser, sec, "statusnone")
             self.statUnsaved = self._parseColour(parser, sec, "statusunsaved")
             self.statSaved   = self._parseColour(parser, sec, "statussaved")
@@ -402,6 +404,7 @@ class GuiTheme:
         self.statUnsaved = QColor(200, 15, 39)
         self.statSaved   = QColor(2, 133, 37)
         self.helpText    = QColor(0, 0, 0)
+        self.errorText   = QColor(255, 0, 0)
         return
 
     def _setGuiFont(self) -> None:

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -36,7 +36,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import formatFileFilter, formatInt, getFileSize, openExternalPath
+from novelwriter.common import cssCol, formatFileFilter, formatInt, getFileSize, openExternalPath
 from novelwriter.error import formatException
 from novelwriter.extensions.modified import NIconToolButton, NNonBlockingDialog
 from novelwriter.types import QtDialogClose
@@ -186,7 +186,7 @@ class GuiDictionaries(NNonBlockingDialog):
             (self.tr("Free or Libre Office extension"), "*.sox *.oxt"), "*"
         ])
         soxFile, _ = QFileDialog.getOpenFileName(
-            self, self.tr("Browse Files"), "", filter=ffilter
+            self, self.tr("Browse Files"), str(CONFIG.homePath()), filter=ffilter
         )
         if soxFile:
             path = Path(soxFile).absolute()
@@ -257,10 +257,8 @@ class GuiDictionaries(NNonBlockingDialog):
         cursor.movePosition(QTextCursor.MoveOperation.End)
         if cursor.position() > 0:
             cursor.insertText("\n")
-        if err:
-            cursor.insertHtml(f"<font color='red'>{text}</font>")
-        else:
-            cursor.insertText(text)
+        textCol = cssCol(SHARED.theme.errorText if err else self.palette().text().color())
+        cursor.insertHtml(f"<font style='color: {textCol}'>{text}</font>")
         cursor.movePosition(QTextCursor.MoveOperation.End)
         cursor.deleteChar()
         self.infoBox.setTextCursor(cursor)


### PR DESCRIPTION
**Summary:**

This PR adds a new error text colour setting to the themes definition. This is used to fix an issue with the dictionary install tool.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
