### PR TITLE
Fix minor issue with editor word counter

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1251,7 +1251,8 @@ class GuiDocEditor(QPlainTextEdit):
             self._nwItem.setCharCount(cCount)
             self._nwItem.setWordCount(wCount)
             self._nwItem.setParaCount(pCount)
-            if needsRefresh:
+            if needsRefresh and not self.textCursor().hasSelection():
+                # Selection counter should take precedence (#2155)
                 self._nwItem.notifyToRefresh()
                 self.docFooter.updateWordCount(wCount, False)
         return


### PR DESCRIPTION
**Summary:**

The selection counter in the editor should take precedence over the scheduled word counter.

**Related Issue(s):**

Closes #2155

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
