### PR TITLE
Fix novel selector bug

### DIFF
--- a/novelwriter/extensions/novelselector.py
+++ b/novelwriter/extensions/novelselector.py
@@ -90,12 +90,13 @@ class NovelSelector(QComboBox):
     @pyqtSlot()
     def refreshNovelList(self) -> None:
         """Rebuild the list of novel items."""
+        cHandle = self.currentData()
+
         self._blockSignal = True
         self._firstHandle = None
         self.clear()
 
         icon = SHARED.theme.getIcon(nwLabels.CLASS_ICON[nwItemClass.NOVEL])
-        handle = self.currentData()
         for tHandle, nwItem in SHARED.project.tree.iterRoots(nwItemClass.NOVEL):
             if self._listFormat:
                 name = self._listFormat.format(nwItem.itemName)
@@ -110,7 +111,7 @@ class NovelSelector(QComboBox):
             self.insertSeparator(self.count())
             self.addItem(icon, self.tr("All Novel Folders"), "")
 
-        self.setHandle(handle)
+        self.setHandle(cHandle)
         self.setEnabled(self.count() > 1)
         self._blockSignal = False
 


### PR DESCRIPTION
**Summary:**

The previous selected item must be stored before clearing the dropdown box in the novel selector widget.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
