### PR TITLE
Allow full font style settings for GUI and editor

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -241,5 +241,3 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
         nwGUI.postLaunchTasks(cmdOpen)
 
         sys.exit(nwApp.exec())
-
-    return None

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -235,7 +235,6 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
         # Run Config steps that require the QApplication
         CONFIG.loadConfig()
         CONFIG.initLocalisation(nwApp)
-        CONFIG.setTextFont(CONFIG.textFont, CONFIG.textSize)  # Makes sure these are valid
 
         # Launch main GUI
         nwGUI = GuiMain()

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -217,6 +217,7 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     # Import GUI (after dependency checks), and launch
     from novelwriter.guimain import GuiMain
     if testMode:
+        CONFIG.loadConfig()
         nwGUI = GuiMain()
         return nwGUI
 
@@ -232,6 +233,7 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
         sys.excepthook = exceptionHandler
 
         # Run Config steps that require the QApplication
+        CONFIG.loadConfig()
         CONFIG.initLocalisation(nwApp)
         CONFIG.setTextFont(CONFIG.textFont, CONFIG.textSize)  # Makes sure these are valid
 

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -216,28 +216,28 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
 
     # Import GUI (after dependency checks), and launch
     from novelwriter.guimain import GuiMain
+
     if testMode:
+        # Only used for testing where the test framework creates the app
         CONFIG.loadConfig()
-        nwGUI = GuiMain()
-        return nwGUI
+        return GuiMain()
 
-    else:
-        nwApp = QApplication([CONFIG.appName, (f"-style={qtStyle}")])
-        nwApp.setApplicationName(CONFIG.appName)
-        nwApp.setApplicationVersion(__version__)
-        nwApp.setOrganizationDomain(__domain__)
-        nwApp.setOrganizationName(__domain__)
-        nwApp.setDesktopFileName(CONFIG.appName)
+    app = QApplication([CONFIG.appName, (f"-style={qtStyle}")])
+    app.setApplicationName(CONFIG.appName)
+    app.setApplicationVersion(__version__)
+    app.setOrganizationDomain(__domain__)
+    app.setOrganizationName(__domain__)
+    app.setDesktopFileName(CONFIG.appName)
 
-        # Connect the exception handler before making the main GUI
-        sys.excepthook = exceptionHandler
+    # Connect the exception handler before making the main GUI
+    sys.excepthook = exceptionHandler
 
-        # Run Config steps that require the QApplication
-        CONFIG.loadConfig()
-        CONFIG.initLocalisation(nwApp)
+    # Run Config steps that require the QApplication
+    CONFIG.loadConfig()
+    CONFIG.initLocalisation(app)
 
-        # Launch main GUI
-        nwGUI = GuiMain()
-        nwGUI.postLaunchTasks(cmdOpen)
+    # Launch main GUI
+    nwGUI = GuiMain()
+    nwGUI.postLaunchTasks(cmdOpen)
 
-        sys.exit(nwApp.exec())
+    sys.exit(app.exec())

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -37,7 +37,7 @@ from urllib.parse import urljoin
 from urllib.request import pathname2url
 
 from PyQt5.QtCore import QCoreApplication, QUrl
-from PyQt5.QtGui import QColor, QDesktopServices
+from PyQt5.QtGui import QColor, QDesktopServices, QFont, QFontInfo
 
 from novelwriter.constants import nwConst, nwLabels, nwUnicode, trConst
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
@@ -399,6 +399,14 @@ def numberToRoman(value: int, toLower: bool = False) -> str:
 def cssCol(col: QColor, alpha: int | None = None) -> str:
     """Convert a QColor object to an rgba entry to use in CSS."""
     return f"rgba({col.red()}, {col.green()}, {col.blue()}, {alpha or col.alpha()})"
+
+
+def describeFont(font: QFont) -> str:
+    """Describe a font in a way that can be displayed on the GUI."""
+    if isinstance(font, QFont):
+        info = QFontInfo(font)
+        return f"{font.family()} {info.styleName()} @ {font.pointSize()} pt"
+    return "Error"
 
 
 ##

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -131,43 +131,42 @@ class Config:
         self.askBeforeBackup = True   # Flag for asking before running automatic backup
 
         # Text Editor Settings
-        self.textFont        = ""     # Editor font
-        self.textSize        = 12     # Editor font size
-        self.textWidth       = 700    # Editor text width
-        self.textMargin      = 40     # Editor/viewer text margin
-        self.tabWidth        = 40     # Editor tabulator width
+        self.textFont        = QFont()  # Editor font
+        self.textWidth       = 700      # Editor text width
+        self.textMargin      = 40       # Editor/viewer text margin
+        self.tabWidth        = 40       # Editor tabulator width
 
-        self.focusWidth      = 800    # Focus Mode text width
-        self.hideFocusFooter = False  # Hide document footer in Focus Mode
-        self.showFullPath    = True   # Show full document path in editor header
-        self.autoSelect      = True   # Auto-select word when applying format with no selection
+        self.focusWidth      = 800      # Focus Mode text width
+        self.hideFocusFooter = False    # Hide document footer in Focus Mode
+        self.showFullPath    = True     # Show full document path in editor header
+        self.autoSelect      = True     # Auto-select word when applying format with no selection
 
-        self.doJustify       = False  # Justify text
-        self.showTabsNSpaces = False  # Show tabs and spaces in editor
-        self.showLineEndings = False  # Show line endings in editor
-        self.showMultiSpaces = True   # Highlight multiple spaces in the text
+        self.doJustify       = False    # Justify text
+        self.showTabsNSpaces = False    # Show tabs and spaces in editor
+        self.showLineEndings = False    # Show line endings in editor
+        self.showMultiSpaces = True     # Highlight multiple spaces in the text
 
-        self.doReplace       = True   # Enable auto-replace as you type
-        self.doReplaceSQuote = True   # Smart single quotes
-        self.doReplaceDQuote = True   # Smart double quotes
-        self.doReplaceDash   = True   # Replace multiple hyphens with dashes
-        self.doReplaceDots   = True   # Replace three dots with ellipsis
+        self.doReplace       = True     # Enable auto-replace as you type
+        self.doReplaceSQuote = True     # Smart single quotes
+        self.doReplaceDQuote = True     # Smart double quotes
+        self.doReplaceDash   = True     # Replace multiple hyphens with dashes
+        self.doReplaceDots   = True     # Replace three dots with ellipsis
 
-        self.autoScroll      = False  # Typewriter-like scrolling
-        self.autoScrollPos   = 30     # Start point for typewriter-like scrolling
-        self.scrollPastEnd   = True   # Scroll past end of document, and centre cursor
+        self.autoScroll      = False    # Typewriter-like scrolling
+        self.autoScrollPos   = 30       # Start point for typewriter-like scrolling
+        self.scrollPastEnd   = True     # Scroll past end of document, and centre cursor
 
-        self.dialogStyle     = 2      # Quote type to use for dialogue
-        self.allowOpenDial   = True   # Allow open-ended dialogue quotes
-        self.narratorBreak   = ""     # Symbol to use for narrator break
-        self.dialogLine      = ""     # Symbol to use for dialogue line
-        self.altDialogOpen   = ""     # Alternative dialog symbol, open
-        self.altDialogClose  = ""     # Alternative dialog symbol, close
-        self.highlightEmph   = True   # Add colour to text emphasis
+        self.dialogStyle     = 2        # Quote type to use for dialogue
+        self.allowOpenDial   = True     # Allow open-ended dialogue quotes
+        self.narratorBreak   = ""       # Symbol to use for narrator break
+        self.dialogLine      = ""       # Symbol to use for dialogue line
+        self.altDialogOpen   = ""       # Alternative dialog symbol, open
+        self.altDialogClose  = ""       # Alternative dialog symbol, close
+        self.highlightEmph   = True     # Add colour to text emphasis
 
-        self.stopWhenIdle    = True   # Stop the status bar clock when the user is idle
-        self.userIdleTime    = 300    # Time of inactivity to consider user idle
-        self.incNotesWCount  = True   # The status bar word count includes notes
+        self.stopWhenIdle    = True     # Stop the status bar clock when the user is idle
+        self.userIdleTime    = 300      # Time of inactivity to consider user idle
+        self.incNotesWCount  = True     # The status bar word count includes notes
 
         # User-Selected Symbol Settings
         self.fmtApostrophe   = nwUnicode.U_RSQUO
@@ -383,23 +382,28 @@ class Config:
 
         return
 
-    def setTextFont(self, family: str | None, pointSize: int = 12) -> None:
+    def setTextFont(self, value: QFont | str | None) -> None:
         """Set the text font if it exists. If it doesn't, or is None,
         set to default font.
         """
-        fontDB = QFontDatabase()
-        fontFam = fontDB.families()
-        self.textSize = pointSize
-        if family is None or family not in fontFam:
-            logger.warning("Unknown font '%s'", family)
-            if self.osWindows and "Arial" in fontFam:
-                self.textFont = "Arial"
-            elif self.osDarwin and "Helvetica" in fontFam:
-                self.textFont = "Helvetica"
-            else:
-                self.textFont = fontDB.systemFont(QFontDatabase.SystemFont.GeneralFont).family()
+        if isinstance(value, QFont):
+            self.textFont = value
+        elif value and isinstance(value, str):
+            self.textFont = QFont()
+            self.textFont.fromString(value)
         else:
-            self.textFont = family
+            font = QFont()
+            fontDB = QFontDatabase()
+            fontFam = fontDB.families()
+            if self.osWindows and "Arial" in fontFam:
+                font.setFamily("Arial")
+                font.setPointSize(12)
+            elif self.osDarwin and "Helvetica" in fontFam:
+                font.setFamily("Helvetica")
+                font.setPointSize(12)
+            else:
+                font = fontDB.systemFont(QFontDatabase.SystemFont.GeneralFont)
+            self.textFont = font
         return
 
     ##
@@ -585,19 +589,17 @@ class Config:
         sec = "Main"
         self.guiTheme     = conf.rdStr(sec, "theme", self.guiTheme)
         self.guiSyntax    = conf.rdStr(sec, "syntax", self.guiSyntax)
-        guiFont           = conf.rdStr(sec, "guifont", "")
+        guiFont           = conf.rdStr(sec, "font", "")
         self.guiLocale    = conf.rdStr(sec, "localisation", self.guiLocale)
         self.hideVScroll  = conf.rdBool(sec, "hidevscroll", self.hideVScroll)
         self.hideHScroll  = conf.rdBool(sec, "hidehscroll", self.hideHScroll)
         self.lastNotes    = conf.rdStr(sec, "lastnotes", self.lastNotes)
         self._lastPath    = conf.rdPath(sec, "lastpath", self._lastPath)
 
-        # If we have an old config file with the following settings, use those instead
-        legacyFont = conf.rdStr(sec, "font", "")
-        legacySize = conf.rdInt(sec, "fontsize", 11)
-        if legacyFont:
-            guiFont = QFont()
-            guiFont.fromString(f"{legacyFont},{legacySize}")
+        # If we have an old config file, we have an explicit font size,
+        # in which case we convert the old settings.
+        if fontSize := conf.rdInt(sec, "fontsize", 0):
+            guiFont = f"{guiFont},{fontSize}"
 
         self.setGuiFont(guiFont)
 
@@ -621,8 +623,7 @@ class Config:
 
         # Editor
         sec = "Editor"
-        self.textFont        = conf.rdStr(sec, "textfont", self.textFont)
-        self.textSize        = conf.rdInt(sec, "textsize", self.textSize)
+        textFont             = conf.rdStr(sec, "textfont", "")
         self.textWidth       = conf.rdInt(sec, "width", self.textWidth)
         self.textMargin      = conf.rdInt(sec, "margin", self.textMargin)
         self.tabWidth        = conf.rdInt(sec, "tabwidth", self.tabWidth)
@@ -660,6 +661,13 @@ class Config:
         self.highlightEmph   = conf.rdBool(sec, "highlightemph", self.highlightEmph)
         self.stopWhenIdle    = conf.rdBool(sec, "stopwhenidle", self.stopWhenIdle)
         self.userIdleTime    = conf.rdInt(sec, "useridletime", self.userIdleTime)
+
+        # If we have an old config file, we have an explicit font size,
+        # in which case we convert the old settings.
+        if textSize := conf.rdInt(sec, "textsize", 0):
+            textFont = f"{textFont},{textSize}"
+
+        self.setTextFont(textFont)
 
         # State
         sec = "State"
@@ -731,8 +739,7 @@ class Config:
         }
 
         conf["Editor"] = {
-            "textfont":        str(self.textFont),
-            "textsize":        str(self.textSize),
+            "textfont":        str(self.textFont.toString()),
             "width":           str(self.textWidth),
             "margin":          str(self.textMargin),
             "tabwidth":        str(self.tabWidth),

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -392,13 +392,14 @@ class Config:
             self.textFont = QFont()
             self.textFont.fromString(value)
         else:
-            font = QFont()
             fontDB = QFontDatabase()
             fontFam = fontDB.families()
             if self.osWindows and "Arial" in fontFam:
+                font = QFont()
                 font.setFamily("Arial")
                 font.setPointSize(12)
             elif self.osDarwin and "Helvetica" in fontFam:
+                font = QFont()
                 font.setFamily("Helvetica")
                 font.setPointSize(12)
             else:
@@ -587,21 +588,14 @@ class Config:
 
         # Main
         sec = "Main"
-        self.guiTheme     = conf.rdStr(sec, "theme", self.guiTheme)
-        self.guiSyntax    = conf.rdStr(sec, "syntax", self.guiSyntax)
-        guiFont           = conf.rdStr(sec, "font", "")
-        self.guiLocale    = conf.rdStr(sec, "localisation", self.guiLocale)
-        self.hideVScroll  = conf.rdBool(sec, "hidevscroll", self.hideVScroll)
-        self.hideHScroll  = conf.rdBool(sec, "hidehscroll", self.hideHScroll)
-        self.lastNotes    = conf.rdStr(sec, "lastnotes", self.lastNotes)
-        self._lastPath    = conf.rdPath(sec, "lastpath", self._lastPath)
-
-        # If we have an old config file, we have an explicit font size,
-        # in which case we convert the old settings.
-        if fontSize := conf.rdInt(sec, "fontsize", 0):
-            guiFont = f"{guiFont},{fontSize}"
-
-        self.setGuiFont(guiFont)
+        self.setGuiFont(conf.rdStr(sec, "font", ""))
+        self.guiTheme    = conf.rdStr(sec, "theme", self.guiTheme)
+        self.guiSyntax   = conf.rdStr(sec, "syntax", self.guiSyntax)
+        self.guiLocale   = conf.rdStr(sec, "localisation", self.guiLocale)
+        self.hideVScroll = conf.rdBool(sec, "hidevscroll", self.hideVScroll)
+        self.hideHScroll = conf.rdBool(sec, "hidehscroll", self.hideHScroll)
+        self.lastNotes   = conf.rdStr(sec, "lastnotes", self.lastNotes)
+        self._lastPath   = conf.rdPath(sec, "lastpath", self._lastPath)
 
         # Sizes
         sec = "Sizes"
@@ -623,7 +617,7 @@ class Config:
 
         # Editor
         sec = "Editor"
-        textFont             = conf.rdStr(sec, "textfont", "")
+        self.setTextFont(conf.rdStr(sec, "textfont", ""))
         self.textWidth       = conf.rdInt(sec, "width", self.textWidth)
         self.textMargin      = conf.rdInt(sec, "margin", self.textMargin)
         self.tabWidth        = conf.rdInt(sec, "tabwidth", self.tabWidth)
@@ -661,13 +655,6 @@ class Config:
         self.highlightEmph   = conf.rdBool(sec, "highlightemph", self.highlightEmph)
         self.stopWhenIdle    = conf.rdBool(sec, "stopwhenidle", self.stopWhenIdle)
         self.userIdleTime    = conf.rdInt(sec, "useridletime", self.userIdleTime)
-
-        # If we have an old config file, we have an explicit font size,
-        # in which case we convert the old settings.
-        if textSize := conf.rdInt(sec, "textsize", 0):
-            textFont = f"{textFont},{textSize}"
-
-        self.setTextFont(textFont)
 
         # State
         sec = "State"
@@ -710,9 +697,9 @@ class Config:
         }
 
         conf["Main"] = {
+            "font":         self.guiFont.toString(),
             "theme":        str(self.guiTheme),
             "syntax":       str(self.guiSyntax),
-            "guifont":      str(self.guiFont.toString()),
             "localisation": str(self.guiLocale),
             "hidevscroll":  str(self.hideVScroll),
             "hidehscroll":  str(self.hideHScroll),
@@ -739,7 +726,7 @@ class Config:
         }
 
         conf["Editor"] = {
-            "textfont":        str(self.textFont.toString()),
+            "textfont":        self.textFont.toString(),
             "width":           str(self.textWidth),
             "margin":          str(self.textMargin),
             "tabwidth":        str(self.tabWidth),

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -39,7 +39,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtGui import QFont, QFontDatabase
 from PyQt5.QtWidgets import QApplication
 
-from novelwriter.common import NWConfigParser, checkInt, checkPath, formatTimeStamp
+from novelwriter.common import NWConfigParser, checkInt, checkPath, describeFont, formatTimeStamp
 from novelwriter.constants import nwFiles, nwUnicode
 from novelwriter.error import formatException, logException
 
@@ -109,7 +109,7 @@ class Config:
         self.guiLocale    = self._qLocale.name()
         self.guiTheme     = "default"        # GUI theme
         self.guiSyntax    = "default_light"  # Syntax theme
-        self.guiFont      = QFont()          # Defaults to system default font in theme class
+        self.guiFont      = QFont()          # Main GUI font
         self.guiScale     = 1.0              # Set automatically by Theme class
         self.hideVScroll  = False            # Hide vertical scroll bars on main widgets
         self.hideHScroll  = False            # Hide horizontal scroll bars on main widgets
@@ -377,6 +377,7 @@ class Config:
             else:
                 font = fontDB.systemFont(QFontDatabase.SystemFont.GeneralFont)
             self.guiFont = font
+            logger.debug("GUI font set to: %s", describeFont(font))
 
         QApplication.setFont(self.guiFont)
 
@@ -405,6 +406,7 @@ class Config:
             else:
                 font = fontDB.systemFont(QFontDatabase.SystemFont.GeneralFont)
             self.textFont = font
+            logger.debug("Text font set to: %s", describeFont(font))
         return
 
     ##
@@ -571,8 +573,9 @@ class Config:
 
         if not cnfPath.exists():
             # Initial file, so we just create one from defaults
-            self.saveConfig()
             self.setGuiFont(None)
+            self.setTextFont(None)
+            self.saveConfig()
             return True
 
         try:

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -76,7 +76,7 @@ SETTINGS_TEMPLATE = {
     "text.includeBodyText":    (bool, True),
     "text.ignoredKeywords":    (str, ""),
     "text.addNoteHeadings":    (bool, True),
-    "format.textFont":         (str, CONFIG.textFont),
+    "format.textFont":         (str, CONFIG.textFont.family()),
     "format.textSize":         (int, 12),
     "format.lineHeight":       (float, 1.15, 0.75, 3.0),
     "format.justifyText":      (bool, False),

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -288,7 +288,7 @@ class NWBuildDocument:
         textFont = self._build.getStr("format.textFont")
         textSize = self._build.getInt("format.textSize")
 
-        fontFamily = textFont or CONFIG.textFont
+        fontFamily = textFont or CONFIG.textFont.family()
         bldFont = QFont(fontFamily, textSize)
         fontInfo = QFontInfo(bldFont)
         textFixed = fontInfo.fixedPitch()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import logging
 
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import QCloseEvent, QFont, QKeyEvent, QKeySequence
+from PyQt5.QtGui import QCloseEvent, QKeyEvent, QKeySequence
 from PyQt5.QtWidgets import (
     QAbstractButton, QApplication, QCompleter, QDialog, QDialogButtonBox,
     QFileDialog, QFontDialog, QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout,
@@ -140,6 +140,7 @@ class GuiPreferences(QDialog):
 
         # Temporary Variables
         self._guiFont = CONFIG.guiFont
+        self._textFont = CONFIG.textFont
 
         # Label
         self.sidebar.addLabel(self.tr("General"))
@@ -230,24 +231,14 @@ class GuiPreferences(QDialog):
         self.textFont = QLineEdit(self)
         self.textFont.setReadOnly(True)
         self.textFont.setMinimumWidth(fontWidth)
-        self.textFont.setText(CONFIG.textFont)
+        self.textFont.setText(describeFont(CONFIG.textFont))
+        self.textFont.setCursorPosition(0)
         self.textFontButton = NIconToolButton(self, iSz, "more")
         self.textFontButton.clicked.connect(self._selectTextFont)
         self.mainForm.addRow(
-            self.tr("Document font family"), self.textFont,
+            self.tr("Document font"), self.textFont,
             self.tr("Applies to both document editor and viewer."), stretch=(3, 2),
             button=self.textFontButton
-        )
-
-        # Document Font Size
-        self.textSize = NSpinBox(self)
-        self.textSize.setMinimum(8)
-        self.textSize.setMaximum(60)
-        self.textSize.setSingleStep(1)
-        self.textSize.setValue(CONFIG.textSize)
-        self.mainForm.addRow(
-            self.tr("Document font size"), self.textSize,
-            self.tr("Applies to both document editor and viewer."), unit=self.tr("pt")
         )
 
         # Emphasise Labels
@@ -823,13 +814,11 @@ class GuiPreferences(QDialog):
     @pyqtSlot()
     def _selectTextFont(self) -> None:
         """Open the QFontDialog and set a font for the font style."""
-        current = QFont()
-        current.setFamily(CONFIG.textFont)
-        current.setPointSize(CONFIG.textSize)
-        font, status = QFontDialog.getFont(current, self)
+        font, status = QFontDialog.getFont(CONFIG.textFont, self)
         if status:
-            self.textFont.setText(font.family())
-            self.textSize.setValue(font.pointSize())
+            self.textFont.setText(describeFont(font))
+            self.textFont.setCursorPosition(0)
+            self._textFont = font
         return
 
     @pyqtSlot()
@@ -907,7 +896,7 @@ class GuiPreferences(QDialog):
         CONFIG.emphLabels     = emphLabels
         CONFIG.showFullPath   = self.showFullPath.isChecked()
         CONFIG.incNotesWCount = self.incNotesWCount.isChecked()
-        CONFIG.setTextFont(self.textFont.text(), self.textSize.value())
+        CONFIG.textFont       = self._textFont
 
         # Auto Save
         CONFIG.autoSaveDoc  = self.autoSaveDoc.value()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -881,9 +881,9 @@ class GuiPreferences(QDialog):
 
         CONFIG.guiLocale   = guiLocale
         CONFIG.guiTheme    = guiTheme
-        CONFIG.guiFont     = self._guiFont
         CONFIG.hideVScroll = self.hideVScroll.isChecked()
         CONFIG.hideHScroll = self.hideHScroll.isChecked()
+        CONFIG.setGuiFont(self._guiFont)
 
         # Document Style
         guiSyntax  = self.guiSyntax.currentData()
@@ -896,7 +896,7 @@ class GuiPreferences(QDialog):
         CONFIG.emphLabels     = emphLabels
         CONFIG.showFullPath   = self.showFullPath.isChecked()
         CONFIG.incNotesWCount = self.incNotesWCount.isChecked()
-        CONFIG.textFont       = self._textFont
+        CONFIG.setTextFont(self._textFont)
 
         # Auto Save
         CONFIG.autoSaveDoc  = self.autoSaveDoc.value()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -377,16 +377,10 @@ class GuiDocEditor(QPlainTextEdit):
         special attention since there appears to be a bug in Qt 5.15.3.
         See issues #1862 and #1875.
         """
-        font = self.font()
-        font.setFamily(CONFIG.textFont)
-        font.setPointSize(CONFIG.textSize)
-        self.setFont(font)
-
-        # Reset sub-widget font to GUI font
+        self.setFont(CONFIG.textFont)
         self.docHeader.updateFont()
         self.docFooter.updateFont()
         self.docSearch.updateFont()
-
         return
 
     def loadText(self, tHandle: str, tLine: int | None = None) -> bool:

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -474,7 +474,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 charFormat.setBackground(QBrush(color, Qt.BrushStyle.SolidPattern))
 
         if size:
-            charFormat.setFontPointSize(round(size*CONFIG.textSize))
+            charFormat.setFontPointSize(round(size*CONFIG.textFont.pointSize()))
 
         self._hStyles[name] = charFormat
 

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -186,15 +186,9 @@ class GuiDocViewer(QTextBrowser):
         special attention since there appears to be a bug in Qt 5.15.3.
         See issues #1862 and #1875.
         """
-        font = self.font()
-        font.setFamily(CONFIG.textFont)
-        font.setPointSize(CONFIG.textSize)
-        self.setFont(font)
-
-        # Reset sub-widget font to GUI font
+        self.setFont(CONFIG.textFont)
         self.docHeader.updateFont()
         self.docFooter.updateFont()
-
         return
 
     def loadText(self, tHandle: str, updateHistory: bool = True) -> bool:

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -114,9 +114,6 @@ class GuiTheme:
         # Class Setup
         # ===========
 
-        # Init GUI Font
-        self._setGuiFont()
-
         # Load Themes
         self._guiPalette = QPalette()
         self._themeList: list[tuple[str, str]] = []
@@ -409,27 +406,6 @@ class GuiTheme:
         self.statSaved   = QColor(2, 133, 37)
         self.helpText    = QColor(0, 0, 0)
         self.errorText   = QColor(255, 0, 0)
-        return
-
-    def _setGuiFont(self) -> None:
-        """Update the GUI's font style from settings."""
-        font = QFont()
-        fontDB = QFontDatabase()
-        if CONFIG.guiFont not in fontDB.families():
-            if CONFIG.osWindows and "Arial" in fontDB.families():
-                # On Windows we default to Arial if possible
-                font.setFamily("Arial")
-                font.setPointSize(10)
-            else:
-                font = fontDB.systemFont(QFontDatabase.SystemFont.GeneralFont)
-            CONFIG.guiFont = font.family()
-            CONFIG.guiFontSize = font.pointSize()
-        else:
-            font.setFamily(CONFIG.guiFont)
-            font.setPointSize(CONFIG.guiFontSize)
-
-        QApplication.setFont(font)
-
         return
 
     def _listConf(self, targetDict: dict, checkDir: Path) -> bool:

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -787,7 +787,7 @@ class _PreviewWidget(QTextBrowser):
         self._updateDocMargins()
         self._updateBuildAge()
 
-        self.setTextFont(CONFIG.textFont, CONFIG.textSize)
+        self.setTextFont(CONFIG.textFont.family(), CONFIG.textFont.pointSize())
 
         # Age Timer
         self.ageTimer = QTimer(self)

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1175,7 +1175,7 @@ class _FormatTab(NScrollableForm):
         """Populate the widgets."""
         textFont = self._build.getStr("format.textFont")
         if not textFont:
-            textFont = str(CONFIG.textFont)
+            textFont = str(CONFIG.textFont.family())
 
         self.textFont.setText(textFont)
         self.textSize.setValue(self._build.getInt("format.textSize"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ def resetConfigVars():
     """
     CONFIG.setLastPath(_TMP_ROOT)
     CONFIG.setBackupPath(_TMP_ROOT)
+    CONFIG.setGuiFont(None)
     CONFIG.setTextFont(None)
     CONFIG._homePath = _TMP_ROOT
     CONFIG.guiLocale = "en_GB"

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,11 +1,10 @@
 [Meta]
-timestamp = 2024-05-13 15:59:59
+timestamp = 2024-05-20 16:48:20
 
 [Main]
+font = 
 theme = default
 syntax = default_light
-font = 
-fontsize = 11
 localisation = en_GB
 hidevscroll = False
 hidehscroll = False
@@ -30,7 +29,6 @@ askbeforebackup = True
 
 [Editor]
 textfont = 
-textsize = 12
 width = 700
 margin = 40
 tabwidth = 40

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -28,16 +28,16 @@ from xml.etree import ElementTree as ET
 import pytest
 
 from PyQt5.QtCore import QUrl
-from PyQt5.QtGui import QColor, QDesktopServices
+from PyQt5.QtGui import QColor, QDesktopServices, QFontDatabase
 
 from novelwriter.common import (
     NWConfigParser, checkBool, checkFloat, checkInt, checkIntTuple, checkPath,
-    checkString, checkStringNone, checkUuid, cssCol, elide, formatFileFilter,
-    formatInt, formatTime, formatTimeStamp, formatVersion, fuzzyTime,
-    getFileSize, hexToInt, isHandle, isItemClass, isItemLayout, isItemType,
-    isListInstance, isTitleTag, jsonEncode, makeFileNameSafe, minmax,
-    numberToRoman, openExternalPath, readTextFile, simplified, transferCase,
-    xmlIndent, yesNo
+    checkString, checkStringNone, checkUuid, cssCol, describeFont, elide,
+    formatFileFilter, formatInt, formatTime, formatTimeStamp, formatVersion,
+    fuzzyTime, getFileSize, hexToInt, isHandle, isItemClass, isItemLayout,
+    isItemType, isListInstance, isTitleTag, jsonEncode, makeFileNameSafe,
+    minmax, numberToRoman, openExternalPath, readTextFile, simplified,
+    transferCase, xmlIndent, yesNo
 )
 
 from tests.mocked import causeOSError
@@ -485,6 +485,15 @@ def testBaseCommon_cssCol():
     """Test the cssCol function."""
     assert cssCol(QColor(0, 0, 0, 0)) == "rgba(0, 0, 0, 0)"
     assert cssCol(QColor(10, 20, 30, 40)) == "rgba(10, 20, 30, 40)"
+
+
+@pytest.mark.base
+def testBaseCommon_describeFont():
+    """Test the describeFont function."""
+    fontDB = QFontDatabase()
+    font = fontDB.systemFont(QFontDatabase.SystemFont.GeneralFont)
+    assert font.family() in describeFont(font)
+    assert describeFont(None) == "Error"  # type: ignore
 
 
 @pytest.mark.base

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -103,15 +103,19 @@ def testBaseConfig_InitLoadSave(monkeypatch, fncPath, tstPaths):
     if confFile.is_file():
         confFile.unlink()
 
-    # Running init against a new oath should write a new config file
+    # Running init + load against a new path should write a new config file
     tstConf.initConfig(confPath=fncPath, dataPath=fncPath)
     assert tstConf._confPath == fncPath
     assert tstConf._dataPath == fncPath
+    tstConf.loadConfig()
     assert confFile.exists()
 
     # Check that we have a default file
     copyfile(confFile, testFile)
-    ignore = ("timestamp", "lastnotes", "localisation", "lastpath", "backuppath")
+    ignore = (
+        "timestamp", "lastnotes", "localisation",
+        "lastpath", "backuppath", "font", "textfont"
+    )
     assert cmpFiles(testFile, compFile, ignoreStart=ignore)
     tstConf.errorText()  # This clears the error cache
 
@@ -136,6 +140,7 @@ def testBaseConfig_InitLoadSave(monkeypatch, fncPath, tstPaths):
 
     newConf = Config()
     newConf.initConfig(confPath=fncPath, dataPath=fncPath)
+    newConf.loadConfig()
     assert newConf.guiTheme == "foo"
     assert newConf.guiSyntax == "bar"
 

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import pytest
 
 from PyQt5.QtCore import QEvent, Qt
-from PyQt5.QtGui import QFontDatabase, QKeyEvent
+from PyQt5.QtGui import QFont, QFontDatabase, QKeyEvent
 from PyQt5.QtWidgets import QAction, QFileDialog, QFontDialog
 
 from novelwriter import CONFIG, SHARED
@@ -173,32 +173,28 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, tstPaths):
     prefs.guiLocale.setCurrentIndex(prefs.guiLocale.findData("en_US"))
     prefs.guiTheme.setCurrentIndex(prefs.guiTheme.findData("default_dark"))
     with monkeypatch.context() as mp:
-        mp.setattr(QFontDialog, "getFont", lambda *a: (MockFont(), True))
+        mp.setattr(QFontDialog, "getFont", lambda *a: (QFont(), True))
         prefs.guiFontButton.click()
-    prefs.guiFontSize.stepDown()  # Should change it to 41
     prefs.hideVScroll.setChecked(True)
     prefs.hideHScroll.setChecked(True)
 
     assert CONFIG.guiLocale != "en_US"
     assert CONFIG.guiTheme != "default_dark"
-    assert CONFIG.guiFont != "TestFont"
-    assert CONFIG.guiFontSize < 42
+    assert CONFIG.guiFont.family() != ""
     assert CONFIG.hideVScroll is False
     assert CONFIG.hideHScroll is False
 
     # Document Style
     prefs.guiSyntax.setCurrentIndex(prefs.guiSyntax.findData("default_dark"))
     with monkeypatch.context() as mp:
-        mp.setattr(QFontDialog, "getFont", lambda *a: (MockFont(), True))
+        mp.setattr(QFontDialog, "getFont", lambda *a: (QFont(), True))
         prefs.textFontButton.click()
-    prefs.textSize.stepDown()  # Should change it to 41
     prefs.emphLabels.setChecked(False)
     prefs.showFullPath.setChecked(False)
     prefs.incNotesWCount.setChecked(False)
 
     assert CONFIG.guiSyntax != "default_dark"
-    assert CONFIG.textFont != "testFont"
-    assert CONFIG.textSize < 42
+    assert CONFIG.textFont.family() != ""
     assert CONFIG.emphLabels is True
     assert CONFIG.showFullPath is True
     assert CONFIG.incNotesWCount is True
@@ -341,15 +337,13 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, tstPaths):
     # Appearance
     assert CONFIG.guiLocale == "en_US"
     assert CONFIG.guiTheme == "default_dark"
-    assert CONFIG.guiFont == "TestFont"
-    assert CONFIG.guiFontSize == 41
+    assert CONFIG.guiFont == QFont()
     assert CONFIG.hideVScroll is True
     assert CONFIG.hideHScroll is True
 
     # Document Style
     assert CONFIG.guiSyntax == "default_dark"
-    assert CONFIG.textFont == "TestFont"
-    assert CONFIG.textSize == 41
+    assert CONFIG.textFont == QFont()
     assert CONFIG.emphLabels is False
     assert CONFIG.showFullPath is False
     assert CONFIG.incNotesWCount is False

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import pytest
 
 from PyQt5.QtCore import QEvent, Qt, QThreadPool
-from PyQt5.QtGui import QClipboard, QMouseEvent, QTextBlock, QTextCursor, QTextOption
+from PyQt5.QtGui import QClipboard, QFont, QMouseEvent, QTextBlock, QTextCursor, QTextOption
 from PyQt5.QtWidgets import QAction, QApplication, QMenu
 
 from novelwriter import CONFIG, SHARED
@@ -84,7 +84,7 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert docEditor.docHeader._docOutline == {0: "### New Scene"}
 
     # Check that editor handles settings
-    CONFIG.textFont = ""
+    CONFIG.textFont = QFont()
     CONFIG.doJustify = True
     CONFIG.showTabsNSpaces = True
     CONFIG.showLineEndings = True
@@ -96,7 +96,7 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     docEditor.initEditor()
 
     qDoc = docEditor.document()
-    assert CONFIG.textFont == qDoc.defaultFont().family()
+    assert CONFIG.textFont == qDoc.defaultFont()
     assert qDoc.defaultTextOption().alignment() == QtAlignJustify
     assert qDoc.defaultTextOption().flags() & QTextOption.ShowTabsAndSpaces
     assert qDoc.defaultTextOption().flags() & QTextOption.ShowLineAndParagraphSeparators

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -48,27 +48,6 @@ def testGuiTheme_Main(qtbot, nwGUI, tstPaths):
     assert mSize > 0
     assert mainTheme.getTextWidth("m", mainTheme.guiFont) == mSize
 
-    # Init Fonts
-    # ==========
-
-    # The defaults should be set
-    defaultFont = CONFIG.guiFont
-    defaultSize = CONFIG.guiFontSize
-
-    # CHange them to nonsense values
-    CONFIG.guiFont = "notafont"
-    CONFIG.guiFontSize = 99
-
-    # Let the theme class set them back to default
-    mainTheme._setGuiFont()
-    assert CONFIG.guiFont == defaultFont
-    assert CONFIG.guiFontSize == defaultSize
-
-    # A second call should just restore the defaults again
-    mainTheme._setGuiFont()
-    assert CONFIG.guiFont == defaultFont
-    assert CONFIG.guiFontSize == defaultSize
-
     # Scan for Themes
     # ===============
 

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -547,7 +547,7 @@ def testBuildSettings_Format(monkeypatch, qtbot, nwGUI):
     """Test the Format Tab of the GuiBuildSettings dialog."""
     build = BuildSettings()
 
-    textFont = str(CONFIG.textFont)
+    textFont = str(CONFIG.textFont.family())
 
     build.setValue("format.buildLang", "en_US")
     build.setValue("format.textFont", "")  # Will fall back to config value


### PR DESCRIPTION
**Summary:**

This PR enables the full usage of the font style options for the GUI and document font selection. It saves all available font settings to the config file, but since the full settings include the font size, the old setting has been removed and will be reset to default the first time the app is loaded as 2.5

**Related Issue(s):**

Closes #1733

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
