### PR TITLE
Lock project only after successful open

### DIFF
--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -356,6 +356,7 @@ class NWProject:
         self.setProjectChanged(False)
         self._valid = True
         self._state = NWProjectState.READY
+        self._storage.lockSession()  # Lock only after a successful open. See issue #1977.
 
         SHARED.newStatusMessage(self.tr("Opened Project: {0}").format(self._data.name))
 

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -235,7 +235,6 @@ class NWStorage:
             if child.is_dir() and child.name.startswith("data_"):
                 legacy.legacyDataFolder(basePath, child)
 
-        self._writeLockFile()
         self._ready = True
 
         return NWStorageOpen.READY
@@ -248,6 +247,12 @@ class NWStorage:
             # Nothing to do, so we just return
             return True
         return True
+
+    def lockSession(self) -> None:
+        """Lock the session when the project is successfully opened."""
+        if self._ready:
+            self._writeLockFile()
+        return
 
     def closeSession(self) -> None:
         """Run tasks related to closing the session."""

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -142,7 +142,9 @@ def testCoreStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
     storage.clear()
 
     # Open twice, where second should fail due to lockfile
+    # Note that locking is only possible after a successful open
     assert storage.initProjectStorage(fncPath) == NWStorageOpen.READY
+    storage.lockSession()
     assert storage.initProjectStorage(fncPath) == NWStorageOpen.LOCKED
     assert isinstance(storage.lockStatus, list)
     assert len(storage.lockStatus) == 4


### PR DESCRIPTION
**Summary:**

This PR removes the automatic lock file writing during project storage initiation and until after project open is completed.

**Related Issue(s):**

Closes #1977

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
