### PR TITLE
Fix multiple tools dialog issue

### DIFF
--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -797,7 +797,8 @@ class GuiMain(QMainWindow):
     def showBuildManuscriptDialog(self) -> None:
         """Open the build manuscript dialog."""
         if SHARED.hasProject:
-            dialog = GuiManuscript(self)
+            if not (dialog := SHARED.findTopLevelWidget(GuiManuscript)):
+                dialog = GuiManuscript(self)
             dialog.activateDialog()
             dialog.loadContent()
         return
@@ -815,7 +816,8 @@ class GuiMain(QMainWindow):
     def showWritingStatsDialog(self) -> None:
         """Open the session stats dialog."""
         if SHARED.hasProject:
-            dialog = GuiWritingStats(self)
+            if not (dialog := SHARED.findTopLevelWidget(GuiWritingStats)):
+                dialog = GuiWritingStats(self)
             dialog.activateDialog()
             dialog.populateGUI()
         return


### PR DESCRIPTION
**Summary:**

* Fix an issue where multiple Manuscript and Writing Stats dialogs could be opened at once.
* Improve Writing Stats tests.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
