### PR TITLE
Add forced line breaks feature

### DIFF
--- a/novelwriter/assets/i18n/project_en_GB.json
+++ b/novelwriter/assets/i18n/project_en_GB.json
@@ -3,7 +3,7 @@
   "Short Description": "Short Description",
   "Footnotes": "Footnotes",
   "Comment": "Comment",
-  "Note": "Note",
+  "Notes": "Notes",
   "Tag": "Tag",
   "Point of View": "Point of View",
   "Focus": "Focus",

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -61,10 +61,11 @@ class nwConst:
 class nwRegEx:
 
     WORDS  = r"\b[^\s\-\+\/–—\[\]:]+\b"
+    BREAK  = r"(?i)(?<!\\)(\[br\]\n?)"
     FMT_EI = r"(?<![\w\\])(_)(?![\s_])(.+?)(?<![\s\\])(\1)(?!\w)"
     FMT_EB = r"(?<![\w\\])(\*{2})(?![\s\*])(.+?)(?<![\s\\])(\1)(?!\w)"
     FMT_ST = r"(?<![\w\\])(~{2})(?![\s~])(.+?)(?<![\s\\])(\1)(?!\w)"
-    FMT_SC = r"(?i)(?<!\\)(\[[\/\!]?(?:b|i|s|u|m|sup|sub)\])"
+    FMT_SC = r"(?i)(?<!\\)(\[(?:b|/b|i|/i|s|/s|u|/u|m|/m|sup|/sup|sub|/sub|br)\])"
     FMT_SV = r"(?i)(?<!\\)(\[(?:footnote):)(.+?)(?<!\\)(\])"
 
 
@@ -84,6 +85,7 @@ class nwShortcode:
     SUP_C    = "[/sup]"
     SUB_O    = "[sub]"
     SUB_C    = "[/sub]"
+    BREAK    = "[br]"
 
     FOOTNOTE_B = "[footnote:"
 

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -67,7 +67,7 @@ SETTINGS_TEMPLATE: dict[str, tuple[type, str | int | float | bool]] = {
     "headings.centerPart":     (bool, True),
     "headings.centerChapter":  (bool, False),
     "headings.centerScene":    (bool, False),
-    "headings.breakTitle":     (bool, True),
+    "headings.breakTitle":     (bool, False),
     "headings.breakPart":      (bool, True),
     "headings.breakChapter":   (bool, True),
     "headings.breakScene":     (bool, False),

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -267,8 +267,8 @@ class NWBuildDocument:
             self._build.getBool("headings.hideSection")
         )
         bldObj.setTitleStyle(
-            self._build.getBool("headings.centerPart"),
-            self._build.getBool("headings.breakPart")
+            self._build.getBool("headings.centerTitle"),
+            self._build.getBool("headings.breakTitle")
         )
         bldObj.setPartitionStyle(
             self._build.getBool("headings.centerPart"),

--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -137,6 +137,7 @@ class nwDocInsert(Enum):
     VSPACE_M  = 9
     LIPSUM    = 10
     FOOTNOTE  = 11
+    LINE_BRK  = 12
 
 
 class nwView(Enum):

--- a/novelwriter/formats/todocx.py
+++ b/novelwriter/formats/todocx.py
@@ -255,24 +255,19 @@ class ToDocX(Tokenizer):
                 self._processFragments(par, S_NORM, tText, tFormat)
 
             elif tType == BlockTyp.TITLE:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._processFragments(par, S_TITLE, tHead, tFormat)
+                self._processFragments(par, S_TITLE, tText, tFormat)
 
             elif tType == BlockTyp.HEAD1:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._processFragments(par, S_HEAD1, tHead, tFormat)
+                self._processFragments(par, S_HEAD1, tText, tFormat)
 
             elif tType == BlockTyp.HEAD2:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._processFragments(par, S_HEAD2, tHead, tFormat)
+                self._processFragments(par, S_HEAD2, tText, tFormat)
 
             elif tType == BlockTyp.HEAD3:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._processFragments(par, S_HEAD3, tHead, tFormat)
+                self._processFragments(par, S_HEAD3, tText, tFormat)
 
             elif tType == BlockTyp.HEAD4:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._processFragments(par, S_HEAD4, tHead, tFormat)
+                self._processFragments(par, S_HEAD4, tText, tFormat)
 
             elif tType == BlockTyp.SEP:
                 self._processFragments(par, S_SEP, tText)

--- a/novelwriter/formats/tohtml.py
+++ b/novelwriter/formats/tohtml.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from time import time
 
 from novelwriter.common import formatTimeStamp
-from novelwriter.constants import nwHeadFmt, nwHtmlUnicode
+from novelwriter.constants import nwHtmlUnicode
 from novelwriter.core.project import NWProject
 from novelwriter.formats.shared import BlockFmt, BlockTyp, T_Formats, TextFmt, stripEscape
 from novelwriter.formats.tokenizer import Tokenizer
@@ -211,23 +211,23 @@ class ToHtml(Tokenizer):
                 lines.append(f"<p{hStyle}>{self._formatText(tText, tFmt)}</p>\n")
 
             elif tType == BlockTyp.TITLE:
-                tHead = tText.replace(nwHeadFmt.BR, "<br>")
+                tHead = tText.replace("\n", "<br>")
                 lines.append(f"<h1 class='title'{hStyle}>{aNm}{tHead}</h1>\n")
 
             elif tType == BlockTyp.HEAD1:
-                tHead = tText.replace(nwHeadFmt.BR, "<br>")
+                tHead = tText.replace("\n", "<br>")
                 lines.append(f"<{h1}{h1Cl}{hStyle}>{aNm}{tHead}</{h1}>\n")
 
             elif tType == BlockTyp.HEAD2:
-                tHead = tText.replace(nwHeadFmt.BR, "<br>")
+                tHead = tText.replace("\n", "<br>")
                 lines.append(f"<{h2}{hStyle}>{aNm}{tHead}</{h2}>\n")
 
             elif tType == BlockTyp.HEAD3:
-                tHead = tText.replace(nwHeadFmt.BR, "<br>")
+                tHead = tText.replace("\n", "<br>")
                 lines.append(f"<{h3}{hStyle}>{aNm}{tHead}</{h3}>\n")
 
             elif tType == BlockTyp.HEAD4:
-                tHead = tText.replace(nwHeadFmt.BR, "<br>")
+                tHead = tText.replace("\n", "<br>")
                 lines.append(f"<{h4}{hStyle}>{aNm}{tHead}</{h4}>\n")
 
             elif tType == BlockTyp.SEP:

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -526,6 +526,7 @@ class Tokenizer(ABC):
         if self._isNovel:
             self._hFormatter.setHandle(self._handle)
 
+        # Replace all instances of [br] with a placeholder character
         text = REGEX_PATTERNS.lineBreak.sub("\uffff", self._text)
 
         nHead = 0
@@ -534,7 +535,7 @@ class Tokenizer(ABC):
         tHandle = self._handle or ""
         tBlocks: list[T_Block] = [B_EMPTY]
         for bLine in text.splitlines():
-            aLine = bLine.replace("\uffff", "\n")
+            aLine = bLine.replace("\uffff", "")  # Remove placeholder characters
             sLine = aLine.strip().lower()
 
             # Check for blank lines

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -1187,6 +1187,7 @@ class HeadingFormatter:
     def apply(self, hFormat: str, text: str, nHead: int) -> str:
         """Apply formatting to a specific heading."""
         hFormat = hFormat.replace(nwHeadFmt.TITLE, text)
+        hFormat = hFormat.replace(nwHeadFmt.BR, "\n")
         hFormat = hFormat.replace(nwHeadFmt.CH_NUM, str(self._chCount))
         hFormat = hFormat.replace(nwHeadFmt.SC_NUM, str(self._scChCount))
         hFormat = hFormat.replace(nwHeadFmt.SC_ABS, str(self._scAbsCount))

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -56,7 +56,6 @@ class ComStyle(NamedTuple):
     textClass: str = ""
 
 
-B_EMPTY: T_Block = (BlockTyp.EMPTY, "", "", [], BlockFmt.NONE)
 COMMENT_STYLE = {
     nwComment.PLAIN:    ComStyle("Comment", "comment", "comment"),
     nwComment.IGNORE:   ComStyle(),
@@ -67,13 +66,12 @@ COMMENT_STYLE = {
     nwComment.COMMENT:  ComStyle(),
     nwComment.STORY:    ComStyle("", "modifier", "note"),
 }
-
-# Lookups
 HEADINGS = [BlockTyp.TITLE, BlockTyp.HEAD1, BlockTyp.HEAD2, BlockTyp.HEAD3, BlockTyp.HEAD4]
 SKIP_INDENT = [
     BlockTyp.TITLE, BlockTyp.HEAD1, BlockTyp.HEAD2, BlockTyp.HEAD2, BlockTyp.HEAD3,
     BlockTyp.HEAD4, BlockTyp.SEP, BlockTyp.SKIP,
 ]
+B_EMPTY: T_Block = (BlockTyp.EMPTY, "", "", [], BlockFmt.NONE)
 
 
 class Tokenizer(ABC):
@@ -182,8 +180,6 @@ class Tokenizer(ABC):
             (REGEX_PATTERNS.markdownBold,   [0, TextFmt.B_B, 0, TextFmt.B_E]),
             (REGEX_PATTERNS.markdownStrike, [0, TextFmt.D_B, 0, TextFmt.D_E]),
         ]
-        self._rxShortCodes = REGEX_PATTERNS.shortcodePlain
-        self._rxShortCodeVals = REGEX_PATTERNS.shortcodeValue
 
         self._shortCodeFmt = {
             nwShortcode.ITALIC_O: TextFmt.I_B,   nwShortcode.ITALIC_C: TextFmt.I_E,
@@ -1136,12 +1132,12 @@ class Tokenizer(ABC):
         # Post-process text and format
         result = text
         formats = []
-        for pos, end, fmt, key in reversed(sorted(temp, key=lambda x: x[0])):
+        for pos, end, fmt, meta in reversed(sorted(temp, key=lambda x: x[0])):
             if fmt > 0:
                 if end > pos:
                     result = result[:pos] + result[end:]
-                    formats = [(p+pos-end if p > pos else p, f, k) for p, f, k in formats]
-                formats.insert(0, (pos, fmt, key))
+                    formats = [(p+pos-end if p > pos else p, f, m) for p, f, m in formats]
+                formats.insert(0, (pos, fmt, meta))
 
         return result, formats
 

--- a/novelwriter/formats/tomarkdown.py
+++ b/novelwriter/formats/tomarkdown.py
@@ -27,7 +27,7 @@ import logging
 
 from pathlib import Path
 
-from novelwriter.constants import nwHeadFmt, nwUnicode
+from novelwriter.constants import nwUnicode
 from novelwriter.core.project import NWProject
 from novelwriter.formats.shared import BlockFmt, BlockTyp, T_Formats, TextFmt
 from novelwriter.formats.tokenizer import Tokenizer
@@ -113,23 +113,23 @@ class ToMarkdown(Tokenizer):
                 lines.append(f"{tTemp}\n\n")
 
             elif tType == BlockTyp.TITLE:
-                tHead = tText.replace(nwHeadFmt.BR, " - ")
+                tHead = tText.replace("\n", " - ")
                 lines.append(f"# {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD1:
-                tHead = tText.replace(nwHeadFmt.BR, " - ")
+                tHead = tText.replace("\n", " - ")
                 lines.append(f"# {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD2:
-                tHead = tText.replace(nwHeadFmt.BR, " - ")
+                tHead = tText.replace("\n", " - ")
                 lines.append(f"## {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD3:
-                tHead = tText.replace(nwHeadFmt.BR, " - ")
+                tHead = tText.replace("\n", " - ")
                 lines.append(f"### {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD4:
-                tHead = tText.replace(nwHeadFmt.BR, " - ")
+                tHead = tText.replace("\n", " - ")
                 lines.append(f"#### {tHead}\n\n")
 
             elif tType == BlockTyp.SEP:

--- a/novelwriter/formats/tomarkdown.py
+++ b/novelwriter/formats/tomarkdown.py
@@ -113,23 +113,23 @@ class ToMarkdown(Tokenizer):
                 lines.append(f"{tTemp}\n\n")
 
             elif tType == BlockTyp.TITLE:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
+                tHead = tText.replace(nwHeadFmt.BR, " - ")
                 lines.append(f"# {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD1:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
+                tHead = tText.replace(nwHeadFmt.BR, " - ")
                 lines.append(f"# {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD2:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
+                tHead = tText.replace(nwHeadFmt.BR, " - ")
                 lines.append(f"## {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD3:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
+                tHead = tText.replace(nwHeadFmt.BR, " - ")
                 lines.append(f"### {tHead}\n\n")
 
             elif tType == BlockTyp.HEAD4:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
+                tHead = tText.replace(nwHeadFmt.BR, " - ")
                 lines.append(f"#### {tHead}\n\n")
 
             elif tType == BlockTyp.SEP:

--- a/novelwriter/formats/toodt.py
+++ b/novelwriter/formats/toodt.py
@@ -444,24 +444,19 @@ class ToOdt(Tokenizer):
 
             elif tType == BlockTyp.TITLE:
                 # Title must be text:p
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._addTextPar(xText, S_TITLE, oStyle, tHead, isHead=False)
+                self._addTextPar(xText, S_TITLE, oStyle, tText, isHead=False)
 
             elif tType == BlockTyp.HEAD1:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._addTextPar(xText, S_HEAD1, oStyle, tHead, isHead=True, oLevel="1")
+                self._addTextPar(xText, S_HEAD1, oStyle, tText, isHead=True, oLevel="1")
 
             elif tType == BlockTyp.HEAD2:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._addTextPar(xText, S_HEAD2, oStyle, tHead, isHead=True, oLevel="2")
+                self._addTextPar(xText, S_HEAD2, oStyle, tText, isHead=True, oLevel="2")
 
             elif tType == BlockTyp.HEAD3:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._addTextPar(xText, S_HEAD3, oStyle, tHead, isHead=True, oLevel="3")
+                self._addTextPar(xText, S_HEAD3, oStyle, tText, isHead=True, oLevel="3")
 
             elif tType == BlockTyp.HEAD4:
-                tHead = tText.replace(nwHeadFmt.BR, "\n")
-                self._addTextPar(xText, S_HEAD4, oStyle, tHead, isHead=True, oLevel="4")
+                self._addTextPar(xText, S_HEAD4, oStyle, tText, isHead=True, oLevel="4")
 
             elif tType == BlockTyp.SEP:
                 self._addTextPar(xText, S_SEP, oStyle, tText)

--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -34,7 +34,7 @@ from PyQt5.QtGui import (
 )
 from PyQt5.QtPrintSupport import QPrinter
 
-from novelwriter.constants import nwHeadFmt, nwStyles, nwUnicode
+from novelwriter.constants import nwStyles, nwUnicode
 from novelwriter.core.project import NWProject
 from novelwriter.formats.shared import BlockFmt, BlockTyp, T_Formats, TextFmt
 from novelwriter.formats.tokenizer import HEADINGS, Tokenizer
@@ -217,7 +217,7 @@ class ToQTextDocument(Tokenizer):
             elif tType in HEADINGS:
                 bFmt, cFmt = self._genHeadStyle(tType, tMeta, bFmt)
                 newBlock(cursor, bFmt)
-                cursor.insertText(tText.replace(nwHeadFmt.BR, "\n"), cFmt)
+                cursor.insertText(tText, cFmt)
 
             elif tType == BlockTyp.SEP:
                 newBlock(cursor, bFmt)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -877,6 +877,8 @@ class GuiDocEditor(QPlainTextEdit):
                 after = False
             elif insert == nwDocInsert.FOOTNOTE:
                 self._insertCommentStructure(nwComment.FOOTNOTE)
+            elif insert == nwDocInsert.LINE_BRK:
+                text = nwShortcode.BREAK
 
         if text:
             if block:

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -570,13 +570,19 @@ class GuiMainMenu(QMenuBar):
             lambda: self.requestDocInsert.emit(nwDocInsert.SHORT)
         )
 
-        # Insert > Symbols
-        self.mInsBreaks = self.insMenu.addMenu(self.tr("Page Break and Space"))
+        # Insert > Breaks and Vertical Space
+        self.mInsBreaks = self.insMenu.addMenu(self.tr("Breaks and Vertical Space"))
 
         # Insert > New Page
         self.aInsNewPage = self.mInsBreaks.addAction(self.tr("Page Break"))
         self.aInsNewPage.triggered.connect(
             lambda: self.requestDocInsert.emit(nwDocInsert.NEW_PAGE)
+        )
+
+        # Insert > Forced Line Break
+        self.aInsLineBreak = self.mInsBreaks.addAction(self.tr("Forced Line Break"))
+        self.aInsLineBreak.triggered.connect(
+            lambda: self.requestDocInsert.emit(nwDocInsert.LINE_BRK)
         )
 
         # Insert > Vertical Space (Single)

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -33,6 +33,7 @@ class RegExPatterns:
 
     # Static RegExes
     _rxWords   = re.compile(nwRegEx.WORDS, re.UNICODE)
+    _rxBreak   = re.compile(nwRegEx.BREAK, re.UNICODE)
     _rxItalic  = re.compile(nwRegEx.FMT_EI, re.UNICODE)
     _rxBold    = re.compile(nwRegEx.FMT_EB, re.UNICODE)
     _rxStrike  = re.compile(nwRegEx.FMT_ST, re.UNICODE)
@@ -43,6 +44,11 @@ class RegExPatterns:
     def wordSplit(self) -> re.Pattern:
         """Split text into words."""
         return self._rxWords
+
+    @property
+    def lineBreak(self) -> re.Pattern:
+        """Find forced line break."""
+        return self._rxBreak
 
     @property
     def markdownItalic(self) -> re.Pattern:

--- a/sample/content/53b69b83cdafc.nwd
+++ b/sample/content/53b69b83cdafc.nwd
@@ -1,8 +1,15 @@
 %%~name: Title Page
 %%~path: 7031beac91f75/53b69b83cdafc
 %%~kind: NOVEL/DOCUMENT
-%%~hash: c5dc35d18ecb074a9e41a1410d1bff8021cf0a5b
-%%~date: Unknown/2023-08-25 16:51:52
+%%~hash: 4072adb6d21ff877577f033f19714d9bd01396f3
+%%~date: Unknown/2024-10-24 16:25:44
+
+Jane Smith[br]
+42 Main Street[br]
+1234 Capital City <<
+
+[vspace:5]
+
 #! My Novel
 
 >> **By Jane Smith** <<

--- a/sample/content/ba8a28a246524.nwd
+++ b/sample/content/ba8a28a246524.nwd
@@ -1,24 +1,24 @@
 %%~name: Interlude
 %%~path: 7031beac91f75/ba8a28a246524
 %%~kind: NOVEL/DOCUMENT
-%%~hash: 721d3d15e0233186354ac6fa61f27db10f38e6bc
-%%~date: Unknown/2024-03-14 22:55:04
+%%~hash: 5c8f68d48573b576dcaacf6d6928c496ec361b9d
+%%~date: Unknown/2024-10-24 01:22:15
 ##! Interlude
 
 % Notice that this document has a title with a ‘!’ in it in addition to the two hash symbols. This means it is an unnumbered chapter. Unnumbered chapters can be treated separately from numbered chapters during export. Perfect for when you want to add an interlude, or for a prologue or epilogue.
 
-I am the very model of a modern Major-General
-I've information vegetable, animal, and mineral
-I know the kings of England, and I quote the fights historical
-From Marathon to Waterloo, in order categorical
+I am the very model of a modern Major-General[br]
+I've information vegetable, animal, and mineral[br]
+I know the kings of England, and I quote the fights historical[br]
+From Marathon to Waterloo, in order categorical <<
 
-I'm very well acquainted, too, with matters mathematical <<
-I understand equations, both the simple and quadratical
-About binomial theorem I'm teeming with a lot o’ news
-With many cheerful facts about the square of the hypotenuse
+I'm very well acquainted, too, with matters mathematical[br]
+I understand equations, both the simple and quadratical[br]
+About binomial theorem I'm teeming with a lot o’ news[br]
+With many cheerful facts about the square of the hypotenuse <<
 
-	With many cheerful facts about the square of the hypotenuse <<
-	With many cheerful facts about the square of the hypotenuse
-	With many cheerful facts about the square of the hypotepotenuse
+	With many cheerful facts about the square of the hypotenuse[br]
+	With many cheerful facts about the square of the hypotenuse[br]
+	With many cheerful facts about the square of the hypotepotenuse <<
 
 % Notice that the lines in the verse end in a single line break. Single line breaks do not create a new paragraph but instead insert a break within the paragraph. Press Ctrl+R to see what this renders like.

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.6a2" hexVersion="0x020600a2" fileVersion="1.5" fileRevision="4" timeStamp="2024-10-23 17:41:09">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2074" autoCount="277" editTime="93039">
+<novelWriterXML appVersion="2.6a2" hexVersion="0x020600a2" fileVersion="1.5" fileRevision="4" timeStamp="2024-10-24 16:26:12">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2077" autoCount="279" editTime="93511">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -36,13 +36,13 @@
       <entry key="i56be10" count="1" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
-  <content items="31" novelWords="996" notesWords="416">
+  <content items="31" novelWords="1004" notesWords="416">
     <item handle="7031beac91f75" parent="None" root="7031beac91f75" order="0" type="ROOT" class="NOVEL">
       <meta expanded="yes" />
       <name status="sc24b8f" import="ia857f0">Novel</name>
     </item>
     <item handle="53b69b83cdafc" parent="7031beac91f75" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="95" wordCount="19" paraCount="2" cursorPos="31" />
+      <meta expanded="no" heading="H1" charCount="136" wordCount="27" paraCount="3" cursorPos="69" />
       <name status="sc24b8f" import="ia857f0" active="yes">Title Page</name>
     </item>
     <item handle="974e400180a99" parent="7031beac91f75" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
@@ -58,7 +58,7 @@
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2953" wordCount="520" paraCount="15" cursorPos="66" />
+      <meta expanded="no" heading="H3" charCount="2937" wordCount="520" paraCount="15" cursorPos="4" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
@@ -66,7 +66,7 @@
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="357" />
+      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="1182" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">

--- a/tests/reference/mBuildDocBuild_NWD_Lorem_Ipsum.json
+++ b/tests/reference/mBuildDocBuild_NWD_Lorem_Ipsum.json
@@ -2,19 +2,19 @@
   "meta": {
     "projectName": "Lorem Ipsum",
     "novelAuthor": "lipsum.com",
-    "buildTime": 1729029144,
-    "buildTimeStr": "2024-10-15 23:52:24"
+    "buildTime": 1729725334,
+    "buildTimeStr": "2024-10-24 01:15:34"
   },
   "text": {
     "nwd": [
       [
         "#! Lorem Ipsum",
         "",
-        "**By lipsum.com**",
+        ">> **By lipsum.com** <<",
         "",
-        "\u201cNeque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit\u2026\u201d",
+        ">> \u201cNeque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit\u2026\u201d <<",
         "",
-        "\u201cThere is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain\u2026\u201d"
+        ">> \u201cThere is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain\u2026\u201d <<"
       ],
       [
         "",
@@ -36,7 +36,7 @@
       [
         "# Act One",
         "",
-        "\u201cFusce maximus felis libero\u201d"
+        ">> \u201cFusce maximus felis libero\u201d <<"
       ],
       [
         "## Chapter One",

--- a/tests/reference/mBuildDocBuild_NWD_Lorem_Ipsum.txt
+++ b/tests/reference/mBuildDocBuild_NWD_Lorem_Ipsum.txt
@@ -1,10 +1,10 @@
 #! Lorem Ipsum
 
-**By lipsum.com**
+>> **By lipsum.com** <<
 
-“Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit…”
+>> “Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit…” <<
 
-“There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain…”
+>> “There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain…” <<
 
 
 % Exctracted from the lipsum.com website.
@@ -23,7 +23,7 @@ _Lorem Ipsum_ is simply dummy text[footnote:f9kgf] of the printing and typesetti
 
 # Act One
 
-“Fusce maximus felis libero”
+>> “Fusce maximus felis libero” <<
 
 ## Chapter One
 

--- a/tests/test_core/test_core_docbuild.py
+++ b/tests/test_core/test_core_docbuild.py
@@ -412,7 +412,7 @@ def testCoreDocBuild_Custom(mockGUI, fncPath: Path):
     assert error == []
     assert docFile.read_text(encoding="utf-8") == (
         "#! New Novel\n\n"
-        "By Jane Doe\n\n"
+        ">> By Jane Doe <<\n\n"
         "## New Chapter\n\n\n"
         "### New Scene\n\n\n"
     )
@@ -442,7 +442,7 @@ def testCoreDocBuild_Custom(mockGUI, fncPath: Path):
     assert error == []
     assert docFile.read_text(encoding="utf-8") == (
         "#! New Novel\n\n"
-        "By Jane Doe\n\n"
+        ">> By Jane Doe <<\n\n"
         "## New Chapter\n\n\n"
         "### New Scene\n\n\n"
     )
@@ -566,7 +566,7 @@ def testCoreDocBuild_IterBuild(mockGUI, fncPath: Path, mockRnd):
     assert isinstance(docBuild.lastBuild, ToRaw)
     assert docFile.read_text(encoding="utf-8") == (
         "#! New Novel\n\n"
-        "By Jane Doe\n\n"
+        ">> By Jane Doe <<\n\n"
         "## New Chapter\n\n\n"
         "### New Scene\n\n\n"
         "#! Notes: Plot\n\n"

--- a/tests/test_formats/test_fmt_tohtml.py
+++ b/tests/test_formats/test_fmt_tohtml.py
@@ -25,6 +25,7 @@ import json
 import pytest
 
 from novelwriter import CONFIG
+from novelwriter.constants import nwHeadFmt
 from novelwriter.core.project import NWProject
 from novelwriter.formats.shared import BlockFmt, BlockTyp
 from novelwriter.formats.tohtml import ToHtml
@@ -44,32 +45,35 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
     html._isFirst = True
 
     # Header 1
-    html._text = "# Partition\n"
+    html._text = "# Title\n"
+    html.setPartitionFormat(f"Part{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: center;'>Partition</h1>\n"
+        "<h1 class='title' style='text-align: center;'>Part<br>Title</h1>\n"
     )
 
     # Header 2
-    html._text = "## Chapter Title\n"
+    html._text = "## Title\n"
+    html.setChapterFormat(f"Chapter {nwHeadFmt.CH_NUM}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 style='page-break-before: always;'>Chapter Title</h1>\n"
+        "<h1 style='page-break-before: always;'>Chapter 1<br>Title</h1>\n"
     )
 
     # Header 3
-    html._text = "### Scene Title\n"
+    html._text = "### Title\n"
+    html.setSceneFormat(f"Scene {nwHeadFmt.SC_ABS}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     html.tokenizeText()
     html.doConvert()
-    assert html._pages[-1] == "<h2>Scene Title</h2>\n"
+    assert html._pages[-1] == "<h2>Scene 1<br>Title</h2>\n"
 
     # Header 4
-    html._text = "#### Section Title\n"
+    html._text = "#### Title\n"
     html.tokenizeText()
     html.doConvert()
-    assert html._pages[-1] == "<h3>Section Title</h3>\n"
+    assert html._pages[-1] == "<h3>Title</h3>\n"
 
     # Title
     html._text = "#! Title\n"

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -421,8 +421,8 @@ def testFmtToken_HeaderFormat(mockGUI):
 
 
 @pytest.mark.core
-def testFmtToken_HeaderStyle(mockGUI):
-    """Test the styling of headers in the Tokenizer class."""
+def testFmtToken_HeaderStyleNone(mockGUI):
+    """Test header styling disabled."""
     project = NWProject()
     tokens = BareTokenizer(project)
 
@@ -432,13 +432,12 @@ def testFmtToken_HeaderStyle(mockGUI):
         tokens.tokenizeText()
         return tokens._blocks[0][4]
 
-    # No Styles
-    # =========
-
+    tokens.setTitleStyle(False, False)
     tokens.setPartitionStyle(False, False)
     tokens.setChapterStyle(False, False)
     tokens.setSceneStyle(False, False)
 
+    assert tokens._titleStyle == BlockFmt.NONE
     assert tokens._partStyle == BlockFmt.NONE
     assert tokens._chapterStyle == BlockFmt.NONE
     assert tokens._sceneStyle == BlockFmt.NONE
@@ -451,7 +450,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.NONE
     assert processStyle("### Scene\n", False) == BlockFmt.NONE
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", False) == BlockFmt.NONE
 
     # First Document is True
@@ -459,7 +458,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", True) == BlockFmt.NONE
     assert processStyle("### Scene\n", True) == BlockFmt.NONE
     assert processStyle("#### Section\n", True) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", True) == BlockFmt.CENTRE
+    assert processStyle("#! My Novel\n", True) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", True) == BlockFmt.NONE
 
     # Note Docs
@@ -470,7 +469,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.NONE
     assert processStyle("### Scene\n", False) == BlockFmt.NONE
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", False) == BlockFmt.NONE
 
     # First Document is True
@@ -478,16 +477,28 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", True) == BlockFmt.NONE
     assert processStyle("### Scene\n", True) == BlockFmt.NONE
     assert processStyle("#### Section\n", True) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", True) == BlockFmt.CENTRE
+    assert processStyle("#! My Novel\n", True) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", True) == BlockFmt.NONE
 
-    # Center Headers
-    # ==============
 
+@pytest.mark.core
+def testFmtToken_HeaderStyleCenter(mockGUI):
+    """Test header styling centred."""
+    project = NWProject()
+    tokens = BareTokenizer(project)
+
+    def processStyle(text: str, first: bool) -> BlockFmt:
+        tokens._text = text
+        tokens._isFirst = first
+        tokens.tokenizeText()
+        return tokens._blocks[0][4]
+
+    tokens.setTitleStyle(True, False)
     tokens.setPartitionStyle(True, False)
     tokens.setChapterStyle(True, False)
     tokens.setSceneStyle(True, False)
 
+    assert tokens._titleStyle == BlockFmt.CENTRE
     assert tokens._partStyle == BlockFmt.CENTRE
     assert tokens._chapterStyle == BlockFmt.CENTRE
     assert tokens._sceneStyle == BlockFmt.CENTRE
@@ -500,7 +511,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.CENTRE
     assert processStyle("### Scene\n", False) == BlockFmt.CENTRE
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE
     assert processStyle("##! Prologue\n", False) == BlockFmt.CENTRE
 
     # First Document is True
@@ -519,7 +530,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.NONE
     assert processStyle("### Scene\n", False) == BlockFmt.NONE
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE
     assert processStyle("##! Prologue\n", False) == BlockFmt.NONE
 
     # First Document is True
@@ -530,13 +541,25 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("#! My Novel\n", True) == BlockFmt.CENTRE
     assert processStyle("##! Prologue\n", True) == BlockFmt.NONE
 
-    # Page Break Headers
-    # ==================
 
+@pytest.mark.core
+def testFmtToken_HeaderStylePageBreak(mockGUI):
+    """Test header styling page break."""
+    project = NWProject()
+    tokens = BareTokenizer(project)
+
+    def processStyle(text: str, first: bool) -> BlockFmt:
+        tokens._text = text
+        tokens._isFirst = first
+        tokens.tokenizeText()
+        return tokens._blocks[0][4]
+
+    tokens.setTitleStyle(False, True)
     tokens.setPartitionStyle(False, True)
     tokens.setChapterStyle(False, True)
     tokens.setSceneStyle(False, True)
 
+    assert tokens._titleStyle == BlockFmt.PBB
     assert tokens._partStyle == BlockFmt.PBB
     assert tokens._chapterStyle == BlockFmt.PBB
     assert tokens._sceneStyle == BlockFmt.PBB
@@ -549,7 +572,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.PBB
     assert processStyle("### Scene\n", False) == BlockFmt.PBB
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.PBB
     assert processStyle("##! Prologue\n", False) == BlockFmt.PBB
 
     # First Document is True
@@ -557,7 +580,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", True) == BlockFmt.NONE
     assert processStyle("### Scene\n", True) == BlockFmt.NONE
     assert processStyle("#### Section\n", True) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", True) == BlockFmt.CENTRE
+    assert processStyle("#! My Novel\n", True) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", True) == BlockFmt.NONE
 
     # Note Docs
@@ -568,7 +591,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.NONE
     assert processStyle("### Scene\n", False) == BlockFmt.NONE
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.PBB
     assert processStyle("##! Prologue\n", False) == BlockFmt.NONE
 
     # First Document is True
@@ -576,16 +599,28 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", True) == BlockFmt.NONE
     assert processStyle("### Scene\n", True) == BlockFmt.NONE
     assert processStyle("#### Section\n", True) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", True) == BlockFmt.CENTRE
+    assert processStyle("#! My Novel\n", True) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", True) == BlockFmt.NONE
 
-    # Page Break and Centre Headers
-    # =============================
 
+@pytest.mark.core
+def testFmtToken_HeaderStylePageBreakCenter(mockGUI):
+    """Test header styling page break and centred."""
+    project = NWProject()
+    tokens = BareTokenizer(project)
+
+    def processStyle(text: str, first: bool) -> BlockFmt:
+        tokens._text = text
+        tokens._isFirst = first
+        tokens.tokenizeText()
+        return tokens._blocks[0][4]
+
+    tokens.setTitleStyle(True, True)
     tokens.setPartitionStyle(True, True)
     tokens.setChapterStyle(True, True)
     tokens.setSceneStyle(True, True)
 
+    assert tokens._titleStyle == BlockFmt.CENTRE | BlockFmt.PBB
     assert tokens._partStyle == BlockFmt.CENTRE | BlockFmt.PBB
     assert tokens._chapterStyle == BlockFmt.CENTRE | BlockFmt.PBB
     assert tokens._sceneStyle == BlockFmt.CENTRE | BlockFmt.PBB
@@ -628,15 +663,46 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("#! My Novel\n", True) == BlockFmt.CENTRE
     assert processStyle("##! Prologue\n", True) == BlockFmt.NONE
 
-    # Check Separation
-    # ================
+
+@pytest.mark.core
+def testFmtToken_HeaderStyleSeparation(mockGUI):
+    """Test header styling separation."""
+    project = NWProject()
+    tokens = BareTokenizer(project)
+
+    def processStyle(text: str, first: bool) -> BlockFmt:
+        tokens._text = text
+        tokens._isFirst = first
+        tokens.tokenizeText()
+        return tokens._blocks[0][4]
+
     tokens._isNovel = True
 
     # Title Styles
+    tokens.setTitleStyle(True, True)
+    tokens.setPartitionStyle(False, False)
+    tokens.setChapterStyle(False, False)
+    tokens.setSceneStyle(False, False)
+
+    assert tokens._titleStyle == BlockFmt.CENTRE | BlockFmt.PBB
+    assert tokens._partStyle == BlockFmt.NONE
+    assert tokens._chapterStyle == BlockFmt.NONE
+    assert tokens._sceneStyle == BlockFmt.NONE
+
+    assert processStyle("# Title\n", False) == BlockFmt.NONE
+    assert processStyle("## Chapter\n", False) == BlockFmt.NONE
+    assert processStyle("### Scene\n", False) == BlockFmt.NONE
+    assert processStyle("#### Section\n", False) == BlockFmt.NONE
+    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("##! Prologue\n", False) == BlockFmt.NONE
+
+    # Partition Styles
+    tokens.setTitleStyle(False, False)
     tokens.setPartitionStyle(True, True)
     tokens.setChapterStyle(False, False)
     tokens.setSceneStyle(False, False)
 
+    assert tokens._titleStyle == BlockFmt.NONE
     assert tokens._partStyle == BlockFmt.CENTRE | BlockFmt.PBB
     assert tokens._chapterStyle == BlockFmt.NONE
     assert tokens._sceneStyle == BlockFmt.NONE
@@ -645,14 +711,16 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.NONE
     assert processStyle("### Scene\n", False) == BlockFmt.NONE
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", False) == BlockFmt.NONE
 
     # Chapter Styles
+    tokens.setTitleStyle(False, False)
     tokens.setPartitionStyle(False, False)
     tokens.setChapterStyle(True, True)
     tokens.setSceneStyle(False, False)
 
+    assert tokens._titleStyle == BlockFmt.NONE
     assert tokens._partStyle == BlockFmt.NONE
     assert tokens._chapterStyle == BlockFmt.CENTRE | BlockFmt.PBB
     assert tokens._sceneStyle == BlockFmt.NONE
@@ -661,14 +729,16 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
     assert processStyle("### Scene\n", False) == BlockFmt.NONE
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
 
     # Scene Styles
+    tokens.setTitleStyle(False, False)
     tokens.setPartitionStyle(False, False)
     tokens.setChapterStyle(False, False)
     tokens.setSceneStyle(True, True)
 
+    assert tokens._titleStyle == BlockFmt.NONE
     assert tokens._partStyle == BlockFmt.NONE
     assert tokens._chapterStyle == BlockFmt.NONE
     assert tokens._sceneStyle == BlockFmt.CENTRE | BlockFmt.PBB
@@ -677,7 +747,7 @@ def testFmtToken_HeaderStyle(mockGUI):
     assert processStyle("## Chapter\n", False) == BlockFmt.NONE
     assert processStyle("### Scene\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
     assert processStyle("#### Section\n", False) == BlockFmt.NONE
-    assert processStyle("#! My Novel\n", False) == BlockFmt.CENTRE | BlockFmt.PBB
+    assert processStyle("#! My Novel\n", False) == BlockFmt.NONE
     assert processStyle("##! Prologue\n", False) == BlockFmt.NONE
 
 

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -842,13 +842,13 @@ def testFmtToken_MarginFormat(mockGUI):
     ]
     assert tokens._raw[-1] == (
         "Some regular text\n\n"
-        "Some left-aligned text\n\n"
-        "Some right-aligned text\n\n"
-        "Some centered text\n\n"
-        "Left-indented block\n\n"
-        "Right-indented block\n\n"
-        "Double-indented block\n\n"
-        "Right-indent, right-aligned\n\n\n"
+        "Some left-aligned text <<\n\n"
+        ">> Some right-aligned text\n\n"
+        ">> Some centered text <<\n\n"
+        "> Left-indented block\n\n"
+        "Right-indented block <\n\n"
+        "> Double-indented block <\n\n"
+        ">> Right-indent, right-aligned <\n\n\n"
     )
 
 

--- a/tests/test_formats/test_fmt_tomarkdown.py
+++ b/tests/test_formats/test_fmt_tomarkdown.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import pytest
 
+from novelwriter.constants import nwHeadFmt
 from novelwriter.core.project import NWProject
 from novelwriter.formats.shared import BlockFmt, BlockTyp
 from novelwriter.formats.tomarkdown import ToMarkdown
@@ -37,22 +38,25 @@ def testFmtToMarkdown_ConvertHeaders(mockGUI):
     md._isFirst = True
 
     # Header 1
-    md._text = "# Partition\n"
+    md._text = "# Title\n"
+    md.setPartitionFormat(f"Part{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     md.tokenizeText()
     md.doConvert()
-    assert md._pages[-1] == "# Partition\n\n"
+    assert md._pages[-1] == "# Part - Title\n\n"
 
     # Header 2
-    md._text = "## Chapter Title\n"
+    md._text = "## Title\n"
+    md.setChapterFormat(f"Chapter {nwHeadFmt.CH_NUM}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     md.tokenizeText()
     md.doConvert()
-    assert md._pages[-1] == "## Chapter Title\n\n"
+    assert md._pages[-1] == "## Chapter 1 - Title\n\n"
 
     # Header 3
-    md._text = "### Scene Title\n"
+    md._text = "### Title\n"
+    md.setSceneFormat(f"Scene {nwHeadFmt.SC_ABS}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     md.tokenizeText()
     md.doConvert()
-    assert md._pages[-1] == "### Scene Title\n\n"
+    assert md._pages[-1] == "### Scene 1 - Title\n\n"
 
     # Header 4
     md._text = "#### Section Title\n"

--- a/tests/test_formats/test_fmt_toodt.py
+++ b/tests/test_formats/test_fmt_toodt.py
@@ -281,6 +281,7 @@ def testFmtToOdt_ConvertHeaders(mockGUI):
 
     # Header 1
     odt._text = "# Title\n"
+    odt.setPartitionFormat(f"Part{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     odt.tokenizeText()
     odt.initDocument()
     odt.doConvert()
@@ -288,12 +289,14 @@ def testFmtToOdt_ConvertHeaders(mockGUI):
     assert odt.errData == []
     assert xmlToText(odt._xText) == (
         '<office:text>'
-        '<text:h text:style-name="P1" text:outline-level="1">Title</text:h>'
+        '<text:h text:style-name="P1" text:outline-level="1">Part'
+        '<text:line-break />Title</text:h>'
         '</office:text>'
     )
 
     # Header 2
-    odt._text = "## Chapter\n"
+    odt._text = "## Title\n"
+    odt.setChapterFormat(f"Chapter {nwHeadFmt.CH_NUM}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     odt.tokenizeText()
     odt.initDocument()
     odt.doConvert()
@@ -301,12 +304,14 @@ def testFmtToOdt_ConvertHeaders(mockGUI):
     assert odt.errData == []
     assert xmlToText(odt._xText) == (
         '<office:text>'
-        '<text:h text:style-name="P2" text:outline-level="2">Chapter</text:h>'
+        '<text:h text:style-name="P2" text:outline-level="2">Chapter 1'
+        '<text:line-break />Title</text:h>'
         '</office:text>'
     )
 
     # Header 3
-    odt._text = "### Scene\n"
+    odt._text = "### Title\n"
+    odt.setSceneFormat(f"Scene {nwHeadFmt.SC_ABS}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     odt.tokenizeText()
     odt.initDocument()
     odt.doConvert()
@@ -314,12 +319,13 @@ def testFmtToOdt_ConvertHeaders(mockGUI):
     assert odt.errData == []
     assert xmlToText(odt._xText) == (
         '<office:text>'
-        '<text:h text:style-name="Heading_20_3" text:outline-level="3">Scene</text:h>'
+        '<text:h text:style-name="Heading_20_3" text:outline-level="3">Scene 1'
+        '<text:line-break />Title</text:h>'
         '</office:text>'
     )
 
     # Header 4
-    odt._text = "#### Section\n"
+    odt._text = "#### Title\n"
     odt.tokenizeText()
     odt.initDocument()
     odt.doConvert()
@@ -327,7 +333,7 @@ def testFmtToOdt_ConvertHeaders(mockGUI):
     assert odt.errData == []
     assert xmlToText(odt._xText) == (
         '<office:text>'
-        '<text:h text:style-name="Heading_20_4" text:outline-level="4">Section</text:h>'
+        '<text:h text:style-name="Heading_20_4" text:outline-level="4">Title</text:h>'
         '</office:text>'
     )
 

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -522,12 +522,17 @@ def testGuiMainMenu_Insert(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd
     nwGUI.mainMenu.aInsShort.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "Stuff\n%Short: \n"
 
-    # Insert Break or Space
-    # =====================
+    # Breaks and Vertical Space
+    # =========================
 
     nwGUI.docEditor.setPlainText("### Stuff\n")
     nwGUI.mainMenu.aInsNewPage.activate(QAction.ActionEvent.Trigger)
     assert nwGUI.docEditor.getText() == "[newpage]\n### Stuff\n"
+
+    nwGUI.docEditor.setPlainText("Line OneLine Two\n")
+    nwGUI.docEditor.setCursorPosition(8)
+    nwGUI.mainMenu.aInsLineBreak.activate(QAction.ActionEvent.Trigger)
+    assert nwGUI.docEditor.getText() == "Line One[br]Line Two\n"
 
     nwGUI.docEditor.setPlainText("### Stuff\n")
     nwGUI.mainMenu.aInsVSpaceS.activate(QAction.ActionEvent.Trigger)

--- a/tests/test_text/test_text_counting.py
+++ b/tests/test_text/test_text_counting.py
@@ -47,6 +47,7 @@ def testTextCounting_preProcessText():
         "[vspace:3]\n\n"
         "[New Page]\n\n"
         "[footnote:abcd]\n\n"
+        "[br]\n\n"
         "Dashes\u2013and even longer\u2014dashes.\n\n"
     )
 
@@ -60,7 +61,7 @@ def testTextCounting_preProcessText():
         "#### Heading Four",
         "", "", "",
         "A paragraph.", "",
-        "", "", "", "", "", "",
+        "", "", "", "", "", "", "", "",
         "Dashes and even longer dashes.", ""
     ]
 
@@ -68,7 +69,7 @@ def testTextCounting_preProcessText():
     assert preProcessText(text, keepHeaders=False) == [
         "", "", "",
         "A paragraph.", "",
-        "", "", "", "", "", "",
+        "", "", "", "", "", "", "", "",
         "Dashes and even longer dashes.", ""
     ]
 

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -198,6 +198,17 @@ def testTextPatterns_ShortcodesPlain():
 
     assert allMatches(regEx, "one [x]two[/x] three") == []
 
+    # Line Break Substitution
+    # =======================
+    regEx = REGEX_PATTERNS.lineBreak
+
+    assert regEx.sub("\n", "one[br]two") == "one\ntwo"
+    assert regEx.sub("\n", "one[br]\ntwo") == "one\ntwo"
+    assert regEx.sub("\n", "one[br]\n\ntwo") == "one\n\ntwo"
+    assert regEx.sub("\n", "one[BR]two") == "one\ntwo"
+    assert regEx.sub("\n", "one[BR]\ntwo") == "one\ntwo"
+    assert regEx.sub("\n", "one[BR]\n\ntwo") == "one\n\ntwo"
+
 
 @pytest.mark.core
 def testTextPatterns_ShortcodesValue():


### PR DESCRIPTION
**Summary:**

This PR:
* Adds a new shortcode `[br]` that can be used to insert forced line breaks in text paragraphs. They only work in plain text paragraphs that already support line breaks. If they are put anywhere else, they are stripped out when building the document or manuscript. There are other ways to add breaks in headings.
* Move the handling of line breaks in heading to the Tokenizer class so that the format classes can ignore these.
* Fixes a bug in the raw output format that was stripping the alignment and indentation tags.

**Related Issue(s):**

Closes #1991

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
