### PR TITLE
Fix project tree status/importance for folders

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1366,9 +1366,8 @@ class _TreeContextMenu(QMenu):
 
     def _changeItemStatus(self, key: str) -> None:
         """Set a new status value of an item."""
-        if self._item.isFileType():
-            self._item.setStatus(key)
-            self._item.notifyToRefresh()
+        self._item.setStatus(key)
+        self._item.notifyToRefresh()
         return
 
     def _iterSetItemStatus(self, key: str) -> None:
@@ -1383,9 +1382,8 @@ class _TreeContextMenu(QMenu):
 
     def _changeItemImport(self, key: str) -> None:
         """Set a new importance value of an item."""
-        if self._item.isFileType():
-            self._item.setImport(key)
-            self._item.notifyToRefresh()
+        self._item.setImport(key)
+        self._item.notifyToRefresh()
         return
 
     def _iterSetItemImport(self, key: str) -> None:

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.6b1" hexVersion="0x020600b1" fileVersion="1.5" fileRevision="4" timeStamp="2024-11-12 00:38:25">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2140" autoCount="281" editTime="95407">
+<novelWriterXML appVersion="2.6b2" hexVersion="0x020600b2" fileVersion="1.5" fileRevision="4" timeStamp="2024-12-29 16:15:38">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2141" autoCount="281" editTime="95426">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>


### PR DESCRIPTION
**Summary:**

This PR fixes a bug where it was not possible to change the status/importance value for folders. The method that applies the change explicitly filtered for files. I don't know how that check snuck in there, because it wasn't there in the old implementation. Probably a bad copy/paste when it was re-implemented for the new tree.

**Related Issue(s):**

Closes #2145

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
