### PR TITLE
Track recent projects via UUID

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -110,7 +110,7 @@ def checkBool(value: Any, default: bool) -> bool:
     return default
 
 
-def checkUuid(value: Any, default: str) -> str:
+def checkUuid(value: Any, default: str = "") -> str:
     """Try to process a value as an UUID, or return a default."""
     try:
         return str(uuid.UUID(value))

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -110,7 +110,7 @@ def checkBool(value: Any, default: bool) -> bool:
     return default
 
 
-def checkUuid(value: Any, default: str = "") -> str:
+def checkUuid(value: Any, default: str) -> str:
     """Try to process a value as an UUID, or return a default."""
     try:
         return str(uuid.UUID(value))

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -353,9 +353,7 @@ class NWProject:
 
         # Update recent projects
         if storePath := self._storage.storagePath:
-            CONFIG.recentProjects.update(
-                storePath, self._data.name, sum(self._data.initCounts), time()
-            )
+            CONFIG.recentProjects.update(storePath, self._data, time())
 
         # Check the project tree consistency
         # This also handles any orphaned files found
@@ -421,9 +419,7 @@ class NWProject:
 
         # Update recent projects
         if storagePath := self._storage.storagePath:
-            CONFIG.recentProjects.update(
-                storagePath, self._data.name, sum(self._data.currCounts), saveTime
-            )
+            CONFIG.recentProjects.update(storagePath, self._data, saveTime)
 
         SHARED.newStatusMessage(self.tr("Saved Project: {0}").format(self._data.name))
         self.setProjectChanged(False)

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -31,6 +31,7 @@ from pytestqt.qtbot import QtBot
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwFiles
+from novelwriter.core.projectdata import NWProjectData
 from novelwriter.enum import nwItemClass
 from novelwriter.tools.welcome import GuiWelcome
 from novelwriter.types import QtMouseLeft
@@ -72,8 +73,18 @@ def testToolWelcome_Open(qtbot: QtBot, monkeypatch, nwGUI, fncPath):
     monkeypatch.setattr(QMenu, "exec", lambda *a: None)
     monkeypatch.setattr(QMenu, "setParent", lambda *a: None)
 
-    CONFIG.recentProjects.update("/stuff/project_one", "Project One", 12345, 1690000000)
-    CONFIG.recentProjects.update("/stuff/project_two", "Project Two", 54321, 1700000000)
+    data1 = NWProjectData(SHARED.project)
+    data2 = NWProjectData(SHARED.project)
+
+    data1.setUuid(None)
+    data2.setUuid(None)
+    data1.setName("Project One")
+    data2.setName("Project Two")
+    data1.setCurrCounts(12345, 0)
+    data2.setCurrCounts(54321, 0)
+
+    CONFIG.recentProjects.update("/stuff/project_one", data1, 1690000000)
+    CONFIG.recentProjects.update("/stuff/project_two", data2, 1700000000)
     dateOne = CONFIG.localDate(datetime.fromtimestamp(1700000000))
     dateTwo = CONFIG.localDate(datetime.fromtimestamp(1690000000))
 


### PR DESCRIPTION
**Summary:**

Add a UUID record to recent projects so that duplicate entries of the same project can be avoided.

**Related Issue(s):**

Closes #2217

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
