### PR TITLE
Add support for log colour env variables

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import getopt
 import logging
+import os
 import sys
 
 from typing import TYPE_CHECKING
@@ -86,8 +87,11 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     if sysArgs is None:
         sysArgs = sys.argv[1:]
 
+    fColor = os.environ.get("FORCE_COLOR")
+    nColor = os.environ.get("NO_COLOR")
+
     # Valid Input Options
-    shortOpt = "hv"
+    shortOpt = "hvc"
     longOpt = [
         "help",
         "version",
@@ -131,7 +135,7 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
 
     # Defaults
     logLevel = logging.WARN
-    fmtFlags = 0b00
+    fmtFlags = 0b01 if fColor else 0b00
     confPath = None
     dataPath = None
     qtStyle  = "Fusion"
@@ -161,7 +165,7 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
             CONFIG.isDebug = True
             fmtFlags = fmtFlags | 0b10
             logLevel = logging.DEBUG
-        elif inOpt == "--color":
+        elif inOpt == "--color" and not nColor:
             fmtFlags = fmtFlags | 0b01
         elif inOpt == "--style":
             qtStyle = inArg

--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -91,7 +91,7 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     nColor = os.environ.get("NO_COLOR")
 
     # Valid Input Options
-    shortOpt = "hvc"
+    shortOpt = "hvidc"
     longOpt = [
         "help",
         "version",
@@ -124,9 +124,9 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
         "Usage:\n"
         " -h, --help     Print this message.\n"
         " -v, --version  Print program version and exit.\n"
-        "     --info     Print additional runtime information.\n"
-        "     --debug    Print debug output. Includes --info.\n"
-        "     --color    Add ANSI colors to log output.\n"
+        " -i, --info     Print additional runtime information.\n"
+        " -d, --debug    Print debug output. Includes --info.\n"
+        " -c, --color    Add ANSI colors to log output.\n"
         "     --meminfo  Show memory usage information in the status bar.\n"
         "     --style=   Sets Qt style flag. Defaults to 'Fusion'.\n"
         "     --config=  Alternative config file.\n"
@@ -159,22 +159,22 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
         elif inOpt in ("-v", "--version"):
             print("novelWriter Version %s [%s]" % (__version__, __date__))
             sys.exit(0)
-        elif inOpt == "--info":
+        elif inOpt in ("-i", "--info"):
             logLevel = logging.INFO
-        elif inOpt == "--debug":
+        elif inOpt in ("-d", "--debug"):
             CONFIG.isDebug = True
             fmtFlags = fmtFlags | 0b10
             logLevel = logging.DEBUG
-        elif inOpt == "--color" and not nColor:
+        elif inOpt in ("-c", "--color") and not nColor:
             fmtFlags = fmtFlags | 0b01
+        elif inOpt == "--meminfo":
+            CONFIG.memInfo = True
         elif inOpt == "--style":
             qtStyle = inArg
         elif inOpt == "--config":
             confPath = inArg
         elif inOpt == "--data":
             dataPath = inArg
-        elif inOpt == "--meminfo":
-            CONFIG.memInfo = True
 
     if fmtFlags & 0b01:
         # This will overwrite the default level names, and also ensure that


### PR DESCRIPTION
**Summary:**

This PR adds support for [NO_COLOR](http://no-color.org/) and [FORCE_COLOR](https://force-color.org/) environment variables. It also adds single character switches for these command line flags.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
