### PR TITLE
Add word counts to ODT output

### DIFF
--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -89,11 +89,6 @@ class NWBuildDocument:
     #  Setters
     ##
 
-    def setCountEnabled(self, state: bool) -> None:
-        """Turn on/off stats for builds."""
-        self._count = state
-        return
-
     def setBuildOutline(self, state: bool) -> None:
         """Turn on/off outline for builds."""
         self._outline = state
@@ -130,8 +125,8 @@ class NWBuildDocument:
         makeObj = ToQTextDocument(self._project)
         filtered = self._setupBuild(makeObj)
 
-        self._outline = True
         self._count = True
+        self._outline = True
 
         font = QFont()
         font.fromString(self._build.getStr("format.textFont"))
@@ -169,6 +164,7 @@ class NWBuildDocument:
         filtered = self._setupBuild(makeObj)
         makeObj.initDocument()
 
+        self._count = True
         for i, tHandle in enumerate(self._queue):
             self._error = None
             if filtered.get(tHandle, (False, 0))[0]:
@@ -199,6 +195,7 @@ class NWBuildDocument:
         makeObj = ToHtml(self._project)
         filtered = self._setupBuild(makeObj)
 
+        self._count = False
         for i, tHandle in enumerate(self._queue):
             self._error = None
             if filtered.get(tHandle, (False, 0))[0]:
@@ -235,6 +232,7 @@ class NWBuildDocument:
         if self._build.getBool("format.replaceTabs"):
             makeObj.replaceTabs(nSpaces=4, spaceChar=" ")
 
+        self._count = False
         for i, tHandle in enumerate(self._queue):
             self._error = None
             if filtered.get(tHandle, (False, 0))[0]:
@@ -262,6 +260,7 @@ class NWBuildDocument:
 
         makeObj.setKeepMarkdown(True)
 
+        self._count = False
         for i, tHandle in enumerate(self._queue):
             self._error = None
             if filtered.get(tHandle, (False, 0))[0]:

--- a/novelwriter/core/toodt.py
+++ b/novelwriter/core/toodt.py
@@ -532,11 +532,20 @@ class ToOdt(Tokenizer):
         return
 
     def closeDocument(self) -> None:
-        """Pack the automatic styles of the XML document."""
+        """Add additional collected information to the XML."""
         for style in self._autoPara.values():
             style.packXML(self._xAuto)
         for style in self._autoText.values():
             style.packXML(self._xAuto)
+        if self._counts:
+            xFields = ET.Element(_mkTag("text", "user-field-decls"))
+            for key, value in self._counts.items():
+                ET.SubElement(xFields, _mkTag("text", "user-field-decl"), attrib={
+                    _mkTag("office", "value-type"): "float",
+                    _mkTag("office", "value"): str(value),
+                    _mkTag("text", "name"): f"Manuscript{key[:1].upper()}{key[1:]}",
+                })
+            self._xText.insert(0, xFields)
         return
 
     def saveFlatXML(self, path: str | Path) -> None:

--- a/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
+++ b/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2024-05-24T21:31:12</meta:creation-date>
-    <meta:generator>novelWriter/2.5a4</meta:generator>
+    <meta:creation-date>2024-09-30T14:08:16</meta:creation-date>
+    <meta:generator>novelWriter/2.6a0</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
     <meta:editing-cycles>45</meta:editing-cycles>
     <meta:editing-duration>P0DT0H36M8S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2024-05-24T21:31:12</dc:date>
+    <dc:date>2024-09-30T14:08:16</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -116,6 +116,19 @@
   </office:master-styles>
   <office:body>
     <office:text>
+      <text:user-field-decls>
+        <text:user-field-decl office:value-type="float" office:value="19" text:name="ManuscriptTitleCount" />
+        <text:user-field-decl office:value-type="float" office:value="45" text:name="ManuscriptParagraphCount" />
+        <text:user-field-decl office:value-type="float" office:value="4163" text:name="ManuscriptAllWords" />
+        <text:user-field-decl office:value-type="float" office:value="3809" text:name="ManuscriptTextWords" />
+        <text:user-field-decl office:value-type="float" office:value="54" text:name="ManuscriptTitleWords" />
+        <text:user-field-decl office:value-type="float" office:value="27849" text:name="ManuscriptAllChars" />
+        <text:user-field-decl office:value-type="float" office:value="25528" text:name="ManuscriptTextChars" />
+        <text:user-field-decl office:value-type="float" office:value="311" text:name="ManuscriptTitleChars" />
+        <text:user-field-decl office:value-type="float" office:value="23782" text:name="ManuscriptAllWordChars" />
+        <text:user-field-decl office:value-type="float" office:value="21761" text:name="ManuscriptTextWordChars" />
+        <text:user-field-decl office:value-type="float" office:value="276" text:name="ManuscriptTitleWordChars" />
+      </text:user-field-decls>
       <text:p text:style-name="Title">Lorem Ipsum</text:p>
       <text:p text:style-name="P1"><text:span text:style-name="T1">By lipsum.com</text:span></text:p>
       <text:p text:style-name="P1">“Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit…”</text:p>

--- a/tests/test_core/test_core_docbuild.py
+++ b/tests/test_core/test_core_docbuild.py
@@ -85,11 +85,9 @@ def testCoreDocBuild_OpenDocument(monkeypatch, mockGUI, prjLipsum, fncPath, tstP
     build.unpack(BUILD_CONF)
 
     docBuild = NWBuildDocument(project, build)
-    docBuild.setCountEnabled(True)
     docBuild.setBuildOutline(True)
     docBuild.queueAll()
 
-    assert docBuild._count is True
     assert docBuild._outline is True
 
     assert len(docBuild) == 21


### PR DESCRIPTION
**Summary:**

This PR adds word and character count variables to ODT manuscript files.

**Related Issue(s):**

Closes #2033

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
