### PR TITLE
Revert font setting in custom class

### DIFF
--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -34,7 +34,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout, QWidget
 )
 
-from novelwriter import CONFIG, SHARED
+from novelwriter import CONFIG
 
 DEFAULT_SCALE = 0.9
 
@@ -266,7 +266,7 @@ class NColourLabel(QLabel):
         self._color = color or default
         self._faded = faded or default
 
-        font = SHARED.theme.guiFont
+        font = self.font()
         font.setPointSizeF(scale*font.pointSizeF())
         font.setWeight(QFont.Weight.Bold if bold else QFont.Weight.Normal)
         if color:


### PR DESCRIPTION
**Summary:**

This PR reverts a change from #1940 that uses a font from theme when setting the default font in the custom colour label class. This caused some strange behaviour likely due to a loop somewhere when loading the Preferences dialog, which uses it multiple times.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
