### PR TITLE
Make sure imported status labels are saved

### DIFF
--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -570,6 +570,7 @@ class _StatusPage(NFixedPage):
                     for row in csv.reader(fo):
                         if entry := self._store.fromRaw(row):
                             self._addItem(None, entry)
+                            self._changed = True
             except Exception as exc:
                 SHARED.error("Could not read file.", exc=exc)
                 return

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -362,6 +362,7 @@ def testDlgProjSettings_StatusImportExport(qtbot, monkeypatch, nwGUI, projPath, 
         status._importLabels()
 
     assert status.listBox.topLevelItemCount() == 4
+    assert status.changed is False
 
     # Import File
     with monkeypatch.context() as mp:
@@ -369,6 +370,7 @@ def testDlgProjSettings_StatusImportExport(qtbot, monkeypatch, nwGUI, projPath, 
         status._importLabels()
 
     assert status.listBox.topLevelItemCount() == 8
+    assert status.changed is True
 
     item4 = status.listBox.topLevelItem(4)
     assert item4 is not None


### PR DESCRIPTION
**Summary:**

This PR fixes an issue where the changed flag was net set at import, so the changes were ignored when clicking "Save".

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
