### PR TITLE
Rewrite build tools

### DIFF
--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -25,9 +25,7 @@ jobs:
 
       - name: Build Assets
         run: |
-          python pkgutils.py manual
-          python pkgutils.py sample
-          python pkgutils.py qtlrelease
+          python pkgutils.py build-assets
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -6,7 +6,7 @@ jobs:
   buildAssets:
     uses: ./.github/workflows/build_assets.yml
 
-  buildLinux:
+  buildLinux-AppImage:
     needs: buildAssets
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -15,5 +15,23 @@ jobs:
         with:
           python-version: "3.12"
           architecture: x64
+
       - name: Checkout Source
         uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nw-assets
+          path: novelwriter/assets
+
+      - name: Build Setup Installer
+        run: python pkgutils.py build-win-exe
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Win-Setup
+          path: dist/*.exe
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -33,7 +33,9 @@ jobs:
         run: |
           pip install -U -r requirements.txt -r tests/requirements.txt
       - name: Run Build Commands
-        run: python pkgutils.py build-assets
+        run: |
+          python pkgutils.py qtlrelease
+          python pkgutils.py sample
       - name: Run Tests
         run: |
           export QT_QPA_PLATFORM=offscreen

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install -U -r requirements.txt -r tests/requirements.txt
       - name: Run Build Commands
-        run: python pkgutils.py qtlrelease sample
+        run: python pkgutils.py build-assets
       - name: Run Tests
         run: |
           export QT_QPA_PLATFORM=offscreen

--- a/pkgutils.py
+++ b/pkgutils.py
@@ -1384,7 +1384,14 @@ def xdgUninstall(args: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
     """Parse command line options and run the commands."""
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        usage="pkgutils.py [command] [--flags]",
+        description=(
+            "This tool provides setup and build commands for installing or distibuting "
+            "novelWriter as a package on Linux, Mac and Windows, as well as developer tools "
+            "for internationalisation."
+        )
+    )
     parsers = parser.add_subparsers()
 
     # Version

--- a/pkgutils.py
+++ b/pkgutils.py
@@ -956,7 +956,7 @@ def makeWindowsEmbedded(args: argparse.Namespace) -> None:
     bldDir = CURR_DIR / "dist"
     outDir = bldDir / "novelWriter"
     libDir = outDir / "lib"
-    if outDir.exists:
+    if outDir.exists():
         shutil.rmtree(outDir)
 
     bldDir.mkdir(exist_ok=True)

--- a/setup/make_pip.sh
+++ b/setup/make_pip.sh
@@ -18,7 +18,7 @@ if [ ! -d $ENVPATH ]; then
 fi
 source $ENVPATH/bin/activate
 pip3 install -r docs/source/requirements.txt
-python3 pkgutils.py qtlrelease manual sample
+python3 pkgutils.py build-assets
 deactivate
 
 echo ""

--- a/setup/make_release.sh
+++ b/setup/make_release.sh
@@ -17,8 +17,7 @@ if [ ! -d $ENVPATH ]; then
 fi
 source $ENVPATH/bin/activate
 pip3 install -r docs/source/requirements.txt
-python3 pkgutils.py clean-assets
-python3 pkgutils.py qtlrelease manual sample
+python3 pkgutils.py build-assets
 deactivate
 
 echo ""

--- a/setup/make_release.sh
+++ b/setup/make_release.sh
@@ -21,12 +21,6 @@ python3 pkgutils.py build-assets
 deactivate
 
 echo ""
-echo " Building Windows Source Zip"
-echo "================================================================================"
-echo ""
-python3 pkgutils.py windows-zip
-
-echo ""
 echo " Building Linux Packages"
 echo "================================================================================"
 echo ""

--- a/setup/win_setup_embed.iss
+++ b/setup/win_setup_embed.iss
@@ -1,6 +1,6 @@
 ; Script for building setup.exe installer with Inno Setup
 
-#define nwAppDir "%%dir%%\dist"
+#define nwAppDir "%%dist%%"
 #define nwAppName "novelWriter"
 #define nwAppVersion "%%version%%"
 #define nwAppPublisher "novelWriter"


### PR DESCRIPTION
**Summary:**

This PR:
* Rewrites the `pkgutils.py` file to use `argprase` and `pathlib` everywhere.
* Splits the GitHub Actions build job into one per platform.
* Adds build job for Windows.
* Drops the intermediate zip file for Windows build and build directly from source.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
