### PR TITLE
Add Python 3.13 and fix theme issue

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,7 +14,7 @@ jobs:
   testLinux:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/docs/source/more_customise.rst
+++ b/docs/source/more_customise.rst
@@ -4,7 +4,7 @@
 Customisations
 **************
 
-.. _Enchant: https://abiword.github.io/enchant
+.. _Enchant: https://rrthomas.github.io/enchant/
 .. _Free Desktop: https://cgit.freedesktop.org/libreoffice/dictionaries/tree/
 
 There are a few ways you can customise novelWriter yourself. Currently, you can add new GUI themes,

--- a/novelwriter/assets/themes/default_light.conf
+++ b/novelwriter/assets/themes/default_light.conf
@@ -29,5 +29,5 @@ helptext        =  92,  92,  92
 fadedtext       = 108, 108, 108
 errortext       = 255,  92,  92
 statusnone      = 120, 120, 120
-statussaved     = 200,  15,  39
-statusunsaved   =   2, 133,  37
+statussaved     =   2, 133,  37
+statusunsaved   = 200,  15,  39

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Development Status :: 5 - Production/Stable",

--- a/setup/launchpad_setup.cfg
+++ b/setup/launchpad_setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
**Summary:**

This MR adds Python 3.13 support for the 2.5 branch and fixes an issue with the default light theme. It also fixes a broken link in the docs.

**Related Issue(s):**

Closes #2042
Closes #2057

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
