### PR TITLE
Improve open project error message

### DIFF
--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -254,13 +254,23 @@ class NWProject:
         status = self._storage.initProjectStorage(projPath, clearLock)
         if status != NWStorageOpen.READY:
             if status == NWStorageOpen.UNKOWN:
-                SHARED.error(self.tr("Not a known project file format."))
+                SHARED.error(
+                    self.tr("Not a known project file format."),
+                    info=self.tr("Path: {0}").format(str(projPath))
+                )
             elif status == NWStorageOpen.NOT_FOUND:
-                SHARED.error(self.tr("Project file not found."))
+                SHARED.error(
+                    self.tr("Project file not found."),
+                    info=self.tr("Path: {0}").format(str(projPath))
+                )
+            elif status == NWStorageOpen.FAILED:
+                SHARED.error(
+                    self.tr("Failed to open project."),
+                    info=self.tr("Path: {0}").format(str(projPath)),
+                    exc=self._storage.exc
+                )
             elif status == NWStorageOpen.LOCKED:
                 self._state = NWProjectState.LOCKED
-            elif status == NWStorageOpen.FAILED:
-                SHARED.error(self.tr("Failed to open project."), exc=self._storage.exc)
             return False
 
         # Read Project XML


### PR DESCRIPTION
**Summary:**

This PR adds path info to the error dialogs that pops up when opening a project path fails.

**Related Issue(s):**

Closes #1944

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
