### PR TITLE
Rewriter narrator break for dialogue highlighting

### DIFF
--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -543,33 +543,6 @@ class GuiPreferences(NDialog):
             self.tr("Applies to the selected quote styles.")
         )
 
-        self.allowOpenDial = NSwitch(self)
-        self.allowOpenDial.setChecked(CONFIG.allowOpenDial)
-        self.mainForm.addRow(
-            self.tr("Allow open-ended dialogue"), self.allowOpenDial,
-            self.tr("Highlight dialogue line with no closing quote.")
-        )
-
-        self.narratorBreak = QLineEdit(self)
-        self.narratorBreak.setMaxLength(1)
-        self.narratorBreak.setFixedWidth(boxFixed)
-        self.narratorBreak.setAlignment(QtAlignCenter)
-        self.narratorBreak.setText(CONFIG.narratorBreak)
-        self.mainForm.addRow(
-            self.tr("Dialogue narrator break symbol"), self.narratorBreak,
-            self.tr("Symbol to indicate injected narrator break.")
-        )
-
-        self.dialogLine = QLineEdit(self)
-        self.dialogLine.setMaxLength(1)
-        self.dialogLine.setFixedWidth(boxFixed)
-        self.dialogLine.setAlignment(QtAlignCenter)
-        self.dialogLine.setText(CONFIG.dialogLine)
-        self.mainForm.addRow(
-            self.tr("Dialogue line symbol"), self.dialogLine,
-            self.tr("Lines starting with this symbol are dialogue.")
-        )
-
         self.altDialogOpen = QLineEdit(self)
         self.altDialogOpen.setMaxLength(4)
         self.altDialogOpen.setFixedWidth(boxFixed)
@@ -585,6 +558,33 @@ class GuiPreferences(NDialog):
         self.mainForm.addRow(
             self.tr("Alternative dialogue symbols"), [self.altDialogOpen, self.altDialogClose],
             self.tr("Custom highlighting of dialogue text.")
+        )
+
+        self.allowOpenDial = NSwitch(self)
+        self.allowOpenDial.setChecked(CONFIG.allowOpenDial)
+        self.mainForm.addRow(
+            self.tr("Allow open-ended dialogue"), self.allowOpenDial,
+            self.tr("Highlight dialogue line with no closing quote.")
+        )
+
+        self.dialogLine = QLineEdit(self)
+        self.dialogLine.setMaxLength(1)
+        self.dialogLine.setFixedWidth(boxFixed)
+        self.dialogLine.setAlignment(QtAlignCenter)
+        self.dialogLine.setText(CONFIG.dialogLine)
+        self.mainForm.addRow(
+            self.tr("Dialogue line symbol"), self.dialogLine,
+            self.tr("Lines starting with this symbol are dialogue.")
+        )
+
+        self.narratorBreak = QLineEdit(self)
+        self.narratorBreak.setMaxLength(1)
+        self.narratorBreak.setFixedWidth(boxFixed)
+        self.narratorBreak.setAlignment(QtAlignCenter)
+        self.narratorBreak.setText(CONFIG.narratorBreak)
+        self.mainForm.addRow(
+            self.tr("Dialogue narrator break symbol"), self.narratorBreak,
+            self.tr("Symbol to indicate injected narrator break.")
         )
 
         self.highlightEmph = NSwitch(self)

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -339,8 +339,8 @@ class Tokenizer(ABC):
                     REGEX_PATTERNS.altDialogStyle,
                     (TextFmt.COL_B, "altdialog"), (TextFmt.COL_E, ""),
                 ))
-            self._dialogLine = CONFIG.dialogLine
-            self._narratorBreak = CONFIG.narratorBreak
+            self._dialogLine = CONFIG.dialogLine.strip()[:1]
+            self._narratorBreak = CONFIG.narratorBreak.strip()[:1]
         return
 
     def setTitleMargins(self, upper: float, lower: float) -> None:

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -136,8 +136,8 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._txtRules.clear()
         self._cmnRules.clear()
 
-        self._dialogLine = CONFIG.dialogLine
-        self._narratorBreak = CONFIG.narratorBreak
+        self._dialogLine = CONFIG.dialogLine.strip()[:1]
+        self._narratorBreak = CONFIG.narratorBreak.strip()[:1]
 
         # Multiple or Trailing Spaces
         if CONFIG.showMultiSpaces:

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -97,18 +97,6 @@ class RegExPatterns:
         return re.compile(f"\\B[{symO}].*?(?:[{symC}]\\B{rxEnd})", re.UNICODE)
 
     @property
-    def dialogLine(self) -> re.Pattern:
-        """Dialogue line rule based on user settings."""
-        sym = re.escape(CONFIG.dialogLine)
-        return re.compile(f"^{sym}.*?$", re.UNICODE)
-
-    @property
-    def narratorBreak(self) -> re.Pattern:
-        """Dialogue narrator break rule based on user settings."""
-        sym = re.escape(CONFIG.narratorBreak)
-        return re.compile(f"\\B{sym}\\S.*?\\S{sym}\\B", re.UNICODE)
-
-    @property
     def altDialogStyle(self) -> re.Pattern:
         """Dialogue alternative rule based on user settings."""
         symO = re.escape(CONFIG.altDialogOpen)

--- a/tests/reference/guiEditor_Main_Final_000000000000f.nwd
+++ b/tests/reference/guiEditor_Main_Final_000000000000f.nwd
@@ -1,8 +1,8 @@
 %%~name: New Scene
 %%~path: 000000000000d/000000000000f
 %%~kind: NOVEL/DOCUMENT
-%%~hash: 2a863dc53e09b0b1b0294ae7ea001853dddd596d
-%%~date: 2023-10-17 20:52:56/2023-10-17 20:53:01
+%%~hash: 0566024662fb6ed7ed645717addd64dabf058915
+%%~date: 2024-10-27 13:03:13/2024-10-27 13:03:18
 # Novel
 
 ## Chapter
@@ -33,6 +33,10 @@ This is another paragraph of much longer nonsense text. It is in fact 1 very ver
 ‘Full line single quoted text.’
 
 Some “ double quoted text with spaces padded ”.
+
+– Hi, I am a character speaking.
+
+– Hi, I am also a character speaking, – said another character. – How are you?
 
 @object: NoSpaceAdded
 

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.4rc1" hexVersion="0x020400c1" fileVersion="1.5" fileRevision="3" timeStamp="2024-04-14 23:46:11">
-  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="3">
+<novelWriterXML appVersion="2.6a3" hexVersion="0x020600a3" fileVersion="1.5" fileRevision="4" timeStamp="2024-10-27 13:01:24">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="6">
     <name>New Project</name>
     <author>Jane Doe</author>
   </project>
@@ -28,7 +28,7 @@
       <entry key="i000007" count="0" red="50" green="200" blue="0" shape="SQUARE">Main</entry>
     </importance>
   </settings>
-  <content items="11" novelWords="142" notesWords="27">
+  <content items="11" novelWords="161" notesWords="27">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
       <meta expanded="yes" />
       <name status="s000000" import="i000004">Novel</name>
@@ -46,7 +46,7 @@
       <name status="s000000" import="i000004" active="yes">New Chapter</name>
     </item>
     <item handle="000000000000f" parent="000000000000d" root="0000000000008" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H1" charCount="808" wordCount="135" paraCount="15" cursorPos="1026" />
+      <meta expanded="no" heading="H1" charCount="918" wordCount="154" paraCount="17" cursorPos="1140" />
       <name status="s000000" import="i000004" active="yes">New Scene</name>
     </item>
     <item handle="0000000000009" parent="None" root="0000000000009" order="1" type="ROOT" class="PLOT">

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -1251,8 +1251,6 @@ def testFmtToken_Dialogue(mockGUI):
     CONFIG.dialogStyle    = 3
     CONFIG.altDialogOpen  = "::"
     CONFIG.altDialogClose = "::"
-    CONFIG.dialogLine     = "\u2013"
-    CONFIG.narratorBreak  = "\u2013"
 
     project = NWProject()
     tokens = BareTokenizer(project)
@@ -1305,7 +1303,24 @@ def testFmtToken_Dialogue(mockGUI):
         BlockFmt.NONE
     )]
 
+    # Dialogue line
+    CONFIG.dialogLine = "\u2013"
+    tokens.setDialogueHighlight(True)
+    tokens._text = "\u2013 Dialogue line without narrator break.\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == [(
+        BlockTyp.TEXT, "",
+        "\u2013 Dialogue line without narrator break.",
+        [
+            (0,  TextFmt.COL_B, "dialog"),
+            (39, TextFmt.COL_E, ""),
+        ],
+        BlockFmt.NONE
+    )]
+
     # Dialogue line with narrator break
+    CONFIG.narratorBreak = "\u2013"
+    tokens.setDialogueHighlight(True)
     tokens._text = "\u2013 Dialogue with a narrator break, \u2013he said,\u2013 see?\n"
     tokens.tokenizeText()
     assert tokens._blocks == [(
@@ -1314,7 +1329,7 @@ def testFmtToken_Dialogue(mockGUI):
         [
             (0,  TextFmt.COL_B, "dialog"),
             (34, TextFmt.COL_E, ""),
-            (44, TextFmt.COL_B, "dialog"),
+            (43, TextFmt.COL_B, "dialog"),
             (49, TextFmt.COL_E, ""),
         ],
         BlockFmt.NONE

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -258,7 +258,6 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     # Syntax Highlighting
     CONFIG.dialogStyle = 3
     CONFIG.dialogLine = "–"
-    CONFIG.narratorBreak = "–"
     CONFIG.altDialogOpen = "<|"
     CONFIG.altDialogClose = "|>"
 
@@ -431,6 +430,9 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
 
+    # Dialogue
+    # ========
+
     for c in "\"Full line double quoted text.\"":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
@@ -452,6 +454,25 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     docEditor._typPadBefore = ""
     docEditor._typPadAfter = ""
+
+    # Dialogue Line
+    for c in "-- Hi, I am a character speaking.":
+        qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+
+    # Narrator Break
+    CONFIG.narratorBreak = "–"
+    docEditor = nwGUI.docEditor
+    docEditor._qDocument.syntaxHighlighter.initHighlighter()
+
+    for c in "-- Hi, I am also a character speaking, -- said another character. -- How are you?":
+        qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+
+    # Special Formatting
+    # ==================
 
     # Insert spaces before colon, but ignore tags and synopsis
     docEditor._typPadBefore = ":"

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -327,34 +327,8 @@ def testTextPatterns_DialogueSpecial():
     CONFIG.fmtDQuoteClose = nwUnicode.U_RDQUO
 
     CONFIG.dialogStyle = 3
-    CONFIG.dialogLine = nwUnicode.U_ENDASH
-    CONFIG.narratorBreak = nwUnicode.U_ENDASH
     CONFIG.altDialogOpen = "::"
     CONFIG.altDialogClose = "::"
-
-    # Dialogue Line
-    # =============
-    regEx = REGEX_PATTERNS.dialogLine
-
-    # Check dialogue line in first position
-    assert allMatches(regEx, "\u2013 one two three") == [
-        [("\u2013 one two three", 0, 15)]
-    ]
-
-    # Check dialogue line in second position
-    assert allMatches(regEx, " \u2013 one two three") == []
-
-    # Narrator Break
-    # ==============
-    regEx = REGEX_PATTERNS.narratorBreak
-
-    # Narrator break with no padding
-    assert allMatches(regEx, "one \u2013two\u2013 three") == [
-        [("\u2013two\u2013", 4, 9)]
-    ]
-
-    # Narrator break with padding
-    assert allMatches(regEx, "one \u2013 two \u2013 three") == []
 
     # Alternative Dialogue
     # ====================


### PR DESCRIPTION
**Summary:**

This PR rewrites the RegEx-based narrator break highlighting for dialogue with a string-split based one that better handles the various use cases.

**Related Issue(s):**

Closes #2066

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
