### PR TITLE
Clean up Qt enums

### DIFF
--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -27,7 +27,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
-from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QFont, QPalette
 from PyQt5.QtWidgets import (
     QAbstractButton, QFrame, QHBoxLayout, QLabel, QLayout, QScrollArea,
@@ -35,6 +34,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG
+from novelwriter.types import QtScrollAsNeeded
 
 DEFAULT_SCALE = 0.9
 
@@ -76,8 +76,8 @@ class NScrollablePage(QScrollArea):
         self._widget = QWidget(self)
         self.setWidget(self._widget)
         self.setWidgetResizable(True)
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
+        self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
         self.setFrameShadow(QFrame.Shadow.Sunken)
         self.setFrameShape(QFrame.Shape.StyledPanel)
         return
@@ -113,8 +113,8 @@ class NScrollableForm(QScrollArea):
 
         self.setWidget(self._widget)
         self.setWidgetResizable(True)
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
+        self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
         self.setFrameShadow(QFrame.Shadow.Sunken)
         self.setFrameShape(QFrame.Shape.StyledPanel)
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -177,12 +177,12 @@ class GuiDocEditor(QPlainTextEdit):
         self.keyContext.activated.connect(self._openContextFromCursor)
 
         self.followTag1 = QShortcut(self)
-        self.followTag1.setKey(Qt.Key.Key_Return | QtModCtrl)
+        self.followTag1.setKey("Ctrl+Return")
         self.followTag1.setContext(Qt.ShortcutContext.WidgetShortcut)
         self.followTag1.activated.connect(self._processTag)
 
         self.followTag2 = QShortcut(self)
-        self.followTag2.setKey(Qt.Key.Key_Enter | QtModCtrl)
+        self.followTag2.setKey("Ctrl+Enter")
         self.followTag2.setContext(Qt.ShortcutContext.WidgetShortcut)
         self.followTag2.activated.connect(self._processTag)
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -66,7 +66,7 @@ from novelwriter.tools.lipsum import GuiLipsum
 from novelwriter.types import (
     QtAlignCenterTop, QtAlignJustify, QtAlignLeft, QtAlignLeftTop,
     QtAlignRight, QtKeepAnchor, QtModCtrl, QtModNone, QtModShift, QtMouseLeft,
-    QtMoveAnchor, QtMoveLeft, QtMoveRight
+    QtMoveAnchor, QtMoveLeft, QtMoveRight, QtScrollAlwaysOff, QtScrollAsNeeded
 )
 
 logger = logging.getLogger(__name__)
@@ -354,14 +354,14 @@ class GuiDocEditor(QPlainTextEdit):
         # Scrolling
         self.setCenterOnScroll(CONFIG.scrollPastEnd)
         if CONFIG.hideVScroll:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
 
         if CONFIG.hideHScroll:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setHorizontalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
 
         # Refresh the tab stops
         self.setTabStopDistance(CONFIG.getTabWidth())

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -46,7 +46,10 @@ from novelwriter.extensions.configlayout import NColourLabel
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
-from novelwriter.types import QtAlignCenterTop, QtKeepAnchor, QtMouseLeft, QtMoveAnchor
+from novelwriter.types import (
+    QtAlignCenterTop, QtKeepAnchor, QtMouseLeft, QtMoveAnchor,
+    QtScrollAlwaysOff, QtScrollAsNeeded
+)
 
 logger = logging.getLogger(__name__)
 
@@ -177,14 +180,14 @@ class GuiDocViewer(QTextBrowser):
 
         # Scroll bars
         if CONFIG.hideVScroll:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
 
         if CONFIG.hideHScroll:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setHorizontalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
 
         # Refresh the tab stops
         self.setTabStopDistance(CONFIG.getTabWidth())

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -184,7 +184,7 @@ class GuiMainMenu(QMenuBar):
         # Project > Exit
         self.aExitNW = self.projMenu.addAction(self.tr("Exit"))
         self.aExitNW.setShortcut("Ctrl+Q")
-        self.aExitNW.setMenuRole(QAction.QuitRole)
+        self.aExitNW.setMenuRole(QAction.MenuRole.QuitRole)
         self.aExitNW.triggered.connect(lambda: self.mainGui.closeMain())
 
         return
@@ -941,7 +941,7 @@ class GuiMainMenu(QMenuBar):
         # Tools > Preferences
         self.aPreferences = self.toolsMenu.addAction(self.tr("Preferences"))
         self.aPreferences.setShortcut("Ctrl+,")
-        self.aPreferences.setMenuRole(QAction.PreferencesRole)
+        self.aPreferences.setMenuRole(QAction.MenuRole.PreferencesRole)
         self.aPreferences.triggered.connect(self.mainGui.showPreferencesDialog)
 
         return
@@ -953,12 +953,12 @@ class GuiMainMenu(QMenuBar):
 
         # Help > About
         self.aAboutNW = self.helpMenu.addAction(self.tr("About novelWriter"))
-        self.aAboutNW.setMenuRole(QAction.AboutRole)
+        self.aAboutNW.setMenuRole(QAction.MenuRole.AboutRole)
         self.aAboutNW.triggered.connect(self.mainGui.showAboutNWDialog)
 
         # Help > About Qt5
         self.aAboutQt = self.helpMenu.addAction(self.tr("About Qt5"))
-        self.aAboutQt.setMenuRole(QAction.AboutQtRole)
+        self.aAboutQt.setMenuRole(QAction.MenuRole.AboutQtRole)
         self.aAboutQt.triggered.connect(self.mainGui.showAboutQtDialog)
 
         # Help > Separator

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -47,8 +47,8 @@ from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.extensions.novelselector import NovelSelector
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import (
-    QtAlignRight, QtDecoration, QtMouseLeft, QtMouseMiddle, QtSizeExpanding,
-    QtUserRole
+    QtAlignRight, QtDecoration, QtMouseLeft, QtMouseMiddle, QtScrollAlwaysOff,
+    QtScrollAsNeeded, QtSizeExpanding, QtUserRole
 )
 
 logger = logging.getLogger(__name__)
@@ -433,14 +433,14 @@ class GuiNovelTree(QTreeWidget):
         """Set or update tree widget settings."""
         # Scroll bars
         if CONFIG.hideVScroll:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
 
         if CONFIG.hideHScroll:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setHorizontalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
 
         return
 

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -49,7 +49,7 @@ from novelwriter.extensions.configlayout import NColourLabel
 from novelwriter.extensions.novelselector import NovelSelector
 from novelwriter.types import (
     QtAlignLeftTop, QtAlignRight, QtAlignRightTop, QtDecoration,
-    QtSizeExpanding, QtUserRole
+    QtScrollAlwaysOff, QtScrollAsNeeded, QtSizeExpanding, QtUserRole
 )
 
 logger = logging.getLogger(__name__)
@@ -433,13 +433,13 @@ class GuiOutlineTree(QTreeWidget):
     def initSettings(self) -> None:
         """Set or update outline settings."""
         if CONFIG.hideVScroll:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
         if CONFIG.hideHScroll:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setHorizontalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
         return
 
     def clearContent(self) -> None:
@@ -976,8 +976,8 @@ class GuiOutlineDetails(QScrollArea):
         self.outerWidget.setLayout(self.outerBox)
         self.setWidget(self.outerWidget)
 
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
+        self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
         self.setWidgetResizable(True)
         self.setFrameStyle(QFrame.Shape.NoFrame)
 
@@ -990,13 +990,13 @@ class GuiOutlineDetails(QScrollArea):
     def initSettings(self) -> None:
         """Set or update outline settings."""
         if CONFIG.hideVScroll:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
         if CONFIG.hideHScroll:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setHorizontalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
         self.updateClasses()
         return
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -51,8 +51,8 @@ from novelwriter.enum import nwDocMode, nwItemClass, nwItemLayout, nwItemType
 from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import (
-    QtAlignLeft, QtAlignRight, QtMouseLeft, QtMouseMiddle, QtSizeExpanding,
-    QtUserRole
+    QtAlignLeft, QtAlignRight, QtMouseLeft, QtMouseMiddle, QtScrollAlwaysOff,
+    QtScrollAsNeeded, QtSizeExpanding, QtUserRole
 )
 
 logger = logging.getLogger(__name__)
@@ -578,13 +578,13 @@ class GuiProjectTree(QTreeWidget):
         """Set or update tree widget settings."""
         # Scroll bars
         if CONFIG.hideVScroll:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setVerticalScrollBarPolicy(QtScrollAsNeeded)
         if CONFIG.hideHScroll:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.setHorizontalScrollBarPolicy(QtScrollAlwaysOff)
         else:
-            self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+            self.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
         return
 
     ##

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -293,15 +293,15 @@ class GuiMain(QMainWindow):
         self._connectMenuActions()
 
         self.keyReturn = QShortcut(self)
-        self.keyReturn.setKey(Qt.Key.Key_Return)
+        self.keyReturn.setKey("Return")
         self.keyReturn.activated.connect(self._keyPressReturn)
 
         self.keyEnter = QShortcut(self)
-        self.keyEnter.setKey(Qt.Key.Key_Enter)
+        self.keyEnter.setKey("Enter")
         self.keyEnter.activated.connect(self._keyPressReturn)
 
         self.keyEscape = QShortcut(self)
-        self.keyEscape.setKey(Qt.Key.Key_Escape)
+        self.keyEscape.setKey("Esc")
         self.keyEscape.activated.connect(self._keyPressEscape)
 
         # Initialise Main GUI

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -441,9 +441,9 @@ class _GuiAlert(QMessageBox):
         Yes/No buttons or just an Ok button.
         """
         if isYesNo:
-            self.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            self.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
         else:
-            self.setStandardButtons(QMessageBox.Ok)
+            self.setStandardButtons(QMessageBox.StandardButton.Ok)
         pSz = 2*self._theme.baseIconHeight
         if level == self.INFO:
             self.setIconPixmap(self._theme.getPixmap("alert_info", (pSz, pSz)))

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -297,7 +297,7 @@ class _OpenProjectPage(QWidget):
         self.selectedPath.addAction(self.aMissing, QLineEdit.ActionPosition.TrailingPosition)
 
         self.keyDelete = QShortcut(self)
-        self.keyDelete.setKey(Qt.Key.Key_Delete)
+        self.keyDelete.setKey("Del")
         self.keyDelete.activated.connect(self._deleteSelectedItem)
 
         # Assemble

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -49,7 +49,7 @@ from novelwriter.extensions.configlayout import NWrappedWidgetBox
 from novelwriter.extensions.modified import NDialog, NIconToolButton, NSpinBox
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.extensions.versioninfo import VersionInfoWidget
-from novelwriter.types import QtAlignLeft, QtAlignRightTop, QtSelected
+from novelwriter.types import QtAlignLeft, QtAlignRightTop, QtScrollAsNeeded, QtSelected
 
 logger = logging.getLogger(__name__)
 
@@ -501,8 +501,8 @@ class _NewProjectPage(QWidget):
         self.scrollArea = QScrollArea(self)
         self.scrollArea.setWidget(self.projectForm)
         self.scrollArea.setWidgetResizable(True)
-        self.scrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self.scrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.scrollArea.setHorizontalScrollBarPolicy(QtScrollAsNeeded)
+        self.scrollArea.setVerticalScrollBarPolicy(QtScrollAsNeeded)
 
         self.enterForm = self.projectForm.enterForm
 

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -110,6 +110,11 @@ QtSizeIgnored = QSizePolicy.Policy.Ignored
 QtSizeMinimum = QSizePolicy.Policy.Minimum
 QtSizeMinimumExpanding = QSizePolicy.Policy.MinimumExpanding
 
+# Scroll Bar Policy
+
+QtScrollAlwaysOff = Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+QtScrollAsNeeded = Qt.ScrollBarPolicy.ScrollBarAsNeeded
+
 # Other
 
 QRegExUnicode = QRegularExpression.PatternOption.UseUnicodePropertiesOption

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -133,7 +133,7 @@ FONT_WEIGHTS: dict[int, int] = {
     QFont.Weight.Black:      900,
 }
 
-FONT_STYLE: dict[int, str] = {
+FONT_STYLE: dict[QFont.Style, str] = {
     QFont.Style.StyleNormal:  "normal",
     QFont.Style.StyleItalic:  "italic",
     QFont.Style.StyleOblique: "oblique",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,7 @@ def projPath(fncPath):
 def mockGUI(qtbot, monkeypatch):
     """Create a mock instance of novelWriter's main GUI class."""
     monkeypatch.setattr(QMessageBox, "exec", lambda *a: None)
-    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.Yes)
     gui = MockGuiMain()
     theme = MockTheme()
     monkeypatch.setattr(SHARED, "_gui", gui)
@@ -156,7 +156,7 @@ def mockGUI(qtbot, monkeypatch):
 def nwGUI(qtbot, monkeypatch, functionFixture):
     """Create an instance of the novelWriter GUI."""
     monkeypatch.setattr(QMessageBox, "exec", lambda *a: None)
-    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.Yes)
 
     nwGUI = main(["--testmode", f"--config={_TMP_CONF}", f"--data={_TMP_CONF}"])
     qtbot.addWidget(nwGUI)

--- a/tests/test_base/test_base_shared.py
+++ b/tests/test_base/test_base_shared.py
@@ -126,7 +126,7 @@ def testBaseSharedData_Projects(monkeypatch, caplog, fncPath):
 def testBaseSharedData_Alerts(qtbot, monkeypatch, caplog):
     """Test SharedData class alert helper functions."""
     monkeypatch.setattr(QMessageBox, "exec", lambda *a: None)
-    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.Yes)
 
     shared = SharedData()
 

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -271,14 +271,14 @@ def testCoreProject_Open(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
     # Won't convert legacy file
     with monkeypatch.context() as mp:
         mp.setattr(ProjectXMLReader, "state", property(lambda *a: XMLReadState.WAS_LEGACY))
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         assert project.openProject(fncPath, clearLock=True) is False
         assert "The file format of your project is about to be" in SHARED.lastAlert
 
     # Won't open project from newer version
     with monkeypatch.context() as mp:
         mp.setattr(ProjectXMLReader, "hexVersion", property(lambda *a: 0x99999999))
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         assert project.openProject(fncPath, clearLock=True) is False
         assert "This project was saved by a newer version" in SHARED.lastAlert
 

--- a/tests/test_dialogs/test_dlg_about.py
+++ b/tests/test_dialogs/test_dlg_about.py
@@ -58,4 +58,4 @@ def testDlgAbout_QtDialog(monkeypatch, nwGUI):
     # Open About
     # All it can do is check against a crash
     nwGUI.showAboutQtDialog()
-    nwGUI.mainMenu.aAboutQt.activate(QAction.Trigger)
+    nwGUI.mainMenu.aAboutQt.activate(QAction.ActionEvent.Trigger)

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -46,7 +46,7 @@ def testDlgProjSettings_Dialog(qtbot, monkeypatch, nwGUI):
     monkeypatch.setattr(GuiProjectSettings, "result", lambda *a: QtAccepted)
 
     # Check that we cannot open when there is no project
-    nwGUI.mainMenu.aProjectSettings.activate(QAction.Trigger)
+    nwGUI.mainMenu.aProjectSettings.activate(QAction.ActionEvent.Trigger)
     assert SHARED.findTopLevelWidget(GuiProjectSettings) is None
 
     # Pretend we have a project
@@ -54,7 +54,7 @@ def testDlgProjSettings_Dialog(qtbot, monkeypatch, nwGUI):
     SHARED.project.data.setSpellLang("en")
 
     # Get the dialog object
-    nwGUI.mainMenu.aProjectSettings.activate(QAction.Trigger)
+    nwGUI.mainMenu.aProjectSettings.activate(QAction.ActionEvent.Trigger)
     qtbot.waitUntil(
         lambda: SHARED.findTopLevelWidget(GuiProjectSettings) is not None, timeout=1000
     )

--- a/tests/test_dialogs/test_dlg_wordlist.py
+++ b/tests/test_dialogs/test_dlg_wordlist.py
@@ -47,7 +47,7 @@ def testDlgWordList_Dialog(qtbot, monkeypatch, nwGUI, fncPath, projPath):
     nwGUI.openProject(projPath)
 
     # Load the dialog
-    nwGUI.mainMenu.aEditWordList.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditWordList.activate(QAction.ActionEvent.Trigger)
     qtbot.waitUntil(lambda: SHARED.findTopLevelWidget(GuiWordList) is not None, timeout=1000)
 
     wList = SHARED.findTopLevelWidget(GuiWordList)

--- a/tests/test_ext/test_ext_eventfilters.py
+++ b/tests/test_ext/test_ext_eventfilters.py
@@ -27,7 +27,7 @@ from PyQt5.QtGui import QKeyEvent, QWheelEvent
 from PyQt5.QtWidgets import QWidget
 
 from novelwriter.extensions.eventfilters import WheelEventFilter
-from novelwriter.types import QtModShift
+from novelwriter.types import QtModNone, QtModShift
 
 
 class MockWidget(QWidget):
@@ -57,7 +57,11 @@ def testExtEventFilters_WheelEventFilter():
 
     # Sending a mouse wheel event forwards it
     pos = QPoint(0, 0)
-    event = QWheelEvent(pos, pos, pos, pos, Qt.NoButton, Qt.NoModifier, Qt.NoScrollPhase, False)
+    event = QWheelEvent(
+        pos, pos, pos, pos,
+        Qt.MouseButton.NoButton, QtModNone, Qt.ScrollMomentum.NoScrollPhase,
+        False,
+    )
     eFilter.eventFilter(obj, event)
     assert widget.count == 1
 

--- a/tests/test_ext/test_ext_eventfilters.py
+++ b/tests/test_ext/test_ext_eventfilters.py
@@ -59,8 +59,8 @@ def testExtEventFilters_WheelEventFilter():
     pos = QPoint(0, 0)
     event = QWheelEvent(
         pos, pos, pos, pos,
-        Qt.MouseButton.NoButton, QtModNone, Qt.ScrollMomentum.NoScrollPhase,
-        False,
+        Qt.MouseButton.NoButton, QtModNone,
+        Qt.ScrollPhase.NoScrollPhase, False,
     )
     eFilter.eventFilter(obj, event)
     assert widget.count == 1

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1881,7 +1881,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert cursor.selectedText() == "est"
 
     # Activate search
-    nwGUI.mainMenu.aFind.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFind.activate(QAction.ActionEvent.Trigger)
     assert docSearch.isVisible()
     assert docSearch.searchText == "est"
 
@@ -1895,16 +1895,16 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert abs(docEditor.getCursorPosition() - 1513) < 3
 
     # Activate loop search
-    docSearch.toggleLoop.activate(QAction.Trigger)
+    docSearch.toggleLoop.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleLoop.isChecked()
     assert CONFIG.searchLoop is True
 
     # Find next by menu Search > Find Next
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 647) < 3
 
     # Close search
-    docSearch.cancelSearch.activate(QAction.Trigger)
+    docSearch.cancelSearch.activate(QAction.ActionEvent.Trigger)
     assert docSearch.isVisible() is False
     docEditor.setCursorPosition(15)
 
@@ -1920,7 +1920,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert docEditor.getCursorPosition() < 3  # No result
 
     # Enable RegEx search
-    docSearch.toggleRegEx.activate(QAction.Trigger)
+    docSearch.toggleRegEx.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleRegEx.isChecked()
     assert CONFIG.searchRegEx is True
 
@@ -1943,50 +1943,50 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert abs(docEditor.getCursorPosition() - 223) < 3
 
     # Find next and then prev
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 324) < 3
-    nwGUI.mainMenu.aFindPrev.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindPrev.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 223) < 3
 
     # Make RegEx case sensitive
-    docSearch.toggleCase.activate(QAction.Trigger)
+    docSearch.toggleCase.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleCase.isChecked()
     assert CONFIG.searchCase is True
 
     # Find next/prev (one result)
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 626) < 3
-    nwGUI.mainMenu.aFindPrev.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindPrev.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 626) < 3
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 626) < 3
 
     # Trigger replace
-    nwGUI.mainMenu.aReplace.activate(QAction.Trigger)
+    nwGUI.mainMenu.aReplace.activate(QAction.ActionEvent.Trigger)
     docSearch.setReplaceText("foo")
 
     # Disable RegEx case sensitive
-    docSearch.toggleCase.activate(QAction.Trigger)
+    docSearch.toggleCase.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleCase.isChecked() is False
     assert CONFIG.searchCase is False
 
     # Toggle replace preserve case
-    docSearch.toggleMatchCap.activate(QAction.Trigger)
+    docSearch.toggleMatchCap.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleMatchCap.isChecked()
     assert CONFIG.searchMatchCap is True
 
     # Replace "Sus" with "Foo" via menu
     docEditor.setCursorPosition(605)
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
-    nwGUI.mainMenu.aReplaceNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
+    nwGUI.mainMenu.aReplaceNext.activate(QAction.ActionEvent.Trigger)
     assert docEditor.getText()[623:634] == "Foopendisse"
 
     # Find next/prev to loop file
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 223) < 3
-    nwGUI.mainMenu.aFindPrev.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindPrev.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 1805) < 3
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 223) < 3
 
     # Replace "sus" with "foo" via replace button
@@ -1999,53 +1999,53 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     assert docEditor.getText() == origText
 
     # Disable RegEx search
-    docSearch.toggleRegEx.activate(QAction.Trigger)
+    docSearch.toggleRegEx.activate(QAction.ActionEvent.Trigger)
     assert not docSearch.toggleRegEx.isChecked()
     assert CONFIG.searchRegEx is False
 
     # Close search and select "est" again
-    docSearch.cancelSearch.activate(QAction.Trigger)
+    docSearch.cancelSearch.activate(QAction.ActionEvent.Trigger)
     docEditor.setCursorPosition(645)
     docEditor._makeSelection(QTextCursor.WordUnderCursor)
     cursor = docEditor.textCursor()
     assert cursor.selectedText() == "est"
 
     # Activate search again
-    nwGUI.mainMenu.aFind.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFind.activate(QAction.ActionEvent.Trigger)
     assert docSearch.isVisible()
     assert docSearch.searchText == "est"
 
     # Enable full word search
-    docSearch.toggleWord.activate(QAction.Trigger)
+    docSearch.toggleWord.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleWord.isChecked()
     assert CONFIG.searchWord is True
 
     # Only one match
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 647) < 3
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 647) < 3
 
     # Enable next doc search
-    docSearch.toggleProject.activate(QAction.Trigger)
+    docSearch.toggleProject.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleProject.isChecked()
     assert CONFIG.searchNextFile is True
 
     # Next match
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert docEditor.docHandle == "2426c6f0ca922"  # Next document
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 620) < 3
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 1127) < 3
 
     # Next doc, no match
     assert CONFIG.searchNextFile is True
     docSearch.setSearchText("abcdef")
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert docEditor.docHandle != "2426c6f0ca922"
     assert docEditor.docHandle == "04468803b92e1"
-    nwGUI.mainMenu.aFindNext.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert docEditor.docHandle != "04468803b92e1"
     assert docEditor.docHandle == "7a992350f3eb6"
 

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -34,7 +34,7 @@ from novelwriter.gui.doceditor import GuiDocEditor
 from novelwriter.text.counting import standardCounter
 from novelwriter.types import (
     QtAlignJustify, QtAlignLeft, QtKeepAnchor, QtModCtrl, QtMouseLeft,
-    QtMoveAnchor, QtMoveRight
+    QtMoveAnchor, QtMoveRight, QtScrollAlwaysOff, QtScrollAsNeeded
 )
 
 from tests.mocked import causeOSError
@@ -73,8 +73,8 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     # Check Defaults
     qDoc = docEditor.document()
     assert qDoc.defaultTextOption().alignment() == QtAlignLeft
-    assert docEditor.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-    assert docEditor.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
+    assert docEditor.verticalScrollBarPolicy() == QtScrollAsNeeded
+    assert docEditor.horizontalScrollBarPolicy() == QtScrollAsNeeded
     assert docEditor._typPadChar == nwUnicode.U_NBSP
     assert docEditor.docHeader.itemTitle.text() == (
         "Novel  \u203a  New Chapter  \u203a  New Scene"
@@ -98,8 +98,8 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert qDoc.defaultTextOption().alignment() == QtAlignJustify
     assert qDoc.defaultTextOption().flags() & QTextOption.ShowTabsAndSpaces
     assert qDoc.defaultTextOption().flags() & QTextOption.ShowLineAndParagraphSeparators
-    assert docEditor.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
-    assert docEditor.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
+    assert docEditor.verticalScrollBarPolicy() == QtScrollAlwaysOff
+    assert docEditor.horizontalScrollBarPolicy() == QtScrollAlwaysOff
     assert docEditor._typPadChar == nwUnicode.U_THNBSP
     assert docEditor.docHeader.itemTitle.text() == "New Scene"
 

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1153,16 +1153,16 @@ def testGuiEditor_TextManipulation(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert docEditor.getText() == text
 
     # Select All
-    qtbot.keyClick(docEditor, Qt.Key_A, modifier=Qt.ControlModifier, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Delete, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_A, modifier=QtModCtrl, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Delete, delay=KEY_DELAY)
     assert docEditor.getText() == ""
 
     # Undo
-    qtbot.keyClick(docEditor, Qt.Key_Z, modifier=Qt.ControlModifier, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Z, modifier=QtModCtrl, delay=KEY_DELAY)
     assert docEditor.getText() == text
 
     # Redo
-    qtbot.keyClick(docEditor, Qt.Key_Y, modifier=Qt.ControlModifier, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Y, modifier=QtModCtrl, delay=KEY_DELAY)
     assert docEditor.getText() == ""
 
     # qtbot.stop()
@@ -1679,8 +1679,8 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     nwGUI.docEditor.setFocus()
     for c in "### Scene One":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     # Type Keyword @
     qtbot.keyClick(docEditor, "@", delay=KEY_DELAY)
@@ -1695,7 +1695,7 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     assert len(completer.actions()) == 0
 
     # Delete character and go select @char
-    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
     assert len(completer.actions()) == 2
     completer.actions()[0].trigger()
     assert docEditor.getText() == (
@@ -1712,13 +1712,13 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     assert [a.text() for a in completer.actions()] == []
 
     # Deleting it and typing "a", should leave "Jane"
-    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, "a", delay=KEY_DELAY)
     assert [a.text() for a in completer.actions()] == ["Jane"]
 
     # Selecting "Jane" should insert it
     completer.actions()[0].trigger()
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     assert docEditor.getText() == (
         "### Scene One\n\n"
         "@char: Jane\n"
@@ -1727,21 +1727,21 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     # Start a new line with a nonsense keyword, which should be handled
     for c in "@: ":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
 
     # Send keypresses to the completer object
     qtbot.keyClick(docEditor, "@", delay=KEY_DELAY)
     assert len(completer.actions()) == len(nwKeyWords.VALID_KEYS)
     qtbot.keyClick(completer, "f", delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
     qtbot.keyClick(completer, " ", delay=KEY_DELAY)
     qtbot.keyClick(completer, "h", delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key_Escape, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key.Key_Escape, delay=KEY_DELAY)
     assert docEditor.getText() == (
         "### Scene One\n\n"
         "@char: Jane\n"
@@ -1887,7 +1887,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     # Find next by enter key
     monkeypatch.setattr(docSearch.searchBox, "hasFocus", lambda: True)
-    qtbot.keyClick(docSearch.searchBox, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docSearch.searchBox, Qt.Key.Key_Return, delay=KEY_DELAY)
     assert abs(docEditor.getCursorPosition() - 1299) < 3
 
     # Find next by button

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -34,7 +34,7 @@ from novelwriter.gui.doceditor import GuiDocEditor
 from novelwriter.text.counting import standardCounter
 from novelwriter.types import (
     QtAlignJustify, QtAlignLeft, QtKeepAnchor, QtModCtrl, QtMouseLeft,
-    QtMoveRight
+    QtMoveAnchor, QtMoveRight
 )
 
 from tests.mocked import causeOSError
@@ -989,8 +989,8 @@ def testGuiEditor_TextManipulation(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     # Past Paragraph
     docEditor.replaceText(text)
     cursor = docEditor.textCursor()
-    cursor.setPosition(13, QTextCursor.MoveAnchor)
-    cursor.setPosition(1000, QTextCursor.KeepAnchor)
+    cursor.setPosition(13, QtMoveAnchor)
+    cursor.setPosition(1000, QtKeepAnchor)
     docEditor.setTextCursor(cursor)
     docEditor._wrapSelection("=")
 
@@ -1021,8 +1021,8 @@ def testGuiEditor_TextManipulation(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     # Past Paragraph
     docEditor.replaceText(text)
     cursor = docEditor.textCursor()
-    cursor.setPosition(13, QTextCursor.MoveAnchor)
-    cursor.setPosition(1000, QTextCursor.KeepAnchor)
+    cursor.setPosition(13, QtMoveAnchor)
+    cursor.setPosition(1000, QtKeepAnchor)
     docEditor.setTextCursor(cursor)
     docEditor._toggleFormat(1, "=")
 
@@ -1130,8 +1130,8 @@ def testGuiEditor_TextManipulation(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     text = "### A Scene\n\n%s\n\n%s" % (parOne, parTwo)
     docEditor.replaceText(text)
     cursor = docEditor.textCursor()
-    cursor.setPosition(16, QTextCursor.MoveAnchor)
-    cursor.setPosition(680, QTextCursor.KeepAnchor)
+    cursor.setPosition(16, QtMoveAnchor)
+    cursor.setPosition(680, QtKeepAnchor)
     docEditor.setTextCursor(cursor)
     docEditor._removeInParLineBreaks()
 

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -133,7 +133,7 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     # Open again via menu
     assert nwGUI.projView.projTree.setSelectedHandle("88243afbe5ed8")
-    nwGUI.mainMenu.aViewDoc.activate(QAction.Trigger)
+    nwGUI.mainMenu.aViewDoc.activate(QAction.ActionEvent.Trigger)
 
     # Open context menu
     menuOpened = False

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -38,6 +38,7 @@ from novelwriter.gui.noveltree import GuiNovelView
 from novelwriter.gui.outline import GuiOutlineView
 from novelwriter.gui.projtree import GuiProjectTree
 from novelwriter.tools.welcome import GuiWelcome
+from novelwriter.types import QtModCtrl, QtModShift
 
 from tests.mocked import causeOSError
 from tests.tools import NWD_IGNORE, XML_IGNORE, C, buildTestProject, cmpFiles
@@ -266,18 +267,18 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     # Type something into the document
     nwGUI.docEditor.setFocus()
-    qtbot.keyClick(docEditor, "a", modifier=Qt.ControlModifier, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Jane Doe":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@tag: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "This is a file about Jane.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     # Add a Plot File
     nwGUI._switchFocus(nwFocus.TREE)
@@ -288,18 +289,18 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     # Type something into the document
     nwGUI.docEditor.setFocus()
-    qtbot.keyClick(docEditor, "a", modifier=Qt.ControlModifier, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Main Plot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@tag: MainPlot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "This is a file [i]detailing[/i] the main plot.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     # Add a World File
     nwGUI._switchFocus(nwFocus.TREE)
@@ -315,18 +316,18 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     # Type something into the document
     nwGUI.docEditor.setFocus()
-    qtbot.keyClick(docEditor, "a", modifier=Qt.ControlModifier, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Main Location":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@tag: Home":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "This is a file describing Jane's home.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     # Trigger autosaves before making more changes
     nwGUI._autoSaveDocument()
@@ -342,67 +343,67 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     # Type something into the document
     nwGUI.docEditor.setFocus()
-    qtbot.keyClick(docEditor, "a", modifier=Qt.ControlModifier, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Novel":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "## Chapter":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "@pov: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@plot: MainPlot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "### Scene":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "% How about a comment?":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@pov: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@plot: MainPlot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@location: Home":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "#### Some Section":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "@char: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "This is a paragraph of nonsense text.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     # Don't allow Shift+Enter to insert a line separator (issue #1150)
     for c in "This is another paragraph":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Enter, modifier=Qt.ShiftModifier, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Enter, modifier=QtModShift, delay=KEY_DELAY)
     for c in "with a line separator in it.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     # Auto-Replace
     # ============
@@ -422,23 +423,23 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
     for c in "How about three hyphens - -":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Left, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Right, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Left, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Right, delay=KEY_DELAY)
     for c in "- for long dash? It works too.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "\"Full line double quoted text.\"":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "'Full line single quoted text.'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     # Insert spaces before and after quotes
     docEditor._typPadBefore = "\u201d"
@@ -446,8 +447,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     for c in "Some \"double quoted text with spaces padded\".":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     docEditor._typPadBefore = ""
     docEditor._typPadAfter = ""
@@ -457,23 +458,23 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     for c in "@object: NoSpaceAdded":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "% synopsis: No space before this colon.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "Add space before this colon: See?":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "But don't add a double space : See?":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     docEditor._typPadBefore = ""
 
@@ -482,33 +483,33 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     for c in "\t\"Tab-indented text\"":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in ">\"Paragraph-indented text\"":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in ">>\"Right-aligned text\"":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in "\t'Tab-indented text'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in ">'Paragraph-indented text'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     for c in ">>'Right-aligned text'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     docEditor.wCounterDoc.run()
 
@@ -517,8 +518,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     for c in "Some text with tesst in it.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
     currPos = docEditor.getCursorPosition()
     assert docEditor._qDocument.spellErrorAtPos(currPos) == ("", -1, -1, [])

--- a/tests/test_gui/test_gui_i18n.py
+++ b/tests/test_gui/test_gui_i18n.py
@@ -50,7 +50,7 @@ def testGuiI18n_Localisation(qtbot, monkeypatch, language, nwGUI, projPath):
     """Test loading the gui with a specific language."""
     monkeypatch.setattr(QDialog, "exec", lambda *a: None)
     monkeypatch.setattr(QMessageBox, "exec", lambda *a: None)
-    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.Yes)
+    monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.Yes)
 
     # Set the test language
     CONFIG.guiLocale = language

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -29,6 +29,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.enum import nwDocAction, nwDocInsert
 from novelwriter.gui.doceditor import GuiDocEditor
+from novelwriter.types import QtKeepAnchor, QtMoveRight
 
 from tests.tools import C, buildTestProject, writeFile
 
@@ -301,7 +302,7 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     ))
     cursor = nwGUI.docEditor.textCursor()
     cursor.setPosition(74)
-    cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor, 29)
+    cursor.movePosition(QtMoveRight, QtKeepAnchor, 29)
     nwGUI.docEditor.setTextCursor(cursor)
     nwGUI.mainMenu.aFmtRmBreaks.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == (
@@ -567,7 +568,7 @@ def testGuiMainMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd
 
     # The document isn't empty, so the message box should pop
     with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "result", lambda *a, **k: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a, **k: QMessageBox.StandardButton.No)
         assert not nwGUI.importDocument()
         assert nwGUI.docEditor.getText() == "Bar"
 

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -49,45 +49,45 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     cleanText = nwGUI.docEditor.getText()[54:101]
 
     # Bold
-    nwGUI.mainMenu.aFmtBold.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtBold.activate(QAction.ActionEvent.Trigger)
     fmtStr = "**Pellentesque** nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:105] == fmtStr
-    nwGUI.mainMenu.aFmtBold.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtBold.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Italic
-    nwGUI.mainMenu.aFmtItalic.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtItalic.activate(QAction.ActionEvent.Trigger)
     fmtStr = "_Pellentesque_ nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:103] == fmtStr
-    nwGUI.mainMenu.aFmtItalic.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtItalic.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Strikethrough
-    nwGUI.mainMenu.aFmtStrike.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtStrike.activate(QAction.ActionEvent.Trigger)
     fmtStr = "~~Pellentesque~~ nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:105] == fmtStr
-    nwGUI.mainMenu.aFmtStrike.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtStrike.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Should get us back to plain
-    nwGUI.mainMenu.aFmtBold.activate(QAction.Trigger)
-    nwGUI.mainMenu.aFmtItalic.activate(QAction.Trigger)
-    nwGUI.mainMenu.aFmtItalic.activate(QAction.Trigger)
-    nwGUI.mainMenu.aFmtBold.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtBold.activate(QAction.ActionEvent.Trigger)
+    nwGUI.mainMenu.aFmtItalic.activate(QAction.ActionEvent.Trigger)
+    nwGUI.mainMenu.aFmtItalic.activate(QAction.ActionEvent.Trigger)
+    nwGUI.mainMenu.aFmtBold.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Double Quotes
-    nwGUI.mainMenu.aFmtDQuote.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtDQuote.activate(QAction.ActionEvent.Trigger)
     fmtStr = "“Pellentesque” nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:103] == fmtStr
-    nwGUI.mainMenu.aEditUndo.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditUndo.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Single Quotes
-    nwGUI.mainMenu.aFmtSQuote.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtSQuote.activate(QAction.ActionEvent.Trigger)
     fmtStr = "‘Pellentesque’ nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:103] == fmtStr
-    nwGUI.mainMenu.aEditUndo.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditUndo.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Block Formats
@@ -96,51 +96,51 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwGUI.docEditor.setCursorPosition(57)
 
     # Header 1
-    nwGUI.mainMenu.aFmtHead1.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtHead1.activate(QAction.ActionEvent.Trigger)
     fmtStr = "# Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:103] == fmtStr
 
     # Header 2
-    nwGUI.mainMenu.aFmtHead2.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtHead2.activate(QAction.ActionEvent.Trigger)
     fmtStr = "## Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:104] == fmtStr
 
     # Header 3
-    nwGUI.mainMenu.aFmtHead3.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtHead3.activate(QAction.ActionEvent.Trigger)
     fmtStr = "### Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:105] == fmtStr
 
     # Header 4
-    nwGUI.mainMenu.aFmtHead4.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtHead4.activate(QAction.ActionEvent.Trigger)
     fmtStr = "#### Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:106] == fmtStr
 
     # Title Format
-    nwGUI.mainMenu.aFmtTitle.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtTitle.activate(QAction.ActionEvent.Trigger)
     fmtStr = "#! Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:104] == fmtStr
 
     # Unnumbered Chapter
-    nwGUI.mainMenu.aFmtUnNum.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtUnNum.activate(QAction.ActionEvent.Trigger)
     fmtStr = "##! Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:105] == fmtStr
 
     # Hard Scene
-    nwGUI.mainMenu.aFmtHardSc.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtHardSc.activate(QAction.ActionEvent.Trigger)
     fmtStr = "###! Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:106] == fmtStr
 
     # Clear Format
-    nwGUI.mainMenu.aFmtNoFormat.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtNoFormat.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Comment On
-    nwGUI.mainMenu.aFmtComment.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtComment.activate(QAction.ActionEvent.Trigger)
     fmtStr = "% Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:103] == fmtStr
 
     # Comment Off
-    nwGUI.mainMenu.aFmtComment.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtComment.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Check comment with no space before text
@@ -149,26 +149,26 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     fmtStr = "%Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:102] == fmtStr
 
-    nwGUI.mainMenu.aFmtNoFormat.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtNoFormat.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Undo/Redo
-    nwGUI.mainMenu.aEditUndo.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditUndo.activate(QAction.ActionEvent.Trigger)
     fmtStr = "%Pellentesque nec erat ut nulla posuere commodo."
     assert nwGUI.docEditor.getText()[54:102] == fmtStr
-    nwGUI.mainMenu.aEditRedo.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditRedo.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:101] == cleanText
 
     # Cut, Copy and Paste
     nwGUI.docEditor.setCursorPosition(54)
     nwGUI.docEditor._makeSelection(QTextCursor.WordUnderCursor)
 
-    nwGUI.mainMenu.aEditCut.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditCut.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:104] == (
         " nec erat ut nulla posuere commodo. Curabitur nisi"
     )
 
-    nwGUI.mainMenu.aEditPaste.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditPaste.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:104] == (
         "Pellentesque nec erat ut nulla posuere commodo. Cu"
     )
@@ -176,21 +176,21 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwGUI.docEditor.setCursorPosition(54)
     nwGUI.docEditor._makeSelection(QTextCursor.WordUnderCursor)
 
-    nwGUI.mainMenu.aEditCopy.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditCopy.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:104] == (
         "Pellentesque nec erat ut nulla posuere commodo. Cu"
     )
 
     nwGUI.docEditor.setCursorPosition(54)
-    nwGUI.mainMenu.aEditPaste.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditPaste.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[54:104] == (
         "PellentesquePellentesque nec erat ut nulla posuere"
     )
-    nwGUI.mainMenu.aEditUndo.activate(QAction.Trigger)
+    nwGUI.mainMenu.aEditUndo.activate(QAction.ActionEvent.Trigger)
 
     # Select Paragraph/All
     nwGUI.docEditor.setCursorPosition(57)
-    nwGUI.mainMenu.aSelectPar.activate(QAction.Trigger)
+    nwGUI.mainMenu.aSelectPar.activate(QAction.ActionEvent.Trigger)
     cursor = nwGUI.docEditor.textCursor()
     assert cursor.selectedText() == (
         "Pellentesque nec erat ut nulla posuere commodo. Curabitur nisi augue, imperdiet et porta "
@@ -203,7 +203,7 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     )
 
     nwGUI.docEditor.setCursorPosition(57)
-    nwGUI.mainMenu.aSelectAll.activate(QAction.Trigger)
+    nwGUI.mainMenu.aSelectAll.activate(QAction.ActionEvent.Trigger)
     cursor = nwGUI.docEditor.textCursor()
     assert len(cursor.selectedText()) == 1910
 
@@ -219,32 +219,32 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwGUI.docEditor.setCursorPosition(0)
 
     # Left Align
-    nwGUI.mainMenu.aFmtAlignLeft.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtAlignLeft.activate(QAction.ActionEvent.Trigger)
     fmtStr = "A single, short paragraph. <<"
     assert nwGUI.docEditor.getText()[:29] == fmtStr
 
     # Right Align
-    nwGUI.mainMenu.aFmtAlignRight.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtAlignRight.activate(QAction.ActionEvent.Trigger)
     fmtStr = ">> A single, short paragraph."
     assert nwGUI.docEditor.getText()[:29] == fmtStr
 
     # Centre Align
-    nwGUI.mainMenu.aFmtAlignCentre.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtAlignCentre.activate(QAction.ActionEvent.Trigger)
     fmtStr = ">> A single, short paragraph. <<"
     assert nwGUI.docEditor.getText()[:32] == fmtStr
 
     # Left Indent
-    nwGUI.mainMenu.aFmtIndentLeft.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtIndentLeft.activate(QAction.ActionEvent.Trigger)
     fmtStr = "> A single, short paragraph."
     assert nwGUI.docEditor.getText()[:28] == fmtStr
 
     # Right Indent
-    nwGUI.mainMenu.aFmtIndentRight.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtIndentRight.activate(QAction.ActionEvent.Trigger)
     fmtStr = "> A single, short paragraph. <"
     assert nwGUI.docEditor.getText()[:30] == fmtStr
 
     # No Format
-    nwGUI.mainMenu.aFmtNoFormat.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtNoFormat.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText()[:30] == cleanText
 
     # Other Checks
@@ -256,16 +256,16 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
         "Also text with \"double\" quotes which are \"less tricky\".\n\n"
     ))
 
-    nwGUI.mainMenu.aSelectAll.activate(QAction.Trigger)
-    nwGUI.mainMenu.aFmtReplSng.activate(QAction.Trigger)
+    nwGUI.mainMenu.aSelectAll.activate(QAction.ActionEvent.Trigger)
+    nwGUI.mainMenu.aFmtReplSng.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == (
         "### New Text\n\n"
         "Text with ‘single’ quotes and ‘tricky stuff’s’.\n\n"
         "Also text with \"double\" quotes which are \"less tricky\".\n\n"
     )
 
-    nwGUI.mainMenu.aSelectAll.activate(QAction.Trigger)
-    nwGUI.mainMenu.aFmtReplDbl.activate(QAction.Trigger)
+    nwGUI.mainMenu.aSelectAll.activate(QAction.ActionEvent.Trigger)
+    nwGUI.mainMenu.aFmtReplDbl.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == (
         "### New Text\n\n"
         "Text with ‘single’ quotes and ‘tricky stuff’s’.\n\n"
@@ -281,7 +281,7 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
         "Here is some text\non multiple\nlines.\n\n"
         "With another paragraph\nhere."
     ))
-    nwGUI.mainMenu.aFmtRmBreaks.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtRmBreaks.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == (
         "### New Text\n\n"
         "@char: Someone\n"
@@ -303,7 +303,7 @@ def testGuiMainMenu_EditFormat(qtbot, monkeypatch, nwGUI, prjLipsum):
     cursor.setPosition(74)
     cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor, 29)
     nwGUI.docEditor.setTextCursor(cursor)
-    nwGUI.mainMenu.aFmtRmBreaks.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFmtRmBreaks.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == (
         "### New Text\n\n"
         "@char: Someone\n"
@@ -367,95 +367,95 @@ def testGuiMainMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd
     nwGUI.docEditor.clear()
 
     # Check Menu Entries
-    nwGUI.mainMenu.aInsENDash.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsENDash.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_ENDASH
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsEMDash.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsEMDash.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_EMDASH
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsHorBar.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsHorBar.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_HBAR
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsFigDash.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsFigDash.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_FGDASH
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsQuoteLS.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsQuoteLS.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == CONFIG.fmtSQuoteOpen
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsQuoteRS.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsQuoteRS.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == CONFIG.fmtSQuoteClose
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsQuoteLD.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsQuoteLD.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == CONFIG.fmtDQuoteOpen
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsQuoteRD.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsQuoteRD.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == CONFIG.fmtDQuoteClose
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsMSApos.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsMSApos.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_MAPOS
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsEllipsis.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsEllipsis.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_HELLIP
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsPrime.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsPrime.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_PRIME
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsDPrime.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsDPrime.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_DPRIME
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsBullet.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsBullet.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_BULL
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsHyBull.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsHyBull.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_HYBULL
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsFlower.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsFlower.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_FLOWER
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsPerMille.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsPerMille.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_PERMIL
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsDegree.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsDegree.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_DEGREE
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsMinus.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsMinus.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_MINUS
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsTimes.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsTimes.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_TIMES
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsDivide.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsDivide.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_DIVIDE
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsNBSpace.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsNBSpace.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_NBSP
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsThinSpace.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsThinSpace.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_THSP
     nwGUI.docEditor.clear()
 
-    nwGUI.mainMenu.aInsThinNBSpace.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsThinNBSpace.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == nwUnicode.U_THNBSP
     nwGUI.docEditor.clear()
 
@@ -463,43 +463,43 @@ def testGuiMainMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd
     # ===============
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.TAG_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.TAG_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.TAG_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.POV_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.POV_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.POV_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.FOCUS_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.FOCUS_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.FOCUS_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.CHAR_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.CHAR_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.CHAR_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.PLOT_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.PLOT_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.PLOT_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.TIME_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.TIME_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.TIME_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.WORLD_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.WORLD_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.WORLD_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.OBJECT_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.OBJECT_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.OBJECT_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.ENTITY_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.ENTITY_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.ENTITY_KEY
 
     nwGUI.docEditor.setPlainText("Stuff")
-    nwGUI.mainMenu.mInsKWItems[nwKeyWords.CUSTOM_KEY][0].activate(QAction.Trigger)
+    nwGUI.mainMenu.mInsKWItems[nwKeyWords.CUSTOM_KEY][0].activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%s: " % nwKeyWords.CUSTOM_KEY
 
     # Faulty Keyword Inserts
@@ -514,26 +514,26 @@ def testGuiMainMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd
     # =======================
 
     nwGUI.docEditor.setPlainText("Stuff\n")
-    nwGUI.mainMenu.aInsSynopsis.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsSynopsis.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%Synopsis: \n"
 
     nwGUI.docEditor.setPlainText("Stuff\n")
-    nwGUI.mainMenu.aInsShort.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsShort.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%Short: \n"
 
     # Insert Break or Space
     # =====================
 
     nwGUI.docEditor.setPlainText("### Stuff\n")
-    nwGUI.mainMenu.aInsNewPage.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsNewPage.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "[newpage]\n### Stuff\n"
 
     nwGUI.docEditor.setPlainText("### Stuff\n")
-    nwGUI.mainMenu.aInsVSpaceS.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsVSpaceS.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "[vspace]\n### Stuff\n"
 
     nwGUI.docEditor.setPlainText("### Stuff\n")
-    nwGUI.mainMenu.aInsVSpaceM.activate(QAction.Trigger)
+    nwGUI.mainMenu.aInsVSpaceM.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "[vspace:2]\n### Stuff\n"
 
     nwGUI.docEditor.clear()
@@ -572,13 +572,13 @@ def testGuiMainMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd
         assert nwGUI.docEditor.getText() == "Bar"
 
     # Finally, accept the replaced text, this time we use the menu entry to trigger it
-    nwGUI.mainMenu.aImportFile.activate(QAction.Trigger)
+    nwGUI.mainMenu.aImportFile.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Foo"
 
     # Reveal File Location
     # ====================
 
-    nwGUI.mainMenu.aFileDetails.activate(QAction.Trigger)
+    nwGUI.mainMenu.aFileDetails.activate(QAction.ActionEvent.Trigger)
     path = str(projPath / "content" / "000000000000f.nwd")
     assert SHARED.lastAlert.endswith(f"File Location: {path}")
 

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -32,7 +32,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwFocus, nwItemType
 from novelwriter.gui.noveltree import GuiNovelTree, NovelTreeColumn
-from novelwriter.types import QtMouseLeft
+from novelwriter.types import QtMouseLeft, QtMouseMiddle
 
 from tests.tools import C, buildTestProject
 
@@ -127,17 +127,17 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     scItem.setSelected(True)
     assert scItem.isSelected()
     assert nwGUI.docViewer.docHandle is None
-    qtbot.mouseClick(vPort, Qt.MiddleButton, pos=vPort.rect().center(), delay=10)
+    qtbot.mouseClick(vPort, QtMouseMiddle, pos=vPort.rect().center(), delay=10)
     assert nwGUI.docViewer.docHandle is None
 
     scRect = novelTree.visualItemRect(scItem)
     oldData = scItem.data(novelTree.C_TITLE, novelTree.D_HANDLE)
     scItem.setData(novelTree.C_TITLE, novelTree.D_HANDLE, None)
-    qtbot.mouseClick(vPort, Qt.MiddleButton, pos=scRect.center(), delay=10)
+    qtbot.mouseClick(vPort, QtMouseMiddle, pos=scRect.center(), delay=10)
     assert nwGUI.docViewer.docHandle is None
 
     scItem.setData(novelTree.C_TITLE, novelTree.D_HANDLE, oldData)
-    qtbot.mouseClick(vPort, Qt.MiddleButton, pos=scRect.center(), delay=10)
+    qtbot.mouseClick(vPort, QtMouseMiddle, pos=scRect.center(), delay=10)
     assert nwGUI.docViewer.docHandle == C.hSceneDoc
 
     # Last Column

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -152,7 +152,7 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, projPath):
     # Trigger the menu entry for all hidden columns
     for hItem in nwOutline:
         if outlineTree.DEF_HIDDEN[hItem]:
-            outlineMenu.actionMap[hItem].activate(QAction.Trigger)
+            outlineMenu.actionMap[hItem].activate(QAction.ActionEvent.Trigger)
 
     # Now no columns should be hidden
     outlineTree._saveHeaderState()

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -26,11 +26,11 @@ from shutil import copyfile
 
 import pytest
 
-from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QAction, QFileDialog, QWidget
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.enum import nwItemClass, nwOutline, nwView
+from novelwriter.types import QtScrollAlwaysOff, QtScrollAsNeeded
 
 from tests.tools import buildTestProject, cmpFiles, writeFile
 
@@ -53,18 +53,18 @@ def testGuiOutline_Main(qtbot, monkeypatch, nwGUI, projPath):
     CONFIG.hideVScroll = True
     CONFIG.hideHScroll = True
     outlineView.initSettings()
-    assert outlineTree.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
-    assert outlineTree.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
-    assert outlineData.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
-    assert outlineData.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
+    assert outlineTree.verticalScrollBarPolicy() == QtScrollAlwaysOff
+    assert outlineTree.horizontalScrollBarPolicy() == QtScrollAlwaysOff
+    assert outlineData.verticalScrollBarPolicy() == QtScrollAlwaysOff
+    assert outlineData.horizontalScrollBarPolicy() == QtScrollAlwaysOff
 
     CONFIG.hideVScroll = False
     CONFIG.hideHScroll = False
     outlineView.initSettings()
-    assert outlineTree.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-    assert outlineTree.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-    assert outlineData.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-    assert outlineData.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
+    assert outlineTree.verticalScrollBarPolicy() == QtScrollAsNeeded
+    assert outlineTree.horizontalScrollBarPolicy() == QtScrollAsNeeded
+    assert outlineData.verticalScrollBarPolicy() == QtScrollAsNeeded
+    assert outlineData.horizontalScrollBarPolicy() == QtScrollAsNeeded
 
     # Check focus
     with monkeypatch.context() as mp:

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -37,7 +37,10 @@ from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwFocus, nwItemClass, nwItemLayout, nwItemType
 from novelwriter.gui.projtree import GuiProjectTree, GuiProjectView, _TreeContextMenu
 from novelwriter.guimain import GuiMain
-from novelwriter.types import QtAccepted, QtModNone, QtMouseLeft, QtMouseMiddle, QtRejected
+from novelwriter.types import (
+    QtAccepted, QtModNone, QtMouseLeft, QtMouseMiddle, QtRejected,
+    QtScrollAlwaysOff, QtScrollAsNeeded
+)
 
 from tests.mocked import causeOSError
 from tests.tools import C, buildTestProject
@@ -957,14 +960,14 @@ def testGuiProjTree_Other(qtbot, monkeypatch, nwGUI: GuiMain, projPath, mockRnd)
     CONFIG.hideVScroll = True
     CONFIG.hideHScroll = True
     projView.initSettings()
-    assert projTree.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
-    assert projTree.horizontalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
+    assert projTree.verticalScrollBarPolicy() == QtScrollAlwaysOff
+    assert projTree.horizontalScrollBarPolicy() == QtScrollAlwaysOff
 
     CONFIG.hideVScroll = False
     CONFIG.hideHScroll = False
     projView.initSettings()
-    assert projTree.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-    assert projTree.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
+    assert projTree.verticalScrollBarPolicy() == QtScrollAsNeeded
+    assert projTree.horizontalScrollBarPolicy() == QtScrollAsNeeded
 
     # Method: revealNewTreeItem
     # =========================

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -411,7 +411,7 @@ def testGuiProjTree_MoveItemToTrash(qtbot, caplog, monkeypatch, nwGUI, projPath,
 
     # User cancels action
     with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         assert projTree.moveItemToTrash(C.hTitlePage) is False
         assert project.tree.isTrash(C.hTitlePage) is False
 
@@ -456,7 +456,7 @@ def testGuiProjTree_PermanentlyDeleteItem(qtbot, caplog, monkeypatch, nwGUI, pro
 
     # User cancels action
     with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         assert projTree.permDeleteItem(C.hTitlePage) is False
         assert C.hTitlePage in project.tree
 
@@ -506,7 +506,7 @@ def testGuiProjTree_EmptyTrash(qtbot, caplog, monkeypatch, nwGUI, projPath, mock
 
     # User cancels
     with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         assert projTree.emptyTrash() is False
         assert C.hTitlePage in project.tree
         assert C.hChapterDir in project.tree
@@ -751,7 +751,7 @@ def testGuiProjTree_Duplicate(qtbot, monkeypatch, nwGUI: GuiMain, projPath, mock
 
     # Duplicate title page, but select no
     with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         assert projTree._duplicateFromHandle(C.hTitlePage) is False
         assert len(SHARED.project.tree) == 8
 
@@ -1313,7 +1313,7 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Click no on the dialog
     with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         ctxMenu._covertFolderToFile(nwItemLayout.DOCUMENT)
         assert SHARED.project.tree[hNewFolderOne].isFolderType()  # type: ignore
 

--- a/tests/test_tools/test_tools_lipsum.py
+++ b/tests/test_tools/test_tools_lipsum.py
@@ -35,7 +35,7 @@ from tests.tools import C, buildTestProject
 def testToolLipsum_Main(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test the Lorem Ipsum tool."""
     # Check that we cannot open when there is no project
-    nwGUI.mainMenu.aLipsumText.activate(QAction.Trigger)
+    nwGUI.mainMenu.aLipsumText.activate(QAction.ActionEvent.Trigger)
     assert SHARED.findTopLevelWidget(GuiLipsum) is None
 
     buildTestProject(nwGUI, projPath)

--- a/tests/test_tools/test_tools_manusbuild.py
+++ b/tests/test_tools/test_tools_manusbuild.py
@@ -133,7 +133,7 @@ def testToolManuscriptBuild_Main(
     manus.buildPath.setText(str(fncPath))
     manus.buildName.setText("TestBuild")
     with monkeypatch.context() as mp:
-        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.No)
+        mp.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.No)
         assert manus._runBuild() is False
 
     # Test that the open button works

--- a/tests/test_tools/test_tools_manuscript.py
+++ b/tests/test_tools/test_tools_manuscript.py
@@ -47,7 +47,7 @@ def testToolManuscript_Init(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     SHARED.project.storage.getDocument(C.hChapterDoc).writeDocument("## A Chapter\n\n\t\tHi")
     allText = "New Novel\nBy Jane Doe\nA Chapter\n\t\tHi"
 
-    nwGUI.mainMenu.aBuildManuscript.activate(QAction.Trigger)
+    nwGUI.mainMenu.aBuildManuscript.activate(QAction.ActionEvent.Trigger)
     qtbot.waitUntil(lambda: SHARED.findTopLevelWidget(GuiManuscript) is not None, timeout=1000)
     manus = SHARED.findTopLevelWidget(GuiManuscript)
     assert isinstance(manus, GuiManuscript)

--- a/tests/test_tools/test_tools_writingstats.py
+++ b/tests/test_tools/test_tools_writingstats.py
@@ -45,7 +45,7 @@ def testToolWritingStats_Main(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     sessFile = projPath / "meta" / nwFiles.SESS_FILE
 
     # Open the Writing Stats dialog
-    nwGUI.mainMenu.aWritingStats.activate(QAction.Trigger)
+    nwGUI.mainMenu.aWritingStats.activate(QAction.ActionEvent.Trigger)
     qtbot.waitUntil(lambda: SHARED.findTopLevelWidget(GuiWritingStats) is not None, timeout=1000)
 
     sessLog = SHARED.findTopLevelWidget(GuiWritingStats)


### PR DESCRIPTION
**Summary:**

This PR cleans up a lot more Qt enums. This is needed for PyQt6 support.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
