### PR TITLE
Make sure selection model exists before accessing

### DIFF
--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1020,7 +1020,9 @@ class GuiProjectTree(QTreeView):
     def _clearSelection(self) -> None:
         """Clear the currently selected items."""
         self.clearSelection()
-        self.selectionModel().clearCurrentIndex()
+        if model := self.selectionModel():
+            # Selection model can be None (#2173)
+            model.clearCurrentIndex()
         return
 
     def _selectedRows(self) -> list[QModelIndex]:


### PR DESCRIPTION
**Summary:**

This fixes a bug where the project tree selection model is None if no model has ever been loaded.

**Related Issue(s):**

Closes #2173

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
