### PR TITLE
Allow more characters to be used in file names

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -523,12 +523,11 @@ def readTextFile(path: str | Path) -> str:
 
 
 def makeFileNameSafe(text: str) -> str:
-    """Return a filename safe string.
+    """Return a filename-safe string.
     See: https://unicode.org/reports/tr15/#Norm_Forms
     """
     text = unicodedata.normalize("NFKC", text).strip()
-    allowed = (" ", ".", "-", "_")
-    return "".join(c for c in text if c.isalnum() or c in allowed)
+    return "".join(c for c in text if c.isprintable() and c not in r'\/:*?"<>|')
 
 
 def getFileSize(path: Path) -> int:

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -621,12 +621,39 @@ def testBaseCommon_readTextFile(monkeypatch, fncPath, ipsumText):
 @pytest.mark.base
 def testBaseCommon_makeFileNameSafe():
     """Test the makeFileNameSafe function."""
-    assert makeFileNameSafe(" aaaa ") == "aaaa"
-    assert makeFileNameSafe("aaaa,bbbb") == "aaaabbbb"
-    assert makeFileNameSafe("aaaa\tbbbb") == "aaaabbbb"
-    assert makeFileNameSafe("aaaa bbbb") == "aaaa bbbb"
-    assert makeFileNameSafe("æøå") == "æøå"
+    # Trim edges
+    assert makeFileNameSafe(" Name ") == "Name"
+
+    # Normalise Unicode
     assert makeFileNameSafe("Stuff œﬁ2⁵") == "Stuff œfi25"
+
+    # No control characters
+    assert makeFileNameSafe("One\tTwo") == "OneTwo"
+    assert makeFileNameSafe("One\nTwo") == "OneTwo"
+    assert makeFileNameSafe("One\rTwo") == "OneTwo"
+
+    # Invalid special characters
+    assert makeFileNameSafe("One\\Two") == "OneTwo"
+    assert makeFileNameSafe("One/Two") == "OneTwo"
+    assert makeFileNameSafe("One:Two") == "OneTwo"
+    assert makeFileNameSafe("One*Two") == "OneTwo"
+    assert makeFileNameSafe("One?Two") == "OneTwo"
+    assert makeFileNameSafe('One"Two') == "OneTwo"
+    assert makeFileNameSafe("One<Two") == "OneTwo"
+    assert makeFileNameSafe("One>Two") == "OneTwo"
+    assert makeFileNameSafe("One|Two") == "OneTwo"
+
+    # Names that are valid
+    assert makeFileNameSafe("One Two") == "One Two"
+    assert makeFileNameSafe("One,Two") == "One,Two"
+    assert makeFileNameSafe("One-Two") == "One-Two"
+    assert makeFileNameSafe("One–Two") == "One–Two"
+    assert makeFileNameSafe("One—Two") == "One—Two"
+    assert makeFileNameSafe("Bob's Story") == "Bob's Story"
+
+    # Unicode
+    assert makeFileNameSafe("æøå") == "æøå"
+    assert makeFileNameSafe("ßÜ") == "ßÜ"
 
 
 @pytest.mark.base


### PR DESCRIPTION
**Summary:**

File and folder names are currently restricted to mostly alphanumeric characters, plus a few more. This PR changes it so that only non-printable characters are disallowed, plus a handful of other characters primarily disallowed by Windows.

**Related Issue(s):**

Closes #1917

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
