### PR TITLE
Improve dialog handling

### DIFF
--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import logging
 
 from PyQt5.QtCore import Qt, pyqtSlot
-from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import (
     QAbstractItemView, QDialogButtonBox, QGridLayout, QLabel, QListWidget,
     QListWidgetItem, QVBoxLayout, QWidget
@@ -37,7 +36,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.extensions.configlayout import NColourLabel
 from novelwriter.extensions.modified import NDialog
 from novelwriter.extensions.switch import NSwitch
-from novelwriter.types import QtDialogCancel, QtDialogOk, QtDialogReset, QtUserRole
+from novelwriter.types import QtAccepted, QtDialogCancel, QtDialogOk, QtDialogReset, QtUserRole
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +117,7 @@ class GuiDocMerge(NDialog):
         logger.debug("Delete: GuiDocMerge")
         return
 
-    def getData(self) -> dict:
+    def data(self) -> dict:
         """Return the user's choices."""
         finalItems = []
         for i in range(self.listBox.count()):
@@ -131,15 +130,15 @@ class GuiDocMerge(NDialog):
 
         return self._data
 
-    ##
-    #  Events
-    ##
-
-    def closeEvent(self, event: QCloseEvent) -> None:
-        """Capture the close event and perform cleanup."""
-        event.accept()
-        self.deleteLater()
-        return
+    @classmethod
+    def getData(cls, parent: QWidget, handle: str, items: list[str]) -> tuple[dict, bool]:
+        """Pop the dialog and return the result."""
+        cls = GuiDocMerge(parent, handle, items)
+        cls.exec()
+        data = cls.data()
+        accepted = cls.result() == QtAccepted
+        cls.deleteLater()
+        return data, accepted
 
     ##
     #  Private Slots

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -29,19 +29,20 @@ import logging
 from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QDialog, QDialogButtonBox, QGridLayout, QLabel,
-    QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+    QAbstractItemView, QDialogButtonBox, QGridLayout, QLabel, QListWidget,
+    QListWidgetItem, QVBoxLayout, QWidget
 )
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.extensions.configlayout import NColourLabel
+from novelwriter.extensions.modified import NDialog
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import QtDialogCancel, QtDialogOk, QtDialogReset, QtUserRole
 
 logger = logging.getLogger(__name__)
 
 
-class GuiDocMerge(QDialog):
+class GuiDocMerge(NDialog):
 
     D_HANDLE = QtUserRole
 

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import logging
 
 from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import (
     QAbstractItemView, QComboBox, QDialogButtonBox, QGridLayout, QLabel,
     QListWidget, QListWidgetItem, QVBoxLayout, QWidget
@@ -37,7 +36,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.extensions.configlayout import NColourLabel
 from novelwriter.extensions.modified import NDialog
 from novelwriter.extensions.switch import NSwitch
-from novelwriter.types import QtDialogCancel, QtDialogOk, QtUserRole
+from novelwriter.types import QtAccepted, QtDialogCancel, QtDialogOk, QtUserRole
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +145,7 @@ class GuiDocSplit(NDialog):
         logger.debug("Delete: GuiDocSplit")
         return
 
-    def getData(self) -> tuple[dict, list]:
+    def data(self) -> tuple[dict, list[str]]:
         """Return the user's choices. Also save the users options for
         the next time the dialog is used.
         """
@@ -179,15 +178,15 @@ class GuiDocSplit(NDialog):
 
         return self._data, self._text
 
-    ##
-    #  Events
-    ##
-
-    def closeEvent(self, event: QCloseEvent) -> None:
-        """Capture the close event and perform cleanup."""
-        event.accept()
-        self.deleteLater()
-        return
+    @classmethod
+    def getData(cls, parent: QWidget, handle: str) -> tuple[dict, list[str], bool]:
+        """Pop the dialog and return the result."""
+        cls = GuiDocSplit(parent, handle)
+        cls.exec()
+        data, text = cls.data()
+        accepted = cls.result() == QtAccepted
+        cls.deleteLater()
+        return data, text, accepted
 
     ##
     #  Private Slots

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -29,19 +29,20 @@ import logging
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QComboBox, QDialog, QDialogButtonBox, QGridLayout,
-    QLabel, QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+    QAbstractItemView, QComboBox, QDialogButtonBox, QGridLayout, QLabel,
+    QListWidget, QListWidgetItem, QVBoxLayout, QWidget
 )
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.extensions.configlayout import NColourLabel
+from novelwriter.extensions.modified import NDialog
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import QtDialogCancel, QtDialogOk, QtUserRole
 
 logger = logging.getLogger(__name__)
 
 
-class GuiDocSplit(QDialog):
+class GuiDocSplit(NDialog):
 
     LINE_ROLE  = QtUserRole
     LEVEL_ROLE = QtUserRole + 1

--- a/novelwriter/dialogs/editlabel.py
+++ b/novelwriter/dialogs/editlabel.py
@@ -31,12 +31,13 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG
+from novelwriter.extensions.modified import NDialog
 from novelwriter.types import QtDialogCancel, QtDialogOk
 
 logger = logging.getLogger(__name__)
 
 
-class GuiEditLabel(QDialog):
+class GuiEditLabel(NDialog):
 
     def __init__(self, parent: QWidget, text: str = "") -> None:
         super().__init__(parent=parent)

--- a/novelwriter/dialogs/editlabel.py
+++ b/novelwriter/dialogs/editlabel.py
@@ -25,14 +25,11 @@ from __future__ import annotations
 
 import logging
 
-from PyQt5.QtWidgets import (
-    QDialog, QDialogButtonBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout,
-    QWidget
-)
+from PyQt5.QtWidgets import QDialogButtonBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout, QWidget
 
 from novelwriter import CONFIG
 from novelwriter.extensions.modified import NDialog
-from novelwriter.types import QtDialogCancel, QtDialogOk
+from novelwriter.types import QtAccepted, QtDialogCancel, QtDialogOk
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +89,6 @@ class GuiEditLabel(NDialog):
         cls = GuiEditLabel(parent, text=text)
         cls.exec()
         label = cls.itemLabel
-        accepted = cls.result() == QDialog.DialogCode.Accepted
+        accepted = cls.result() == QtAccepted
         cls.deleteLater()
         return label, accepted

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -27,10 +27,10 @@ from __future__ import annotations
 import logging
 
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import QCloseEvent, QKeyEvent, QKeySequence
+from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import (
-    QAbstractButton, QApplication, QCompleter, QDialog, QDialogButtonBox,
-    QFileDialog, QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout, QWidget
+    QAbstractButton, QApplication, QCompleter, QDialogButtonBox, QFileDialog,
+    QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout, QWidget
 )
 
 from novelwriter import CONFIG, SHARED
@@ -38,7 +38,9 @@ from novelwriter.common import describeFont
 from novelwriter.constants import nwConst, nwUnicode
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 from novelwriter.extensions.configlayout import NColourLabel, NScrollableForm
-from novelwriter.extensions.modified import NComboBox, NDoubleSpinBox, NIconToolButton, NSpinBox
+from novelwriter.extensions.modified import (
+    NComboBox, NDialog, NDoubleSpinBox, NIconToolButton, NSpinBox
+)
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import (
@@ -49,7 +51,7 @@ from novelwriter.types import (
 logger = logging.getLogger(__name__)
 
 
-class GuiPreferences(QDialog):
+class GuiPreferences(NDialog):
 
     newPreferencesReady = pyqtSignal(bool, bool, bool, bool)
 
@@ -770,13 +772,6 @@ class GuiPreferences(QDialog):
         QApplication.processEvents()
         self.done(nwConst.DLG_FINISHED)
         self.deleteLater()
-        return
-
-    def keyPressEvent(self, event: QKeyEvent) -> None:
-        """Overload keyPressEvent to block enter key to save."""
-        if event.matches(QKeySequence.StandardKey.Cancel):
-            self.close()
-        event.ignore()
         return
 
     ##

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -29,7 +29,7 @@ import logging
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QCloseEvent, QColor
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QApplication, QColorDialog, QDialog, QDialogButtonBox,
+    QAbstractItemView, QApplication, QColorDialog, QDialogButtonBox,
     QHBoxLayout, QLineEdit, QMenu, QStackedWidget, QToolButton, QTreeWidget,
     QTreeWidgetItem, QVBoxLayout, QWidget
 )
@@ -40,7 +40,7 @@ from novelwriter.constants import nwLabels, trConst
 from novelwriter.core.status import NWStatus, StatusEntry
 from novelwriter.enum import nwStatusShape
 from novelwriter.extensions.configlayout import NColourLabel, NFixedPage, NScrollableForm
-from novelwriter.extensions.modified import NComboBox, NIconToolButton
+from novelwriter.extensions.modified import NComboBox, NDialog, NIconToolButton
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import (
@@ -51,7 +51,7 @@ from novelwriter.types import (
 logger = logging.getLogger(__name__)
 
 
-class GuiProjectSettings(QDialog):
+class GuiProjectSettings(NDialog):
 
     PAGE_SETTINGS = 0
     PAGE_STATUS   = 1

--- a/novelwriter/dialogs/quotes.py
+++ b/novelwriter/dialogs/quotes.py
@@ -34,12 +34,13 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG
 from novelwriter.constants import nwQuotes, trConst
+from novelwriter.extensions.modified import NDialog
 from novelwriter.types import QtAlignCenter, QtAlignTop, QtDialogCancel, QtDialogOk, QtUserRole
 
 logger = logging.getLogger(__name__)
 
 
-class GuiQuoteSelect(QDialog):
+class GuiQuoteSelect(NDialog):
 
     _selected = ""
 

--- a/novelwriter/dialogs/quotes.py
+++ b/novelwriter/dialogs/quotes.py
@@ -28,14 +28,17 @@ import logging
 from PyQt5.QtCore import QSize, pyqtSlot
 from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtWidgets import (
-    QDialog, QDialogButtonBox, QFrame, QHBoxLayout, QLabel, QListWidget,
+    QDialogButtonBox, QFrame, QHBoxLayout, QLabel, QListWidget,
     QListWidgetItem, QVBoxLayout, QWidget
 )
 
 from novelwriter import CONFIG
 from novelwriter.constants import nwQuotes, trConst
 from novelwriter.extensions.modified import NDialog
-from novelwriter.types import QtAlignCenter, QtAlignTop, QtDialogCancel, QtDialogOk, QtUserRole
+from novelwriter.types import (
+    QtAccepted, QtAlignCenter, QtAlignTop, QtDialogCancel, QtDialogOk,
+    QtUserRole
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +130,7 @@ class GuiQuoteSelect(NDialog):
         cls = GuiQuoteSelect(parent, current=current)
         cls.exec()
         quote = cls._selected
-        accepted = cls.result() == QDialog.DialogCode.Accepted
+        accepted = cls.result() == QtAccepted
         cls.deleteLater()
         return quote, accepted
 

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QApplication, QDialog, QDialogButtonBox, QFileDialog,
+    QAbstractItemView, QApplication, QDialogButtonBox, QFileDialog,
     QHBoxLayout, QLineEdit, QListWidget, QVBoxLayout, QWidget
 )
 
@@ -38,13 +38,13 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatFileFilter
 from novelwriter.core.spellcheck import UserDictionary
 from novelwriter.extensions.configlayout import NColourLabel
-from novelwriter.extensions.modified import NIconToolButton
+from novelwriter.extensions.modified import NDialog, NIconToolButton
 from novelwriter.types import QtDialogClose, QtDialogSave
 
 logger = logging.getLogger(__name__)
 
 
-class GuiWordList(QDialog):
+class GuiWordList(NDialog):
 
     newWordListReady = pyqtSignal()
 

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -31,7 +31,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import QSize, Qt
-from PyQt5.QtGui import QWheelEvent
+from PyQt5.QtGui import QKeyEvent, QKeySequence, QWheelEvent
 from PyQt5.QtWidgets import (
     QApplication, QComboBox, QDialog, QDoubleSpinBox, QSpinBox, QToolButton,
     QWidget
@@ -43,7 +43,17 @@ if TYPE_CHECKING:  # pragma: no cover
     from novelwriter.guimain import GuiMain
 
 
-class NToolDialog(QDialog):
+class NDialog(QDialog):
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        """Overload keyPressEvent and forward escape to close."""
+        if event.matches(QKeySequence.StandardKey.Cancel):
+            self.close()
+        event.ignore()
+        return
+
+
+class NToolDialog(NDialog):
 
     def __init__(self, parent: GuiMain) -> None:
         super().__init__(parent=parent)
@@ -62,7 +72,7 @@ class NToolDialog(QDialog):
         return
 
 
-class NNonBlockingDialog(QDialog):
+class NNonBlockingDialog(NDialog):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent=parent)

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -28,19 +28,20 @@ import random
 
 from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtWidgets import (
-    QDialog, QDialogButtonBox, QGridLayout, QHBoxLayout, QLabel, QSpinBox,
-    QVBoxLayout, QWidget
+    QDialogButtonBox, QGridLayout, QHBoxLayout, QLabel, QSpinBox, QVBoxLayout,
+    QWidget
 )
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import readTextFile
+from novelwriter.extensions.modified import NDialog
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import QtAlignLeft, QtAlignRight, QtDialogClose, QtRoleAction
 
 logger = logging.getLogger(__name__)
 
 
-class GuiLipsum(QDialog):
+class GuiLipsum(NDialog):
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from PyQt5.QtCore import QTimer, pyqtSlot
 from PyQt5.QtGui import QCloseEvent
 from PyQt5.QtWidgets import (
-    QAbstractButton, QAbstractItemView, QDialog, QDialogButtonBox, QFileDialog,
+    QAbstractButton, QAbstractItemView, QDialogButtonBox, QFileDialog,
     QGridLayout, QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem,
     QPushButton, QSplitter, QVBoxLayout, QWidget
 )
@@ -42,14 +42,14 @@ from novelwriter.core.buildsettings import BuildSettings
 from novelwriter.core.docbuild import NWBuildDocument
 from novelwriter.core.item import NWItem
 from novelwriter.enum import nwBuildFmt
-from novelwriter.extensions.modified import NIconToolButton
+from novelwriter.extensions.modified import NDialog, NIconToolButton
 from novelwriter.extensions.simpleprogress import NProgressSimple
 from novelwriter.types import QtAlignCenter, QtDialogClose, QtRoleAction, QtRoleReject, QtUserRole
 
 logger = logging.getLogger(__name__)
 
 
-class GuiManuscriptBuild(QDialog):
+class GuiManuscriptBuild(NDialog):
     """GUI Tools: Manuscript Build Dialog
 
     This is the tool for running the build itself. It can be accessed

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -34,8 +34,8 @@ from PyQt5.QtCore import (
 )
 from PyQt5.QtGui import QCloseEvent, QColor, QFont, QPainter, QPaintEvent, QPen
 from PyQt5.QtWidgets import (
-    QAction, QApplication, QDialog, QFileDialog, QFormLayout, QHBoxLayout,
-    QLabel, QLineEdit, QListView, QMenu, QPushButton, QScrollArea, QShortcut,
+    QAction, QApplication, QFileDialog, QFormLayout, QHBoxLayout, QLabel,
+    QLineEdit, QListView, QMenu, QPushButton, QScrollArea, QShortcut,
     QStackedWidget, QStyledItemDelegate, QStyleOptionViewItem, QVBoxLayout,
     QWidget
 )
@@ -46,7 +46,7 @@ from novelwriter.constants import nwFiles
 from novelwriter.core.coretools import ProjectBuilder
 from novelwriter.enum import nwItemClass
 from novelwriter.extensions.configlayout import NWrappedWidgetBox
-from novelwriter.extensions.modified import NIconToolButton, NSpinBox
+from novelwriter.extensions.modified import NDialog, NIconToolButton, NSpinBox
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.extensions.versioninfo import VersionInfoWidget
 from novelwriter.types import QtAlignLeft, QtAlignRightTop, QtSelected
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 PANEL_ALPHA = 178
 
 
-class GuiWelcome(QDialog):
+class GuiWelcome(NDialog):
 
     openProjectRequest = pyqtSignal(Path)
 

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from PyQt5.QtCore import QRegularExpression, Qt
 from PyQt5.QtGui import QColor, QFont, QPainter, QTextCharFormat, QTextCursor, QTextFormat
-from PyQt5.QtWidgets import QDialogButtonBox, QSizePolicy, QStyle
+from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QSizePolicy, QStyle
 
 # Qt Alignment Flags
 
@@ -79,6 +79,9 @@ QtMouseLeft = Qt.MouseButton.LeftButton
 QtMouseMiddle = Qt.MouseButton.MiddleButton
 
 # Dialog Button Box Types
+
+QtAccepted = QDialog.DialogCode.Accepted
+QtRejected = QDialog.DialogCode.Rejected
 
 QtDialogApply = QDialogButtonBox.StandardButton.Apply
 QtDialogCancel = QDialogButtonBox.StandardButton.Cancel

--- a/tests/test_dialogs/test_dlg_dialogs.py
+++ b/tests/test_dialogs/test_dlg_dialogs.py
@@ -23,10 +23,11 @@ from __future__ import annotations
 import pytest
 
 from PyQt5.QtCore import QItemSelectionModel
-from PyQt5.QtWidgets import QDialog, QListWidgetItem
+from PyQt5.QtWidgets import QListWidgetItem
 
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.quotes import GuiQuoteSelect
+from novelwriter.types import QtAccepted, QtRejected
 
 
 @pytest.mark.gui
@@ -47,17 +48,17 @@ def testDlgOther_QuoteSelect(qtbot, monkeypatch, nwGUI):
         assert nwQuot.previewLabel.text() == lastItem
 
     nwQuot.accept()
-    assert nwQuot.result() == QDialog.DialogCode.Accepted
+    assert nwQuot.result() == QtAccepted
     assert nwQuot.selectedQuote == lastItem
     nwQuot.close()
 
     # Test Class Method
     with monkeypatch.context() as mp:
-        mp.setattr(GuiQuoteSelect, "result", lambda *a: QDialog.DialogCode.Accepted)
+        mp.setattr(GuiQuoteSelect, "result", lambda *a: QtAccepted)
         assert GuiQuoteSelect.getQuote(nwGUI, current="X") == ("X", True)
 
     with monkeypatch.context() as mp:
-        mp.setattr(GuiQuoteSelect, "result", lambda *a: QDialog.DialogCode.Rejected)
+        mp.setattr(GuiQuoteSelect, "result", lambda *a: QtRejected)
         assert GuiQuoteSelect.getQuote(nwGUI, current="X") == ("X", False)
 
     # qtbot.stop()
@@ -69,13 +70,13 @@ def testDlgOther_EditLabel(qtbot, monkeypatch):
     monkeypatch.setattr(GuiEditLabel, "exec", lambda *a: None)
 
     with monkeypatch.context() as mp:
-        mp.setattr(GuiEditLabel, "result", lambda *a: QDialog.DialogCode.Accepted)
+        mp.setattr(GuiEditLabel, "result", lambda *a: QtAccepted)
         newLabel, dlgOk = GuiEditLabel.getLabel(None, text="Hello World")  # type: ignore
         assert dlgOk is True
         assert newLabel == "Hello World"
 
     with monkeypatch.context() as mp:
-        mp.setattr(GuiEditLabel, "result", lambda *a: QDialog.DialogCode.Rejected)
+        mp.setattr(GuiEditLabel, "result", lambda *a: QtRejected)
         newLabel, dlgOk = GuiEditLabel.getLabel(None, text="Hello World")  # type: ignore
         assert dlgOk is False
         assert newLabel == "Hello World"

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -23,13 +23,13 @@ from __future__ import annotations
 import pytest
 
 from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QAction, QColorDialog, QDialog
+from PyQt5.QtWidgets import QAction, QColorDialog
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
 from novelwriter.enum import nwItemType, nwStatusShape
-from novelwriter.types import QtMouseLeft
+from novelwriter.types import QtAccepted, QtMouseLeft
 
 from tests.tools import C, buildTestProject
 
@@ -43,7 +43,7 @@ def testDlgProjSettings_Dialog(qtbot, monkeypatch, nwGUI):
     """
     # Block the GUI blocking thread
     monkeypatch.setattr(GuiProjectSettings, "exec", lambda *a: None)
-    monkeypatch.setattr(GuiProjectSettings, "result", lambda *a: QDialog.DialogCode.Accepted)
+    monkeypatch.setattr(GuiProjectSettings, "result", lambda *a: QtAccepted)
 
     # Check that we cannot open when there is no project
     nwGUI.mainMenu.aProjectSettings.activate(QAction.Trigger)

--- a/tests/test_dialogs/test_dlg_wordlist.py
+++ b/tests/test_dialogs/test_dlg_wordlist.py
@@ -23,11 +23,12 @@ from __future__ import annotations
 import pytest
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QAction, QDialog, QFileDialog
+from PyQt5.QtWidgets import QAction, QFileDialog
 
 from novelwriter import SHARED
 from novelwriter.core.spellcheck import UserDictionary
 from novelwriter.dialogs.wordlist import GuiWordList
+from novelwriter.types import QtAccepted
 
 from tests.mocked import causeOSError
 from tests.tools import buildTestProject
@@ -39,7 +40,7 @@ def testDlgWordList_Dialog(qtbot, monkeypatch, nwGUI, fncPath, projPath):
     buildTestProject(nwGUI, projPath)
 
     monkeypatch.setattr(GuiWordList, "exec", lambda *a: None)
-    monkeypatch.setattr(GuiWordList, "result", lambda *a: QDialog.DialogCode.Accepted)
+    monkeypatch.setattr(GuiWordList, "result", lambda *a: QtAccepted)
     monkeypatch.setattr(GuiWordList, "accept", lambda *a: None)
 
     # Open project

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -26,7 +26,7 @@ import pytest
 
 from PyQt5.QtCore import QEvent, QMimeData, QPoint, Qt, QTimer
 from PyQt5.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent, QMouseEvent
-from PyQt5.QtWidgets import QDialog, QMenu, QMessageBox, QTreeWidget, QTreeWidgetItem
+from PyQt5.QtWidgets import QMenu, QMessageBox, QTreeWidget, QTreeWidgetItem
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.core.item import NWItem
@@ -37,7 +37,7 @@ from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwWidget
 from novelwriter.gui.projtree import GuiProjectTree, GuiProjectView, _TreeContextMenu
 from novelwriter.guimain import GuiMain
-from novelwriter.types import QtModeNone, QtMouseLeft, QtMouseMiddle
+from novelwriter.types import QtAccepted, QtModeNone, QtMouseLeft, QtMouseMiddle, QtRejected
 
 from tests.mocked import causeOSError
 from tests.tools import C, buildTestProject
@@ -529,8 +529,9 @@ def testGuiProjTree_MergeDocuments(qtbot, monkeypatch, nwGUI, projPath, mockRnd,
 
     monkeypatch.setattr(GuiDocMerge, "__init__", lambda *a: None)
     monkeypatch.setattr(GuiDocMerge, "exec", lambda *a: None)
-    monkeypatch.setattr(GuiDocMerge, "result", lambda *a: QDialog.DialogCode.Accepted)
-    monkeypatch.setattr(GuiDocMerge, "getData", lambda *a: mergeData)
+    monkeypatch.setattr(GuiDocMerge, "deleteLater", lambda *a: None)
+    monkeypatch.setattr(GuiDocMerge, "result", lambda *a: QtAccepted)
+    monkeypatch.setattr(GuiDocMerge, "data", lambda *a: mergeData)
 
     buildTestProject(nwGUI, projPath)
 
@@ -585,7 +586,7 @@ def testGuiProjTree_MergeDocuments(qtbot, monkeypatch, nwGUI, projPath, mockRnd,
 
     # User cancels merge
     with monkeypatch.context() as mp:
-        mp.setattr(GuiDocMerge, "result", lambda *a: QDialog.DialogCode.Rejected)
+        mp.setattr(GuiDocMerge, "result", lambda *a: QtRejected)
         assert projTree._mergeDocuments(hChapter1, True) is False
 
     # The merge goes through
@@ -628,8 +629,9 @@ def testGuiProjTree_SplitDocument(qtbot, monkeypatch, nwGUI, projPath, mockRnd, 
 
     monkeypatch.setattr(GuiDocSplit, "__init__", lambda *a: None)
     monkeypatch.setattr(GuiDocSplit, "exec", lambda *a: None)
-    monkeypatch.setattr(GuiDocSplit, "result", lambda *a: QDialog.DialogCode.Accepted)
-    monkeypatch.setattr(GuiDocSplit, "getData", lambda *a: (splitData, splitText))
+    monkeypatch.setattr(GuiDocSplit, "deleteLater", lambda *a: None)
+    monkeypatch.setattr(GuiDocSplit, "result", lambda *a: QtAccepted)
+    monkeypatch.setattr(GuiDocSplit, "data", lambda *a: (splitData, splitText))
 
     # Create a project
     buildTestProject(nwGUI, projPath)
@@ -722,7 +724,7 @@ def testGuiProjTree_SplitDocument(qtbot, monkeypatch, nwGUI, projPath, mockRnd, 
 
     # Cancelled by user
     with monkeypatch.context() as mp:
-        mp.setattr(GuiDocSplit, "result", lambda *a: QDialog.DialogCode.Rejected)
+        mp.setattr(GuiDocSplit, "result", lambda *a: QtRejected)
         assert projTree._splitDocument(hSplitDoc) is False
 
     # qtbot.stop()


### PR DESCRIPTION
**Summary:**

This PR:
* Tackles some potential issues with deleting Qt objects. It changes the split and merge dialog classes to use class methods instead, similar to other pop-up dialogs. Then it can call the deleteLater function for the C++ side after all data is processed and collected, as opposed to before when it was called on close. I am a little uncertain exactly when the delete would happen in the latter case, but I haven't had any bug reports on crashes when using these tools. Still, I think this implementation is safer.
* Adds a custom `NDialog` class to serve as an in-between class for `QDialog`. Currently, all it adds is an overload of `keyPressEvent` to capture Escape key presses and redirect them to `close()`. The default behaviour of Qt hides the dialog without going through close, thus bypassing the `closeEvent` logic.

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All flake8 checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
