### PR TITLE
Update Ubuntu releases

### DIFF
--- a/pkgutils.py
+++ b/pkgutils.py
@@ -753,8 +753,8 @@ def buildForLaunchpad(args: argparse.Namespace) -> None:
 
     distLoop = [
         ("22.04", "jammy", True),
-        ("23.10", "mantic", False),
         ("24.04", "noble", False),
+        ("24.10", "oracular", False),
     ]
 
     print("Building Ubuntu packages for:")


### PR DESCRIPTION
**Summary:**

Ubuntu 23.10 is obsolete and doesn't accept new uploads, so this has been removed for 2.5.1. Packages for Ubuntu 24.10 pre-release have been added.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
