### PR TITLE
Update copyright

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-09-22 [0.0.1]  main
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-09-22 [0.0.1]  main
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -6,7 +6,7 @@ File History:
 Created: 2019-05-12 [0.1.0]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -6,7 +6,7 @@ File History:
 Created: 2019-05-12 [0.1.0]
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -8,7 +8,7 @@ Created: 2022-11-09 [2.0rc2] RecentProjects
 Created: 2024-06-16 [2.5rc1] RecentPaths
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -8,7 +8,7 @@ Created: 2022-11-09 [2.0rc2] RecentProjects
 Created: 2024-06-16 [2.5rc1] RecentPaths
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -6,7 +6,8 @@ File History:
 Created: 2019-04-28 [0.0.1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -6,8 +6,7 @@ File History:
 Created: 2019-04-28 [0.0.1]
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -7,7 +7,7 @@ Created: 2023-02-14 [2.1b1] BuildSettings
 Created: 2023-05-22 [2.1b1] BuildCollection
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -7,7 +7,7 @@ Created: 2023-02-14 [2.1b1] BuildSettings
 Created: 2023-05-22 [2.1b1] BuildCollection
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -9,7 +9,7 @@ Created: 2022-11-03 [2.0rc2] ProjectBuilder
 Created: 2023-07-20 [2.1b1]  DocDuplicator
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -9,7 +9,7 @@ Created: 2022-11-03 [2.0rc2] ProjectBuilder
 Created: 2023-07-20 [2.1b1]  DocDuplicator
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-12-01 [2.1b1] NWBuildDocument
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-12-01 [2.1b1] NWBuildDocument
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-09-29 [0.0.1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-09-29 [0.0.1]
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -10,7 +10,7 @@ Created: 2022-05-29 [2.0rc1] TagsIndex
 Created: 2022-05-29 [2.0rc1] ItemIndex
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -10,7 +10,7 @@ Created: 2022-05-29 [2.0rc1] TagsIndex
 Created: 2022-05-29 [2.0rc1] ItemIndex
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-10-27 [0.0.1] NWItem
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-10-27 [0.0.1] NWItem
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -7,7 +7,7 @@ Created: 2024-11-16 [2.6b2] ProjectNode
 Created: 2024-11-16 [2.6b2] ProjectModel
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -7,7 +7,7 @@ Created: 2024-11-16 [2.6b2] ProjectNode
 Created: 2024-11-16 [2.6b2] ProjectModel
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -7,7 +7,7 @@ Created:   2019-10-21 [0.3.1] OptionState
 Rewritten: 2020-02-19 [0.4.5] OptionState
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -7,7 +7,7 @@ Created:   2019-10-21 [0.3.1] OptionState
 Rewritten: 2020-02-19 [0.4.5] OptionState
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -6,7 +6,8 @@ File History:
 Created: 2018-09-29 [0.0.1] NWProject
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -6,8 +6,7 @@ File History:
 Created: 2018-09-29 [0.0.1] NWProject
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-10-30 [2.0rc2] NWProjectData
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-10-30 [2.0rc2] NWProjectData
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -8,7 +8,7 @@ Created: 2022-09-28 [2.0rc2] ProjectXMLReader
 Created: 2022-10-31 [2.0rc2] ProjectXMLWriter
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -8,7 +8,7 @@ Created: 2022-09-28 [2.0rc2] ProjectXMLReader
 Created: 2022-10-31 [2.0rc2] ProjectXMLWriter
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-06-11 [2.1b1] NWSessionLog
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-06-11 [2.1b1] NWSessionLog
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -7,7 +7,7 @@ Created: 2019-06-11 [0.1.5] NWSpellEnchant
 Created: 2023-06-13 [2.1b1] UserDictionary
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -7,7 +7,7 @@ Created: 2019-06-11 [0.1.5] NWSpellEnchant
 Created: 2023-06-13 [2.1b1] UserDictionary
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -7,7 +7,7 @@ Created:   2019-05-19 [0.1.3] NWStatus
 Rewritten: 2022-04-05 [2.0b1] NWStatus
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -7,7 +7,7 @@ Created:   2019-05-19 [0.1.3] NWStatus
 Rewritten: 2022-04-05 [2.0b1] NWStatus
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-11-01 [2.0rc2] NWStorage
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-11-01 [2.0rc2] NWStorage
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -7,7 +7,7 @@ Created:   2020-05-07 [0.4.5] NWTree
 Rewritten: 2024-11-16 [2.6b2] NWTree
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -7,7 +7,7 @@ Created:   2020-05-07 [0.4.5] NWTree
 Rewritten: 2024-11-16 [2.6b2] NWTree
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -6,8 +6,7 @@ File History:
 Created: 2020-05-21 [0.5.2] GuiAbout
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -6,7 +6,8 @@ File History:
 Created: 2020-05-21 [0.5.2] GuiAbout
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -7,7 +7,8 @@ Created:   2020-01-23 [0.4.3]  GuiDocMerge
 Rewritten: 2022-10-06 [2.0rc1] GuiDocMerge
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/docmerge.py
+++ b/novelwriter/dialogs/docmerge.py
@@ -7,8 +7,7 @@ Created:   2020-01-23 [0.4.3]  GuiDocMerge
 Rewritten: 2022-10-06 [2.0rc1] GuiDocMerge
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -7,8 +7,7 @@ Created:   2020-02-01 [0.4.3]  GuiDocSplit
 Rewritten: 2022-10-12 [2.0rc1] GuiDocSplit
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/docsplit.py
+++ b/novelwriter/dialogs/docsplit.py
@@ -7,7 +7,8 @@ Created:   2020-02-01 [0.4.3]  GuiDocSplit
 Rewritten: 2022-10-12 [2.0rc1] GuiDocSplit
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/editlabel.py
+++ b/novelwriter/dialogs/editlabel.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-06-11 [2.0rc1] GuiEditLabel
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/editlabel.py
+++ b/novelwriter/dialogs/editlabel.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-06-11 [2.0rc1] GuiEditLabel
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -7,8 +7,7 @@ Created:   2019-06-10 [0.1.5] GuiPreferences
 Rewritten: 2024-01-08 [2.3b1] GuiPreferences
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -7,7 +7,8 @@ Created:   2019-06-10 [0.1.5] GuiPreferences
 Rewritten: 2024-01-08 [2.3b1] GuiPreferences
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -7,7 +7,8 @@ Created:   2018-09-29 [0.0.1] GuiProjectSettings
 Rewritten: 2024-01-26 [2.3b1] GuiProjectSettings
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -7,8 +7,7 @@ Created:   2018-09-29 [0.0.1] GuiProjectSettings
 Rewritten: 2024-01-26 [2.3b1] GuiProjectSettings
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/quotes.py
+++ b/novelwriter/dialogs/quotes.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-06-18 [0.9.0] GuiQuoteSelect
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/quotes.py
+++ b/novelwriter/dialogs/quotes.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-06-18 [0.9.0] GuiQuoteSelect
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -6,7 +6,7 @@ File History:
 Created: 2021-02-12 [1.2rc1] GuiWordList
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -6,7 +6,7 @@ File History:
 Created: 2021-02-12 [1.2rc1] GuiWordList
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-11-02 [0.0.1]
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -6,7 +6,7 @@ File History:
 Created: 2018-11-02 [0.0.1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-08-02 [0.10.2]
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-08-02 [0.10.2]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -10,7 +10,7 @@ Created: 2024-01-26 [2.3b1] NFixedPage
 Created: 2024-03-12 [2.4b1] NWrappedWidgetBox
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -10,7 +10,7 @@ Created: 2024-01-26 [2.3b1] NFixedPage
 Created: 2024-03-12 [2.4b1] NWrappedWidgetBox
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/eventfilters.py
+++ b/novelwriter/extensions/eventfilters.py
@@ -7,7 +7,7 @@ Created: 2023-08-31 [2.1rc1] WheelEventFilter
 Created: 2023-11-28 [2.2]    StatusTipFilter
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/eventfilters.py
+++ b/novelwriter/extensions/eventfilters.py
@@ -7,7 +7,7 @@ Created: 2023-08-31 [2.1rc1] WheelEventFilter
 Created: 2023-11-28 [2.2]    StatusTipFilter
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -10,7 +10,7 @@ Created: 2024-05-01 [2.5b1] NToolDialog
 Created: 2024-05-01 [2.5b1] NNonBlockingDialog
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -10,7 +10,7 @@ Created: 2024-05-01 [2.5b1] NToolDialog
 Created: 2024-05-01 [2.5b1] NNonBlockingDialog
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/novelselector.py
+++ b/novelwriter/extensions/novelselector.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-11-17 [2.0] NovelSelector
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/novelselector.py
+++ b/novelwriter/extensions/novelselector.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-11-17 [2.0] NovelSelector
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/pagedsidebar.py
+++ b/novelwriter/extensions/pagedsidebar.py
@@ -8,7 +8,7 @@ Created: 2023-02-21 [2.1b1] NPagedToolButton
 Created: 2023-02-21 [2.1b1] NPagedToolLabel
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/pagedsidebar.py
+++ b/novelwriter/extensions/pagedsidebar.py
@@ -8,7 +8,7 @@ Created: 2023-02-21 [2.1b1] NPagedToolButton
 Created: 2023-02-21 [2.1b1] NPagedToolLabel
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/progressbars.py
+++ b/novelwriter/extensions/progressbars.py
@@ -7,7 +7,7 @@ Created: 2023-06-07 [2.1b1] NProgressCircle
 Created: 2023-06-09 [2.1b1] NProgressSimple
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/progressbars.py
+++ b/novelwriter/extensions/progressbars.py
@@ -7,7 +7,7 @@ Created: 2023-06-07 [2.1b1] NProgressCircle
 Created: 2023-06-09 [2.1b1] NProgressSimple
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/statusled.py
+++ b/novelwriter/extensions/statusled.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-05-17 [0.5.1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/statusled.py
+++ b/novelwriter/extensions/statusled.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-05-17 [0.5.1]
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/switch.py
+++ b/novelwriter/extensions/switch.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-05-03 [0.4.5]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/switch.py
+++ b/novelwriter/extensions/switch.py
@@ -6,7 +6,7 @@ File History:
 Created: 2020-05-03 [0.4.5]
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/switchbox.py
+++ b/novelwriter/extensions/switchbox.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-04-16 [2.1b1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/switchbox.py
+++ b/novelwriter/extensions/switchbox.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-04-16 [2.1b1]
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/versioninfo.py
+++ b/novelwriter/extensions/versioninfo.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-02-14 [2.3b1] VersionInfoWidget
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/extensions/versioninfo.py
+++ b/novelwriter/extensions/versioninfo.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-02-14 [2.3b1] VersionInfoWidget
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/shared.py
+++ b/novelwriter/formats/shared.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-10-21 [2.6b1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/shared.py
+++ b/novelwriter/formats/shared.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-10-21 [2.6b1]
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/todocx.py
+++ b/novelwriter/formats/todocx.py
@@ -7,7 +7,7 @@ Created: 2024-10-18 [2.6b1] ToDocX
 Created: 2024-10-18 [2.6b1] DocXParagraph
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/todocx.py
+++ b/novelwriter/formats/todocx.py
@@ -7,7 +7,7 @@ Created: 2024-10-18 [2.6b1] ToDocX
 Created: 2024-10-18 [2.6b1] DocXParagraph
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/tohtml.py
+++ b/novelwriter/formats/tohtml.py
@@ -6,7 +6,7 @@ File History:
 Created: 2019-05-07 [0.0.1] ToHtml
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/tohtml.py
+++ b/novelwriter/formats/tohtml.py
@@ -6,7 +6,7 @@ File History:
 Created: 2019-05-07 [0.0.1] ToHtml
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -7,7 +7,7 @@ Created: 2019-05-05 [0.0.1] Tokenizer
 Created: 2023-05-23 [2.1b1] HeadingFormatter
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -7,7 +7,7 @@ Created: 2019-05-05 [0.0.1] Tokenizer
 Created: 2023-05-23 [2.1b1] HeadingFormatter
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/tomarkdown.py
+++ b/novelwriter/formats/tomarkdown.py
@@ -6,7 +6,7 @@ File History:
 Created: 2021-02-06 [1.2b1] ToMarkdown
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/tomarkdown.py
+++ b/novelwriter/formats/tomarkdown.py
@@ -6,7 +6,7 @@ File History:
 Created: 2021-02-06 [1.2b1] ToMarkdown
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/toodt.py
+++ b/novelwriter/formats/toodt.py
@@ -9,7 +9,7 @@ Created: 2021-01-27 [1.2b1] ODTTextStyle
 Created: 2021-08-14 [1.5b1] XMLParagraph
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/toodt.py
+++ b/novelwriter/formats/toodt.py
@@ -9,7 +9,7 @@ Created: 2021-01-27 [1.2b1] ODTTextStyle
 Created: 2021-08-14 [1.5b1] XMLParagraph
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-05-21 [2.5b1] ToQTextDocument
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-05-21 [2.5b1] ToQTextDocument
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-05-21 [2.5b1] ToQTextDocument
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/toraw.py
+++ b/novelwriter/formats/toraw.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-10-15 [2.6b1] ToRaw
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/formats/toraw.py
+++ b/novelwriter/formats/toraw.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-10-15 [2.6b1] ToRaw
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -14,7 +14,8 @@ Created:   2023-11-06 [2.2b1] MetaCompleter
 Created:   2023-11-07 [2.2b1] GuiDocToolBar
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -14,8 +14,7 @@ Created:   2023-11-06 [2.2b1] MetaCompleter
 Created:   2023-11-07 [2.2b1] GuiDocToolBar
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -7,7 +7,7 @@ Created: 2019-04-06 [0.0.1] GuiDocHighlighter
 Created: 2023-09-10 [2.2b1] TextBlockData
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -7,7 +7,7 @@ Created: 2019-04-06 [0.0.1] GuiDocHighlighter
 Created: 2023-09-10 [2.2b1] TextBlockData
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -9,7 +9,8 @@ Created: 2020-06-09 [0.8]   GuiDocViewFooter
 Created: 2020-09-08 [1.0b1] GuiDocViewHistory
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -9,8 +9,7 @@ Created: 2020-06-09 [0.8]   GuiDocViewFooter
 Created: 2020-09-08 [1.0b1] GuiDocViewHistory
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/docviewerpanel.py
+++ b/novelwriter/gui/docviewerpanel.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-11-14 [2.2rc1] GuiDocViewerPanel
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/docviewerpanel.py
+++ b/novelwriter/gui/docviewerpanel.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-11-14 [2.2rc1] GuiDocViewerPanel
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-09-07 [2.2b1] GuiTextDocument
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-09-07 [2.2b1] GuiTextDocument
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-09-07 [2.2b1] GuiTextDocument
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -6,7 +6,8 @@ File History:
 Created: 2019-04-24 [0.0.1] GuiItemDetails
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -6,8 +6,7 @@ File History:
 Created: 2019-04-24 [0.0.1] GuiItemDetails
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -6,7 +6,8 @@ File History:
 Created: 2019-04-27 [0.0.1] GuiMainMenu
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -6,8 +6,7 @@ File History:
 Created: 2019-04-27 [0.0.1] GuiMainMenu
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -8,7 +8,7 @@ Created: 2022-06-12 [2.0rc1] GuiNovelView
 Created: 2022-06-12 [2.0rc1] GuiNovelToolBar
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -8,7 +8,7 @@ Created: 2022-06-12 [2.0rc1] GuiNovelView
 Created: 2022-06-12 [2.0rc1] GuiNovelToolBar
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -10,7 +10,7 @@ Created: 2019-11-16 [0.4.1]  GuiOutlineHeaderMenu
 Created: 2020-06-02 [0.7]    GuiOutlineDetails
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -10,7 +10,7 @@ Created: 2019-11-16 [0.4.1]  GuiOutlineHeaderMenu
 Created: 2020-06-02 [0.7]    GuiOutlineDetails
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -11,7 +11,8 @@ Rewritten: 2024-11-17 [2.6b2]  GuiProjectTree
 Rewritten: 2024-11-20 [2.6b2]  _TreeContextMenu
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -11,8 +11,7 @@ Rewritten: 2024-11-17 [2.6b2]  GuiProjectTree
 Rewritten: 2024-11-20 [2.6b2]  _TreeContextMenu
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-03-21 [2.4b1]  GuiProjectSearch
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-03-21 [2.4b1]  GuiProjectSearch
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-03-21 [2.4b1]  GuiProjectSearch
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-05-10 [2.0rc1] GuiSideBar
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-05-10 [2.0rc1] GuiSideBar
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -6,7 +6,7 @@ File History:
 Created: 2019-04-20 [0.0.1] GuiMainStatus
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -6,7 +6,7 @@ File History:
 Created: 2019-04-20 [0.0.1] GuiMainStatus
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -7,7 +7,7 @@ Created: 2019-05-18 [0.1.3] GuiTheme
 Created: 2019-11-08 [0.4]   GuiIcons
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -7,7 +7,7 @@ Created: 2019-05-18 [0.1.3] GuiTheme
 Created: 2019-11-08 [0.4]   GuiIcons
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -6,8 +6,7 @@ File History:
 Created: 2018-09-22 [0.0.1] GuiMain
 
 This file is a part of novelWriter
-Copyright (C) 2018 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -6,7 +6,8 @@ File History:
 Created: 2018-09-22 [0.0.1] GuiMain
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2018 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -7,7 +7,7 @@ Created: 2023-08-10 [2.1rc1] SharedData
 Created: 2023-08-14 [2.1rc1] _GuiAlert
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -7,7 +7,7 @@ Created: 2023-08-10 [2.1rc1] SharedData
 Created: 2023-08-14 [2.1rc1] _GuiAlert
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/text/counting.py
+++ b/novelwriter/text/counting.py
@@ -8,7 +8,7 @@ Rewritten: 2024-02-27 [2.4b1] preProcessText, standardCounter
 Created:   2024-02-27 [2.4b1] bodyTextCounter
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/text/counting.py
+++ b/novelwriter/text/counting.py
@@ -8,7 +8,7 @@ Rewritten: 2024-02-27 [2.4b1] preProcessText, standardCounter
 Created:   2024-02-27 [2.4b1] bodyTextCounter
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -7,7 +7,7 @@ Created: 2024-06-01 [2.5rc1] RegExPatterns
 Created: 2024-11-04 [2.6b1]  DialogParser
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -7,7 +7,7 @@ Created: 2024-06-01 [2.5rc1] RegExPatterns
 Created: 2024-11-04 [2.6b1]  DialogParser
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-11-19 [2.2rc1] GuiDictionaries
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-11-19 [2.2rc1] GuiDictionaries
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-04-02 [2.0rc1] GuiLipsum
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/lipsum.py
+++ b/novelwriter/tools/lipsum.py
@@ -6,7 +6,7 @@ File History:
 Created: 2022-04-02 [2.0rc1] GuiLipsum
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-05-24 [2.1b1] GuiManuscriptBuild
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-05-24 [2.1b1] GuiManuscriptBuild
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-05-13 [2.1b1] GuiManuscript
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-05-13 [2.1b1] GuiManuscript
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-02-13 [2.1b1] GuiBuildSettings
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-02-13 [2.1b1] GuiBuildSettings
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-01-18 [2.3b1] GuiNovelDetails
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-01-18 [2.3b1] GuiNovelDetails
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-12-14 [2.3b1] GuiWelcome
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -6,7 +6,7 @@ File History:
 Created: 2023-12-14 [2.3b1] GuiWelcome
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -6,8 +6,7 @@ File History:
 Created: 2019-10-20 [0.3.0] GuiWritingStats
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -6,7 +6,8 @@ File History:
 Created: 2019-10-20 [0.3.0] GuiWritingStats
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-04-01 [2.4rc1]
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -6,7 +6,7 @@ File History:
 Created: 2024-04-01 [2.4rc1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/pkgutils.py
+++ b/pkgutils.py
@@ -8,7 +8,9 @@ Created: 2019-05-16 [0.5.1]
 Renamed: 2023-07-26 [2.1b1]
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2021 Bruno Meneguello
+Copyright (C) 2023 Rachel Powers
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/pkgutils.py
+++ b/pkgutils.py
@@ -8,9 +8,7 @@ Created: 2019-05-16 [0.5.1]
 Renamed: 2023-07-26 [2.1b1]
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
-Copyright (C) 2021 Bruno Meneguello
-Copyright (C) 2023 Rachel Powers
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/setup/debian/copyright
+++ b/setup/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: Veronica Berglyd Olsen <code@vkbo.net>
 Source: https://github.com/vkbo/novelWriter
 
 Files: *
-Copyright: 2018-2024, Veronica Berglyd Olsen
+Copyright: 2018-2025, Veronica Berglyd Olsen
 License: GPL-3.0-or-later
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/setup/iss_license.txt
+++ b/setup/iss_license.txt
@@ -1,6 +1,6 @@
 novelWriter License
 
-Copyright (C) 2018-2024  Veronica Berglyd Olsen
+Copyright (C) 2018-2025  Veronica Berglyd Olsen
 License: GPL v3+ <https://www.gnu.org/licenses/gpl-3.0.html>
 
 This program is free software: you can redistribute it and/or modify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ novelWriter – Test Suite Configuration
 ======================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ novelWriter – Test Suite Configuration
 ======================================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/mocked.py
+++ b/tests/mocked.py
@@ -3,7 +3,7 @@ novelWriter – Test Suite Mocked Classes
 =======================================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/mocked.py
+++ b/tests/mocked.py
@@ -3,7 +3,7 @@ novelWriter – Test Suite Mocked Classes
 =======================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -3,7 +3,7 @@ novelWriter – Common Functions Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -3,7 +3,7 @@ novelWriter – Common Functions Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -3,7 +3,7 @@ novelWriter – Config Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -3,7 +3,7 @@ novelWriter – Config Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_error.py
+++ b/tests/test_base/test_base_error.py
@@ -3,7 +3,7 @@ novelWriter – Error Handler Tester
 ==================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_error.py
+++ b/tests/test_base/test_base_error.py
@@ -3,7 +3,7 @@ novelWriter – Error Handler Tester
 ==================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_init.py
+++ b/tests/test_base/test_base_init.py
@@ -3,7 +3,7 @@ novelWriter – Main Init Tester
 ==============================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_init.py
+++ b/tests/test_base/test_base_init.py
@@ -3,7 +3,7 @@ novelWriter – Main Init Tester
 ==============================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_shared.py
+++ b/tests/test_base/test_base_shared.py
@@ -3,7 +3,7 @@ novelWriter – SharedData Class Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_base/test_base_shared.py
+++ b/tests/test_base/test_base_shared.py
@@ -3,7 +3,7 @@ novelWriter – SharedData Class Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_buildsettings.py
+++ b/tests/test_core/test_core_buildsettings.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Build Settings Tester
 ==============================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_buildsettings.py
+++ b/tests/test_core/test_core_buildsettings.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Build Settings Tester
 ==============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -3,7 +3,7 @@ novelWriter – Project Document Tools Tester
 ===========================================
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_coretools.py
+++ b/tests/test_core/test_core_coretools.py
@@ -3,7 +3,7 @@ novelWriter – Project Document Tools Tester
 ===========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_docbuild.py
+++ b/tests/test_core/test_core_docbuild.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Builder Class Tests
 ============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_docbuild.py
+++ b/tests/test_core/test_core_docbuild.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Builder Class Tests
 ============================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_document.py
+++ b/tests/test_core/test_core_document.py
@@ -3,7 +3,7 @@ novelWriter – NWDocument Class Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_document.py
+++ b/tests/test_core/test_core_document.py
@@ -3,7 +3,7 @@ novelWriter – NWDocument Class Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -3,7 +3,7 @@ novelWriter – NWIndex Class Tester
 ==================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -3,7 +3,7 @@ novelWriter – NWIndex Class Tester
 ==================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_item.py
+++ b/tests/test_core/test_core_item.py
@@ -3,7 +3,7 @@ novelWriter – NWItem Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_item.py
+++ b/tests/test_core/test_core_item.py
@@ -3,7 +3,7 @@ novelWriter – NWItem Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_itemmodel.py
+++ b/tests/test_core/test_core_itemmodel.py
@@ -3,7 +3,7 @@ novelWriter – Item Model Tester
 ===============================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_itemmodel.py
+++ b/tests/test_core/test_core_itemmodel.py
@@ -3,7 +3,7 @@ novelWriter – Item Model Tester
 ===============================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_options.py
+++ b/tests/test_core/test_core_options.py
@@ -3,7 +3,7 @@ novelWriter – OptionState Class Tester
 ======================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_options.py
+++ b/tests/test_core/test_core_options.py
@@ -3,7 +3,7 @@ novelWriter – OptionState Class Tester
 ======================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -3,7 +3,7 @@ novelWriter – NWProject Class Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -3,7 +3,7 @@ novelWriter – NWProject Class Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -3,7 +3,7 @@ novelWriter – ProjectXMLReader/Writer Class Tester
 ==================================================
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -3,7 +3,7 @@ novelWriter – ProjectXMLReader/Writer Class Tester
 ==================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_sessions.py
+++ b/tests/test_core/test_core_sessions.py
@@ -3,7 +3,7 @@ novelWriter – NWSessionLog Class Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_sessions.py
+++ b/tests/test_core/test_core_sessions.py
@@ -3,7 +3,7 @@ novelWriter – NWSessionLog Class Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_spellcheck.py
+++ b/tests/test_core/test_core_spellcheck.py
@@ -3,7 +3,7 @@ novelWriter – Spell Check Classes Tester
 ========================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_spellcheck.py
+++ b/tests/test_core/test_core_spellcheck.py
@@ -3,7 +3,7 @@ novelWriter – Spell Check Classes Tester
 ========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_status.py
+++ b/tests/test_core/test_core_status.py
@@ -3,7 +3,7 @@ novelWriter – NWStatus Class Tester
 ===================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_status.py
+++ b/tests/test_core/test_core_status.py
@@ -3,7 +3,7 @@ novelWriter – NWStatus Class Tester
 ===================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_status.py
+++ b/tests/test_core/test_core_status.py
@@ -3,7 +3,7 @@ novelWriter – NWStatus Class Tester
 ===================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -3,7 +3,7 @@ novelWriter – NWStorage Class Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -3,7 +3,7 @@ novelWriter – NWStorage Class Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -3,7 +3,7 @@ novelWriter – NWStorage Class Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -3,7 +3,7 @@ novelWriter – NWTree Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -3,7 +3,7 @@ novelWriter – NWTree Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_about.py
+++ b/tests/test_dialogs/test_dlg_about.py
@@ -3,7 +3,7 @@ novelWriter – About Dialog Class Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_about.py
+++ b/tests/test_dialogs/test_dlg_about.py
@@ -3,7 +3,7 @@ novelWriter – About Dialog Class Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_about.py
+++ b/tests/test_dialogs/test_dlg_about.py
@@ -3,7 +3,7 @@ novelWriter – About Dialog Class Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_dialogs.py
+++ b/tests/test_dialogs/test_dlg_dialogs.py
@@ -3,7 +3,7 @@ novelWriter – Other Dialog Classes Tester
 =========================================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_dialogs.py
+++ b/tests/test_dialogs/test_dlg_dialogs.py
@@ -3,7 +3,7 @@ novelWriter – Other Dialog Classes Tester
 =========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_docmerge.py
+++ b/tests/test_dialogs/test_dlg_docmerge.py
@@ -3,7 +3,7 @@ novelWriter – Merge and Split Dialog Classes Tester
 ===================================================
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_docmerge.py
+++ b/tests/test_dialogs/test_dlg_docmerge.py
@@ -3,7 +3,7 @@ novelWriter – Merge and Split Dialog Classes Tester
 ===================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_docsplit.py
+++ b/tests/test_dialogs/test_dlg_docsplit.py
@@ -3,7 +3,7 @@ novelWriter – Merge and Split Dialog Classes Tester
 ===================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_docsplit.py
+++ b/tests/test_dialogs/test_dlg_docsplit.py
@@ -3,7 +3,7 @@ novelWriter – Merge and Split Dialog Classes Tester
 ===================================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_docsplit.py
+++ b/tests/test_dialogs/test_dlg_docsplit.py
@@ -3,7 +3,7 @@ novelWriter – Merge and Split Dialog Classes Tester
 ===================================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -3,7 +3,7 @@ novelWriter – Preferences Dialog Class Tester
 =============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -3,7 +3,7 @@ novelWriter – Preferences Dialog Class Tester
 =============================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -3,7 +3,7 @@ novelWriter – Project Settings Dialog Class Tester
 ==================================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -3,7 +3,7 @@ novelWriter – Project Settings Dialog Class Tester
 ==================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_wordlist.py
+++ b/tests/test_dialogs/test_dlg_wordlist.py
@@ -3,7 +3,7 @@ novelWriter – Other Dialog Classes Tester
 =========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_dialogs/test_dlg_wordlist.py
+++ b/tests/test_dialogs/test_dlg_wordlist.py
@@ -3,7 +3,7 @@ novelWriter – Other Dialog Classes Tester
 =========================================
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_eventfilters.py
+++ b/tests/test_ext/test_ext_eventfilters.py
@@ -3,7 +3,7 @@ novelWriter – Wheel Event Filter Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_eventfilters.py
+++ b/tests/test_ext/test_ext_eventfilters.py
@@ -3,7 +3,7 @@ novelWriter – Wheel Event Filter Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_modified.py
+++ b/tests/test_ext/test_ext_modified.py
@@ -3,7 +3,7 @@ novelWriter – Modified Widgets Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_modified.py
+++ b/tests/test_ext/test_ext_modified.py
@@ -3,7 +3,7 @@ novelWriter – Modified Widgets Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_progressbars.py
+++ b/tests/test_ext/test_ext_progressbars.py
@@ -3,7 +3,7 @@ novelWriter – Progress Bar Tester
 =================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_progressbars.py
+++ b/tests/test_ext/test_ext_progressbars.py
@@ -3,7 +3,7 @@ novelWriter – Progress Bar Tester
 =================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_switch.py
+++ b/tests/test_ext/test_ext_switch.py
@@ -3,7 +3,7 @@ novelWriter – Switch Tester
 ===========================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_switch.py
+++ b/tests/test_ext/test_ext_switch.py
@@ -3,7 +3,7 @@ novelWriter – Switch Tester
 ===========================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_versioninfo.py
+++ b/tests/test_ext/test_ext_versioninfo.py
@@ -3,7 +3,7 @@ novelWriter – Version Info Widget Tester
 ========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_ext/test_ext_versioninfo.py
+++ b/tests/test_ext/test_ext_versioninfo.py
@@ -3,7 +3,7 @@ novelWriter – Version Info Widget Tester
 ========================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_todocx.py
+++ b/tests/test_formats/test_fmt_todocx.py
@@ -3,7 +3,7 @@ novelWriter – ToDocX Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_todocx.py
+++ b/tests/test_formats/test_fmt_todocx.py
@@ -3,7 +3,7 @@ novelWriter – ToDocX Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_tohtml.py
+++ b/tests/test_formats/test_fmt_tohtml.py
@@ -3,7 +3,7 @@ novelWriter – ToHtml Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_tohtml.py
+++ b/tests/test_formats/test_fmt_tohtml.py
@@ -3,7 +3,7 @@ novelWriter – ToHtml Class Tester
 =================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -3,7 +3,7 @@ novelWriter – Tokenizer Class Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -3,7 +3,7 @@ novelWriter – Tokenizer Class Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_tomarkdown.py
+++ b/tests/test_formats/test_fmt_tomarkdown.py
@@ -3,7 +3,7 @@ novelWriter – ToMd Class Tester
 ===============================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_tomarkdown.py
+++ b/tests/test_formats/test_fmt_tomarkdown.py
@@ -3,7 +3,7 @@ novelWriter – ToMd Class Tester
 ===============================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_tomarkdown.py
+++ b/tests/test_formats/test_fmt_tomarkdown.py
@@ -3,7 +3,7 @@ novelWriter – ToMd Class Tester
 ===============================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_toodt.py
+++ b/tests/test_formats/test_fmt_toodt.py
@@ -3,7 +3,7 @@ novelWriter – ToOdt Class Tester
 ================================
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_toodt.py
+++ b/tests/test_formats/test_fmt_toodt.py
@@ -3,7 +3,7 @@ novelWriter – ToOdt Class Tester
 ================================
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_toodt.py
+++ b/tests/test_formats/test_fmt_toodt.py
@@ -3,7 +3,7 @@ novelWriter – ToOdt Class Tester
 ================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_toqdoc.py
+++ b/tests/test_formats/test_fmt_toqdoc.py
@@ -3,7 +3,7 @@ novelWriter – ToQTextDocument Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_formats/test_fmt_toqdoc.py
+++ b/tests/test_formats/test_fmt_toqdoc.py
@@ -3,7 +3,7 @@ novelWriter – ToQTextDocument Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Editor Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Editor Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Editor Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Viewer Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Viewer Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_docviewerpanel.py
+++ b/tests/test_gui/test_gui_docviewerpanel.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Viewer Panel Class Tester
 ================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_docviewerpanel.py
+++ b/tests/test_gui/test_gui_docviewerpanel.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Viewer Panel Class Tester
 ================================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Editor Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Editor Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_i18n.py
+++ b/tests/test_gui/test_gui_i18n.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI i18n Tests
 =================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_i18n.py
+++ b/tests/test_gui/test_gui_i18n.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI i18n Tests
 =================================
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Main Menu Class Tester
 =============================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_mainmenu.py
+++ b/tests/test_gui/test_gui_mainmenu.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Main Menu Class Tester
 =============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Novel Tree Class Tester
 ==============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Novel Tree Class Tester
 ==============================================
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Outline Class Tester
 ===========================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_outline.py
+++ b/tests/test_gui/test_gui_outline.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Outline Class Tester
 ===========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Project Tree Class Tester
 ================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Project Tree Class Tester
 ================================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_search.py
+++ b/tests/test_gui/test_gui_search.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Project Search Tester
 ============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_search.py
+++ b/tests/test_gui/test_gui_search.py
@@ -3,7 +3,7 @@ novelWriter – Main GUI Project Search Tester
 ============================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_statusbar.py
+++ b/tests/test_gui/test_gui_statusbar.py
@@ -3,7 +3,7 @@ novelWriter – Main Status Bar Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_statusbar.py
+++ b/tests/test_gui/test_gui_statusbar.py
@@ -3,7 +3,7 @@ novelWriter – Main Status Bar Class Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright (C) 2021 Veronica Berglyd Olsen
+Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -3,7 +3,7 @@ novelWriter – GUI Theme and Icons Classes Tester
 ================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -3,7 +3,7 @@ novelWriter – GUI Theme and Icons Classes Tester
 ================================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_text/test_text_counting.py
+++ b/tests/test_text/test_text_counting.py
@@ -3,7 +3,7 @@ novelWriter – Counter Module Tester
 ===================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_text/test_text_counting.py
+++ b/tests/test_text/test_text_counting.py
@@ -3,7 +3,7 @@ novelWriter – Counter Module Tester
 ===================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -3,7 +3,7 @@ novelWriter – Patterns Module Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -3,7 +3,7 @@ novelWriter – Patterns Module Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_dictionaries.py
+++ b/tests/test_tools/test_tools_dictionaries.py
@@ -3,7 +3,7 @@ novelWriter – Dictionary Downloader Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_dictionaries.py
+++ b/tests/test_tools/test_tools_dictionaries.py
@@ -3,7 +3,7 @@ novelWriter – Dictionary Downloader Tester
 ==========================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_lipsum.py
+++ b/tests/test_tools/test_tools_lipsum.py
@@ -3,7 +3,7 @@ novelWriter – Lorem Ipsum Tool Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_lipsum.py
+++ b/tests/test_tools/test_tools_lipsum.py
@@ -3,7 +3,7 @@ novelWriter – Lorem Ipsum Tool Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_lipsum.py
+++ b/tests/test_tools/test_tools_lipsum.py
@@ -3,7 +3,7 @@ novelWriter – Lorem Ipsum Tool Tester
 =====================================
 
 This file is a part of novelWriter
-Copyright (C) 2022 Veronica Berglyd Olsen
+Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manusbuild.py
+++ b/tests/test_tools/test_tools_manusbuild.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Build Dialog Tester
 ============================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manusbuild.py
+++ b/tests/test_tools/test_tools_manusbuild.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Build Dialog Tester
 ============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manuscript.py
+++ b/tests/test_tools/test_tools_manuscript.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Tool Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manuscript.py
+++ b/tests/test_tools/test_tools_manuscript.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Tool Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manuscript.py
+++ b/tests/test_tools/test_tools_manuscript.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Tool Tester
 ====================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Build Settings Dialog Tester
 =====================================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Build Settings Dialog Tester
 =====================================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors and novelWriter contributors
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -3,7 +3,7 @@ novelWriter – Manuscript Build Settings Dialog Tester
 =====================================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_noveldetails.py
+++ b/tests/test_tools/test_tools_noveldetails.py
@@ -3,7 +3,7 @@ novelWriter – Novel Details Tool Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright (C) 2024 Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_noveldetails.py
+++ b/tests/test_tools/test_tools_noveldetails.py
@@ -3,7 +3,7 @@ novelWriter – Novel Details Tool Tester
 =======================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2024 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -3,7 +3,7 @@ novelWriter – Welcome Window Tester
 ===================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -3,7 +3,7 @@ novelWriter – Welcome Window Tester
 ===================================
 
 This file is a part of novelWriter
-Copyright (C) 2023 Veronica Berglyd Olsen
+Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_writingstats.py
+++ b/tests/test_tools/test_tools_writingstats.py
@@ -3,7 +3,7 @@ novelWriter – Writing Stats Dialog Class Tester
 ===============================================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/test_tools/test_tools_writingstats.py
+++ b/tests/test_tools/test_tools_writingstats.py
@@ -3,7 +3,7 @@ novelWriter – Writing Stats Dialog Class Tester
 ===============================================
 
 This file is a part of novelWriter
-Copyright (C) 2020 Veronica Berglyd Olsen
+Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -3,7 +3,7 @@ novelWriter – Test Suite Tools
 ==============================
 
 This file is a part of novelWriter
-Copyright 2018–2024, Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -3,7 +3,7 @@ novelWriter – Test Suite Tools
 ==============================
 
 This file is a part of novelWriter
-Copyright (C) 2019 Veronica Berglyd Olsen
+Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
**Summary:**

This PR updates the copyright notices in the source, but changes how they are expressed so this won't need to be done each year except for in the two license files included in Debian and Windows releases.

* For source code files, only the year the file was created is used, if the code was new at the time.
* If the code in the file was moved there, the year the class object was created is used instead.
* There will no loner be a year range added, preventing the need for yearly updates.
* Additional copyright entries are added for major contributions to the file by other people than the main author. For minor or trivial changes, this is not added.

These copyright statements are pretty much redundant, but they are useful meta data about the code's history. If there at some point are a lot of contributors to files, the names may be replaced with "and contributors". This is a non-issue at this time.

Only @bkmeneguello and @Ryex have been added to the list in a handful of files.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
