### PR TITLE
Fix updating of importance labels

### DIFF
--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -121,7 +121,7 @@ class NWStatus:
         return key
 
     def update(self, update: list[tuple[str | None, StatusEntry]]) -> None:
-        """Update the list of statuses, and from removed list."""
+        """Update the list of statuses."""
         self._store.clear()
         for key, entry in update:
             self._store[self._checkKey(key)] = entry
@@ -129,6 +129,9 @@ class NWStatus:
         # Check if we need a new default
         if self._default not in self._store:
             self._default = next(iter(self._store)) if self._store else None
+
+        # Emit the change signal
+        SHARED.projectSingalProxy({"event": "statusLabels", "kind": self._prefix})
 
         return
 

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -58,7 +58,7 @@ class GuiProjectSettings(NDialog):
     PAGE_IMPORT   = 2
     PAGE_REPLACE  = 3
 
-    newProjectSettingsReady = pyqtSignal(bool)
+    newProjectSettingsReady = pyqtSignal()
 
     def __init__(self, parent: QWidget, gotoPage: int = PAGE_SETTINGS) -> None:
         super().__init__(parent=parent)
@@ -175,7 +175,7 @@ class GuiProjectSettings(NDialog):
         projAuthor = self.settingsPage.projAuthor.text()
         projLang   = self.settingsPage.projLang.currentData()
         spellLang  = self.settingsPage.spellLang.currentData()
-        doBackup   = not self.settingsPage.doBackup.isChecked()
+        doBackup   = not self.settingsPage.noBackup.isChecked()
 
         project.data.setName(projName)
         project.data.setAuthor(projAuthor)
@@ -183,23 +183,19 @@ class GuiProjectSettings(NDialog):
         project.data.setSpellLang(spellLang)
         project.setProjectLang(projLang)
 
-        rebuildTrees = False
-
         if self.statusPage.changed:
             logger.debug("Updating status labels")
             project.data.itemStatus.update(self.statusPage.getNewList())
-            rebuildTrees = True
 
         if self.importPage.changed:
             logger.debug("Updating importance labels")
             project.data.itemImport.update(self.importPage.getNewList())
-            rebuildTrees = True
 
         if self.replacePage.changed:
             logger.debug("Updating auto-replace settings")
             project.data.setAutoReplace(self.replacePage.getNewList())
 
-        self.newProjectSettingsReady.emit(rebuildTrees)
+        self.newProjectSettingsReady.emit()
         QApplication.processEvents()
         self.close()
 
@@ -289,10 +285,10 @@ class _SettingsPage(NScrollableForm):
             self.spellLang.setCurrentIndex(idx)
 
         # Backup on Close
-        self.doBackup = NSwitch(self)
-        self.doBackup.setChecked(not data.doBackup)
+        self.noBackup = NSwitch(self)
+        self.noBackup.setChecked(not data.doBackup)
         self.addRow(
-            self.tr("Disable backup on close"), self.doBackup,
+            self.tr("Disable backup on close"), self.noBackup,
             self.tr("Overrides main preferences.")
         )
 

--- a/novelwriter/gui/docviewerpanel.py
+++ b/novelwriter/gui/docviewerpanel.py
@@ -189,6 +189,13 @@ class GuiDocViewerPanel(QWidget):
         self._updateTabVisibility()
         return
 
+    @pyqtSlot(str)
+    def updateStatusLabels(self, kind: str) -> None:
+        """Update the importance labels."""
+        if kind == "i":
+            self._loadAllTags()
+        return
+
     ##
     #  Private Slots
     ##

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -166,6 +166,7 @@ class GuiProjectView(QWidget):
 
     def openProjectTasks(self) -> None:
         """Run open project tasks."""
+        self.populateTree()
         self.projBar.buildQuickLinksMenu()
         self.projBar.setEnabled(True)
         return

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -189,9 +189,6 @@ class GuiMain(QMainWindow):
         self.splitView.setVisible(False)
         self.docEditor.closeSearch()
 
-        # Initialise the Project Tree
-        self.rebuildTrees()
-
         # Assemble Main Window Elements
         self.mainBox = QHBoxLayout()
         self.mainBox.addWidget(self.sideBar)
@@ -463,7 +460,6 @@ class GuiMain(QMainWindow):
 
         # Update GUI
         self._updateWindowTitle(SHARED.project.data.name)
-        self.rebuildTrees()
         self.docEditor.toggleSpellCheck(SHARED.project.data.spellCheck)
         self.mainStatus.setRefTime(SHARED.project.projOpened)
         self.projView.openProjectTasks()
@@ -735,11 +731,6 @@ class GuiMain(QMainWindow):
             if tHandle:
                 self.openDocument(tHandle, sTitle=sTitle, changeFocus=False, doScroll=False)
 
-        return
-
-    def rebuildTrees(self) -> None:
-        """Rebuild the project tree."""
-        self.projView.populateTree()
         return
 
     def rebuildIndex(self, beQuiet: bool = False) -> None:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -223,6 +223,7 @@ class GuiMain(QMainWindow):
         SHARED.projectStatusMessage.connect(self.mainStatus.setStatusMessage)
         SHARED.spellLanguageChanged.connect(self.mainStatus.setLanguage)
         SHARED.statusLabelsChanged.connect(self.docViewerPanel.updateStatusLabels)
+        SHARED.statusLabelsChanged.connect(self.projView.refreshUserLabels)
 
         self.mainMenu.requestDocAction.connect(self._passDocumentAction)
         self.mainMenu.requestDocInsert.connect(self._passDocumentInsert)
@@ -1099,15 +1100,13 @@ class GuiMain(QMainWindow):
 
         return
 
-    @pyqtSlot(bool)
-    def _processProjectSettingsChanges(self, rebuildTrees: bool) -> None:
+    @pyqtSlot()
+    def _processProjectSettingsChanges(self) -> None:
         """Refresh data dependent on project settings."""
         logger.debug("Applying new project settings")
         SHARED.updateSpellCheckLanguage()
         self.itemDetails.refreshDetails()
         self._updateWindowTitle(SHARED.project.data.name)
-        if rebuildTrees:
-            self.rebuildTrees()
         return
 
     @pyqtSlot()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -222,6 +222,7 @@ class GuiMain(QMainWindow):
         SHARED.projectStatusChanged.connect(self.mainStatus.updateProjectStatus)
         SHARED.projectStatusMessage.connect(self.mainStatus.setStatusMessage)
         SHARED.spellLanguageChanged.connect(self.mainStatus.setLanguage)
+        SHARED.statusLabelsChanged.connect(self.docViewerPanel.updateStatusLabels)
 
         self.mainMenu.requestDocAction.connect(self._passDocumentAction)
         self.mainMenu.requestDocInsert.connect(self._passDocumentInsert)

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -64,6 +64,7 @@ class SharedData(QObject):
     indexCleared = pyqtSignal()
     indexAvailable = pyqtSignal()
     mainClockTick = pyqtSignal()
+    statusLabelsChanged = pyqtSignal(str)
 
     def __init__(self) -> None:
         super().__init__()
@@ -307,6 +308,14 @@ class SharedData(QObject):
             self.indexCleared.emit()
         elif event == "buildIndex":
             self.indexAvailable.emit()
+        return
+
+    def projectSingalProxy(self, data: dict) -> None:
+        """Emit signals on project data change."""
+        event = data.get("event")
+        logger.debug("Received '%s' event from project data", event)
+        if event == "statusLabels":
+            self.statusLabelsChanged.emit(data.get("kind", ""))
         return
 
     ##

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -161,7 +161,7 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, mockRn
     project.tree[hCharNote].setImport(C.iMajor)  # type: ignore
     project.tree[hWorldNote].setImport(C.iMain)  # type: ignore
 
-    nwGUI.rebuildTrees()
+    nwGUI.projView.populateTree()
     project.countStatus()
 
     assert [e.count for _, e in project.data.itemStatus.iterItems()] == [2, 0, 2, 1]

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -113,13 +113,13 @@ def testDlgProjSettings_SettingsPage(qtbot, monkeypatch, nwGUI, fncPath, projPat
     assert settings.projAuthor.text() == "Jane Smith"
     assert settings.projLang.currentData() == "en"
     assert settings.spellLang.currentData() == "en"
-    assert settings.doBackup.isChecked() is False
+    assert settings.noBackup.isChecked() is False
 
     settings.projName.setText("Project Name")
     settings.projAuthor.setText("Jane Doe")
     settings.projLang.setCurrentIndex(settings.projLang.findData("de"))
     settings.spellLang.setCurrentIndex(settings.spellLang.findData("de"))
-    settings.doBackup.setChecked(True)
+    settings.noBackup.setChecked(True)
 
     projSettings._doSave()
     assert project.data.name == "Project Name"
@@ -128,7 +128,7 @@ def testDlgProjSettings_SettingsPage(qtbot, monkeypatch, nwGUI, fncPath, projPat
     assert project.data.spellLang == "de"
     assert project.data.doBackup is False
 
-    nwGUI._processProjectSettingsChanges(False)
+    nwGUI._processProjectSettingsChanges()
     assert nwGUI.windowTitle() == "Project Name - novelWriter"
 
     # qtbot.stop()

--- a/tests/test_gui/test_gui_docviewerpanel.py
+++ b/tests/test_gui/test_gui_docviewerpanel.py
@@ -221,7 +221,7 @@ def testGuiViewerPanel_Tags(qtbot, monkeypatch, caplog, nwGUI, projPath, mockRnd
     nwJohn = SHARED.project.tree[hJohn]
     assert isinstance(nwJohn, NWItem)
     nwJohn.setActive(False)
-    projTree.setTreeItemValues(hJohn)
+    projTree.setTreeItemValues(nwJohn)
     projTree._alertTreeChange(hJohn, flush=False)
     assert charTab.topLevelItemCount() == 1
 

--- a/tests/test_gui/test_gui_docviewerpanel.py
+++ b/tests/test_gui/test_gui_docviewerpanel.py
@@ -225,4 +225,10 @@ def testGuiViewerPanel_Tags(qtbot, monkeypatch, caplog, nwGUI, projPath, mockRnd
     projTree._alertTreeChange(hJohn, flush=False)
     assert charTab.topLevelItemCount() == 1
 
+    # Update Labels
+    assert charTab.topLevelItem(0).text(charTab.C_IMPORT) == "New"
+    SHARED.project.data.itemImport.add(C.iNew, "Stuff", (100, 100, 100), "SQUARE", 0)
+    viewPanel.updateStatusLabels("i")
+    assert charTab.topLevelItem(0).text(charTab.C_IMPORT) == "Stuff"
+
     # qtbot.stop()

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -186,6 +186,10 @@ def testGuiProjTree_NewItems(qtbot, caplog, monkeypatch, nwGUI, projPath, mockRn
     # Adding an invalid item directly to the tree should also fail
     assert projTree._addTreeItem(None) is None
 
+    # Setting values for a non-existing tree item should be handled
+    projTree.setTreeItemValues(None)
+    projTree.setTreeItemValues(C.hInvalid)  # The function used to take handles
+
     # Clean up
     # qtbot.stop()
     nwGUI.closeProject()

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -197,7 +197,7 @@ def buildTestProject(obj: object, projPath: Path) -> None:
     project._valid = True
 
     if nwGUI is not None:
-        nwGUI.rebuildTrees()
+        nwGUI.projView.populateTree()
 
     return
 


### PR DESCRIPTION
**Summary:**

This PR:
* Adds a new signal for updating status or importance labels that is now emitted when the StatusEntry class receives updates.
* Changes the main project tree to also listen to these signals, which calls the method to update item values on all relevant items. This is faster than the previous full tree rebuild.
* The update values function now takes an NWItem as input rather than an item handle. This should be slightly faster in most cases as most callers already have the item ready.

**Related Issue(s):**

Closes #1992

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
