### PR TITLE
Fix default button issue on Build dialog

### DIFF
--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -179,14 +179,20 @@ class GuiManuscriptBuild(NDialog):
         self.buildBox.setVerticalSpacing(sp4)
 
         # Dialog Buttons
+        self.buttonBox = QDialogButtonBox(self)
+
         self.btnOpen = QPushButton(SHARED.theme.getIcon("browse"), self.tr("Open Folder"), self)
         self.btnOpen.setIconSize(bSz)
+        self.btnOpen.setAutoDefault(False)
+        self.buttonBox.addButton(self.btnOpen, QtRoleAction)
+
         self.btnBuild = QPushButton(SHARED.theme.getIcon("export"), self.tr("&Build"), self)
         self.btnBuild.setIconSize(bSz)
+        self.btnBuild.setAutoDefault(True)
+        self.buttonBox.addButton(self.btnBuild, QtRoleAction)
 
-        self.dlgButtons = QDialogButtonBox(QtDialogClose, self)
-        self.dlgButtons.addButton(self.btnOpen, QtRoleAction)
-        self.dlgButtons.addButton(self.btnBuild, QtRoleAction)
+        self.btnClose = self.buttonBox.addButton(QtDialogClose)
+        self.btnClose.setAutoDefault(False)
 
         # Assemble GUI
         # ============
@@ -213,7 +219,7 @@ class GuiManuscriptBuild(NDialog):
         self.outerBox.addSpacing(sp4)
         self.outerBox.addLayout(self.buildBox, 0)
         self.outerBox.addSpacing(sp16)
-        self.outerBox.addWidget(self.dlgButtons, 0)
+        self.outerBox.addWidget(self.buttonBox, 0)
         self.outerBox.setSpacing(0)
 
         self.setLayout(self.outerBox)
@@ -229,7 +235,7 @@ class GuiManuscriptBuild(NDialog):
         # Signals
         self.btnReset.clicked.connect(self._doResetBuildName)
         self.btnBrowse.clicked.connect(self._doSelectPath)
-        self.dlgButtons.clicked.connect(self._dialogButtonClicked)
+        self.buttonBox.clicked.connect(self._dialogButtonClicked)
         self.listFormats.itemSelectionChanged.connect(self._resetProgress)
 
         logger.debug("Ready: GuiManuscriptBuild")
@@ -260,7 +266,7 @@ class GuiManuscriptBuild(NDialog):
     @pyqtSlot("QAbstractButton*")
     def _dialogButtonClicked(self, button: QAbstractButton) -> None:
         """Handle button clicks from the dialog button box."""
-        role = self.dlgButtons.buttonRole(button)
+        role = self.buttonBox.buttonRole(button)
         if role == QtRoleAction:
             if button == self.btnBuild:
                 self._runBuild()

--- a/tests/test_tools/test_tools_manusbuild.py
+++ b/tests/test_tools/test_tools_manusbuild.py
@@ -95,7 +95,7 @@ def testToolManuscriptBuild_Main(
         assert (fncPath / "TestBuild").with_suffix(nwLabels.BUILD_EXT[fmt]).exists()
         lastFmt = fmt
 
-    manus._dialogButtonClicked(manus.dlgButtons.button(QtDialogClose))
+    manus._dialogButtonClicked(manus.buttonBox.button(QtDialogClose))
     manus.deleteLater()
 
     assert build.lastBuildName == "TestBuild"
@@ -150,5 +150,5 @@ def testToolManuscriptBuild_Main(
         assert lastUrl.startswith("file://")
 
     # Finish
-    manus._dialogButtonClicked(manus.dlgButtons.button(QtDialogClose))
+    manus._dialogButtonClicked(manus.buttonBox.button(QtDialogClose))
     # qtbot.stop()


### PR DESCRIPTION
**Summary:**

This PR turns on auto default on all other buttons than "Build" on the Build dialog.

**Related Issue(s):**

Closes #2101

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
