### PR TITLE
Add ANSI colours to log output

### DIFF
--- a/tests/test_base/test_base_init.py
+++ b/tests/test_base/test_base_init.py
@@ -25,7 +25,7 @@ import sys
 
 import pytest
 
-from novelwriter import CONFIG, logger, main
+from novelwriter import CONFIG, ColorFormatter, logger, main
 
 from tests.mocked import MockGuiMain
 
@@ -99,14 +99,14 @@ def testBaseInit_Options(monkeypatch, fncPath):
 
     # Log Levels
     nwGUI = main(
-        ["--testmode", "--info", f"--config={fncPath}", f"--data={fncPath}"]
+        ["--testmode", "--info", "--color", f"--config={fncPath}", f"--data={fncPath}"]
     )
     assert nwGUI is not None
     assert logger.getEffectiveLevel() == logging.INFO
     assert nwGUI.closeMain() == "closeMain"
 
     nwGUI = main(
-        ["--testmode", "--debug", f"--config={fncPath}", f"--data={fncPath}"]
+        ["--testmode", "--debug", "--color", f"--config={fncPath}", f"--data={fncPath}"]
     )
     assert nwGUI is not None
     assert logger.getEffectiveLevel() == logging.DEBUG
@@ -171,3 +171,24 @@ def testBaseInit_Imports(caplog, monkeypatch, fncPath):
     assert "At least Python" in caplog.messages[0]
     assert "At least Qt5" in caplog.messages[1]
     assert "At least PyQt5" in caplog.messages[2]
+
+
+@pytest.mark.base
+def testBaseInit_ColorFormatter(qtbot, monkeypatch, fncPath, tstPaths):
+    """Check launching the main GUI."""
+    formatter = ColorFormatter(fmt="<{message:}>", style="{")
+
+    record = logging.LogRecord("", logging.INFO, "", 1, "Info", None, None)
+    assert formatter.format(record) == "\x1b[1;32m<Info>\x1b[0m"
+
+    record = logging.LogRecord("", logging.DEBUG, "", 1, "Debug", None, None)
+    assert formatter.format(record) == "\x1b[1;34m<Debug>\x1b[0m"
+
+    record = logging.LogRecord("", logging.WARNING, "", 1, "Warning", None, None)
+    assert formatter.format(record) == "\x1b[1;33m<Warning>\x1b[0m"
+
+    record = logging.LogRecord("", logging.ERROR, "", 1, "Error", None, None)
+    assert formatter.format(record) == "\x1b[1;31m<Error>\x1b[0m"
+
+    record = logging.LogRecord("", logging.CRITICAL, "", 1, "Critical", None, None)
+    assert formatter.format(record) == "\x1b[1;31m<Critical>\x1b[0m"


### PR DESCRIPTION
**Summary:**

This PR adds colours to the log output when the `--color` flag is provided.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
