### PR TITLE
Ensure editor content is saved before using it

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -32,10 +32,8 @@ from enum import Enum
 from time import time
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import QPoint, QTimer, Qt, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import (
-    QDragEnterEvent, QDragMoveEvent, QDropEvent, QIcon, QMouseEvent, QPalette
-)
+from PyQt5.QtCore import QPoint, Qt, QTimer, pyqtSignal, pyqtSlot
+from PyQt5.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent, QIcon, QMouseEvent, QPalette
 from PyQt5.QtWidgets import (
     QAbstractItemView, QAction, QDialog, QFrame, QHBoxLayout, QHeaderView,
     QLabel, QMenu, QShortcut, QSizePolicy, QTreeWidget, QTreeWidgetItem,
@@ -44,14 +42,14 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import minmax
-from novelwriter.constants import nwHeaders, nwUnicode, trConst, nwLabels
+from novelwriter.constants import nwHeaders, nwLabels, nwUnicode, trConst
 from novelwriter.core.coretools import DocDuplicator, DocMerger, DocSplitter
 from novelwriter.core.item import NWItem
 from novelwriter.dialogs.docmerge import GuiDocMerge
 from novelwriter.dialogs.docsplit import GuiDocSplit
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
-from novelwriter.enum import nwDocMode, nwItemType, nwItemClass, nwItemLayout
+from novelwriter.enum import nwDocMode, nwItemClass, nwItemLayout, nwItemType
 from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import QtAlignLeft, QtAlignRight, QtMouseLeft, QtMouseMiddle, QtUserRole
@@ -1830,6 +1828,7 @@ class _TreeContextMenu(QMenu):
 
     def _itemHeader(self) -> None:
         """Check if there is a header that can be used for rename."""
+        SHARED.ensureEditorSaved(self._handle)
         if hItem := SHARED.project.index.getItemHeading(self._handle, "T0001"):
             action = self.addAction(self.tr("Rename to Heading"))
             action.triggered.connect(

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -204,6 +204,19 @@ class SharedData(QObject):
         self._resetIdleTimer()
         return
 
+    def ensureEditorSaved(self, tHandle: str | None) -> None:
+        """Ensure that the editor content is saved. Optionally, only if
+        it is a specific handle.
+        """
+        docEditor = self.mainGui.docEditor
+        if (
+            self.hasProject and docEditor.docHandle
+            and (tHandle is None or tHandle == docEditor.docHandle)
+        ):
+            logger.debug("Saving editor document before action")
+            docEditor.saveText()
+        return
+
     def updateSpellCheckLanguage(self, reload: bool = False) -> None:
         """Update the active spell check language from settings."""
         from novelwriter import CONFIG

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -343,7 +343,7 @@ class GuiManuscript(NDialog):
             return
 
         # Make sure editor content is saved before we start
-        SHARED.mainGui.saveDocument()
+        SHARED.ensureEditorSaved(None)
 
         docBuild = NWBuildDocument(SHARED.project, build)
         docBuild.setPreviewMode(True)


### PR DESCRIPTION
**Summary:**

This PR:
* Adds a method to the shared object that can be called when it is important that the content of the document editor is saved before it is used to perform an action.
* Use this method in the Manuscript tool (replaces the old implementation).
* Adds this to the "Rename to Heading" context menu handler in the project tree.

**Related Issue(s):**

Closes #1914

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
