### PR TITLE
Don't use "match" as a variable

### DIFF
--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -343,9 +343,9 @@ class DocSearch:
         count = 0
         capped = False
         results = []
-        for match in self._regEx.finditer(text):
-            pos = match.start(0)
-            num = len(match.group(0))
+        for res in self._regEx.finditer(text):
+            pos = res.start(0)
+            num = len(res.group(0))
             lim = text[:pos].rfind("\n") + 1
             cut = text[lim:pos].rfind(" ") + lim + 1
             context = text[cut:cut+100].partition("\n")[0]

--- a/novelwriter/core/tokenizer.py
+++ b/novelwriter/core/tokenizer.py
@@ -1109,36 +1109,36 @@ class Tokenizer(ABC):
 
         # Match Markdown
         for regEx, fmts in self._rxMarkdown:
-            for match in regEx.finditer(text):
+            for res in regEx.finditer(text):
                 temp.extend(
-                    (match.start(n), match.end(n), fmt, "")
+                    (res.start(n), res.end(n), fmt, "")
                     for n, fmt in enumerate(fmts) if fmt > 0
                 )
 
         # Match Shortcodes
-        for match in REGEX_PATTERNS.shortcodePlain.finditer(text):
+        for res in REGEX_PATTERNS.shortcodePlain.finditer(text):
             temp.append((
-                match.start(1), match.end(1),
-                self._shortCodeFmt.get(match.group(1).lower(), 0),
+                res.start(1), res.end(1),
+                self._shortCodeFmt.get(res.group(1).lower(), 0),
                 "",
             ))
 
         # Match Shortcode w/Values
         tHandle = self._handle or ""
-        for match in REGEX_PATTERNS.shortcodeValue.finditer(text):
-            kind = self._shortCodeVals.get(match.group(1).lower(), 0)
+        for res in REGEX_PATTERNS.shortcodeValue.finditer(text):
+            kind = self._shortCodeVals.get(res.group(1).lower(), 0)
             temp.append((
-                match.start(0), match.end(0),
+                res.start(0), res.end(0),
                 self.FMT_STRIP if kind == skip else kind,
-                f"{tHandle}:{match.group(2)}",
+                f"{tHandle}:{res.group(2)}",
             ))
 
         # Match Dialogue
         if self._rxDialogue and hDialog:
             for regEx, fmtB, fmtE in self._rxDialogue:
-                for match in regEx.finditer(text):
-                    temp.append((match.start(0), 0, fmtB, ""))
-                    temp.append((match.end(0), 0, fmtE, ""))
+                for res in regEx.finditer(text):
+                    temp.append((res.start(0), 0, fmtB, ""))
+                    temp.append((res.end(0), 0, fmtE, ""))
 
         # Post-process text and format
         result = text

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -402,10 +402,10 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         if hRules:
             for rX, hRule in hRules:
-                for match in re.finditer(rX, text[xOff:]):
+                for res in re.finditer(rX, text[xOff:]):
                     for xM, hFmt in hRule.items():
-                        xPos = match.start(xM) + xOff
-                        xEnd = match.end(xM) + xOff
+                        xPos = res.start(xM) + xOff
+                        xEnd = res.end(xM) + xOff
                         for x in range(xPos, xEnd):
                             cFmt = self.format(x)
                             if cFmt.fontStyleName() != "markup":
@@ -484,18 +484,18 @@ class TextBlockData(QTextBlockUserData):
         if "[" in text:
             # Strip shortcodes
             for regEx in [RX_FMT_SC, RX_FMT_SV]:
-                for match in regEx.finditer(text, offset):
-                    if (s := match.start(0)) >= 0 and (e := match.end(0)) >= 0:
+                for res in regEx.finditer(text, offset):
+                    if (s := res.start(0)) >= 0 and (e := res.end(0)) >= 0:
                         pad = " "*(e - s)
                         text = f"{text[:s]}{pad}{text[e:]}"
 
         self._spellErrors = []
         checker = SHARED.spelling
-        for match in RX_WORDS.finditer(text.replace("_", " "), offset):
+        for res in RX_WORDS.finditer(text.replace("_", " "), offset):
             if (
-                (word := match.group(0))
+                (word := res.group(0))
                 and not (word.isnumeric() or word.isupper() or checker.checkWord(word))
             ):
-                self._spellErrors.append((match.start(0), match.end(0)))
+                self._spellErrors.append((res.start(0), res.end(0)))
 
         return self._spellErrors

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -32,10 +32,10 @@ from novelwriter.text.patterns import REGEX_PATTERNS
 def allMatches(regEx: re.Pattern, text: str) -> list[list[str]]:
     """Get all matches for a regex."""
     result = []
-    for match in regEx.finditer(text):
+    for res in regEx.finditer(text):
         result.append([
-            (match.group(n), match.start(n), match.end(n))
-            for n in range((match.lastindex or 0) + 1)
+            (res.group(n), res.start(n), res.end(n))
+            for n in range((res.lastindex or 0) + 1)
         ])
     return result
 


### PR DESCRIPTION
**Summary:**

As of Python 3.10, `match` is a reserved keyword, and should not be used as a variable.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
