### PR TITLE
Fix bugs in the document viewer

### DIFF
--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -832,7 +832,7 @@ class Tokenizer(ABC):
                     sAlign |= self.A_IND_R
 
                 # Process formats
-                tLine, tFmt = self._extractFormats(aLine)
+                tLine, tFmt = self._extractFormats(aLine, hDialog=self._isNovel)
                 tokens.append((
                     self.T_TEXT, nHead, tLine, tFmt, sAlign
                 ))
@@ -1098,8 +1098,13 @@ class Tokenizer(ABC):
     #  Internal Functions
     ##
 
-    def _extractFormats(self, text: str, skip: int = 0) -> tuple[str, T_Formats]:
-        """Extract format markers from a text paragraph."""
+    def _extractFormats(
+        self, text: str, skip: int = 0, hDialog: bool = False
+    ) -> tuple[str, T_Formats]:
+        """Extract format markers from a text paragraph. In order to
+        also process dialogue highlighting, the hDialog flag must be set
+        to True. See issues #2011 and #2013.
+        """
         temp: list[tuple[int, int, int, str]] = []
 
         # Match Markdown
@@ -1137,7 +1142,7 @@ class Tokenizer(ABC):
             ))
 
         # Match Dialogue
-        if self._rxDialogue:
+        if self._rxDialogue and hDialog:
             for regEx, fmtB, fmtE in self._rxDialogue:
                 rxItt = regEx.globalMatch(text, 0)
                 while rxItt.hasNext():

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -1150,8 +1150,9 @@ class Tokenizer(ABC):
         formats = []
         for pos, n, fmt, key in reversed(sorted(temp, key=lambda x: x[0])):
             if fmt > 0:
-                result = result[:pos] + result[pos+n:]
-                formats = [(p-n, f, k) for p, f, k in formats]
+                if n > 0:
+                    result = result[:pos] + result[pos+n:]
+                    formats = [(p-n if p > pos else p, f, k) for p, f, k in formats]
                 formats.insert(0, (pos, fmt, key))
 
         return result, formats

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -229,15 +229,13 @@ class GuiDocViewer(QTextBrowser):
             QApplication.restoreOverrideCursor()
             return False
 
-        # Refresh the tab stops
-        self.setTabStopDistance(CONFIG.getTabWidth())
-
-        # Must be before setHtml
+        # Must be before setDocument
         if updateHistory:
             self.docHistory.append(tHandle)
 
         self.setDocumentTitle(tHandle)
         self.setDocument(qDoc.document)
+        self.setTabStopDistance(CONFIG.getTabWidth())
 
         if self._docHandle == tHandle:
             # This is a refresh, so we set the scrollbar back to where it was

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -823,6 +823,7 @@ class _PreviewWidget(QTextBrowser):
 
         document.setDocumentMargin(CONFIG.getTextMargin())
         self.setDocument(document)
+        self.setTabStopDistance(CONFIG.getTabWidth())
 
         self._docTime = int(time())
         self._updateBuildAge()

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -1100,6 +1100,7 @@ def testCoreToken_Dialogue(mockGUI):
     project = NWProject()
     tokens = BareTokenizer(project)
     tokens.setDialogueHighlight(True)
+    tokens._isNovel = True
 
     # Single quotes
     tokens._text = "Text with \u2018dialogue one,\u2019 and \u2018dialogue two.\u2019\n"

--- a/tests/test_core/test_core_tokenizer.py
+++ b/tests/test_core/test_core_tokenizer.py
@@ -1161,6 +1161,24 @@ def testCoreToken_Dialogue(mockGUI):
         Tokenizer.A_NONE
     )]
 
+    # Special Cases
+    # =============
+
+    # Dialogue + formatting on same index (Issue #2012)
+    tokens._text = "[i]\u201cDialogue text.\u201d[/i]\n"
+    tokens.tokenizeText()
+    assert tokens._tokens == [(
+        Tokenizer.T_TEXT, 0,
+        "\u201cDialogue text.\u201d",
+        [
+            (0,  Tokenizer.FMT_I_B, ""),
+            (0,  Tokenizer.FMT_DL_B, ""),
+            (16, Tokenizer.FMT_I_E, ""),
+            (16, Tokenizer.FMT_DL_E, ""),
+        ],
+        Tokenizer.A_NONE
+    )]
+
 
 @pytest.mark.core
 def testCoreToken_SpecialFormat(mockGUI):


### PR DESCRIPTION
**Summary:**

This PR fixes a number of bugs with the new document viewer in 2.5:

* Tab stop distances are now properly set after a document is loaded. Loading a new document resets it to default value, and need to be updated.
* The Tokenizer can now properly handle multiple formatting markers that are set on the same character location. Previously, the order of the position-sorted markers would affect whether they came out correctly or not.
* The Tokenizer now only applies dialogue highlighting to plain text paragraphs in novel documents. Previously, the viewer would highlight all quotes as dialog.

**Related Issue(s):**

Closes #1996
Closes #2011
Closes #2012
Closes #2013

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
