### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,7 +14,7 @@ jobs:
   testLinux:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ documentation.
 
 ## Implementation
 
-novelWriter is written with Python 3 (3.9+) using Qt5 and PyQt5 (5.15 only), and is released on
+novelWriter is written with Python 3 (3.10+) using Qt5 and PyQt5 (5.15 only), and is released on
 Linux, Windows and macOS. It can in principle run on any Operating System that also supports Qt,
 PyQt and Python.
 

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -201,9 +201,9 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     # Check Packages and Versions
     errorData = []
     errorCode = 0
-    if sys.hexversion < 0x030900f0:
+    if sys.hexversion < 0x030a00f0:
         errorData.append(
-            "At least Python 3.9 is required, found %s" % CONFIG.verPyString
+            "At least Python 3.10 is required, found %s" % CONFIG.verPyString
         )
         errorCode |= 0x04
     if CONFIG.verQtValue < 0x050f00:

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -33,7 +33,7 @@ from collections.abc import Callable
 from configparser import ConfigParser
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import Any, Literal, TypeGuard, TypeVar
 from urllib.parse import urljoin
 from urllib.request import pathname2url
 
@@ -43,9 +43,6 @@ from PyQt5.QtGui import QColor, QDesktopServices, QFont, QFontDatabase, QFontInf
 from novelwriter.constants import nwConst, nwLabels, nwUnicode, trConst
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 from novelwriter.error import logException
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import TypeGuard  # Requires Python 3.10
 
 logger = logging.getLogger(__name__)
 

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -60,9 +60,7 @@ NODE_FLAGS = Qt.ItemFlag.ItemIsEnabled
 NODE_FLAGS |= Qt.ItemFlag.ItemIsSelectable
 NODE_FLAGS |= Qt.ItemFlag.ItemIsDropEnabled
 
-if TYPE_CHECKING:  # pragma: no cover
-    # Requires Python 3.10
-    T_NodeData = str | QIcon | QFont | Qt.AlignmentFlag | None
+T_NodeData = str | QIcon | QFont | Qt.AlignmentFlag | None
 
 
 class ProjectNode:

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -30,7 +30,6 @@ from enum import Enum
 from functools import partial
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import QCoreApplication
 
@@ -45,14 +44,11 @@ from novelwriter.core.options import OptionState
 from novelwriter.core.projectdata import NWProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.sessions import NWSessionLog
+from novelwriter.core.status import T_StatusKind, T_UpdateEntry
 from novelwriter.core.storage import NWStorage, NWStorageOpen
 from novelwriter.core.tree import NWTree
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 from novelwriter.error import logException
-
-if TYPE_CHECKING:  # pragma: no cover
-    # Requires Python 3.10
-    from novelwriter.core.status import T_StatusKind, T_UpdateEntry
 
 logger = logging.getLogger(__name__)
 

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -29,7 +29,7 @@ import logging
 import random
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Literal, TypeGuard
+from typing import Literal, TypeGuard
 
 from PyQt5.QtCore import QPointF, Qt
 from PyQt5.QtGui import QColor, QIcon, QPainter, QPainterPath, QPixmap, QPolygonF
@@ -62,10 +62,8 @@ class StatusEntry:
 
 NO_ENTRY = StatusEntry("", QColor(0, 0, 0), nwStatusShape.SQUARE, QIcon(), 0)
 
-if TYPE_CHECKING:  # pragma: no cover
-    # Requires Python 3.10
-    T_UpdateEntry = list[tuple[str | None, StatusEntry]]
-    T_StatusKind = Literal["s", "i"]
+T_UpdateEntry = list[tuple[str | None, StatusEntry]]
+T_StatusKind = Literal["s", "i"]
 
 
 class NWStatus:

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -29,7 +29,7 @@ import logging
 import random
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, TypeGuard
 
 from PyQt5.QtCore import QPointF, Qt
 from PyQt5.QtGui import QColor, QIcon, QPainter, QPainterPath, QPixmap, QPolygonF
@@ -38,9 +38,6 @@ from novelwriter import SHARED
 from novelwriter.common import simplified
 from novelwriter.enum import nwStatusShape
 from novelwriter.types import QtPaintAntiAlias, QtTransparent
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import TypeGuard  # Requires Python 3.10
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = {file = "setup/description_pypi.md", content-type = "text/markdown"}
 license = {text = "GNU General Public License v3"}
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -25,7 +24,7 @@ classifiers = [
     "Natural Language :: English",
     "Topic :: Text Editors",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pyqt5>=5.15",
     "pyenchant>=3.0.0",

--- a/setup/debian/control
+++ b/setup/debian/control
@@ -2,14 +2,14 @@ Source: novelwriter
 Maintainer: Veronica Berglyd Olsen <code@vkbo.net>
 Section: text
 Priority: optional
-Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.9), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
+Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), python3 (>=3.10), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
 Standards-Version: 4.5.1
 Homepage: https://novelwriter.io
-X-Python3-Version: >= 3.9
+X-Python3-Version: >= 3.10
 
 Package: novelwriter
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.9), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
+Depends: ${misc:Depends}, ${python3:Depends}, python3 (>=3.10), python3-pyqt5 (>= 5.15), python3-enchant (>= 2.0)
 Description: A markdown-like text editor for planning and writing novels
  novelWriter is a plain text editor designed for writing novels assembled from
  many smaller text documents. It uses a minimal formatting syntax inspired by

--- a/setup/description_pypi.md
+++ b/setup/description_pypi.md
@@ -10,7 +10,7 @@ synchronisation tools. All text is saved as plain text files with a meta data he
 project structure is stored in a single project XML file, and other meta data is primarily saved as
 JSON files.
 
-The application is written with Python 3 (3.9+) using Qt5 and PyQt5 (5.10+). It is developed on
+The application is written with Python 3 (3.10+) using Qt5 and PyQt5 (5.10+). It is developed on
 Linux, but should in principle work fine on other operating systems as well as long as dependencies
 are met. It is regularly tested on Debian and Ubuntu Linux, Windows, and MacOS.
 

--- a/setup/launchpad_setup.cfg
+++ b/setup/launchpad_setup.cfg
@@ -11,7 +11,6 @@ license_files = LICENSE.md
 license = GNU General Public License v3
 classifiers =
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -30,7 +29,7 @@ project_urls =
 
 [options]
 zip_safe = False
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = True
 packages = find_namespace:
 install_requires =


### PR DESCRIPTION
**Summary:**

This PR drops support for Python 3.9:
* Releases are mainly done with 3.12 anyway.
* Python 3.9 is annoying due to features it's missing.
* Oldest Ubuntu release supported, 22.04, already has Python 3.10.
* Python 3.9 reaches end of life this year anyway (in October).

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
