### PR TITLE
Fix preview indent and status bar LEDs

### DIFF
--- a/novelwriter/core/toqdoc.py
+++ b/novelwriter/core/toqdoc.py
@@ -100,18 +100,18 @@ class ToQTextDocument(Tokenizer):
         self._document.setDefaultFont(self._textFont)
 
         qMetric = QFontMetricsF(self._textFont)
-        mScale = qMetric.ascent()
+        mPx = qMetric.ascent()  # 1 em in pixels
         fPt = self._textFont.pointSizeF()
 
         # Scaled Sizes
         # ============
 
         self._mHead = {
-            self.T_TITLE: (mScale * self._marginTitle[0], mScale * self._marginTitle[1]),
-            self.T_HEAD1: (mScale * self._marginHead1[0], mScale * self._marginHead1[1]),
-            self.T_HEAD2: (mScale * self._marginHead2[0], mScale * self._marginHead2[1]),
-            self.T_HEAD3: (mScale * self._marginHead3[0], mScale * self._marginHead3[1]),
-            self.T_HEAD4: (mScale * self._marginHead4[0], mScale * self._marginHead4[1]),
+            self.T_TITLE: (mPx * self._marginTitle[0], mPx * self._marginTitle[1]),
+            self.T_HEAD1: (mPx * self._marginHead1[0], mPx * self._marginHead1[1]),
+            self.T_HEAD2: (mPx * self._marginHead2[0], mPx * self._marginHead2[1]),
+            self.T_HEAD3: (mPx * self._marginHead3[0], mPx * self._marginHead3[1]),
+            self.T_HEAD4: (mPx * self._marginHead4[0], mPx * self._marginHead4[1]),
         }
 
         self._sHead = {
@@ -122,12 +122,12 @@ class ToQTextDocument(Tokenizer):
             self.T_HEAD4: nwHeaders.H_SIZES.get(4, 1.0) * fPt,
         }
 
-        self._mText = (mScale * self._marginText[0], mScale * self._marginText[1])
-        self._mMeta = (mScale * self._marginMeta[0], mScale * self._marginMeta[1])
-        self._mSep  = (mScale * self._marginSep[0], mScale * self._marginSep[1])
+        self._mText = (mPx * self._marginText[0], mPx * self._marginText[1])
+        self._mMeta = (mPx * self._marginMeta[0], mPx * self._marginMeta[1])
+        self._mSep  = (mPx * self._marginSep[0], mPx * self._marginSep[1])
 
-        self._mIndent = mScale * 2.0
-        self._tIndent = mScale * self._firstWidth
+        self._mIndent = mPx * 2.0
+        self._tIndent = mPx * self._firstWidth
 
         # Block Format
         # ============

--- a/novelwriter/core/toqdoc.py
+++ b/novelwriter/core/toqdoc.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 
 from PyQt5.QtGui import (
-    QColor, QFont, QFontMetrics, QTextBlockFormat, QTextCharFormat,
+    QColor, QFont, QFontMetricsF, QTextBlockFormat, QTextCharFormat,
     QTextCursor, QTextDocument
 )
 
@@ -99,8 +99,8 @@ class ToQTextDocument(Tokenizer):
         self._document.clear()
         self._document.setDefaultFont(self._textFont)
 
-        qMetric = QFontMetrics(self._textFont)
-        mScale = qMetric.height()
+        qMetric = QFontMetricsF(self._textFont)
+        mScale = qMetric.ascent()
         fPt = self._textFont.pointSizeF()
 
         # Scaled Sizes

--- a/novelwriter/extensions/statusled.py
+++ b/novelwriter/extensions/statusled.py
@@ -82,7 +82,7 @@ class StatusLED(QAbstractButton):
         """Draw the LED."""
         painter = QPainter(self)
         painter.setRenderHint(QtPaintAnitAlias, True)
-        painter.setPen(self.palette().mid().color())
+        painter.setPen(self.palette().windowText().color())
         painter.setBrush(self._color)
         painter.setOpacity(1.0)
         painter.drawEllipse(

--- a/novelwriter/extensions/statusled.py
+++ b/novelwriter/extensions/statusled.py
@@ -28,6 +28,7 @@ import logging
 from PyQt5.QtGui import QColor, QPainter, QPaintEvent
 from PyQt5.QtWidgets import QAbstractButton, QWidget
 
+from novelwriter import CONFIG
 from novelwriter.enum import nwTrinary
 from novelwriter.types import QtBlack, QtPaintAnitAlias
 
@@ -36,6 +37,10 @@ logger = logging.getLogger(__name__)
 
 class StatusLED(QAbstractButton):
 
+    __slots__ = (
+        "_neutral", "_postitve", "_negative", "_color", "_state", "_bPx"
+    )
+
     def __init__(self, sW: int, sH: int, parent: QWidget | None = None) -> None:
         super().__init__(parent=parent)
         self._neutral = QtBlack
@@ -43,6 +48,7 @@ class StatusLED(QAbstractButton):
         self._negative = QtBlack
         self._color = QtBlack
         self._state = nwTrinary.NEUTRAL
+        self._bPx = CONFIG.pxInt(1)
         self.setFixedWidth(sW)
         self.setFixedHeight(sH)
         return
@@ -76,8 +82,12 @@ class StatusLED(QAbstractButton):
         """Draw the LED."""
         painter = QPainter(self)
         painter.setRenderHint(QtPaintAnitAlias, True)
-        painter.setPen(self.palette().dark().color())
+        painter.setPen(self.palette().mid().color())
         painter.setBrush(self._color)
         painter.setOpacity(1.0)
-        painter.drawEllipse(1, 1, self.width() - 2, self.height() - 2)
+        painter.drawEllipse(
+            self._bPx, self._bPx,
+            self.width() - 2*self._bPx,
+            self.height() - 2*self._bPx
+        )
         return


### PR DESCRIPTION
**Summary:**

This PR fixes the em unit calculation in the document preview class. It was using font height instead of font ascent as the base unit. This PR also fixes the High DPI scaling of the Status Bar LEDs.

**Related Issue(s):**

Closes #1961

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
