### PR TITLE
Remove "Apply" buttons in Project Settings

### DIFF
--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -371,11 +371,11 @@ class _StatusPage(NFixedPage):
         self.dnButton.clicked.connect(qtLambda(self._moveItem, 1))
 
         # Edit Form
-        self.editName = QLineEdit(self)
-        self.editName.setMaxLength(40)
-        self.editName.setPlaceholderText(self.tr("Select item to edit"))
-        self.editName.setEnabled(False)
-        self.editName.textEdited.connect(self._onNameEdit)
+        self.labelText = QLineEdit(self)
+        self.labelText.setMaxLength(40)
+        self.labelText.setPlaceholderText(self.tr("Select item to edit"))
+        self.labelText.setEnabled(False)
+        self.labelText.textEdited.connect(self._onNameEdit)
 
         buttonStyle = (
             f"QToolButton {{padding: 0 {bPd}px;}} "
@@ -418,7 +418,7 @@ class _StatusPage(NFixedPage):
         self.listControls.addStretch(1)
 
         self.editBox = QHBoxLayout()
-        self.editBox.addWidget(self.editName, 1)
+        self.editBox.addWidget(self.labelText, 1)
         self.editBox.addWidget(self.colorButton, 0)
         self.editBox.addWidget(self.shapeButton, 0)
 
@@ -522,20 +522,20 @@ class _StatusPage(NFixedPage):
             self._shape = entry.shape
             self._setButtonIcons()
 
-            self.editName.setText(entry.name)
-            self.editName.selectAll()
-            self.editName.setFocus()
+            self.labelText.setText(entry.name)
+            self.labelText.selectAll()
+            self.labelText.setFocus()
 
-            self.editName.setEnabled(True)
+            self.labelText.setEnabled(True)
             self.colorButton.setEnabled(True)
             self.shapeButton.setEnabled(True)
         else:
             self._color = QColor(100, 100, 100)
             self._shape = nwStatusShape.SQUARE
             self._setButtonIcons()
-            self.editName.setText("")
+            self.labelText.setText("")
 
-            self.editName.setEnabled(False)
+            self.labelText.setEnabled(False)
             self.colorButton.setEnabled(False)
             self.shapeButton.setEnabled(False)
         return
@@ -639,7 +639,7 @@ class _ReplacePage(NFixedPage):
         self.listBox.setIndentation(0)
         self.listBox.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.listBox.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
-        self.listBox.itemSelectionChanged.connect(self._selectionChanged)
+        self.listBox.itemSelectionChanged.connect(self._onSelectionChanged)
 
         for aKey, aVal in SHARED.project.data.autoReplace.items():
             newItem = QTreeWidgetItem(["<%s>" % aKey, aVal])
@@ -650,10 +650,10 @@ class _ReplacePage(NFixedPage):
 
         # List Controls
         self.addButton = NIconToolButton(self, iSz, "add")
-        self.addButton.clicked.connect(self._addEntry)
+        self.addButton.clicked.connect(self._onEntryCreated)
 
         self.delButton = NIconToolButton(self, iSz, "remove")
-        self.delButton.clicked.connect(self._delEntry)
+        self.delButton.clicked.connect(self._onEntryDeleted)
 
         # Edit Form
         self.editKey = QLineEdit(self)
@@ -736,7 +736,7 @@ class _ReplacePage(NFixedPage):
         return
 
     @pyqtSlot()
-    def _selectionChanged(self) -> None:
+    def _onSelectionChanged(self) -> None:
         """Extract the details from the selected item and populate the
         edit form.
         """
@@ -755,14 +755,14 @@ class _ReplacePage(NFixedPage):
         return
 
     @pyqtSlot()
-    def _addEntry(self) -> None:
+    def _onEntryCreated(self) -> None:
         """Add a new list entry."""
         key = f"<keyword{self.listBox.topLevelItemCount() + 1:d}>"
         self.listBox.addTopLevelItem(QTreeWidgetItem([key, ""]))
         return
 
     @pyqtSlot()
-    def _delEntry(self) -> None:
+    def _onEntryDeleted(self) -> None:
         """Delete the selected entry."""
         if item := self._getSelectedItem():
             self.listBox.takeTopLevelItem(self.listBox.indexOfTopLevelItem(item))

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -957,12 +957,8 @@ class GuiMain(QMainWindow):
                 docEditor = True
             elif self.docViewer.isAncestorOf(new):
                 docViewer = True
-
             self.docEditor.changeFocusState(docEditor)
             self.docViewer.changeFocusState(docViewer)
-
-            logger.debug("Main focus switched to: %s", type(new).__name__)
-
         return
 
     @pyqtSlot(bool)

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -349,7 +349,7 @@ def testDlgProjSettings_Replace(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Nothing to save or delete
     replace.listBox.clearSelection()
-    replace._delEntry()
+    replace._onEntryDeleted()
     assert replace.listBox.topLevelItemCount() == 2
 
     # Create a new entry

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -349,7 +349,6 @@ def testDlgProjSettings_Replace(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Nothing to save or delete
     replace.listBox.clearSelection()
-    replace._applyChanges()
     replace._delEntry()
     assert replace.listBox.topLevelItemCount() == 2
 
@@ -361,13 +360,8 @@ def testDlgProjSettings_Replace(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Edit the entry
     replace.listBox.setCurrentItem(replace.listBox.topLevelItem(2))
-    replace.editKey.setText("")
-    for c in "Th is ":
-        qtbot.keyClick(replace.editKey, c, delay=KEY_DELAY)
-    replace.editValue.setText("")
-    for c in "With This Stuff ":
-        qtbot.keyClick(replace.editValue, c, delay=KEY_DELAY)
-    qtbot.mouseClick(replace.applyButton, QtMouseLeft)
+    replace._onKeyEdit("Th is ")
+    replace._onValueEdit("With This Stuff ")
     assert replace.listBox.topLevelItem(2).text(0) == "<This>"  # type: ignore
     assert replace.listBox.topLevelItem(2).text(1) == "With This Stuff "  # type: ignore
 

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -198,10 +198,9 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, mockRn
         mp.setattr(QColorDialog, "getColor", lambda *a: QColor(20, 30, 40))
         status.addButton.click()
         status.listBox.setCurrentItem(status.listBox.topLevelItem(3))
-        status.editName.setText("Final")
+        status._onNameEdit("Final")
         status.colorButton.click()
         status._selectShape(nwStatusShape.CIRCLE)
-        status.applyButton.click()
         assert status.listBox.topLevelItemCount() == 4
 
     assert status.changed is True
@@ -274,10 +273,9 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, mockRn
         importance.addButton.click()
         importance.listBox.clearSelection()
         importance.listBox.setCurrentItem(importance.listBox.topLevelItem(3))
-        importance.editName.setText("Final")
+        importance._onNameEdit("Final")
         importance.colorButton.click()
         importance._selectShape(nwStatusShape.TRIANGLE)
-        importance.applyButton.click()
         assert importance.listBox.topLevelItemCount() == 4
 
     assert importance.changed is True


### PR DESCRIPTION
**Summary:**

This PR removes the "Apply" button for editing entries in Status and Importance flags, and for Auto-Replace entries. The changes are instead applied immediately.

**Related Issue(s):**

Closes #2150

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
