### PR TITLE
Move project name first in window title

### DIFF
--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1361,10 +1361,7 @@ class GuiMain(QMainWindow):
 
     def _updateWindowTitle(self, projName: str | None = None) -> None:
         """Set the window title and add the project's name."""
-        winTitle = CONFIG.appName
-        if projName is not None:
-            winTitle += " - %s" % projName
-        self.setWindowTitle(winTitle)
+        self.setWindowTitle(" - ".join(filter(None, [projName, CONFIG.appName])))
         return
 
     def _getTagSource(self, tag: str) -> tuple[str | None, str | None]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ flake8-pep585
 flake8-pyproject
 flake8-annotations
 isort
+pyqt5-stubs

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -129,7 +129,7 @@ def testDlgProjSettings_SettingsPage(qtbot, monkeypatch, nwGUI, fncPath, projPat
     assert project.data.doBackup is False
 
     nwGUI._processProjectSettingsChanges(False)
-    assert nwGUI.windowTitle() == "novelWriter - Project Name"
+    assert nwGUI.windowTitle() == "Project Name - novelWriter"
 
     # qtbot.stop()
 


### PR DESCRIPTION
**Summary:**

This PR moves the project name before the app name in the window title of the main window, as is customary in software, at least on Linux. It makes it clearer what is open in the app when the title is also used by the desktop environment to show open apps.

**Related Issue(s):**

Closes #1910

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
