### PR TITLE
Add focus switch on welcome dialog

### DIFF
--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -208,6 +208,7 @@ class GuiWelcome(NDialog):
         """Show the create new project page."""
         self.mainStack.setCurrentWidget(self.tabNew)
         self._setButtonVisibility()
+        self.tabNew.enterForm()
         return
 
     @pyqtSlot()
@@ -503,6 +504,8 @@ class _NewProjectPage(QWidget):
         self.scrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.scrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
 
+        self.enterForm = self.projectForm.enterForm
+
         # Assemble
         # ========
 
@@ -694,6 +697,12 @@ class _NewProjectForm(QWidget):
         self._updateProjPath()
         self._updateFillInfo()
 
+        return
+
+    def enterForm(self) -> None:
+        """Focus the project name field when entering the form."""
+        self.projName.setFocus()
+        self.projName.selectAll()
         return
 
     def getProjectData(self) -> dict:


### PR DESCRIPTION
**Summary:**

This PR adds a new call that switches focus to the required Project Name field when the user activates the New Project Form on the Welcome dialog.

**Related Issue(s):**

Related #1967

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
