### PR TITLE
Fix counting error

### DIFF
--- a/novelwriter/text/counting.py
+++ b/novelwriter/text/counting.py
@@ -30,6 +30,7 @@ import re
 from novelwriter.constants import nwRegEx, nwUnicode
 
 RX_SC = re.compile(nwRegEx.FMT_SC)
+RX_SV = re.compile(nwRegEx.FMT_SV)
 RX_LO = re.compile(r"(?i)(?<!\\)(\[(?:vspace|newpage|new page)(:\d+)?)(?<!\\)(\])")
 
 
@@ -64,6 +65,7 @@ def preProcessText(text: str, keepHeaders: bool = True) -> list[str]:
                 # Strip shortcodes and special formatting
                 # RegEx is slow, so we do this only when necessary
                 line = RX_SC.sub("", line)
+                line = RX_SV.sub("", line)
                 line = RX_LO.sub("", line)
 
         result.append(line)

--- a/tests/reference/coreIndex_LoadSave_tagsIndex.json
+++ b/tests/reference/coreIndex_LoadSave_tagsIndex.json
@@ -17,7 +17,7 @@
     },
     "88d59a277361b": {
       "headings": {
-        "T0001": {"level": "H2", "title": "Prologue", "line": 1, "tag": "", "cCount": 600, "wCount": 92, "pCount": 1, "synopsis": "Explanation from the lipsum.com website."}
+        "T0001": {"level": "H2", "title": "Prologue", "line": 1, "tag": "", "cCount": 584, "wCount": 92, "pCount": 1, "synopsis": "Explanation from the lipsum.com website."}
       },
       "notes": {
         "footnotes": ["f9kgf"]

--- a/tests/test_text/test_text_counting.py
+++ b/tests/test_text/test_text_counting.py
@@ -46,6 +46,7 @@ def testTextCounting_preProcessText():
         "A [b]paragraph[/b].\n\n"
         "[vspace:3]\n\n"
         "[New Page]\n\n"
+        "[footnote:abcd]\n\n"
         "Dashes\u2013and even longer\u2014dashes.\n\n"
     )
 
@@ -59,7 +60,7 @@ def testTextCounting_preProcessText():
         "#### Heading Four",
         "", "", "",
         "A paragraph.", "",
-        "", "", "", "",
+        "", "", "", "", "", "",
         "Dashes and even longer dashes.", ""
     ]
 
@@ -67,7 +68,7 @@ def testTextCounting_preProcessText():
     assert preProcessText(text, keepHeaders=False) == [
         "", "", "",
         "A paragraph.", "",
-        "", "", "", "",
+        "", "", "", "", "", "",
         "Dashes and even longer dashes.", ""
     ]
 


### PR DESCRIPTION
**Summary:**

This fixes a small issue where footnote markers aren't stripped before the character count, resulting in it being included in the count.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
