### PR TITLE
Refactir dialog closing

### DIFF
--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -85,7 +85,7 @@ class GuiAbout(NDialog):
 
         # Buttons
         self.btnBox = QDialogButtonBox(QtDialogClose, self)
-        self.btnBox.rejected.connect(self.close)
+        self.btnBox.rejected.connect(self.reject)
 
         # Assemble
         self.innerBox = QVBoxLayout()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import logging
 
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import QCloseEvent
+from PyQt5.QtGui import QCloseEvent, QKeyEvent, QKeySequence
 from PyQt5.QtWidgets import (
     QAbstractButton, QCompleter, QDialogButtonBox, QFileDialog, QHBoxLayout,
     QLineEdit, QPushButton, QVBoxLayout, QWidget
@@ -768,6 +768,16 @@ class GuiPreferences(NDialog):
         self._saveWindowSize()
         event.accept()
         self.softDelete()
+        return
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        """Overload keyPressEvent and only accept escape. The main
+        purpose here is to prevent Enter/Return from closing the dialog
+        as it is used for the search box.
+        """
+        if event.matches(QKeySequence.StandardKey.Cancel):
+            self.close()
+        event.ignore()
         return
 
     ##

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -92,7 +92,7 @@ class GuiProjectSettings(NDialog):
         # Buttons
         self.buttonBox = QDialogButtonBox(QtDialogSave | QtDialogCancel, self)
         self.buttonBox.accepted.connect(self._doSave)
-        self.buttonBox.rejected.connect(self.close)
+        self.buttonBox.rejected.connect(self.reject)
 
         # Content
         SHARED.project.countStatus()

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -109,7 +109,7 @@ class GuiWordList(NDialog):
         # Buttons
         self.buttonBox = QDialogButtonBox(QtDialogSave | QtDialogClose, self)
         self.buttonBox.accepted.connect(self._doSave)
-        self.buttonBox.rejected.connect(self.close)
+        self.buttonBox.rejected.connect(self.reject)
 
         # Assemble
         self.outerBox = QVBoxLayout()

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -30,8 +30,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import QSize, Qt
-from PyQt5.QtGui import QKeyEvent, QKeySequence, QWheelEvent
+from PyQt5.QtCore import QSize, Qt, pyqtSlot
+from PyQt5.QtGui import QWheelEvent
 from PyQt5.QtWidgets import (
     QApplication, QComboBox, QDialog, QDoubleSpinBox, QSpinBox, QToolButton,
     QWidget
@@ -54,11 +54,11 @@ class NDialog(QDialog):
         self.setParent(None)  # type: ignore
         return
 
-    def keyPressEvent(self, event: QKeyEvent) -> None:
-        """Overload keyPressEvent and forward escape to close."""
-        if event.matches(QKeySequence.StandardKey.Cancel):
-            self.close()
-        event.ignore()
+    @pyqtSlot()
+    def reject(self) -> None:
+        """Overload the reject slot and also call close."""
+        super().reject()
+        self.close()
         return
 
 

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -109,7 +109,7 @@ class GuiDictionaries(NNonBlockingDialog):
 
         # Buttons
         self.buttonBox = QDialogButtonBox(QtDialogClose, self)
-        self.buttonBox.rejected.connect(self._doClose)
+        self.buttonBox.rejected.connect(self.reject)
 
         # Assemble
         self.innerBox = QVBoxLayout()
@@ -218,12 +218,6 @@ class GuiDictionaries(NNonBlockingDialog):
         """Open the dictionary folder."""
         if not openExternalPath(Path(self.inPath.text())):
             SHARED.error("Path not found.")
-        return
-
-    @pyqtSlot()
-    def _doClose(self) -> None:
-        """Close the dialog."""
-        self.close()
         return
 
     ##

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 import random
 
-from PyQt5.QtCore import Qt, pyqtSlot
+from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import (
     QDialogButtonBox, QGridLayout, QHBoxLayout, QLabel, QSpinBox, QVBoxLayout,
     QWidget
@@ -48,12 +48,9 @@ class GuiLipsum(NDialog):
 
         logger.debug("Create: GuiLipsum")
         self.setObjectName("GuiLipsum")
-        if CONFIG.osDarwin:
-            self.setWindowFlag(Qt.WindowType.Tool)
+        self.setWindowTitle(self.tr("Insert Placeholder Text"))
 
         self._lipsumText = ""
-
-        self.setWindowTitle(self.tr("Insert Placeholder Text"))
 
         vSp = CONFIG.pxInt(4)
         nPx = CONFIG.pxInt(64)
@@ -96,7 +93,7 @@ class GuiLipsum(NDialog):
 
         # Buttons
         self.buttonBox = QDialogButtonBox(self)
-        self.buttonBox.rejected.connect(self.close)
+        self.buttonBox.rejected.connect(self.reject)
 
         self.btnClose = self.buttonBox.addButton(QtDialogClose)
         self.btnClose.setAutoDefault(False)
@@ -104,8 +101,6 @@ class GuiLipsum(NDialog):
         self.btnInsert = self.buttonBox.addButton(self.tr("Insert"), QtRoleAction)
         self.btnInsert.clicked.connect(self._doInsert)
         self.btnInsert.setAutoDefault(False)
-
-        self.rejected.connect(self.close)
 
         # Assemble
         self.outerBox = QVBoxLayout()

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -97,7 +97,7 @@ class GuiNovelDetails(NNonBlockingDialog):
 
         # Buttons
         self.buttonBox = QDialogButtonBox(QtDialogClose, self)
-        self.buttonBox.rejected.connect(self.close)
+        self.buttonBox.rejected.connect(self.reject)
 
         # Assemble
         self.topBox = QHBoxLayout()

--- a/tests/test_ext/test_ext_modified.py
+++ b/tests/test_ext/test_ext_modified.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 
 import pytest
 
-from PyQt5.QtCore import QPoint, QPointF, Qt
-from PyQt5.QtGui import QWheelEvent
+from PyQt5.QtCore import QEvent, QPoint, QPointF, Qt
+from PyQt5.QtGui import QKeyEvent, QWheelEvent
+from PyQt5.QtWidgets import QWidget
 
-from novelwriter.extensions.modified import NComboBox, NDoubleSpinBox, NSpinBox
+from novelwriter.extensions.modified import NComboBox, NDialog, NDoubleSpinBox, NSpinBox
+from novelwriter.types import QtModNone, QtRejected
 
 from tests.tools import SimpleDialog
 
@@ -45,6 +47,21 @@ class MockWheelEvent(QWheelEvent):
         super().ignore()
         self.ignored = True
         return
+
+
+@pytest.mark.gui
+def testExtModified_NDialog(qtbot, monkeypatch):
+    """Test the QDialog class."""
+    widget = QWidget()
+    dialog = NDialog(widget)
+    assert dialog.parent() is widget
+
+    dialog.softDelete()
+    assert dialog.parent() is None
+
+    with qtbot.waitSignal(dialog.rejected, timeout=1000):
+        dialog.keyPressEvent(QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Escape, QtModNone))
+        assert dialog.result() == QtRejected
 
 
 @pytest.mark.gui

--- a/tests/test_ext/test_ext_modified.py
+++ b/tests/test_ext/test_ext_modified.py
@@ -51,7 +51,7 @@ class MockWheelEvent(QWheelEvent):
 
 @pytest.mark.gui
 def testExtModified_NDialog(qtbot, monkeypatch):
-    """Test the QDialog class."""
+    """Test the NDialog class."""
     widget = QWidget()
     dialog = NDialog(widget)
     assert dialog.parent() is widget

--- a/tests/test_tools/test_tools_dictionaries.py
+++ b/tests/test_tools/test_tools_dictionaries.py
@@ -152,6 +152,4 @@ def testToolDictionaries_Main(qtbot, monkeypatch, nwGUI, fncPath):
         "Additional dictionaries found: 2"
     )
 
-    # Close
-    nwDicts._doClose()
     # qtbot.stop()

--- a/tests/test_tools/test_tools_lipsum.py
+++ b/tests/test_tools/test_tools_lipsum.py
@@ -25,6 +25,7 @@ import pytest
 from PyQt5.QtWidgets import QAction
 
 from novelwriter import SHARED
+from novelwriter.enum import nwDocInsert
 from novelwriter.tools.lipsum import GuiLipsum
 
 from tests.tools import C, buildTestProject
@@ -63,7 +64,7 @@ def testToolLipsum_Main(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
         mp.setattr(GuiLipsum, "exec", lambda *a: None)
         mp.setattr(GuiLipsum, "lipsumText", "FooBar")
         with qtbot.waitSignal(nwGUI.docEditor.textChanged):
-            nwGUI.mainMenu.aLipsumText.activate(QAction.Trigger)
+            nwGUI.docEditor.insertText(nwDocInsert.LIPSUM)
         assert nwGUI.docEditor.getText() == "### New Scene\n\nFooBar"
 
     # qtbot.stop()

--- a/tests/test_tools/test_tools_lipsum.py
+++ b/tests/test_tools/test_tools_lipsum.py
@@ -62,7 +62,8 @@ def testToolLipsum_Main(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     with monkeypatch.context() as mp:
         mp.setattr(GuiLipsum, "exec", lambda *a: None)
         mp.setattr(GuiLipsum, "lipsumText", "FooBar")
-        nwGUI.mainMenu.aLipsumText.activate(QAction.Trigger)
+        with qtbot.waitSignal(nwGUI.docEditor.textChanged):
+            nwGUI.mainMenu.aLipsumText.activate(QAction.Trigger)
         assert nwGUI.docEditor.getText() == "### New Scene\n\nFooBar"
 
     # qtbot.stop()


### PR DESCRIPTION
**Summary:**

This PR changes the dialog parent class to overload the virtual `reject()` slot and add a call to `close()` to it. This makes this a usable slot for all dialogs as this is the behaviour we want in novelWriter. It also solves an issue where `close()` is used as a slot, even if it isn't a valid slot.

This also fixes a bug introduced with the `NDialog` class in the 2.5 release cycle.

**Related Issue(s):**

Closes #1915

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
