### PR TITLE
Remember last used path for each tool individually

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -438,9 +438,9 @@ class Config:
             return self._appPath / "assets" / target
         return self._appPath / "assets"
 
-    def lastPath(self, key: str | None = None) -> Path:
+    def lastPath(self, key: str) -> Path:
         """Return the last path used by the user, if it exists."""
-        if path := self._recentPaths.getPath(key or "default"):
+        if path := self._recentPaths.getPath(key):
             asPath = Path(path)
             if asPath.is_dir():
                 return asPath

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -344,7 +344,7 @@ class Config:
         self._outlnPanePos = [int(x/self.guiScale) for x in pos]
         return
 
-    def setLastPath(self, path: str | Path, key: str | None = None) -> None:
+    def setLastPath(self, key: str, path: str | Path) -> None:
         """Set the last used path. Only the folder is saved, so if the
         path is not a folder, the parent of the path is used instead.
         """
@@ -353,7 +353,7 @@ class Config:
             if not path.is_dir():
                 path = path.parent
             if path.is_dir():
-                self._recentPaths.setPath(key or "default", path)
+                self._recentPaths.setPath(key, path)
                 self._recentPaths.saveCache()
         return
 

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -181,7 +181,6 @@ class Config:
         self.fmtPadThin      = False
 
         # User Paths
-        self._lastPath   = self._homePath  # The user's last used path
         self._backupPath = self._backPath  # Backup path to use, can be none
 
         # Spell Checking Settings
@@ -518,7 +517,6 @@ class Config:
         logger.debug("Data Path: %s", self._dataPath)
         logger.debug("App Root: %s", self._appRoot)
         logger.debug("App Path: %s", self._appPath)
-        logger.debug("Last Path: %s", self._lastPath)
         logger.debug("PDF Manual: %s", self.pdfDocs)
 
         # If the config and data folders don't exist, create them
@@ -603,7 +601,6 @@ class Config:
         self.hideHScroll = conf.rdBool(sec, "hidehscroll", self.hideHScroll)
         self.lastNotes   = conf.rdStr(sec, "lastnotes", self.lastNotes)
         self.nativeFont  = conf.rdBool(sec, "nativefont", self.nativeFont)
-        self._lastPath   = conf.rdPath(sec, "lastpath", self._lastPath)
 
         # Sizes
         sec = "Sizes"
@@ -713,7 +710,6 @@ class Config:
             "hidehscroll":  str(self.hideHScroll),
             "lastnotes":    str(self.lastNotes),
             "nativefont":   str(self.nativeFont),
-            "lastpath":     str(self._lastPath),
         }
 
         conf["Sizes"] = {

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -5,6 +5,7 @@ novelWriter – Config Class
 File History:
 Created: 2018-09-22 [0.0.1]  Config
 Created: 2022-11-09 [2.0rc2] RecentProjects
+Created: 2024-06-16 [2.5rc1] RecentPaths
 
 This file is a part of novelWriter
 Copyright 2018–2024, Veronica Berglyd Olsen

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -904,7 +904,7 @@ class RecentPaths:
         return
 
     def setPath(self, key: str, path: Path | str) -> None:
-        """Set a path for a given key."""
+        """Set a path for a given key, and save the cache."""
         if key in self.KEYS:
             self._data[key] = str(path)
         self.saveCache()
@@ -915,7 +915,7 @@ class RecentPaths:
         return self._data.get(key)
 
     def loadCache(self) -> bool:
-        """Load the cache file for recent projects."""
+        """Load the cache file for recent paths."""
         self._data = {}
         cacheFile = self._conf.dataPath(nwFiles.RECENT_PATH)
         if cacheFile.is_file():
@@ -933,7 +933,7 @@ class RecentPaths:
         return True
 
     def saveCache(self) -> bool:
-        """Save the cache dictionary of recent projects."""
+        """Save the cache dictionary of recent paths."""
         cacheFile = self._conf.dataPath(nwFiles.RECENT_PATH)
         cacheTemp = cacheFile.with_suffix(".tmp")
         try:

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -353,7 +353,6 @@ class Config:
                 path = path.parent
             if path.is_dir():
                 self._recentPaths.setPath(key, path)
-                self._recentPaths.saveCache()
         return
 
     def setBackupPath(self, path: Path | str) -> None:
@@ -907,6 +906,8 @@ class RecentPaths:
         """Set a path for a given key."""
         if key in self.KEYS:
             self._data[key] = str(path)
+        self.saveCache()
+        return
 
     def getPath(self, key: str) -> str | None:
         """Get a path for a given key, or return None."""
@@ -928,7 +929,6 @@ class RecentPaths:
                 logger.error("Could not load recent paths cache")
                 logException()
                 return False
-
         return True
 
     def saveCache(self) -> bool:
@@ -943,5 +943,4 @@ class RecentPaths:
             logger.error("Could not save recent paths cache")
             logException()
             return False
-
         return True

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -919,15 +919,15 @@ class RecentPaths:
     def loadCache(self) -> bool:
         """Load the cache file for recent projects."""
         self._data = {}
-
         cacheFile = self._conf.dataPath(nwFiles.RECENT_PATH)
         if cacheFile.is_file():
             try:
                 with open(cacheFile, mode="r", encoding="utf-8") as inFile:
                     data = json.load(inFile)
-                for key, path in data.items():
-                    if isinstance(path, str) and key in self.KEYS:
-                        data[key] = path
+                if isinstance(data, dict):
+                    for key, path in data.items():
+                        if key in self.KEYS and isinstance(path, str):
+                            self._data[key] = path
             except Exception:
                 logger.error("Could not load recent paths cache")
                 logException()

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -104,6 +104,7 @@ class nwFiles:
     # Config Files
     CONF_FILE   = "novelwriter.conf"
     RECENT_FILE = "recentProjects.json"
+    RECENT_PATH = "recentPaths.json"
 
     # Project Root Files
     PROJ_FILE   = "nwProject.nwx"

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -219,7 +219,7 @@ class BuildSettings:
         return self._order
 
     @property
-    def lastPath(self) -> Path:
+    def lastBuildPath(self) -> Path:
         """The last used build path."""
         if self._path.is_dir():
             return self._path
@@ -293,7 +293,7 @@ class BuildSettings:
             self._order = value
         return
 
-    def setLastPath(self, path: Path | str | None) -> None:
+    def setLastBuildPath(self, path: Path | str | None) -> None:
         """Set the last used build path."""
         if isinstance(path, str):
             path = Path(path)
@@ -461,7 +461,7 @@ class BuildSettings:
         self.setName(data.get("name", ""))
         self.setBuildID(data.get("uuid", ""))
         self.setOrder(data.get("order", 0))
-        self.setLastPath(data.get("path", None))
+        self.setLastBuildPath(data.get("path", None))
         self.setLastBuildName(data.get("build", ""))
 
         buildFmt = str(data.get("format", ""))

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -523,12 +523,12 @@ class GuiOutlineTree(QTreeWidget):
     @pyqtSlot()
     def exportOutline(self) -> None:
         """Export the outline as a CSV file."""
-        path = CONFIG.lastPath() / f"{makeFileNameSafe(SHARED.project.data.name)}.csv"
+        path = CONFIG.lastPath("outline") / f"{makeFileNameSafe(SHARED.project.data.name)}.csv"
         path, _ = QFileDialog.getSaveFileName(
             self, self.tr("Save Outline As"), str(path), formatFileFilter(["*.csv", "*"])
         )
         if path:
-            CONFIG.setLastPath(path)
+            CONFIG.setLastPath("outline", path)
             logger.info("Writing CSV file: %s", path)
             cols = [col for col in self._treeOrder if not self._colHidden[col]]
             order = [self._colIdx[col] for col in cols]

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -652,7 +652,7 @@ class GuiMain(QMainWindow):
             logger.error("No project open")
             return False
 
-        lastPath = CONFIG.lastPath()
+        lastPath = CONFIG.lastPath("import")
         ffilter = formatFileFilter(["*.txt", "*.md", "*.nwd", "*"])
         loadFile, _ = QFileDialog.getOpenFileName(
             self, self.tr("Import File"), str(lastPath), filter=ffilter
@@ -667,7 +667,7 @@ class GuiMain(QMainWindow):
         try:
             with open(loadFile, mode="rt", encoding="utf-8") as inFile:
                 text = inFile.read()
-            CONFIG.setLastPath(loadFile)
+            CONFIG.setLastPath("import", loadFile)
         except Exception as exc:
             SHARED.error(self.tr(
                 "Could not read file. The file must be an existing text file."

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -220,7 +220,7 @@ class GuiManuscriptBuild(NDialog):
 
         self.btnBuild.setFocus()
         self._populateContentList()
-        self.buildPath.setText(str(self._build.lastPath))
+        self.buildPath.setText(str(self._build.lastBuildPath))
         if self._build.lastBuildName:
             self.buildName.setText(self._build.lastBuildName)
         else:
@@ -274,7 +274,7 @@ class GuiManuscriptBuild(NDialog):
     def _doSelectPath(self) -> None:
         """Select a folder for output."""
         bPath = Path(self.buildPath.text())
-        bPath = bPath if bPath.is_dir() else self._build.lastPath
+        bPath = bPath if bPath.is_dir() else self._build.lastBuildPath
         savePath = QFileDialog.getExistingDirectory(
             self, self.tr("Select Folder"), str(bPath)
         )
@@ -336,7 +336,7 @@ class GuiManuscriptBuild(NDialog):
         for i, _ in docBuild.iterBuild(buildPath, bFormat):
             self.buildProgress.setValue(i+1)
 
-        self._build.setLastPath(bPath)
+        self._build.setLastBuildPath(bPath)
         self._build.setLastBuildName(bName)
         self._build.setLastFormat(bFormat)
 

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -220,8 +220,8 @@ class GuiWelcome(NDialog):
     @pyqtSlot()
     def _browseForProject(self) -> None:
         """Browse for a project to open."""
-        if path := SHARED.getProjectPath(self, path=CONFIG.lastPath(), allowZip=False):
-            CONFIG.setLastPath(path)
+        if path := SHARED.getProjectPath(self, path=CONFIG.lastPath("project"), allowZip=False):
+            CONFIG.setLastPath("project", path)
             self._openProjectPath(path)
         return
 

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -220,7 +220,7 @@ class GuiWelcome(NDialog):
     @pyqtSlot()
     def _browseForProject(self) -> None:
         """Browse for a project to open."""
-        if path := SHARED.getProjectPath(self, path=CONFIG.lastPath("project"), allowZip=False):
+        if path := SHARED.getProjectPath(self, path=CONFIG.homePath(), allowZip=False):
             self._openProjectPath(path)
         return
 

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -221,7 +221,6 @@ class GuiWelcome(NDialog):
     def _browseForProject(self) -> None:
         """Browse for a project to open."""
         if path := SHARED.getProjectPath(self, path=CONFIG.lastPath("project"), allowZip=False):
-            CONFIG.setLastPath("project", path)
             self._openProjectPath(path)
         return
 
@@ -550,7 +549,7 @@ class _NewProjectForm(QWidget):
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
-        self._basePath = CONFIG.homePath()
+        self._basePath = CONFIG.lastPath("project")
         self._fillMode = self.FILL_BLANK
         self._copyPath = None
 
@@ -726,12 +725,13 @@ class _NewProjectForm(QWidget):
     @pyqtSlot()
     def _doBrowse(self) -> None:
         """Select a project folder."""
-        if projDir := QFileDialog.getExistingDirectory(
+        if path := QFileDialog.getExistingDirectory(
             self, self.tr("Select Project Folder"),
             str(self._basePath), options=QFileDialog.Option.ShowDirsOnly
         ):
-            self._basePath = Path(projDir)
+            self._basePath = Path(path)
             self._updateProjPath()
+            CONFIG.setLastPath("project", path)
         return
 
     @pyqtSlot()

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -384,14 +384,14 @@ class GuiWritingStats(NToolDialog):
             return False
 
         # Generate the file name
-        savePath = CONFIG.lastPath() / f"sessionStats.{fileExt}"
+        savePath = CONFIG.lastPath("stats") / f"sessionStats.{fileExt}"
         savePath, _ = QFileDialog.getSaveFileName(
             self, self.tr("Save Data As"), str(savePath), f"{textFmt} (*.{fileExt})"
         )
         if not savePath:
             return False
 
-        CONFIG.setLastPath(savePath)
+        CONFIG.setLastPath("stats", savePath)
 
         # Do the actual writing
         wSuccess = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,6 @@ def resetConfigVars():
     """Reset the CONFIG object and set various values for testing to
     prevent interfering with local OS.
     """
-    # CONFIG.setLastPath(_TMP_ROOT)
     CONFIG.setBackupPath(_TMP_ROOT)
     CONFIG.setGuiFont(None)
     CONFIG.setTextFont(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def resetConfigVars():
     """Reset the CONFIG object and set various values for testing to
     prevent interfering with local OS.
     """
-    CONFIG.setLastPath(_TMP_ROOT)
+    # CONFIG.setLastPath(_TMP_ROOT)
     CONFIG.setBackupPath(_TMP_ROOT)
     CONFIG.setGuiFont(None)
     CONFIG.setTextFont(None)

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2024-05-20 16:48:20
+timestamp = 2024-06-16 00:36:27
 
 [Main]
 font = 
@@ -10,7 +10,6 @@ hidevscroll = False
 hidehscroll = False
 lastnotes = 0x0
 nativefont = True
-lastpath = 
 
 [Sizes]
 mainwindow = 1200, 650

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -213,21 +213,21 @@ def testBaseConfig_Methods(fncPath):
     assert tstConf.assetPath("stuff") == appPath / "assets" / "stuff"
 
     # Last Path
-    assert tstConf.lastPath() == Path.home().absolute()
+    assert tstConf.lastPath("project") == Path.home().absolute()
 
     tmpStuff = fncPath / "stuff"
     tmpStuff.mkdir()
-    tstConf.setLastPath(tmpStuff)
-    assert tstConf.lastPath() == tmpStuff
+    tstConf.setLastPath("project", tmpStuff)
+    assert tstConf.lastPath("project") == tmpStuff
 
     fileStuff = tmpStuff / "more_stuff.txt"
     fileStuff.write_text("Stuff")
-    tstConf.setLastPath(fileStuff)
-    assert tstConf.lastPath() == tmpStuff
+    tstConf.setLastPath("project", fileStuff)
+    assert tstConf.lastPath("project") == tmpStuff
 
     fileStuff.unlink()
     tmpStuff.rmdir()
-    assert tstConf.lastPath() == Path.home().absolute()
+    assert tstConf.lastPath("project") == Path.home().absolute()
 
     # Backup Path
     assert tstConf.backupPath() == tstConf._backPath

--- a/tests/test_core/test_core_buildsettings.py
+++ b/tests/test_core/test_core_buildsettings.py
@@ -73,29 +73,29 @@ def testCoreBuildSettings_ClassAttributes(fncPath: Path):
     assert isUUID(build.buildID)
 
     # Last path must be valid, if not it defaults to $HOME
-    build.setLastPath("/path/to/nowhere")
-    assert build.lastPath == CONFIG.homePath()
+    build.setLastBuildPath("/path/to/nowhere")
+    assert build.lastBuildPath == CONFIG.homePath()
 
-    build.setLastPath(None)
-    assert build.lastPath == CONFIG.homePath()
+    build.setLastBuildPath(None)
+    assert build.lastBuildPath == CONFIG.homePath()
 
     (fncPath / "test.txt").write_text("foobar")
-    build.setLastPath(fncPath / "test.txt")  # Can't be a file
-    assert build.lastPath == CONFIG.homePath()
+    build.setLastBuildPath(fncPath / "test.txt")  # Can't be a file
+    assert build.lastBuildPath == CONFIG.homePath()
 
-    build.setLastPath(fncPath)
-    assert build.lastPath == fncPath
+    build.setLastBuildPath(fncPath)
+    assert build.lastBuildPath == fncPath
 
-    build.setLastPath(str(fncPath))  # String paths are also ok
-    assert build.lastPath == fncPath
+    build.setLastBuildPath(str(fncPath))  # String paths are also ok
+    assert build.lastBuildPath == fncPath
 
     # Last path no longer exists -> fallback to $HOME
     testDir = fncPath / "test_dir"
     testDir.mkdir()
-    build.setLastPath(testDir)
-    assert build.lastPath == testDir
+    build.setLastBuildPath(testDir)
+    assert build.lastBuildPath == testDir
     testDir.rmdir()
-    assert build.lastPath == CONFIG.homePath()
+    assert build.lastBuildPath == CONFIG.homePath()
 
     # Last build name
     build.setLastBuildName(None)  # type: ignore
@@ -119,7 +119,7 @@ def testCoreBuildSettings_ClassAttributes(fncPath: Path):
     # Set some sensible values
     build.setName("Test Build")
     build.setBuildID("5cf45d24-f496-42c9-8733-529a9e52a62b")
-    build.setLastPath(fncPath)
+    build.setLastBuildPath(fncPath)
     build.setLastBuildName("Build Name")
     build.setLastFormat(nwBuildFmt.HTML)
 

--- a/tests/test_tools/test_tools_manusbuild.py
+++ b/tests/test_tools/test_tools_manusbuild.py
@@ -47,7 +47,7 @@ def testToolManuscriptBuild_Main(
     buildTestProject(nwGUI, projPath)
     nwGUI.openProject(projPath)
     build = BuildSettings()
-    build.setLastPath(fncPath)
+    build.setLastBuildPath(fncPath)
 
     manus = GuiManuscriptBuild(nwGUI, build)
     manus.show()
@@ -100,7 +100,7 @@ def testToolManuscriptBuild_Main(
 
     assert build.lastBuildName == "TestBuild"
     assert build.lastFormat == lastFmt
-    assert build.lastPath == fncPath
+    assert build.lastBuildPath == fncPath
 
     # Error Handling
     # ==============


### PR DESCRIPTION
**Summary:**

This PR rewrites the last path handler to store the last used user path for each tool that uses path lookups, instead of only storing one last path entry for everything. The Welcome dialog new project form now uses this to remember the path the user used last time for creating a project.

**Related Issue(s):**

Closes #1930

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
