### PR TITLE
Align headers to bottom of page margin for ODT and DocX

### DIFF
--- a/novelwriter/formats/toodt.py
+++ b/novelwriter/formats/toodt.py
@@ -666,7 +666,7 @@ class ToOdt(Tokenizer):
 
     def _emToCm(self, value: float) -> str:
         """Converts an em value to centimetres."""
-        return f"{value*2.54/72*self._fontSize:.3f}cm"
+        return f"{value*self._fontSize*2.54/72.0:.3f}cm"
 
     def _emToPt(self, scale: float) -> str:
         """Compute relative font size in points."""
@@ -694,10 +694,10 @@ class ToOdt(Tokenizer):
 
         xHead = ET.SubElement(xPage, _mkTag("style", "header-style"))
         ET.SubElement(xHead, _mkTag("style", "header-footer-properties"), attrib={
-            _mkTag("fo", "min-height"): "0.600cm",
+            _mkTag("fo", "min-height"): self._emToCm(1.5),
             _mkTag("fo", "margin-left"): "0.000cm",
             _mkTag("fo", "margin-right"): "0.000cm",
-            _mkTag("fo", "margin-bottom"): "0.500cm",
+            _mkTag("fo", "margin-bottom"): self._emToCm(0.5),
         })
 
         return

--- a/tests/reference/fmtToDocX_SaveDocument_document.xml
+++ b/tests/reference/fmtToDocX_SaveDocument_document.xml
@@ -1432,7 +1432,7 @@
         <w:numFmt w:val="decimal" />
       </w:footnotePr>
       <w:pgSz w:w="11905" w:h="16837" w:orient="portrait" />
-      <w:pgMar w:top="1133" w:right="1133" w:bottom="1133" w:left="1133" w:header="566" w:footer="0" w:gutter="0" />
+      <w:pgMar w:top="1133" w:right="1133" w:bottom="1133" w:left="1133" w:header="713" w:footer="0" w:gutter="0" />
       <w:pgNumType w:start="1" w:fmt="decimal" />
       <w:titlePg />
     </w:sectPr>

--- a/tests/reference/fmtToOdt_SaveFlat_document.fodt
+++ b/tests/reference/fmtToOdt_SaveFlat_document.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2024-11-13T20:28:36</meta:creation-date>
+    <meta:creation-date>2024-11-29T00:34:11</meta:creation-date>
     <meta:generator>novelWriter/2.6b1</meta:generator>
     <meta:initial-creator>Jane Smith</meta:initial-creator>
     <meta:editing-cycles>1234</meta:editing-cycles>
     <meta:editing-duration>P42DT12H34M56S</meta:editing-duration>
     <dc:title>Test Project</dc:title>
-    <dc:date>2024-11-13T20:28:36</dc:date>
+    <dc:date>2024-11-29T00:34:11</dc:date>
     <dc:creator>Jane Smith</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -76,7 +76,7 @@
     <style:page-layout style:name="PM1">
       <style:page-layout-properties fo:page-width="14.800cm" fo:page-height="21.000cm" fo:margin-top="2.000cm" fo:margin-bottom="1.800cm" fo:margin-left="1.700cm" fo:margin-right="1.500cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
+        <style:header-footer-properties fo:min-height="0.635cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.212cm" />
       </style:header-style>
     </style:page-layout>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Heading_20_2">

--- a/tests/reference/fmtToOdt_SaveFull_styles.xml
+++ b/tests/reference/fmtToOdt_SaveFull_styles.xml
@@ -66,7 +66,7 @@
     <style:page-layout style:name="PM1">
       <style:page-layout-properties fo:page-width="21.0cm" fo:page-height="29.7cm" fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
+        <style:header-footer-properties fo:min-height="0.635cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.212cm" />
       </style:header-style>
     </style:page-layout>
   </office:automatic-styles>

--- a/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
+++ b/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2024-11-13T20:33:59</meta:creation-date>
+    <meta:creation-date>2024-11-29T00:39:37</meta:creation-date>
     <meta:generator>novelWriter/2.6b1</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
-    <meta:editing-cycles>50</meta:editing-cycles>
-    <meta:editing-duration>P0DT0H40M48S</meta:editing-duration>
+    <meta:editing-cycles>51</meta:editing-cycles>
+    <meta:editing-duration>P0DT0H40M56S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2024-11-13T20:33:59</dc:date>
+    <dc:date>2024-11-29T00:39:37</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:font-face-decls>
@@ -76,7 +76,7 @@
     <style:page-layout style:name="PM1">
       <style:page-layout-properties fo:page-width="21.000cm" fo:page-height="29.700cm" fo:margin-top="2.000cm" fo:margin-bottom="2.000cm" fo:margin-left="2.000cm" fo:margin-right="2.000cm" />
       <style:header-style>
-        <style:header-footer-properties fo:min-height="0.600cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.500cm" />
+        <style:header-footer-properties fo:min-height="0.635cm" fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:margin-bottom="0.212cm" />
       </style:header-style>
     </style:page-layout>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Text_20_body">

--- a/tests/test_formats/test_fmt_todocx.py
+++ b/tests/test_formats/test_fmt_todocx.py
@@ -628,7 +628,7 @@ def testFmtToDocX_Fields(mockGUI):
         '<w:footnotePr><w:numFmt w:val="decimal" /></w:footnotePr>'
         '<w:pgSz w:w="11905" w:h="16837" w:orient="portrait" />'
         '<w:pgMar w:top="1133" w:right="1133" w:bottom="1133" w:left="1133" '
-        'w:header="566" w:footer="0" w:gutter="0" />'
+        'w:header="748" w:footer="0" w:gutter="0" />'
         '<w:pgNumType w:start="1" w:fmt="decimal" /><w:titlePg />'
         '</w:sectPr></w:body></w:document>'
     )


### PR DESCRIPTION
**Summary:**

This PR changes how page headers in ODT and DocX documents are aligned. They are now approximately half a line above the top margin for both formats.

**Related Issue(s):**

Closes #2120

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
