### PR TITLE
Make sure free form text boxes in Preferences are safe

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -279,6 +279,16 @@ def simplified(text: str) -> str:
     return " ".join(str(text).strip().split())
 
 
+def compact(text: str) -> str:
+    """Compact a string by removing spaces."""
+    return "".join(str(text).split())
+
+
+def uniqueCompact(text: str) -> str:
+    """Return a unique, compact and sorted string."""
+    return "".join(sorted(set(compact(text))))
+
+
 def elide(text: str, length: int) -> str:
     """Elide a piece of text to a maximum length."""
     if len(text) > (cut := max(4, length)):

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -34,7 +34,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import describeFont
+from novelwriter.common import describeFont, uniqueCompact
 from novelwriter.constants import nwUnicode
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 from novelwriter.extensions.configlayout import NColourLabel, NScrollableForm
@@ -952,8 +952,8 @@ class GuiPreferences(NDialog):
         # Text Highlighting
         dialogueStyle   = self.dialogStyle.currentData()
         allowOpenDial   = self.allowOpenDial.isChecked()
-        narratorBreak   = self.narratorBreak.text()
-        dialogueLine    = self.dialogLine.text()
+        narratorBreak   = self.narratorBreak.text().strip()
+        dialogueLine    = self.dialogLine.text().strip()
         altDialogOpen   = self.altDialogOpen.text()
         altDialogClose  = self.altDialogClose.text()
         highlightEmph   = self.highlightEmph.isChecked()
@@ -983,8 +983,8 @@ class GuiPreferences(NDialog):
         CONFIG.doReplaceDQuote = self.doReplaceDQuote.isChecked()
         CONFIG.doReplaceDash   = self.doReplaceDash.isChecked()
         CONFIG.doReplaceDots   = self.doReplaceDots.isChecked()
-        CONFIG.fmtPadBefore    = self.fmtPadBefore.text().strip()
-        CONFIG.fmtPadAfter     = self.fmtPadAfter.text().strip()
+        CONFIG.fmtPadBefore    = uniqueCompact(self.fmtPadBefore.text())
+        CONFIG.fmtPadAfter     = uniqueCompact(self.fmtPadAfter.text())
         CONFIG.fmtPadThin      = self.fmtPadThin.isChecked()
 
         # Quotation Style

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -32,12 +32,12 @@ from PyQt5.QtGui import QColor, QDesktopServices, QFontDatabase
 
 from novelwriter.common import (
     NWConfigParser, checkBool, checkFloat, checkInt, checkIntTuple, checkPath,
-    checkString, checkStringNone, checkUuid, cssCol, describeFont, elide,
-    formatFileFilter, formatInt, formatTime, formatTimeStamp, formatVersion,
-    fuzzyTime, getFileSize, hexToInt, isHandle, isItemClass, isItemLayout,
-    isItemType, isListInstance, isTitleTag, jsonEncode, makeFileNameSafe,
-    minmax, numberToRoman, openExternalPath, readTextFile, simplified,
-    transferCase, xmlIndent, yesNo
+    checkString, checkStringNone, checkUuid, compact, cssCol, describeFont,
+    elide, formatFileFilter, formatInt, formatTime, formatTimeStamp,
+    formatVersion, fuzzyTime, getFileSize, hexToInt, isHandle, isItemClass,
+    isItemLayout, isItemType, isListInstance, isTitleTag, jsonEncode,
+    makeFileNameSafe, minmax, numberToRoman, openExternalPath, readTextFile,
+    simplified, transferCase, uniqueCompact, xmlIndent, yesNo
 )
 
 from tests.mocked import causeOSError
@@ -344,6 +344,27 @@ def testBaseCommon_simplified():
     assert simplified("Hello World") == "Hello World"
     assert simplified("  Hello    World   ") == "Hello World"
     assert simplified("\tHello\n\r\tWorld") == "Hello World"
+
+
+@pytest.mark.base
+def testBaseCommon_compact():
+    """Test the compact function."""
+    assert compact("! ! !") == "!!!"
+    assert compact("1\t2\t3") == "123"
+    assert compact("1\n2\n3") == "123"
+    assert compact("1\r2\r3") == "123"
+    assert compact("1\u00a02\u00a03") == "123"
+
+
+@pytest.mark.base
+def testBaseCommon_uniqueCompact():
+    """Test the uniqueCompact function."""
+    assert uniqueCompact("! ! !") == "!"
+    assert uniqueCompact("1\t2\t3") == "123"
+    assert uniqueCompact("1\n2\n3") == "123"
+    assert uniqueCompact("1\r2\r3") == "123"
+    assert uniqueCompact("1\u00a02\u00a03") == "123"
+    assert uniqueCompact("3 2 1") == "123"
 
 
 @pytest.mark.base

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -379,7 +379,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, tstPaths):
     assert CONFIG.doReplaceDQuote is False
     assert CONFIG.doReplaceDash is False
     assert CONFIG.doReplaceDots is False
-    assert CONFIG.fmtPadBefore == "!?:"
+    assert CONFIG.fmtPadBefore == "!:?"
     assert CONFIG.fmtPadAfter == "¡¿"
     assert CONFIG.fmtPadThin is True
 


### PR DESCRIPTION
**Summary:**

This PR adds a new function that checks free form text box settings in Preferences, and adds constraints to others.

* Narrator break, which can only be one character, has white space stripped,
* Dialog symbol, which can only be one character, has white space stripped.
* Pad before and after symbol box content is now processed so that all white spaces are stripped, and all characters listed are unique. They are also sorted, because the filter uses set, which may return different order on each call.

**Related Issue(s):**

Closes #1985

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
