### PR TITLE
Post release fixes

### DIFF
--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -546,7 +546,7 @@ class GuiPreferences(QDialog):
         self.allowOpenDial = NSwitch(self)
         self.allowOpenDial.setChecked(CONFIG.allowOpenDial)
         self.mainForm.addRow(
-            self.tr("Allow open-ended sialogue"), self.allowOpenDial,
+            self.tr("Allow open-ended dialogue"), self.allowOpenDial,
             self.tr("Highlight dialogue line with no closing quote.")
         )
 
@@ -583,8 +583,8 @@ class GuiPreferences(QDialog):
         self.altDialogClose.setText(CONFIG.altDialogClose)
 
         self.mainForm.addRow(
-            self.tr("Alternative dialog symbols"), [self.altDialogOpen, self.altDialogClose],
-            self.tr("Custom highlighting of dialog text.")
+            self.tr("Alternative dialogue symbols"), [self.altDialogOpen, self.altDialogClose],
+            self.tr("Custom highlighting of dialogue text.")
         )
 
         self.highlightEmph = NSwitch(self)

--- a/pkgutils.py
+++ b/pkgutils.py
@@ -632,8 +632,8 @@ def makeWindowsZip() -> None:
 ##
 
 def makeDebianPackage(
-    signKey: str | None = None, sourceBuild: bool = False,
-    distName: str = "unstable", buildName: str = "", oldSetuptools: bool = False
+    signKey: str | None = None, sourceBuild: bool = False, distName: str = "unstable",
+    buildName: str = "", oldSetuptools: bool = False, forLaunchpad: bool = False
 ) -> str:
     """Build a Debian package."""
     print("")
@@ -651,7 +651,10 @@ def makeDebianPackage(
     pkgDate = email.utils.format_datetime(relDate.replace(hour=12, tzinfo=None))
     print("")
 
-    pkgVers = numVers.replace("a", "~a").replace("b", "~b").replace("rc", "~rc")
+    if forLaunchpad:
+        pkgVers = numVers.replace("a", "~a").replace("b", "~b").replace("rc", "~rc")
+    else:
+        pkgVers = numVers
     pkgVers = f"{pkgVers}+{buildName}" if buildName else pkgVers
 
     # Set Up Folder
@@ -862,6 +865,7 @@ def makeForLaunchpad(doSign: bool = False, isFirst: bool = False) -> None:
             distName=codeName,
             buildName=buildName,
             oldSetuptools=oldSetup,
+            forLaunchpad=True,
         )
         dputCmd.append(dCmd)
 


### PR DESCRIPTION
**Summary:**

This PR:
* Fixes some typos in Preferences
* Adds a check so Debian package files for GitHub release don't include a `~` symbol.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
