### PR TITLE
Add Import/export of status labels

### DIFF
--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -29,7 +29,8 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from novelwriter.common import (
-    checkBool, checkInt, checkStringNone, checkUuid, isHandle, simplified
+    checkBool, checkInt, checkStringNone, checkUuid, isHandle,
+    makeFileNameSafe, simplified
 )
 from novelwriter.core.status import NWStatus
 
@@ -100,6 +101,11 @@ class NWProjectData:
     def name(self) -> str:
         """Return the project name."""
         return self._name
+
+    @property
+    def fileSafeName(self) -> str:
+        """Return the project name in a file name safe format."""
+        return makeFileNameSafe(self._name)
 
     @property
     def author(self) -> str:

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -174,6 +174,20 @@ class NWStatus:
         """Yield entries from the status icons."""
         yield from self._store.items()
 
+    def fromRaw(self, data: list[str]) -> StatusEntry | None:
+        """Create a StatusEntry from a list of three strings consisting
+        of shape, colour, and name. This entry is not automatically
+        added to the list of entries.
+        """
+        try:
+            shape = nwStatusShape[str(data[0])]
+            color = QColor(str(data[1]))
+            icon = NWStatus.createIcon(self._height, color, shape)
+            return StatusEntry(simplified(data[2]), color, shape, icon)
+        except Exception:
+            logger.error("Could not parse entry %s", str(data))
+        return None
+
     @staticmethod
     def createIcon(height: int, color: QColor, shape: nwStatusShape) -> QIcon:
         """Generate an icon for a status label."""

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -446,7 +446,7 @@ class _StatusPage(NFixedPage):
         self.innerBox.addLayout(self.listControls, 0, 1)
         self.innerBox.addLayout(self.editBox, 1, 0)
         self.innerBox.setRowStretch(0, 1)
-        self.innerBox.setColumnStretch(1, 0)
+        self.innerBox.setColumnStretch(0, 1)
 
         self.outerBox = QVBoxLayout()
         self.outerBox.addWidget(self.pageTitle, 0)

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -96,9 +96,11 @@ class GuiWordList(NDialog):
         self.newEntry = QLineEdit(self)
 
         self.addButton = NIconToolButton(self, iSz, "add")
+        self.addButton.setToolTip(self.tr("Add Word"))
         self.addButton.clicked.connect(self._doAdd)
 
         self.delButton = NIconToolButton(self, iSz, "remove")
+        self.delButton.setToolTip(self.tr("Remove Word"))
         self.delButton.clicked.connect(self._doDelete)
 
         self.editBox = QHBoxLayout()
@@ -184,11 +186,10 @@ class GuiWordList(NDialog):
         SHARED.info(self.tr(
             "Note: The import file must be a plain text file with UTF-8 or ASCII encoding."
         ))
-        ffilter = formatFileFilter(["*.txt", "*"])
-        path, _ = QFileDialog.getOpenFileName(
-            self, self.tr("Import File"), str(CONFIG.homePath()), filter=ffilter
-        )
-        if path:
+        if path := QFileDialog.getOpenFileName(
+            self, self.tr("Import File"), str(CONFIG.homePath()),
+            filter=formatFileFilter(["*.txt", "*"]),
+        )[0]:
             try:
                 with open(path, mode="r", encoding="utf-8") as fo:
                     words = set(w.strip() for w in fo.read().split())
@@ -202,10 +203,10 @@ class GuiWordList(NDialog):
     @pyqtSlot()
     def _exportWords(self) -> None:
         """Export words to file."""
-        path, _ = QFileDialog.getSaveFileName(
-            self, self.tr("Export File"), str(CONFIG.homePath())
-        )
-        if path:
+        name = f"{SHARED.project.data.fileSafeName} - {self.windowTitle()}.txt"
+        if path := QFileDialog.getSaveFileName(
+            self, self.tr("Export File"), str(CONFIG.homePath() / name),
+        )[0]:
             try:
                 path = Path(path).with_suffix(".txt")
                 with open(path, mode="w", encoding="utf-8") as fo:

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -41,7 +41,7 @@ from PyQt5.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import checkInt, formatFileFilter, makeFileNameSafe
+from novelwriter.common import checkInt, formatFileFilter
 from novelwriter.constants import nwKeyWords, nwLabels, nwStats, nwStyles, trConst
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass, nwItemLayout, nwItemType, nwOutline
 from novelwriter.error import logException
@@ -541,11 +541,10 @@ class GuiOutlineTree(QTreeWidget):
     @pyqtSlot()
     def exportOutline(self) -> None:
         """Export the outline as a CSV file."""
-        path = CONFIG.lastPath("outline") / f"{makeFileNameSafe(SHARED.project.data.name)}.csv"
-        path, _ = QFileDialog.getSaveFileName(
-            self, self.tr("Save Outline As"), str(path), formatFileFilter(["*.csv", "*"])
-        )
-        if path:
+        name = CONFIG.lastPath("outline") / f"{SHARED.project.data.fileSafeName}.csv"
+        if path := QFileDialog.getSaveFileName(
+            self, self.tr("Save Outline As"), str(name), formatFileFilter(["*.csv", "*"])
+        )[0]:
             CONFIG.setLastPath("outline", path)
             logger.info("Writing CSV file: %s", path)
             cols = [col for col in self._treeOrder if not self._colHidden[col]]

--- a/tests/test_core/test_core_status.py
+++ b/tests/test_core/test_core_status.py
@@ -303,6 +303,20 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
     assert list(nStatus._store.keys()) == [statusKeys[3], statusKeys[2]]
     assert nStatus._default == statusKeys[3]
 
+    # Create
+    # ======
+
+    # A valid entry
+    entry = nStatus.fromRaw(["STAR", "#ff7f00", "Test"])
+    assert entry is not None
+    assert entry.shape == nwStatusShape.STAR
+    assert entry.color == QColor(255, 127, 0)
+    assert entry.name == "Test"
+
+    # Invalid entries
+    assert nStatus.fromRaw(["STAR", "#ff7f00"]) is None
+    assert nStatus.fromRaw(["STUFF", "#ff7f00", "Test"]) is None
+
 
 @pytest.mark.core
 def testCoreStatus_Pack(mockGUI, mockRnd):

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -348,12 +348,12 @@ def testDlgProjSettings_StatusImportExport(qtbot, monkeypatch, nwGUI, projPath, 
         status._exportLabels()
 
     assert expFile.is_file() is True
-    assert expFile.read_text() == (
-        "SQUARE,#646464,New\n"
-        "SQUARE,#c83200,Note\n"
-        "SQUARE,#c89600,Draft\n"
-        "SQUARE,#32c800,Finished\n"
-    )
+    assert expFile.read_text().split() == [
+        "SQUARE,#646464,New",
+        "SQUARE,#c83200,Note",
+        "SQUARE,#c89600,Draft",
+        "SQUARE,#32c800,Finished",
+    ]
 
     # Import Error
     with monkeypatch.context() as mp:


### PR DESCRIPTION
**Summary:**

This PR adds import and export functionality to status and importance labels in Project Settings. The file format is a simple CSV file with shape, colour and label text.

**Related Issue(s):**

Closes #1847

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
