### PR TITLE
Replace Qt RegEx with Python RegEx

### DIFF
--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -23,8 +23,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
-from re import UNICODE, compile
-
 from PyQt5.QtCore import QT_TRANSLATE_NOOP, QCoreApplication
 
 from novelwriter.enum import (
@@ -62,15 +60,12 @@ class nwConst:
 
 class nwRegEx:
 
+    WORDS  = r"\b[^\s\-\+\/–—\[\]:]+\b"
     FMT_EI = r"(?<![\w\\])(_)(?![\s_])(.+?)(?<![\s\\])(\1)(?!\w)"
     FMT_EB = r"(?<![\w\\])(\*{2})(?![\s\*])(.+?)(?<![\s\\])(\1)(?!\w)"
     FMT_ST = r"(?<![\w\\])(~{2})(?![\s~])(.+?)(?<![\s\\])(\1)(?!\w)"
     FMT_SC = r"(?i)(?<!\\)(\[[\/\!]?(?:b|i|s|u|m|sup|sub)\])"
     FMT_SV = r"(?i)(?<!\\)(\[(?:footnote):)(.+?)(?<!\\)(\])"
-
-    RX_WORDS = compile(r"\b[^\s\-\+\/–—\[\]:]+\b", UNICODE)
-    RX_FMT_SC = compile(r"(?i)(?<!\\)(\[[\/\!]?(?:b|i|s|u|m|sup|sub)\])", UNICODE)
-    RX_FMT_SV = compile(r"(?i)(?<!\\)(\[(?:footnote):)(.+?)(?<!\\)(\])", UNICODE)
 
 
 class nwShortcode:

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -68,7 +68,7 @@ class nwRegEx:
     FMT_SC = r"(?i)(?<!\\)(\[[\/\!]?(?:b|i|s|u|m|sup|sub)\])"
     FMT_SV = r"(?i)(?<!\\)(\[(?:footnote):)(.+?)(?<!\\)(\])"
 
-    RX_WORDS = compile(r"\b([^\s\-\+\/–—\[\]:]+)\b", UNICODE)
+    RX_WORDS = compile(r"\b[^\s\-\+\/–—\[\]:]+\b", UNICODE)
     RX_FMT_SC = compile(r"(?i)(?<!\\)(\[[\/\!]?(?:b|i|s|u|m|sup|sub)\])", UNICODE)
     RX_FMT_SV = compile(r"(?i)(?<!\\)(\[(?:footnote):)(.+?)(?<!\\)(\])", UNICODE)
 

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -23,6 +23,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
+from re import UNICODE, compile
+
 from PyQt5.QtCore import QT_TRANSLATE_NOOP, QCoreApplication
 
 from novelwriter.enum import (
@@ -65,6 +67,10 @@ class nwRegEx:
     FMT_ST = r"(?<![\w\\])(~{2})(?![\s~])(.+?)(?<![\s\\])(\1)(?!\w)"
     FMT_SC = r"(?i)(?<!\\)(\[[\/\!]?(?:b|i|s|u|m|sup|sub)\])"
     FMT_SV = r"(?i)(?<!\\)(\[(?:footnote):)(.+?)(?<!\\)(\])"
+
+    RX_WORDS = compile(r"\b([^\s\-\+\/–—\[\]:]+)\b", UNICODE)
+    RX_FMT_SC = compile(r"(?i)(?<!\\)(\[[\/\!]?(?:b|i|s|u|m|sup|sub)\])", UNICODE)
+    RX_FMT_SV = compile(r"(?i)(?<!\\)(\[(?:footnote):)(.+?)(?<!\\)(\])", UNICODE)
 
 
 class nwShortcode:

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -33,7 +33,7 @@ from functools import partial
 from pathlib import Path
 from time import time
 
-from PyQt5.QtCore import QCoreApplication, QRegularExpression
+from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtGui import QFont
 
 from novelwriter import CONFIG
@@ -234,7 +234,7 @@ class Tokenizer(ABC):
             nwShortcode.FOOTNOTE_B: self.FMT_FNOTE,
         }
 
-        self._rxDialogue: list[tuple[QRegularExpression, int, int]] = []
+        self._rxDialogue: list[tuple[re.Pattern, int, int]] = []
 
         return
 
@@ -1136,11 +1136,9 @@ class Tokenizer(ABC):
         # Match Dialogue
         if self._rxDialogue and hDialog:
             for regEx, fmtB, fmtE in self._rxDialogue:
-                rxItt = regEx.globalMatch(text, 0)
-                while rxItt.hasNext():
-                    rxMatch = rxItt.next()
-                    temp.append((rxMatch.capturedStart(0), 0, fmtB, ""))
-                    temp.append((rxMatch.capturedEnd(0), 0, fmtE, ""))
+                for match in re.finditer(regEx, text):
+                    temp.append((match.start(0), 0, fmtB, ""))
+                    temp.append((match.end(0), 0, fmtE, ""))
 
         # Post-process text and format
         result = text

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -1116,27 +1116,21 @@ class Tokenizer(ABC):
                 )
 
         # Match Shortcodes
-        rxItt = self._rxShortCodes.globalMatch(text, 0)
-        while rxItt.hasNext():
-            rxMatch = rxItt.next()
+        for match in re.finditer(REGEX_PATTERNS.shortcodePlain, text):
             temp.append((
-                rxMatch.capturedStart(1),
-                rxMatch.capturedLength(1),
-                self._shortCodeFmt.get(rxMatch.captured(1).lower(), 0),
+                match.start(1), len(match.group(1)),
+                self._shortCodeFmt.get(match.group(1).lower(), 0),
                 "",
             ))
 
         # Match Shortcode w/Values
-        rxItt = self._rxShortCodeVals.globalMatch(text, 0)
         tHandle = self._handle or ""
-        while rxItt.hasNext():
-            rxMatch = rxItt.next()
-            kind = self._shortCodeVals.get(rxMatch.captured(1).lower(), 0)
+        for match in re.finditer(REGEX_PATTERNS.shortcodeValue, text):
+            kind = self._shortCodeVals.get(match.group(1).lower(), 0)
             temp.append((
-                rxMatch.capturedStart(0),
-                rxMatch.capturedLength(0),
+                match.start(0), len(match.group(0)),
                 self.FMT_STRIP if kind == skip else kind,
-                f"{tHandle}:{rxMatch.captured(2)}",
+                f"{tHandle}:{match.group(2)}",
             ))
 
         # Match Dialogue

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -1109,11 +1109,9 @@ class Tokenizer(ABC):
 
         # Match Markdown
         for regEx, fmts in self._rxMarkdown:
-            rxItt = regEx.globalMatch(text, 0)
-            while rxItt.hasNext():
-                rxMatch = rxItt.next()
+            for match in re.finditer(regEx, text):
                 temp.extend(
-                    (rxMatch.capturedStart(n), rxMatch.capturedLength(n), fmt, "")
+                    (match.start(n), len(match.group(n)), fmt, "")
                     for n, fmt in enumerate(fmts) if fmt > 0
                 )
 

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -37,12 +37,16 @@ from PyQt5.QtGui import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import checkInt
-from novelwriter.constants import nwHeaders, nwRegEx, nwUnicode
+from novelwriter.constants import nwHeaders, nwUnicode
 from novelwriter.core.index import processComment
 from novelwriter.enum import nwComment
 from novelwriter.text.patterns import REGEX_PATTERNS
 
 logger = logging.getLogger(__name__)
+
+RX_WORDS = REGEX_PATTERNS.wordSplit
+RX_FMT_SC = REGEX_PATTERNS.shortcodePlain
+RX_FMT_SV = REGEX_PATTERNS.shortcodeValue
 
 BLOCK_NONE  = 0
 BLOCK_TEXT  = 1
@@ -479,7 +483,7 @@ class TextBlockData(QTextBlockUserData):
         """
         if "[" in text:
             # Strip shortcodes
-            for rX in [nwRegEx.RX_FMT_SC, nwRegEx.RX_FMT_SV]:
+            for rX in [RX_FMT_SC, RX_FMT_SV]:
                 for match in re.finditer(rX, text[offset:]):
                     iS = match.start(0) + offset
                     iE = match.end(0) + offset
@@ -488,7 +492,7 @@ class TextBlockData(QTextBlockUserData):
 
         self._spellErrors = []
         checker = SHARED.spelling
-        for match in re.finditer(nwRegEx.RX_WORDS, text[offset:].replace("_", " ")):
+        for match in re.finditer(RX_WORDS, text[offset:].replace("_", " ")):
             if (
                 (word := match.group(0))
                 and not (word.isnumeric() or word.isupper() or checker.checkWord(word))

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -41,7 +41,6 @@ from novelwriter.constants import nwHeaders, nwRegEx, nwUnicode
 from novelwriter.core.index import processComment
 from novelwriter.enum import nwComment
 from novelwriter.text.patterns import REGEX_PATTERNS
-from novelwriter.types import QRegExUnicode
 
 logger = logging.getLogger(__name__)
 

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -29,7 +29,7 @@ import re
 
 from time import time
 
-from PyQt5.QtCore import QRegularExpression, Qt
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import (
     QBrush, QColor, QFont, QSyntaxHighlighter, QTextBlockUserData,
     QTextCharFormat, QTextDocument
@@ -398,29 +398,15 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         if hRules:
             for rX, hRule in hRules:
-                if isinstance(rX, QRegularExpression):
-                    rxItt = rX.globalMatch(text, xOff)
-                    while rxItt.hasNext():
-                        rxMatch = rxItt.next()
-                        for xM, hFmt in hRule.items():
-                            xPos = rxMatch.capturedStart(xM)
-                            xEnd = rxMatch.capturedEnd(xM)
-                            for x in range(xPos, xEnd):
-                                cFmt = self.format(x)
-                                if cFmt.fontStyleName() != "markup":
-                                    cFmt.merge(hFmt)
-                                    self.setFormat(x, 1, cFmt)
-                else:
-                    for match in re.finditer(rX, text[xOff:]):
-                        for xM, hFmt in hRule.items():
-                            # print(f"'{match.group(xM)}'", match.start(xM), match.end(xM))
-                            xPos = match.start(xM) + xOff
-                            xEnd = match.end(xM) + xOff
-                            for x in range(xPos, xEnd):
-                                cFmt = self.format(x)
-                                if cFmt.fontStyleName() != "markup":
-                                    cFmt.merge(hFmt)
-                                    self.setFormat(x, 1, cFmt)
+                for match in re.finditer(rX, text[xOff:]):
+                    for xM, hFmt in hRule.items():
+                        xPos = match.start(xM) + xOff
+                        xEnd = match.end(xM) + xOff
+                        for x in range(xPos, xEnd):
+                            cFmt = self.format(x)
+                            if cFmt.fontStyleName() != "markup":
+                                cFmt.merge(hFmt)
+                                self.setFormat(x, 1, cFmt)
 
         data = self.currentBlockUserData()
         if not isinstance(data, TextBlockData):

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -107,8 +107,8 @@ class GuiTextDocument(QTextDocument):
             text = block.text()
             check = pos - block.position()
             if check >= 0:
-                for cPos, cLen in data.spellErrors:
-                    cEnd = cPos + cLen
+                for cPos, cEnd in data.spellErrors:
+                    cLen = cEnd - cPos
                     if cPos <= check <= cEnd:
                         word = text[cPos:cEnd]
                         return word, cPos, cLen, SHARED.spelling.suggestWords(word)

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -23,6 +23,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
+import re
+
 from PyQt5.QtCore import QRegularExpression
 
 from novelwriter import CONFIG
@@ -33,25 +35,19 @@ from novelwriter.types import QRegExUnicode
 class RegExPatterns:
 
     @property
-    def markdownItalic(self) -> QRegularExpression:
+    def markdownItalic(self) -> re.Pattern:
         """Markdown italic style."""
-        rxRule = QRegularExpression(nwRegEx.FMT_EI)
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        return re.compile(nwRegEx.FMT_EI, re.UNICODE)
 
     @property
-    def markdownBold(self) -> QRegularExpression:
+    def markdownBold(self) -> re.Pattern:
         """Markdown bold style."""
-        rxRule = QRegularExpression(nwRegEx.FMT_EB)
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        return re.compile(nwRegEx.FMT_EB, re.UNICODE)
 
     @property
-    def markdownStrike(self) -> QRegularExpression:
+    def markdownStrike(self) -> re.Pattern:
         """Markdown strikethrough style."""
-        rxRule = QRegularExpression(nwRegEx.FMT_ST)
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        return re.compile(nwRegEx.FMT_ST, re.UNICODE)
 
     @property
     def shortcodePlain(self) -> QRegularExpression:

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -32,11 +32,17 @@ from novelwriter.constants import nwRegEx
 class RegExPatterns:
 
     # Static RegExes
+    _rxWords   = re.compile(nwRegEx.WORDS, re.UNICODE)
     _rxItalic  = re.compile(nwRegEx.FMT_EI, re.UNICODE)
     _rxBold    = re.compile(nwRegEx.FMT_EB, re.UNICODE)
     _rxStrike  = re.compile(nwRegEx.FMT_ST, re.UNICODE)
     _rxSCPlain = re.compile(nwRegEx.FMT_SC, re.UNICODE)
     _rxSCValue = re.compile(nwRegEx.FMT_SV, re.UNICODE)
+
+    @property
+    def wordSplit(self) -> re.Pattern:
+        """Split text into words."""
+        return self._rxWords
 
     @property
     def markdownItalic(self) -> re.Pattern:

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -25,11 +25,8 @@ from __future__ import annotations
 
 import re
 
-from PyQt5.QtCore import QRegularExpression
-
 from novelwriter import CONFIG
 from novelwriter.constants import nwRegEx
-from novelwriter.types import QRegExUnicode
 
 
 class RegExPatterns:
@@ -67,7 +64,7 @@ class RegExPatterns:
         return self._rxSCValue
 
     @property
-    def dialogStyle(self) -> QRegularExpression:
+    def dialogStyle(self) -> re.Pattern:
         """Dialogue detection rule based on user settings."""
         symO = ""
         symC = ""
@@ -79,34 +76,26 @@ class RegExPatterns:
             symC += CONFIG.fmtDQuoteClose
 
         rxEnd = "|$" if CONFIG.allowOpenDial else ""
-        rxRule = QRegularExpression(f"\\B[{symO}].*?(?:[{symC}]\\B{rxEnd})")
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        return re.compile(f"\\B[{symO}].*?(?:[{symC}]\\B{rxEnd})", re.UNICODE)
 
     @property
-    def dialogLine(self) -> QRegularExpression:
+    def dialogLine(self) -> re.Pattern:
         """Dialogue line rule based on user settings."""
-        sym = QRegularExpression.escape(CONFIG.dialogLine)
-        rxRule = QRegularExpression(f"^{sym}.*?$")
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        sym = re.escape(CONFIG.dialogLine)
+        return re.compile(f"^{sym}.*?$", re.UNICODE)
 
     @property
-    def narratorBreak(self) -> QRegularExpression:
+    def narratorBreak(self) -> re.Pattern:
         """Dialogue narrator break rule based on user settings."""
-        sym = QRegularExpression.escape(CONFIG.narratorBreak)
-        rxRule = QRegularExpression(f"\\B{sym}\\S.*?\\S{sym}\\B")
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        sym = re.escape(CONFIG.narratorBreak)
+        return re.compile(f"\\B{sym}\\S.*?\\S{sym}\\B", re.UNICODE)
 
     @property
-    def altDialogStyle(self) -> QRegularExpression:
+    def altDialogStyle(self) -> re.Pattern:
         """Dialogue alternative rule based on user settings."""
-        symO = QRegularExpression.escape(CONFIG.altDialogOpen)
-        symC = QRegularExpression.escape(CONFIG.altDialogClose)
-        rxRule = QRegularExpression(f"\\B{symO}.*?{symC}\\B")
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        symO = re.escape(CONFIG.altDialogOpen)
+        symC = re.escape(CONFIG.altDialogClose)
+        return re.compile(f"\\B{symO}.*?{symC}\\B", re.UNICODE)
 
 
 REGEX_PATTERNS = RegExPatterns()

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -34,34 +34,37 @@ from novelwriter.types import QRegExUnicode
 
 class RegExPatterns:
 
+    # Static RegExes
+    _rxItalic  = re.compile(nwRegEx.FMT_EI, re.UNICODE)
+    _rxBold    = re.compile(nwRegEx.FMT_EB, re.UNICODE)
+    _rxStrike  = re.compile(nwRegEx.FMT_ST, re.UNICODE)
+    _rxSCPlain = re.compile(nwRegEx.FMT_SC, re.UNICODE)
+    _rxSCValue = re.compile(nwRegEx.FMT_SV, re.UNICODE)
+
     @property
     def markdownItalic(self) -> re.Pattern:
         """Markdown italic style."""
-        return re.compile(nwRegEx.FMT_EI, re.UNICODE)
+        return self._rxItalic
 
     @property
     def markdownBold(self) -> re.Pattern:
         """Markdown bold style."""
-        return re.compile(nwRegEx.FMT_EB, re.UNICODE)
+        return self._rxBold
 
     @property
     def markdownStrike(self) -> re.Pattern:
         """Markdown strikethrough style."""
-        return re.compile(nwRegEx.FMT_ST, re.UNICODE)
+        return self._rxStrike
 
     @property
-    def shortcodePlain(self) -> QRegularExpression:
+    def shortcodePlain(self) -> re.Pattern:
         """Plain shortcode style."""
-        rxRule = QRegularExpression(nwRegEx.FMT_SC)
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        return self._rxSCPlain
 
     @property
-    def shortcodeValue(self) -> QRegularExpression:
+    def shortcodeValue(self) -> re.Pattern:
         """Plain shortcode style."""
-        rxRule = QRegularExpression(nwRegEx.FMT_SV)
-        rxRule.setPatternOptions(QRegExUnicode)
-        return rxRule
+        return self._rxSCValue
 
     @property
     def dialogStyle(self) -> QRegularExpression:

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -23,7 +23,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
-from PyQt5.QtCore import QRegularExpression, Qt
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QFont, QPainter, QTextCharFormat, QTextCursor, QTextFormat
 from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QSizePolicy, QStyle
 
@@ -114,10 +114,6 @@ QtSizeMinimumExpanding = QSizePolicy.Policy.MinimumExpanding
 
 QtScrollAlwaysOff = Qt.ScrollBarPolicy.ScrollBarAlwaysOff
 QtScrollAsNeeded = Qt.ScrollBarPolicy.ScrollBarAsNeeded
-
-# Other
-
-QRegExUnicode = QRegularExpression.PatternOption.UseUnicodePropertiesOption
 
 # Maps
 

--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -421,7 +421,7 @@ def testCoreTools_DocSearch(monkeypatch, mockGUI, fncPath, mockRnd, ipsumText):
     # Patterns
     # ========
 
-    # Escape Using QRegularExpression
+    # Escape
     assert search._buildPattern("[A-Za-z0-9_]+") == r"\[A\-Za\-z0\-9_\]\+"
 
     # Whole Words

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -24,30 +24,19 @@ import re
 
 import pytest
 
-from PyQt5.QtCore import QRegularExpression
-
 from novelwriter import CONFIG
 from novelwriter.constants import nwUnicode
 from novelwriter.text.patterns import REGEX_PATTERNS
 
 
-def allMatches(regEx: QRegularExpression, text: str) -> list[list[str]]:
+def allMatches(regEx: re.Pattern, text: str) -> list[list[str]]:
     """Get all matches for a regex."""
     result = []
-    if isinstance(regEx, QRegularExpression):
-        itt = regEx.globalMatch(text, 0)
-        while itt.hasNext():
-            match = itt.next()
-            result.append([
-                (match.captured(n), match.capturedStart(n), match.capturedEnd(n))
-                for n in range(match.lastCapturedIndex() + 1)
-            ])
-    else:
-        for match in re.finditer(regEx, text):
-            result.append([
-                (match.group(n), match.start(n), match.end(n))
-                for n in range((match.lastindex or -1) + 1)
-            ])
+    for match in re.finditer(regEx, text):
+        result.append([
+            (match.group(n), match.start(n), match.end(n))
+            for n in range((match.lastindex or 0) + 1)
+        ])
     return result
 
 

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -20,6 +20,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from PyQt5.QtCore import QRegularExpression
@@ -32,13 +34,20 @@ from novelwriter.text.patterns import REGEX_PATTERNS
 def allMatches(regEx: QRegularExpression, text: str) -> list[list[str]]:
     """Get all matches for a regex."""
     result = []
-    itt = regEx.globalMatch(text, 0)
-    while itt.hasNext():
-        match = itt.next()
-        result.append([
-            (match.captured(n), match.capturedStart(n), match.capturedEnd(n))
-            for n in range(match.lastCapturedIndex() + 1)
-        ])
+    if isinstance(regEx, QRegularExpression):
+        itt = regEx.globalMatch(text, 0)
+        while itt.hasNext():
+            match = itt.next()
+            result.append([
+                (match.captured(n), match.capturedStart(n), match.capturedEnd(n))
+                for n in range(match.lastCapturedIndex() + 1)
+            ])
+    else:
+        for match in re.finditer(regEx, text):
+            result.append([
+                (match.group(n), match.start(n), match.end(n))
+                for n in range((match.lastindex or -1) + 1)
+            ])
     return result
 
 

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -41,6 +41,52 @@ def allMatches(regEx: re.Pattern, text: str) -> list[list[str]]:
 
 
 @pytest.mark.core
+def testTextPatterns_Words():
+    """Test the word split regex."""
+    regEx = REGEX_PATTERNS.wordSplit
+
+    # Spaces
+    assert allMatches(regEx, "one two three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+    # Hyphens
+    assert allMatches(regEx, "one-two-three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+    # Em Dashes
+    assert allMatches(regEx, "one\u2014two\u2014three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+    # Em Dashes
+    assert allMatches(regEx, "one\u2014two\u2014three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+    # Plus
+    assert allMatches(regEx, "one+two+three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+    # Slash
+    assert allMatches(regEx, "one/two/three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+    # Brackets
+    assert allMatches(regEx, "one[two]three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+    # Colon
+    assert allMatches(regEx, "one:two:three") == [
+        [("one", 0, 3)], [("two", 4, 7)], [("three", 8, 13)]
+    ]
+
+
+@pytest.mark.core
 def testTextPatterns_Markdown():
     """Test the markdown pattern regexes."""
     # Bold


### PR DESCRIPTION
**Summary:**

This PR replaces QRegularExpression from Qt with Python's standard library regex module.

There are two reasons for doing this:
* The standard library one is a little bit faster, mostly because there is no need to convert strings when calling it like is needed for the Qt one (I suspect that's the reason anyway).
* The PyQt6 interface th QRegularExpression is broken, at least for Qt 6.4.2. The returned matches are sometimes garbled. Presumably due to UTF-16 to UTF-8 conversion, but I'm not sure. Switching to the Python implementation avoids this problem in the future when we switch to Qt6.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
