### PR TITLE
Change context of shape translation strings

### DIFF
--- a/i18n/nw_base.ts
+++ b/i18n/nw_base.ts
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="117" />
       <source>Title</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118" />
       <source>Heading 1 (Partition)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119" />
       <source>Heading 2 (Chapter)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120" />
       <source>Heading 3 (Scene)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121" />
       <source>Heading 4 (Section)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122" />
       <source>Text Paragraph</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123" />
       <source>Scene Separator</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="240" />
       <source>None</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
-      <source>Novel</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
-      <source>Plot</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="289" />
       <location filename="../novelwriter/constants.py" line="241" />
-      <source>Characters</source>
+      <source>Novel</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="292" />
       <location filename="../novelwriter/constants.py" line="242" />
-      <source>Locations</source>
+      <source>Plot</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="291" />
       <location filename="../novelwriter/constants.py" line="243" />
-      <source>Timeline</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
-      <source>Objects</source>
+      <source>Characters</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
-      <source>Entities</source>
+      <location filename="../novelwriter/constants.py" line="244" />
+      <source>Locations</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
+      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="245" />
+      <source>Timeline</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
       <location filename="../novelwriter/constants.py" line="295" />
       <location filename="../novelwriter/constants.py" line="246" />
-      <source>Custom</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="247" />
-      <source>Archive</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="248" />
-      <source>Templates</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="249" />
-      <source>Trash</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
-      <source>Novel Document</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
-      <source>Project Note</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="272" />
-      <source>Root Folder</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="273" />
-      <source>Folder</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="275" />
-      <source>Novel Title Page</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="276" />
-      <source>Novel Chapter</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="277" />
-      <source>Novel Scene</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="278" />
-      <source>Novel Section</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="282" />
-      <source>Active</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="283" />
-      <source>Inactive</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="286" />
-      <source>Tag</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="287" />
-      <source>Point of View</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
-      <source>Focus</source>
+      <source>Objects</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="247" />
+      <source>Entities</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="425" />
+      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="248" />
+      <source>Custom</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="249" />
+      <source>Archive</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="250" />
+      <source>Templates</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="251" />
+      <source>Trash</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="269" />
+      <source>Novel Document</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="281" />
+      <location filename="../novelwriter/constants.py" line="270" />
+      <source>Project Note</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="274" />
+      <source>Root Folder</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="275" />
+      <source>Folder</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="277" />
+      <source>Novel Title Page</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="278" />
+      <source>Novel Chapter</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="279" />
+      <source>Novel Scene</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="280" />
+      <source>Novel Section</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="284" />
+      <source>Active</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="285" />
+      <source>Inactive</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="288" />
+      <source>Tag</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="289" />
+      <source>Point of View</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="325" />
+      <location filename="../novelwriter/constants.py" line="290" />
+      <source>Focus</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="298" />
       <source>Story</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299" />
       <source>Mentions</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317" />
       <source>Level</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318" />
       <source>Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319" />
       <source>Line</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320" />
       <source>Status</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321" />
       <source>Chars</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322" />
       <source>Words</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323" />
       <source>Pars</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324" />
       <source>POV</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335" />
       <source>Synopsis</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351" />
       <source>Open Document (.odt)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352" />
       <source>Flat Open Document (.fodt)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353" />
       <source>Microsoft Word Document (.docx)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354" />
       <source>HTML 5 (.html)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355" />
       <source>novelWriter Markup (.txt)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356" />
       <source>Standard Markdown (.md)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357" />
       <source>Extended Markdown (.md)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358" />
       <source>Portable Document Format (.pdf)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359" />
       <source>JSON + HTML 5 (.json)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360" />
       <source>JSON + novelWriter Markup (.json)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
-      <source>Text files</source>
+      <location filename="../novelwriter/constants.py" line="375" />
+      <source>Square</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
-      <source>Markdown files</source>
+      <location filename="../novelwriter/constants.py" line="376" />
+      <source>Triangle</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377" />
+      <source>Nabla</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378" />
+      <source>Diamond</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379" />
+      <source>Pentagon</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380" />
+      <source>Hexagon</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381" />
+      <source>Star</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382" />
+      <source>Pacman</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385" />
+      <source>1/4 Circle</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386" />
+      <source>Half Circle</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387" />
+      <source>3/4 Circle</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388" />
+      <source>Full Circle</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391" />
+      <source>1 Bar</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392" />
+      <source>2 Bars</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393" />
+      <source>3 Bars</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394" />
+      <source>4 Bars</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397" />
+      <source>1 Block</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398" />
+      <source>2 Blocks</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399" />
+      <source>3 Blocks</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400" />
+      <source>4 Blocks</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="403" />
-      <source>novelWriter files</source>
+      <source>Text files</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="404" />
-      <source>CSV files</source>
+      <source>Markdown files</source>
       <translation type="unfinished" />
     </message>
     <message>
       <location filename="../novelwriter/constants.py" line="405" />
+      <source>novelWriter files</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="406" />
+      <source>CSV files</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="407" />
       <source>All files</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410" />
       <source>Millimetres</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411" />
       <source>Centimetres</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412" />
       <source>Inches</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420" />
       <source>A4</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421" />
       <source>A5</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422" />
       <source>A6</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423" />
       <source>US Legal</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424" />
       <source>US Letter</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467" />
       <source>Straight single quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468" />
       <source>Straight double quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470" />
       <source>Left single quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471" />
       <source>Right single quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472" />
       <source>Single low-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473" />
       <source>Single high-reversed-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474" />
       <source>Left double quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475" />
       <source>Right double quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476" />
       <source>Double low-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477" />
       <source>Double high-reversed-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478" />
       <source>Double low-reversed-9 quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480" />
       <source>Single left-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481" />
       <source>Single right-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482" />
       <source>Double left-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483" />
       <source>Double right-pointing angle quotation mark</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485" />
       <source>Left corner bracket</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486" />
       <source>Right corner bracket</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487" />
       <source>Left white corner bracket</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488" />
       <source>Right white corner bracket</source>
       <translation type="unfinished" />
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253" />
       <source>Project Content</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262" />
       <source>Quick Links</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268" />
       <source>Move Up</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272" />
       <source>Move Down</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312" />
       <source>Add Item</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319" />
       <source>Expand All</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322" />
       <source>Collapse All</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325" />
       <source>Empty Trash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329" />
       <source>More Options</source>
       <translation type="unfinished" />
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626" />
       <source>Did not find anywhere to add the file or folder!</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630" />
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644" />
       <source>New Note</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647" />
       <source>New Chapter</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650" />
       <source>New Scene</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653" />
       <source>New Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656" />
       <source>New Folder</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706" />
       <source>No documents selected for merging.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714" />
       <source>Merged</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772" />
+      <location filename="../novelwriter/gui/projtree.py" line="728" />
       <source>Could not write document content.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787" />
       <source>Do you want to duplicate this document?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789" />
       <source>Do you want to duplicate this item and all child items?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794" />
       <source>Could not duplicate all items.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910" />
       <source>Root folders can only be deleted when they are empty.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914" />
       <source>Permanently delete selected item(s)?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924" />
       <source>Move selected item(s) to Trash?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939" />
       <source>The Trash folder is already empty.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942" />
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation type="unfinished" />
     </message>
@@ -4019,109 +4119,6 @@
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation type="unfinished" />
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
       <location filename="../novelwriter/shared.py" line="278" />
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338" />
       <source>Characters</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339" />
       <source>Characters in Text</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340" />
       <source>Characters in Headings</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341" />
       <source>Paragraphs</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342" />
       <source>Headings</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343" />
       <source>Characters, No Spaces</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344" />
       <source>Characters in Text, No Spaces</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345" />
       <source>Characters in Headings, No Spaces</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346" />
       <source>Words</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347" />
       <source>Words in Text</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348" />
       <source>Words in Headings</source>
       <translation type="unfinished" />
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134" />
       <source>Empty Trash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155" />
       <source>Rename</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170" />
       <source>Duplicate</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190" />
       <source>Open Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195" />
       <source>View Document</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204" />
       <source>Create New ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216" />
       <source>Rename to Heading</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225" />
       <source>Set Active to ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231" />
       <source>Toggle Active</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238" />
       <source>Set Status to ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268" />
+      <location filename="../novelwriter/gui/projtree.py" line="1250" />
       <source>Manage Labels ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256" />
       <source>Set Importance to ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277" />
       <source>Transform ...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299" />
+      <location filename="../novelwriter/gui/projtree.py" line="1295" />
+      <location filename="../novelwriter/gui/projtree.py" line="1291" />
+      <location filename="../novelwriter/gui/projtree.py" line="1287" />
       <source>Convert to {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303" />
       <source>Merge Child Items into Self</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305" />
       <source>Merge Child Items into New</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309" />
       <source>Merge Documents in Folder</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313" />
       <source>Split Document by Headings</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320" />
       <source>Expand All</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322" />
       <source>Collapse All</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332" />
       <source>Delete Permanently</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334" />
       <source>Move to Trash</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410" />
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation type="unfinished" />
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048" />
       <source>From Template</source>
       <translation type="unfinished" />
     </message>

--- a/i18n/nw_cs_CZ.ts
+++ b/i18n/nw_cs_CZ.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Filtry dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Dokumenty románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Poznámky projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Neaktivní dokumenty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Záhlaví</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Formát oddílů</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Formát kapitol</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Nečíslovaný formát</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Formát scény</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Alt. formát scény</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Formát sekce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Stylování názvu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Stylování oddílů</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Stylování kapitoly</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Stylování scén</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Obsah</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Zahrnout synopsi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Zahrnout komentáře</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Zahrnout klíčová slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Zahrnout text těla</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Ignorovat tato klíčová slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Přidat názvy pro poznámky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Formátování textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Písmo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Výška řádku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Zarovnat textové okraje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Nahradit znaky Unicode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Nahradit tabulátor mezerami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Zachovat zalomení řádku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Použít zvýraznění dialogu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>Odsazení prvního řádku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Povolit odsazení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Šířka odsazení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Odsazení prvního odstavce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Textové okraje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Název a oddíl</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Nadpis 1 a Kapitola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Nadpis 2 a Scéna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Nadpis 3 a kapitola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Nadpis 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Odstavec textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Oddělovač scén</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Rozložení stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Jednotka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Velikost stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Okraje stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Styl dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Záhlaví stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Odsazení počtu stránek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Přidat barvy k nadpisům</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Zvýšit velikost záhlaví</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Tučné záhlaví</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>Možnosti HTML</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>Přidat CSS styly</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Zachovat znaky tabulátoru</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>v budoucnu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>právě teď</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>před minutou</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>před {0} minutami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>před hodinou</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>před {0} hodinami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>před jedním dnem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>před {0} dny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>před týdnem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>před {0} týdny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>před měsícem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>před {0} měsíci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>před rokem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>před {0} lety</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Název</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Nadpís 1 (Oddíl)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Nadpis 2 (Kapitola)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Nadpis 3 (Scéna)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Nadpis 4 (Sekce)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Odstavec textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Oddělovač scén</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>Žádný</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Román</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Zápletka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Postavy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Lokality</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Časová osa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Objekty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Subjekty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Vlastní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Archiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Šablony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Koš</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Dokument románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Poznámka projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Kořenová složka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Složky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Titulní stránka románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Kapitola románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Scéna románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Sekce románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>Aktivní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Neaktivní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Štítek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Úhel pohledu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Zaměření</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>Příběh</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Zmínky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Úroveň</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Řádek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Stav</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Znaky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Pars</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>POV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Synopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Open Dokument (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Dokument (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Dokument Microsoft Word (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter Markup (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Standard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Extended Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portable Document Format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter Markup (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Čtverec</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Trojúhelník</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Kosočtverec</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Pětiúhelník</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Šestiúhelník</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Hvězdička</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>1/4 kružnice</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Půlkruh</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4 kružnice</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Úplný kruh</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 čára</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 čáry</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 čáry</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 čáry</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 blok</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 bloky</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 bloky</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 bloky</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>Textový soubor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>Soubory Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>novelWriter soubory</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>CSV soubory</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>Všechny soubory</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Milimetry</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Centimetry</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Palce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Jednoduchá uvozovka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Dvojitá uvozovka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Levá jednoduchá uvozovka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Pravá jednoduchá uvozovka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Jednoduchá uvozovka s nízkými hodnotami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Jednoduchá uvozovka s vysokými hodnotami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Levá dvojitá uvozovka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Pravá dvojitá uvozovka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Dvojítá uvzozovka s nízkými hodnotami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Dvojítá uvozovka s vysokými hodnotami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Dvojítá uvozovka s nízkými hodnotami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Jednoduchá úhlová uvozovka směřující vlevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>Jednoduchá úhlová uvozovka směřující vpravo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Dvojitá úhlová uvozovka směřující vlevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>Dvojitá úhlová uvozovka směřující vpravo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Levý roh závorky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Pravý roh závorky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Levý bílý roh závorky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Pravý bílý roh závorky</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>O novelWriteru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>Tato aplikace je licencována pod {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Poděkování</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Nastavení sestavení Manuscriptu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Název</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>Obecné</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Výběr</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Záhlaví</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formátování</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Přidat slovníky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Stáhněte si slovník z jednoho z odkazů a přidejte jej níže.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Přidat slovník</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Umístění instalace slovníku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Počet dalších slovníků: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Zdarma nebo Libre Office rozšíření</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Procházet soubory</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>Soubor slovníku nelze zpracovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Přidáno: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Řádek: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Slova: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Slova: {0} vybráno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Stav</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Přepnout nástrojovou lištu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Podtržený</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Hledat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Přepnout režim soustředění</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Zavřít</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Najít</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Nahradit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Hledat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Rozlišovat velká a malá písmena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Pouze celá slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>RegEx režim</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Hledání ve smyčce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Hledat další soubor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Preserve Case</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Ukončit hledání</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Najít v aktuálním dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Najít a nahradit v aktuálním dokumentu</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Otevřený dokument: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Tento dokument byl změněn mimo novelWriter, když byl otevřen. Přepsat soubor na disku?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>Dokument nelze uložit.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Uložený dokument: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Kontrola pravopisu vyžaduje balíček PyEnchant. Zdá se, že není nainstalován.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Kontrola pravopisu dokončena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Podrobnosti o dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Vytvořeno: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Aktualizováno: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>Umístění souboru: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Nastavit jako název dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>Otevřít URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Sledovat štítek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Vytvořit poznámku pro štítek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Vyjmout</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Kopírovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Vložit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Vybrat vše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Vybrat slovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Vybrat odstavec</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Návrhy opravy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>Žádné návrhy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Ignorovat slovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Přidat slovo do slovníku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Vyberte prosím nějaký text před voláním nahrazujících uvozovek.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Chcete vytvořit novou poznámku projektu pro značku '{0}'?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Sloučit dokumenty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Dokumenty k sloučení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Přetáhněte předměty, chcete-li změnit řazení, nebo zrušte zaškrtnutí políčka.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Přesunout sloučené položky do koše</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Rozdělit dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Nadpisy dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Vyberte maximální úroveň pro rozdělení do souborů.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Rozdělit Nadpis úrovně 1 (Díl)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Rozdělit na Nadpis úrovně 2 (Kapitola)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Rozdělit na Nadpis úrovně 3 (Scéna)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Rozdělit na Nadpis úrovně 4 (Sekce)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>Rozdělit do nové složky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Vytvořit hierarchii dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Přesunout rozdělený dokument do koše</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Markdown Tučně</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Markdown Kurzíva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Markdown Přeškrtnuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Shortcode Tučně</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Shortcode Kurzíva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Shortcode Přeškrtnuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Shortcode Podtržené</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Shortcode Zvýraznění</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Shortcode Horní index</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Shortcode Dolní index</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Zobrazit/skrýt panel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Komentáře</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Zobrazit komentáře</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Synopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Zobrazit komentáře Synopsis</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Podtržený</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Jít zpět</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Jít vpřed</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Otevřít v editoru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Obnovit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Zavřít</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>Došlo k chybě při generování náhledu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Kopírovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Vybrat vše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Vybrat slovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Vybrat odstavec</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Skrýt neaktivní štítky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>Odkazy</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Popisek položky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Popisek</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Popisek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Stav</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Třída</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Použití</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Vložit plovoucí text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Vložit Lorem Ipsum text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Počet odstavců</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Náhodné řazení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Vložit</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter je připraven ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>Nyní používáte novelWriter verze {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Pro více informací si prosím zkontrolujte poznámky k vydání {0}{1}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>Zavřít současný projekt?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Změny jsou uloženy automaticky.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>Zálohovat aktuální projekt?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>Projekt je již otevřen jinou instancí novelWriter, a je proto uzamčen. Chcete přesto přepsat zámek a pokračovat?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Poznámka: Pokud program nebo počítač dříve havaroval, může být zámek bezpečně přepsán. Nicméně přepsání se nedoporučuje, pokud je projekt otevřen v jiném novelWriter. Může to poškodit projekt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>Projekt byl uzamčen počítačem{0}' ({1} {2}), naposledy aktivním na {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>Index projektu je zastaralý nebo nefunkční. Obnovte index.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Import souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>Nelze přečíst soubor. Soubor musí být textový soubor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Otevřete prosím dokument pro importování textového souboru.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>Import souboru přepíše aktuální obsah dokumentu. Chcete pokračovat?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Indexování dokončeno za {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>Index projektu byl úspěšně obnoven.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>Nelze inicializovat dialog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>Chcete ukončit novelWriter?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Některé změny nebudou aplikovány, dokud nebude novelWriter restartován.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>Nelze najít odkaz na štítek '{0}'. Buď neexistuje, nebo je index zastaralý. Index lze aktualizovat z nabídky Nástroje nebo stisknutím {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Vytvořit nebo otevřít projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Uložit projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Zavřít projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Nastavení projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Detaily románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Přejmenovat položku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Smazat položku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Vysypat koš</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Ukončit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Otevřít dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Uložit dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Zavřít dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>Zobrazit dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Zavřít zobrazení dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Zobrazit podrobnosti o souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Importovat text ze souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Upravit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Zpět</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Opakovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Vyjmout</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Kopírovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Vložit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Vybrat vše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Vybrat odstavec</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;Zobrazit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Přejít do stromového zobrazení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Přejít na dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Přejít na osnovu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Přejít zpět</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Přejít vpřed</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Režim soustředění</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Režim celé obrazovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>&amp;Vložit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Pomlčky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Krátká pomlčka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Dlouhá pomlčka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Horizontální lišta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Pomlčka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Uvozovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Levá jednoduchá citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Pravá jednoduchá citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Levá dvojitá citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Pravá dvojitá citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Alternativní apostrof</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>Obecná interpunkce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Elipsa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Primární</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Dvojitý znak '</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>Bílé mezery</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Nezlomitelná mezera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Úzká mezera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Úzká nezlomitelná mezera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Ostatní symboly</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>Seznam odrážek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Pomlčka Bullet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Značka květiny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Promile</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Znak stupně</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Značka mínusu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Značka násobení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Značka dělení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Štítky a odkazy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Speciální komentáře</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Synopsis komentář</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Krátký popis komentáře</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Počet slov/znaků</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Přerušení a vertikální mezera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Konec stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Vynucené zalomení řádku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Vertikální mezera (Single)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Vertikální mezera (Multi)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Zástupný text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Poznámka pod čarou</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Formát</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Tučné</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Kurzíva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Přeškrtnuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Obalení dvojitých uvozovek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Obalení jednoduchých uvozovek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>Další formáty...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Tučné (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Kurzíva (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Přeškrtnuté (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Podtržené</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Zvýraznění</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Horní index</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Dolní index</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Název románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Neočíslovaná kapitola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Alternativní scéna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Zarovnat vlevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Zarovnat na střed</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Zarovnat doprava</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Odsazení zleva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Odsazení zprava</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Přepnutí komentáře</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Přepnutí ignorování textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Odstranit formát bloku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Nahradit rovné jednoduché uvozovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Nahradit rovné dvojité uvozovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Odstranit zlomy v odstavci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;Hledat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Najít</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Nahradit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Najít další</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Najít předchozí</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Nahradit další</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Najít v projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;Nástroje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Kontrolovat pravopis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Jazyk kontroly pravopisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Výchozí</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Znovu spustit kontrolu pravopisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Seznam slov projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Přidat slovníky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Znovu vytvořit Index</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Záloha projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Vytvořit rukopis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Statistiky psaní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Nastavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>&amp;Nápověda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>O novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>O Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>Uživatelská příručka (Online)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>Uživatelská příručka (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Nahlásit problém (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Položit otázku (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>Webová stránka novelWriter</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>Žádný</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Čas relace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Slova: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Počet slov v projektu (změna relaceí)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Počet slov v románu (změna relace)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Sestavit rukopis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Přidat novou sestavu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Odstranit vybrané sestavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Duplikovat vybrané sestavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Upravit vybraný sestavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Sestavit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Podrobnosti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Podtržený</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Náhled</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Tisk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Sestavit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Zavřít</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Zobrazit zarážky stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>Můj rukopis</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Sestavit rukopis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Výstupní formát</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Obsah</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Cesta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>Názvu souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Obnovit název souboru na výchozí</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Otevřít složku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;Sestavit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Vyberte složku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>Výstupní složka neexistuje.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>Soubor již existuje. Chcete jej přepsat?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Detaily románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Přehled</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Obsah</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Přehled z {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Root Románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Aktualizovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Poslední sloupec</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Nezobrazovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Úhel pohledu postavy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Zaměřit se na postavu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Děj románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Velikost sloupce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>Více možností</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Maximální velikost sloupce v %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>Žádná meta data</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Název</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Kapitola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Scéna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Sekce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Stav</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Synopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Podrobnosti titulu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Referenční štítky</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Vybrat sloupce</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Přehled z</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Aktualizovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>Exportovat do CSV</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Uložit osnovu jako</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Nastavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Hledat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>Obecné</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Vzhled</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Jazyk zobrazení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>Vyžaduje restartování, aby se projevil.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Barevný motiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>Základní barevný motiv a ikony.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Písmo aplikace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Skrýt vertikální posuvné lišty v hlavních oknech</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Rolování je k dispozici pouze s kolečkem myši a klávesami.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Skrýt horizontální posuvné lišty v hlavních oknech</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Použít dialogové okno výběru písma systému</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Vypněte pro použití dialogového okna Qt, který může mít více možností.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Styl dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Barevný motiv dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Barevný motiv pro editor a prohlížeč.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Písmo dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>Vztahuje se jak na editor, tak na prohlížeč.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Zdůraznění oddílů a nápisů kapitoly</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Udělá je mimo stromu projektů.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Zobrazit úplnou cestu v záhlaví dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Přidat názvy nadřazených složek do záhlaví.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Zahrnout poznámky projektu do počtu slov ve stavové liště</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Chování</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Interval ukládání dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>Jak často se dokument automaticky uloží.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>sekundy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Interval ukládání projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>Jak často se projekt automaticky uloží.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Zeptat se před ukončením NovelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Platí pouze v případě, že je projekt otevřený.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Zálohování projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Procházet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Umístění úložiště zálohy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Cesta: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Spustit zálohu, když je projekt uzavřen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Lze přepsat pro jednotlivé projekty v Nastavení projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Zeptat se před spuštěním zálohy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>Pokud je vypnuto, zálohy běží na pozadí.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Čas relace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Pozastavit časovač relace, když se nepíše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Také pozastaví, když se okno aplikace přesune na pozadí.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Editovat neaktivní čas před pozastavením</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>Uživatelská aktivita zahrnuje psaní a změnu obsahu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>minuty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Psaní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Flow textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Maximální šířka textu v "Normálním režimu"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>Nastavte na 0 pro vypnutí této funkce.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Maximální šířka textu v režimu Soustředění</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>Maximální šířka nemůže být vypnuta.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Skrýt zápatí dokumentu v režimu „Soustředění“</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Skrýt informační panel v editoru dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Zarovnat textové okraje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Minimální textová marže</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Šířka tabulátoru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>Šířka tabulátoru po jeho stisknutí v editoru a prohlížeči.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Editace textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Jazyk kontroly pravopisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Dostupné jazyky závisí na systému.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Automatický výběr slova pod kurzorem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>Použít formátování na slovo pod kurzorem, pokud není proveden žádný výběr.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Zobrazit tabulátory a mezery</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Zobrazit konce řádků</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Posouvání editorů</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Posunutí za konec dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>Při posouvání také vycentruje kurzor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Styl psaní ve stylu psacích strojů</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Udržuje kurzor v pevné svislé poloze.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Minimální pozice posunu psacích strojů</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>Procento výšky editoru v horní části.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Zvýraznění textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>Žádný</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>Jednoduché uvozovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>Dvojité uvozovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>Obojí</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Zvýraznit dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Použije se na vybraný styl uvozovek.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Alternativní symboly dialogu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Vlastní zvýraznění textu dialogu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Povolit otevřený dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Zvýraznit čáru dialogu bez uzávěrky.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Symboly Dialogové linie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Řádky začínající některým z těchto symbolů jsou dialogy.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Narrator break symbol</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Symbol označující přerušení v dialogu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Alternativní dialog/narration symbol</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Aleternativní dialog zdůrazňující v kterémkoli odstavci.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Přidat barvu do zvýrazněného textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Platí pouze pro editor dokumentů.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Zvýraznění vícenásobných nebo koncových mezer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Automatizace textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Automaticky nahradit text při psaní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Umožnit editoru nahradit symboly při psaní.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Automaticky nahradit jednoduché uvozovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Pokuste se odhadnout, co je otevření nebo zavření citátu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Automaticky nahradit dvojité uvozovky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Automaticky nahradit pomlčky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>Dvojité a trojité pomlčky jsou krátké a dlouhé pomlčky.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Automaticky nahradit tečky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Tři po sobě jdoucí tečky se stávají elipsy.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Vložte mezeru před</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Automaticky přidat mezeru před kterýmkoli z těchto symbolů.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Vložte mezeru za</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Automaticky přidat mezeru za kterýmkoli z těchto symbolů.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Místo toho použít tenkou mezeru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Vloží tenkou mezeru místo obvyklé mezery.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Styl citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Styl otevřené jednoduché citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>Symbol, který se má použít pro úvodní jednoduchou uvozovku.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Styl uzavření jednoduché citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>Symbol, který se použije pro koncovou jednoduchou uvozovku.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Otevřený styl dvojitých uvozovek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>Symbol, který se použije pro úvodní dvojitou uvozovku.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Styl uzavření dvojité citace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>Symbol, který se použije pro koncovou dvojitou uvozovku.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Adresář záloh</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Vyhledat projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Rozlišovat velká a malá písmena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Pouze celá slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>RegEx režim</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Najít</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Nastavení projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Nastavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Stavy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Důležitost</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Automaticky nahradit</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="253" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Obsah projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="262" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Rychlé odkazy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="268" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Posunout nahoru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="272" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Posunout dolu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="312" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Přidat položku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="319" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Rozbalit Vše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="322" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Sbalit vše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="325" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Vysypat koš</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="329" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>Více možností</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="626" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Nikde nelze přidat soubor nebo složku!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="630" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Do Koše nelze přidat nové soubory nebo složky.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="644" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>Nová poznámka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="647" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>Nová kapitola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="650" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>Nová scéna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="653" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>Nový dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="656" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>Nová složka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="706" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>Pro sloučení nebyly vybrány žádné dokumenty.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="714" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Sloučený</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="772" />
-      <location filename="../novelwriter/gui/projtree.py" line="728" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>Nelze zapsat obsah dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="787" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>Chcete duplikovat tento dokument?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="789" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Chcete duplikovat tuto položku a všechny podřízené položky?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="794" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>Nelze duplikovat všechny položky.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="910" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Kořenové složky mohou být odstraněny, pouze pokud jsou prázdné.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="914" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>Trvale odstranit vybrané položky?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="924" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>Přesunout vybrané položky do koše?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="939" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>Složka Koš je již prázdná.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="942" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Trvale zmazat soubory z koše? Počet: {0}?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Vyberte styl citace</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Zobrazení stromu projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Zobrazení stromu Románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Vyhledat v projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Zobrazení obrysu románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Sestavit rukopis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Detaily románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Statistiky psaní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Nastavení</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Vítejte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>Seznam</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>Nový</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Procházet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Zrušit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Vytvořit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Otevřít</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Seznam slov projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Import slov z textového souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Exportovat slova do textového souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Přidat slovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Odstranit slovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Poznámka: Importovaný soubor musí být prostý textový soubor s kódováním UTF-8 nebo ASCII.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Import souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Export souboru</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Statistiky psaní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Začátek relace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Délka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Neaktivní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Histogram</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Celkem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Celkový čas:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Doba nečinnosti:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Doba filtrování:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Počet slov Románu:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Počet slov poznámek:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Celkový počet slov:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filtry</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Počítat soubory románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Počítat soubory poznámek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>Skrýt nulový počet slov</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>Skrýt záporný počet slov</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Seskupit záznamy podle dne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Zobrazit čas nečinnosti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Limit počtu slov pro histogram</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Uložit jako</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>Datový soubor JSON (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>Datový soubor CSV (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>Datový soubor JSON</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>Datový soubor CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Uložit data jako</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>Soubor {0} byl úspěšně zapsán do:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Nepodařilo se zapsat soubor {0}.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>Nelze odstranit soubor dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Neznámý formát souboru projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Cesta: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>Soubor projektu nebyl nalezen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Nepodařilo se otevřít projekt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Neznámý</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>Soubor projektu se nezdá být soubor novelWriterXML.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Neznámý nebo nepodporovaný formát projektu novelWriter. Projekt nemůže být otevřen touto verzí novelWriter. Soubor byl uložen s novelWriter verzí {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>Nepodařilo se analyzovat xml projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>Formát souboru vašeho projektu bude brzy aktualizován. Pokud budete pokračovat, starší verze novelWriteru již nebudou moci tento projekt otevřít. Pokračovat?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>Tento projekt byl uložen novější verzí novelWriter, verze {0}. Toto je verze {1}. Pokud budete pokračovat v otevírání projektu, některé atributy a nastavení nemusí být zachovány, ale celkový projekt by měl být v pořádku. Pokračovat v otevírání projektu?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Obnoveno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Nalezeno {0} osiřelých souborů v projektu. {1} soubor(y) byly obnoveny.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Otevřený dokument: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>Žádný projekt není otevřen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Nepodařilo se uložit projekt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Uložený projekt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Zálohování projektu ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Projekt nelze zálohovat, protože není nastaven žádný název projektu. Prosím nastavte název projektu v nastavení projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>Složku zálohy nelze vytvořit.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Vytvořena záloha vašeho projektu o velikosti {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>Nelze zapsat záložní archiv.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Projekt byl zálohován na '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>Nový</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Poznámka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Návrh</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Dokončeno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Méně závažná</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Závažná</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Hlavní</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>Všechny složky románu</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>Cílová složka není prázdná. Zvolte prosím jinou složku.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>Nastala chyba při vytváření projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>Nový projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Titulek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Adresa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>Od</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Počet slov</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Shrnutí kapitoly.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Shrnutí scény.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>Stručný popis.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Kapitola {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Scéna {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Hlavní zápletka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Hlavní lokace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>Cílová složka již existuje. Zvolte prosím jinou složku.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>Nelze zkopírovat soubory projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Nepodařilo se vytvořit nový příklad projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Nepodařilo se vytvořit nový příklad projektu. Nelze najít potřebné soubory. Zdá se, že v této instalaci chybí.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>Ok</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;Ok</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Uložit</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Zrušit</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;Zavřít</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Zavřít bez uložení</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>Ok</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Uložit</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Uložit vše</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Otevřít</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Ano</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Ano pro všechny</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;Ne</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>N&amp;e pro všechny</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Přerušit</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Opakovat</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Ignorovat</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Zavřít</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>Zrušit</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Zahodit</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Nápověda</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Použít</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Resetovat</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Obnovit výchozí</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Čtverec</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Trojúhelník</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Kosočtverec</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Pětiúhelník</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Šestiúhelník</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Hvězdička</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>1/4 kružnice</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Půlkruh</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4 kružnice</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Úplný kruh</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 čára</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 čáry</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 čáry</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 čáry</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 blok</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 bloky</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 bloky</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 bloky</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>soubor projektu novelWriter nebo soubor Zip</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>soubor projektu novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Otevřít Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Vybrat písmo</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Znaky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Znaky v textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Znaky v nadpisech</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Odstavce</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Nadpisy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Znaky, žádné mezery</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Znaky v textu, bez mezer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Znaky v nadpisech, žádné mezery</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Slova v textu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Slova v nadpisech</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Poslední verze: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Probíhá kontrola...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Stáhnout z {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Verze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Vydáno dne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Poznámky k verzi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>Zkontrolovat nyní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>Neúspěšné</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Obsah</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Název</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Slova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Stránka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Pokrok</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Slova na stránku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>Odsazení první stránky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Kapitoly na lichých stránkách</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Nepojmenované</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>KONEC</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Nastavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Hodnota</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Jméno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Výběr</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Název</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Skryté</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>Zahrnuto v rukopisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>Vyloučeno z rukopisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Vždy zahrnuto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Vždy vyloučeno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Obnovit výchozí</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Označit výběr jako</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Vybrat kořenové složky</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Informace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Varování</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Chyba</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Otázka</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Skrýt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Upravování {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>Žádný</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Název</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Číslo kapitoly</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Číslo kapitoly (Word)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Číslo kapitoly (Velká písmena Roman)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Číslo kapitoly (Horní index Roman)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Číslo scény (v kapitole)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Číslo scény (absolutní)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Úhel pohledu postavy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Zaměřit se na postavu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Vložit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Použít</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Střed</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Konec stránky</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Vyžadováno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Volitelné</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Vytvořit nový projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Vytvořit ukázkový projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Kopírovat existující projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Název projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Autor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Cesta k projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Projekt, předvyplnit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Nastavte na 0 pro přidání pouze scén</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>Přidat dokumenty kapitoly {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>Přidat dokumenty scény {0} (do každé kapitoly)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Přidání složky pro poznámky k příběhu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Přidat složku pro poznámky postav</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Přidat složku pro poznámky k lokaci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Přidat příklady k výše uvedeným poznámkám</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Kapitoly a scény</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Poznámky projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Vytvořit nový projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Vybrat složku projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Nový projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Ukázkový projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Šablona: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>Je vyžadován název projektu.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>Cesta projektu není dostupná.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Cesta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>Odstranit '{0}' ze seznamu nedávných projektů? Soubory projektu nebudou smazány.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Otevřít Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Odebrat projekt</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Jméno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Revize</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Čas úpravy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Počet slov</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>V Románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>V poznámkách</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Vybraný Román</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Kapitoly</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Scény</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Stiskněte tlačítko "Náhled" pro vygenerování ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>Zpracovávám...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Hotovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Sestaveno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>Bez náhledu</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Počet slov</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Naposledy otevřené</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Automatické nahrazení textu pro náhled a sestavení</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Klíčové slovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Nahradit za</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Vybrat položky k úpravě</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Název projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Změna ovlivní cestu zálohy.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Autor(ři)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Používá se pouze při sestavení rukopisu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Jazyk projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Výchozí</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Jazyk kontroly pravopisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Přepíše hlavní nastavení.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>Zakázat zálohování při zavření</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Stavy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Úrovně stavu dokumentu Románu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Důležitost</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Úrovně důležitosti poznámky projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>Nevyužívá se</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Použito jednou</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>Použito celkem {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Vyberte barvu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Popisek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Použití</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Přidat štítek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Smazat štítek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Posunout nahoru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Posunout dolu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Importovat štítky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Exportova popisky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Vybrat položky k úpravě</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Barva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Koláčový...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Sloupcový...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Blokový...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Tvar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>Nová položka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>Nelze odstranit statuv, který se používá.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Import souboru</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Export souboru</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1134" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Vysypat koš</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1155" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Přejmenovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1170" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Duplikovat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1190" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Otevřít dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1195" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>Zobrazit dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1204" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Vytvořit nový...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1216" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Přejmenování nadpisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1225" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Nastavení Aktivní na ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1231" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Přepnutí na aktivní</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1238" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Nastavit stav na ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1268" />
-      <location filename="../novelwriter/gui/projtree.py" line="1250" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Správa štítků...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1256" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Nastavit důležitost na...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1277" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Transformovat ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1299" />
-      <location filename="../novelwriter/gui/projtree.py" line="1295" />
-      <location filename="../novelwriter/gui/projtree.py" line="1291" />
-      <location filename="../novelwriter/gui/projtree.py" line="1287" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Převést na {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1303" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Sloučit podřízené položky do sebe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1305" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Sloučit podřízené položky do nového</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1309" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Sloučit dokumenty do složky</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1313" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Rozdělit dokument podle nadpisu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1320" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Rozbalit Vše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1322" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Sbalit vše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1332" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Trvale odstranit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1334" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>Přesunout do Koše</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1410" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Chcete převést složku na {0}? Tuto akci nelze vrátit zpět.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1048" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>Ze šablony</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>První položka</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Štítek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Důležitý</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Nadpis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Krátký popis</translation>
     </message>

--- a/i18n/nw_de_DE.ts
+++ b/i18n/nw_de_DE.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Dokumentenfilter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Romandokumente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Projektnotizen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Inaktive Dokumente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Überschriften</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Teil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Kapitel (Unnummeriert)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Szene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Szene (Variante)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Abschnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Teil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Szene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Textinhalt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Einschl. Zusammenfassung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Einschl. Kommentare</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Einschl. Schlagwörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Einschl. Fließtext</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Diese Schlagwörter ignorieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Titel für Notizen einfügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Textformatierung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Schriftart</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Zeilenhöhe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Blocksatz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Unicode ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Tabs durch Leerzeichen ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Harte Zeilenumbrüche behalten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Wörtliche Rede hervorheben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>Zeileneinzug</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Einzug aktivieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Einzug Breite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Einzug erster Absatz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Textabstände</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Titel und Teil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Überschrift 1 und Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Überschrift 2 und Szene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Überschrift 3 und Abschnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Überschrift 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Textabsatz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Szenentrenner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Seitenlayout</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Einheit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Seitenformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Seitenränder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Kopfzeile</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Seitenzahl-Offset</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Überschriften farbig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Überschriften größer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Überschriften fett</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>HTML-Einstellungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>CSS hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Tabs behalten</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>in der Zukunft</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>soeben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>vor einer Minute</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>{0} Minuten her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>eine Stunde her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>{0} Stunden her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>einen Tag her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>{0} Tage her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>eine Woche her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>{0} Wochen her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>einen Monat her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>{0} Monate her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>ein Jahr her</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>{0} Jahre her</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Überschrift 1 (Teil)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Überschrift 2 (Kapitel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Überschrift 3 (Szene)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Überschrift 4 (Abschnitt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Textabsatz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Szenentrenner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>Ohne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Handlung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Charaktere</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Schauplätze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Zeitleiste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Objekte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Organisationen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Benutzerdefiniert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Archiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Vorlagen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Papierkorb</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Romandokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Projektnotiz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Hauptordner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Ordner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Romantitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Szene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Romanabschnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>Aktiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Inaktiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Schlagwort</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Perspektive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Fokus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>Geschichte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Erwähnungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Ebene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Zeile</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Zeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Absätze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>Perspektive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Zusammenfassung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Microsoft-Word-Dokument (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter-Markup (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Standard-Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Erweitertes Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portable Document Format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter-Markup (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Quadrat</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Dreieck</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Raute</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Fünfeck</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Sechseck</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Stern</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>1/4-Kreis</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Halbkreis</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4-Kreis</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Voller Kreis</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 Balken</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 Balken</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 Balken</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 Balken</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 Block</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 Blöcke</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 Blöcke</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 Blöcke</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>Textdateien</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>Markdown-Dateien</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>novelWriter-Dateien</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>CSV-Dateien</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>Alle Dateien</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Millimeter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Zentimeter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Zoll</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Einfaches gerades Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Doppeltes gerades Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Einfaches Anführungszeichen 6 oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Einfaches Anführungszeichen 9 oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Einfaches Anführungszeichen 9 unten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Einfaches Anführungszeichen gespiegelte 9 oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Doppeltes Anführungszeichen 6 oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Doppeltes Anführungszeichen 9 oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Doppeltes Anführungszeichen 9 unten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Doppeltes Anführungszeichen gespiegelte 9 oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Doppeltes Anführungszeichen gespiegelte 9 unten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Einfaches Guillemet linkszeigend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>Einfaches Guillemet rechtszeigend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Doppeltes Guillemet linkszeigend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>Doppeltes Guillemet rechtszeigend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Linke Eckklammer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Rechte Eckklammer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Linke weiße Eckklammer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Rechte weiße Eckklammer</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>Über novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>Diese Anwendung ist unter {0} lizenziert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Mitwirkende</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Buildeinstellungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>Allgemein</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Auswahl</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Überschriften</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formatierung</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Wörterbücher hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Laden Sie ein Wörterbuch von einem der Links herunter und fügen Sie es unten hinzu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Wörterbuch hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Installationspfad der Wörterbücher</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Weitere Wörterbücher gefunden: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Erweiterung für FreeOffice oder LibreOffice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Dateien suchen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>Wörterbuchdatei konnte nicht verarbeitet werden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Hinzugefügt: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Zeile: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Wörter: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Wörter: {0} markiert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Werkzeugleiste ein/aus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Gliederung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Suche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Ablenkungsfrei ein/aus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Schließen</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Suchen nach</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Ersetzen durch</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Suchen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Groß-/Kleinschreibung beachten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Nur ganze Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>RegEx-Modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Suche am Anfang fortsetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Nächstes Dokument durchsuchen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Groß-/Kleinschreibung beibehalten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Suche schließen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Im geöffneten Dokument suchen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Im geöffneten Dokument suchen und ersetzen</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Dokument geöffnet: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Dieses Dokument wurde außerhalb von novelWriter geändert, während es hier geöffnet war. Möchten Sie die externen Änderungen überschreiben?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>Dokument konnte nicht gespeichert werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Dokument gespeichert: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Die Rechtschreibprüfung erfordert das Paket PyEnchant. Es scheint nicht installiert zu sein.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Rechtschreibprüfung abgeschlossen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Erstellt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Aktualisiert: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>Dateispeicherort: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Als Dokumentname verwenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>URL öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Schlagwort öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Notiz für Schlagwort erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Ausschneiden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Kopieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Einfügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Alles markieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Wort markieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Absatz markieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Korrekturvorschläge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>Keine Vorschläge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Wort ignorieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Zum Wörterbuch hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Bitte markieren Sie den Text, in dem die Anführungszeichen ersetzt werden sollen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Möchten Sie für das Schlagwort „{0}“ eine neue Projektnotiz erstellen?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Dokumente zusammenführen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Zusammenzuführende Dokumente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Reihenfolge der Elemente mit Drag &amp; Drop ändern oder abwählen, um Elemente auszuschließen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Zusammengeführte Elemente in den Papierkorb verschieben</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Dokument aufteilen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Überschriften im Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Wählen Sie die höchste Überschriften-Ebene aus, an der das Dokument geteilt werden soll.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Teilen bei Ebene 1 (Teil)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Teilen bei Ebene 2 (Kapitel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Teilen bei Ebene 3 (Szene)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Teilen bei Ebene 4 (Abschnitt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>In einen neuen Ordner aufteilen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Dokumenten-Hierarchie erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Geteiltes Dokument in den Papierkorb verschieben</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Fett mit Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Kursiv mit Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Durchgestrichen mit Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Fett mit Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Kursiv mit Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Durchgestrichen mit Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Unterstrichen mit Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Hervorheben mit Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Hochgestellt mit Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Tiefgestellt mit Shortcode</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Ansichtsbereich ein-/ausblenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Kommentare</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Kommentare anzeigen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Zusammenfassung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Zusammenfassung anzeigen</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Gliederung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Zurück</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Vor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Im Editor öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Aktualisieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Schließen</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>Fehler beim Erstellen der Vorschau.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Kopieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Alles markieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Wort markieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Absatz markieren</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Inaktive Schlagwörter ausblenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>Verweise</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Name</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Gruppe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Kategorie</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Platzhaltertext einfügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Lorem Ipsum einfügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Anzahl der Absätze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Zufällige Reihenfolge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Einfügen</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter ist bereit ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>Sie verwenden jetzt die novelWriter-Version {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Bitte lesen Sie die {0}Versionshinweise{1} für weitere Informationen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>Geöffnetes Projekt schließen?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Alle Änderungen werden automatisch gespeichert.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>Backup des geöffneten Projektes erstellen?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>Das Projekt ist bereits in einer anderen Instanz von novelWriter geöffnet und daher gesperrt. Sperre aufheben und fortfahren?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Hinweis: Nach einem Computer- oder Programmabsturz können Sie die Sperre einfach überschreiben. Falls das Projekt bereits in einer anderen Instanz von novelWriter geöffnet ist, könnte ein Überschreiben der Sperre zu fehlerhaften Daten führen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>Projekt gesperrt von Computer '{0}' ({1} {2}), letzte Aktivität war am {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>Der Index ist nicht aktuell oder defekt. Index wird aktualisiert.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Textdatei importieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>Datei konnte nicht gelesen werden. Bitte wählen Sie eine gültige Datei mit Text aus.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Bitte öffnen Sie zuerst ein Dokument in novelWriter, in welches Sie den Text importieren möchten.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>Das Importieren einer Datei überschreibt den Inhalt des geöffneten Dokuments. Fortfahren?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Index erstellt in {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>Index wurde erfolgreich aktualisiert.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>Der Dialog konnte nicht gestartet werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>Möchten Sie novelWriter beenden?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Einige Änderungen können erst nach Neustart von novelWriter angewendet werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>Der Verweis für das Schlagwort „{0}“ konnte nicht gefunden werden. Entweder es existiert nicht oder der Index ist veraltet. Aktualisieren Sie den Index über den Menüpunkt „Extras“ oder mit der Taste {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Projekt öffnen oder erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Projekt speichern</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Projekt schließen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Projekteinstellungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Romandetails</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Element umbenennen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Element entfernen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Papierkorb leeren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Programm beenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Dokument öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Dokument speichern</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Dokument schließen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>In der Ansicht öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Ansicht schließen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Dateiinformationen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Textdatei importieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Rückgängig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Wiederherstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Ausschneiden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Kopieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Einfügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Alles markieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Absatz markieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;Ansicht</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Zur Strukturansicht wechseln</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Zum Dokument wechseln</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Zur Gliederung wechseln</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Ansicht zurück</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Ansicht weiter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Ablenkungsfrei</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Vollbild</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>&amp;Einfügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Querstriche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Gedankenstrich</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Spiegelstrich</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Horizontaler Balken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Ziffernstrich</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Einfaches Anführungszeichen links</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Einfaches Anführungszeichen rechts</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Doppeltes Anführungszeichen links</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Doppeltes Anführungszeichen rechts</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Apostroph (alternativ)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>Allgemeine Zeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Auslassungspunkte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Hochstrich</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Doppelter Hochstrich</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>Leerzeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Geschützes Leerzeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Schmales Leerzeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Schmales geschütztes Leerzeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Andere Zeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>Aufzählung (Punkt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Aufzählung (Bindestrich)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Sternblume</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Promille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Grad</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Minus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Multiplikation</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Division</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Schlagwörter und Verweise</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Andere Kommentare</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Synopsis-Kommentar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Kommentar für Kurzbeschreibung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Wort-/Seitenanzahl</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Umbrüche und Leerräume</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Seitenumbruch</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Harter Zeilenumbruch</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Senkrechter Abstand (einfach)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Senkrechter Abstand (mehrfach)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Platzhaltertext</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Fußnote</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Fett</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Kursiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Durchgestrichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Doppelte Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Einfache Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>Weitere Formate ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Fett (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Kursiv (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Durchgestrichen (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Unterstrichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Hervorheben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Hochgestellt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Tiefgestellt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Romantitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Unnummeriertes Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Szene (Variante)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Linksbündig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Zentriert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Rechtsbündig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Einrückung links</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Einrückung rechts</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Kommentar ein/aus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Text ignorieren ein/aus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Absatzformatierung entfernen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Einfache gerade Anführungszeichen ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Doppelte gerade Anführungszeichen ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Zeilenumbrüche in Absätzen entfernen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;Suche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Suchen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Nächstes Suchergebnis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Vorheriges Suchergebnis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Nächste Fundstelle ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Im Projekt suchen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;Werkzeuge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Rechtschreibprüfung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Sprache der Rechtschreibprüfung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Standard</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Rechtschreibprüfung wiederholen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Projektwörterbuch</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Wörterbücher hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Index aktualisieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Backup erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Manuskript erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Schreibstatistiken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Einstellungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>&amp;Hilfe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>Über novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>Über Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>Benutzerhandbuch (online)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>Benutzerhandbuch (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Fehler melden (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Frage stellen (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>novelWriter-Website</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>Keine</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Session-Timer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Wörter: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Wörter im Projekt (Wörter in der aktuellen Session)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Wörter im Roman (Wörter in der aktuellen Session)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Manuskript erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Neuen Build hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Ausgewählten Build löschen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Ausgewählten Build duplizieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Ausgewählten Build bearbeiten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Builds</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Gliederung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Vorschau</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Drucken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Schließen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Seitenumbrüche anzeigen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>Mein Manuskript</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Manuskript erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Ausgabeformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Inhaltsverzeichnis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Pfad</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>Dateiname</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Dateiname auf Standard zurücksetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Ordner öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;Erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Verzeichnis wählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>Das Ausgabeverzeichnis existiert nicht.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>Die Datei ist bereits vorhanden. Möchten Sie sie überschreiben?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Romandetails</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Übersicht</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Inhalt</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Gliederung für {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Hauptordner für den Roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Aktualisieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Letzte Spalte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Ausblenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Erzählperspektive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Charakter im Fokus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Romanhandlung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Spaltenbreite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>Weitere Optionen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Maximale Spaltenbreite in %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>Keine Meta-Daten</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Szene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Abschnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Zusammenfassung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Titeldetails</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Referenzen</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Spalten anzeigen</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Gliederung für</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Aktualisieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>CSV exportieren</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Gliederung speichern</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Einstellungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Suchen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>Allgemein</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Darstellung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Anzeigesprache</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>Neustart erforderlich.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Farbschema (Anwendung)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>Allgemeines Farbschema und Icons.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Schriftart (Anwendung)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Vertikale Scrollbalken verbergen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Beschränkt das Scrollen auf Mausrad und Tastatur.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Horizontale Scrollbalken verbergen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Schriftauswahl des Betriebssystems verwenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Deaktivieren, um die Qt-Schriftauswahl zu verwenden. Bietet möglicherweise mehr Optionen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Darstellung (Dokumente)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Farbschema (Dokumente)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Farbschema für Editor und Ansicht.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Schriftart (Dokumente)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>Gilt für Editor und Ansicht.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Dokumente mit höherer Hierarchie optisch hervorheben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Bessere Sichtbarkeit in der Strukturansicht.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Vollständige Dokumentenhierarchie im Editor anzeigen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Zeigt die übergeordneten Elemente an.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Statusleiste: Wörter in Notizen mitzählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Verhalten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Dokument automatisch speichern</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>Wie oft das geöffnete Dokument automatisch gespeichert wird.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>Sekunden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Projekt automatisch speichern</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>Wie oft das gesamte Projekt automatisch gespeichert wird.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Vor dem Beenden von novelWriter fragen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Nur relevant, wenn ein Projekt geöffnet ist.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Backups</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Auswählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Verzeichnis für Backups</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Pfad: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Backup erstellen, wenn ein Projekt geschlossen wird</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Kann auch für einzelne Projekte in den Projekteinstellungen festgelegt werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Jedes Mal nachfragen, bevor ein Backup erstellt wird</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>Falls nein: Backups werden automatisch im Hintergrund erstellt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Session-Timer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Den Timer bei Inaktivität pausieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Pausiert auch, wenn das Programmfenster nicht den Fokus hat.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Pausiert nach Inaktivität</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>Dies berücksichtigt nur Änderungen im Texteditor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>Minuten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Schreiben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Textfluss</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Maximale Textbreite im normalen Modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>„0“ deaktiviert diese Funktion.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Maximale Textbreite im Modus „Ablenkungsfrei“</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>Die maximale Breite kann nicht deaktiviert werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Fußzeile verbergen im Modus „Ablenkungsfrei“</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Verbirgt die Informationsleiste im Editor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Blocksatz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Mindestabstand nach außen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Tabulator</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>Die Breite eines Tabulators im Editor und in der Ansicht.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Textbearbeitung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Rechtschreibprüfung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Verfügbare Sprachen werden vom Betriebssystem bereitgestellt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Wort mit Eingabezeiger gilt als „markiert“</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>Wenn nichts markiert ist, werden Formatierung auf das Wort mit der Eingabemarke angewendet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Tabs und Leerzeilen anzeigen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Zeilenende anzeigen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Bildlauf im Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Am Ende des Dokuments weiterscrollen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>Eingabemarke wird beim Scrollen zentriert.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Wie mit einer Schreibmaschine scrollen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Die Eingabemarke bleibt immer auf der gleichen Linie.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Mindesthöhe für den Schreibmaschinen-Effekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>Prozent der Editor-Höhe, von oben.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Hervorhebung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>Keine</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>Einfache Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>Doppelte Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>Beide</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Wörtliche Rede hervorheben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Wird für die ausgewählten Anführungszeichen angewendet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Alternative Zeichen für wörtliche Rede</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Benutzerdefinierte Hervorhebung von wörtlicher Rede.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Nicht geschlossene Anführungszeichen erlauben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Wörtliche Rede ohne schließendes Anführungszeichen hervorheben.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Zeichen für Dialogzeile</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Zeilen, die mit einem dieser Zeichen beginnen, werden als wörtliche Rede behandeln.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Zeichen für Erzähleinschub</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Zeichen für einen Erzähleinschub innerhalb von wörtlicher Rede.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Wechseln zwischen wörtlicher Rede und Erzählung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Dieses Zeichen wechselt zwischen wörtlicher Rede und Erzählung innerhalb eines Absatzes.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Formatierten Text hervorheben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Gilt nur für den Editor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Mehrere oder nachfolgende Leerzeichen hervorheben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Automatisierung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Text automatisch ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Ersetzen von Zeichen während der Eingabe.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Einfache Anführungszeichen ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Öffnende und schließende Anführungszeichen werden automatisch erkannt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Doppelte Anführungszeichen ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Bindestriche ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>Doppelte und dreifache Bindestriche werden zu Gedankenstrichen und Geviertstrichen umgewandelt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Punkte ersetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Drei aufeinander folgende Punkte werden zu Auslassungspunkten umgewandelt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Geschütztes Leerzeichen einfügen vor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Vor diesen Zeichen wird automatisch ein Leerzeichen eingefügt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Geschütztes Leerzeichen einfügen nach</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Nach diesen Zeichen wird automatisch ein Leerzeichen eingefügt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Schmales Leerzeichen verwenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Schmales Leerzeichen anstelle eines normalen Leerzeichens verwenden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Anführungszeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Einfaches Anführungszeichen öffnend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>Beginn von wörtlicher Rede mit einfachen Anführungszeichen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Einfaches Anführungszeichen schließend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>Ende von wörtlicher Rede mit einfachen Anführungszeichen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Doppeltes Anführungszeichen öffnend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>Beginn von wörtlicher Rede mit doppelten Anführungszeichen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Doppeltes Anführungszeichen schließend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>Ende von wörtlicher Rede mit doppelten Anführungszeichen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Backup-Verzeichnis</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Projektsuche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Groß-/Kleinschreibung beachten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Nur ganze Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>RegEx-Modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Suchen nach</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Projekteinstellungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Einstellungen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Wichtigkeit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Ersetzen</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Projektinhalt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Schnellzugriff</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Nach oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Nach unten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Element hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Alle ausklappen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Alle einklappen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Papierkorb leeren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>Weitere Optionen</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Konnte das Dokument oder den Ordner nirgends hinzufügen!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Im Papierkorb kann kein neuer Ordner erstellt werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>Neue Notiz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>Neues Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>Neue Szene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>Neues Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>Neuer Ordner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>Keine Dokumente zum Zusammenführen ausgewählt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Zusammengeführt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>Inhalt des Dokuments konnte nicht geschrieben werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>Soll dieses Dokument dupliziert werden?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Soll dieses Element und alle untergeordneten Elemente dupliziert werden?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>Nicht alle Elemente konnten dupliziert werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Hauptordner können nur gelöscht werden, wenn sie leer sind.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>Ausgewählte Elemente endgültig löschen?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>Ausgewählte Elemente in den Papierkorb legen?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>Papierkorb ist bereits leer.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>{0} Element(e) endgültig löschen?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Anführungszeichen auswählen</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Projektstruktur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Romanstruktur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Projektsuche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Gliederung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Manuskript erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Romandetails</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Schreibstatistiken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Einstellungen</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Willkommen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>Liste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>Neu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Auswählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Abbrechen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Öffnen</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Projektwörterbuch</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Wörter aus Textdatei importieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Wörter als Textdatei exportieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Wort hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Wort entfernen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Hinweis: Die Importdatei muss eine reine Textdatei mit UTF-8 oder ASCII-Kodierung sein.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Datei importieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Datei exportieren</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Statistiken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Beginn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Dauer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Inaktiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Histogramm</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Gesamt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Dauer:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Inaktiv:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Dauer mit Filtern:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Wörter im Roman:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Wörter in den Notizen:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Wörter gesamt:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Romandokumente mitzählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Notizen mitzählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>Unproduktive Sessions verbergen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>Negative Sessions verbergen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Nach Tag gruppieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Inaktivität anzeigen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Maximale Wörterzahl für das Histogramm</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Speichern als</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>JSON-Datei (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>CSV-Datei (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>JSON-Datei</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>CSV-Datei</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Speichern als</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>{0} erfolgreich gespeichert unter:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Fehler beim Speichern der {0}.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>Datei konnte nicht gelöscht werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Kein bekanntes Format für Projektdateien.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Pfad: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>Projektdatei nicht gefunden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Projekt konnte nicht geöffnet werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Unbekannt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>Projektdatei scheint keine gültiges novelWriterXML zu sein.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Unbekanntes oder nicht unterstütztes novelWriter-Projektformat. Das Projekt kann von dieser novelWriter-Version nicht geöffnet werden. Die Datei wurde gespeichert in Version {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>XML-Datei des Projektes konnte nicht gelesen werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>Das Dateiformat Ihres Projekts soll aktualisiert werden. Wenn Sie fortfahren, werden ältere Versionen von novelWriter dieses Projekt nicht mehr öffnen können. Fortfahren?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>Dieses Projekt wurde in einer aktuelleren novelWriter-Version gespeichert ({0}). Die installierte Version ist {1}. Falls Sie das Projekt dennoch öffnen möchten, könnten einige Eigenschaften und Einstellungen möglicherweise nicht beibehalten werden. Abgesehen davon sollte das Projekt jedoch in Ordnung sein. Projekt öffnen?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Wiederhergestellt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>{0} verwaiste Datei(en) im Projekt gefunden. {1} Datei(en) wurden wiederhergestellt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Projekt geöffnet: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>Es ist kein Projekt offen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Projekt konnte nicht gespeichert werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Projekt gespeichert: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Backup wird erstellt ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Ein Backup konnte nicht erstellt werden, da kein Projektname angegeben ist. Bitte legen Sie einen Projektnamen in den Projekteinstellungen fest.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>Backup-Verzeichnis konnte nicht erstellt werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Ein Backup des Projekts mit der Größe {0}B wurde erstellt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>Backup-Archiv konnte nicht erstellt werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Backup erstellt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>Neu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Notiz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Entwurf</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Fertig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Unwesentlich</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Wichtig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Zentral</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>Alle Romanordner</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>Das Zielverzeichnis ist nicht leer. Bitte wählen Sie ein anderes Verzeichnis.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>Beim Erstellen des Projekts ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>Neues Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Titelseite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Anschrift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>Von</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Zusammenfassung des Kapitels.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Zusammenfassung der Szene.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>Eine kurze Beschreibung.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Kapitel {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Szene {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Haupthandlung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonist</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Hauptschauplatz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>Das Zielverzeichnis existiert bereits. Bitte wählen Sie ein anderes Verzeichnis.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>Projektdateien konnten nicht kopiert werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Beispielprojekt konnte nicht erstellt werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Neues Beispielprojekt konnte nicht erstellt werden. Die dafür benötigten Daten konnten nicht gefunden werden. Anscheinend fehlen die Beispieldaten in Ihrer Installation.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Speichern</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Abbrechen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;Schließen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Schließen ohne speichern</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Speichern</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Alle speichern</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Ö&amp;ffnen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Ja</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Ja für &amp;alle</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;Nein</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>N&amp;ein für alle</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Abbrechen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Erneut versuchen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Ignorieren</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Schließen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>&amp;Abbrechen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Verwerfen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Hilfe</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Anwenden</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Zurücksetzen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Standard wiederherstellen</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Quadrat</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Dreieck</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Raute</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Fünfeck</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Sechseck</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Stern</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>1/4-Kreis</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Halbkreis</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4-Kreis</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Voller Kreis</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 Balken</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 Balken</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 Balken</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 Balken</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 Block</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 Blöcke</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 Blöcke</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 Blöcke</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>novelWriter-Projektdatei oder Zip-Datei</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>novelWriter-Projektdatei</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Projekt öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Schriftart auswählen</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Zeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Zeichen im Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Zeichen in Überschriften</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Absätze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Überschriften</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Zeichen ohne Leerzeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Zeichen im Text ohne Leerzeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Zeichen in Überschriften ohne Leerzeichen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Wörter im Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Wörter in Überschriften</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Aktuelle Version: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Überprüfung läuft ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Download: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Version</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Veröffentlicht am</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Versionshinweise</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>Jetzt prüfen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>Fehler</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Inhaltsverzeichnis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Seiten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Seite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Fortschritt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Wörter pro Seite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>Offset erste Seite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Kapitel auf ungeraden Seiten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Ohne Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>ENDE</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Einstellung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Wert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Auswahl</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Ausgeblendet</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>Im Manuskript enthalten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>Vom Manuskript ausgeschlossen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Immer enthalten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Immer ausgeschlossen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Auf Standard zurücksetzen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Auswahl markieren als</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Hauptordner wählen</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Information</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Warnung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Fehler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Frage</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Ausblenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Bearbeite: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>Keine</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Kapitelnummer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Kapitelnummer (Wort)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Kapitelnummer (Römisch in Großbuchstaben)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Kapitelnummer (Römisch in Kleinbuchstaben)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Szenennummer (im Kapitel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Szenennummer (Absolut)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Erzählperspektive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Charakter im Fokus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Einfügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Anwenden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Zentriert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Seitenumbruch</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Erforderlich</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Optional</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Neues Projekt erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Beispielprojekt erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Vorhandenes Projekt kopieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Projektname</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Autor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Projektpfad</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Projekt vorbereiten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Auf 0 setzen um nur Szenen hinzuzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>{0} Kapiteldokumente hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>{0} Szenendokumente hinzufügen (pro Kapitel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Ordner hinzufügen: Notizen für Handlungsstränge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Ordner hinzufügen: Notizen für Charaktere</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Ordner hinzufügen: Notizen für Schauplätze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Beispielnotizen zur obigen Auswahl hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Kapitel und Szenen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Projektnotizen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Neues Projekt erstellen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Speicherort wählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Neues Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Beispielprojekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Vorlage: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>Ein Projektname ist erforderlich.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>Der Projektpfad ist nicht erreichbar.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Pfad</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>„{0}“ von der Liste der zuletzt geöffneten Projekte entfernen? Ihre Daten werden nicht gelöscht.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Projekt öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Projekt entfernen</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Revisionen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Bearbeitungszeit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>in Romanen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>in Notizen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Ausgewählter Roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Kapitel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Szenen</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Zum Generieren den "Vorschau"-Button anklicken ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>In Bearbeitung ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Fertig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Erstellt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>Keine Vorschau</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Wörter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Zuletzt geöffnet</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Textersetzung für Vorschau und Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Stichwort</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Ersetzen durch</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Element zum Bearbeiten auswählen</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Projektname</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Änderungen wirken sich auf den Backup-Pfad aus.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Autor(en)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Wird nur beim Manuskript-Build verwendet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Projektsprache</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Standard</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Rechtschreibprüfung</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Überschreibt die Einstellungen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>Kein Backup beim Schließen des Projekts</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Romandokumente: Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Wichtigkeit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Projektnotizen: Wichtigkeit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>Nicht verwendet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Einmal verwendet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>Verwendet von {0} Elementen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Farbe wählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Etikett</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Vorkommen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Etikett hinzufügen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Etikett entfernen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Nach oben</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Nach unten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Etiketten importieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Etiketten exportieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Element zum Bearbeiten auswählen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Farbe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Kreise ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Balken ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Blöcke ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Form</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>Neuer Eintrag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>Element ist in Verwendung und konnte nicht gelöscht werden.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Datei importieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Datei exportieren</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Papierkorb leeren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Umbenennen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Duplizieren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Dokument öffnen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>Dokument anzeigen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Neu erstellen ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Umbenennen: Überschrift übernehmen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Aktiv setzen auf ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Aktivieren ein/aus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Status setzen auf ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Beschriftungen verwalten ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Wichtigkeit setzen auf ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Umwandeln ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Umwandeln in {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Unterelemente in dieses Dokument zusammenführen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Unterelemente in neues Dokument zusammenführen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Dokumente im Ordner zusammenführen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Dokument nach Überschriften aufteilen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Alle aufklappen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Alle zuklappen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Endgültig löschen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>In den Papierkorb legen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Möchten Sie den Ordner umwandeln in {0}? Diese Aktion kann nicht rückgängig gemacht werden.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>Von Vorlage</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>Erste Überschrift</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Schlagwort</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Wichtigkeit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Überschrift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Kurzbeschreibung</translation>
     </message>

--- a/i18n/nw_en_US.ts
+++ b/i18n/nw_en_US.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Document Filters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Novel Documents</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Project Notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Inactive Documents</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Partition Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Chapter Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Unnumbered Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Scene Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Alt. Scene Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Section Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Title Styling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Partition Styling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Chapter Styling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Scene Styling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Text Content</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Include Synopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Include Comments</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Include Keywords</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Include Body Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Ignore These Keywords</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Add Titles for Notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Text Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Text Font</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Line Height</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Justify Text Margins</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Replace Unicode Characters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Replace Tabs with Spaces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Preserve Hard Line Breaks</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Apply Dialog Highlighting</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>First Line Indent</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Enable Indent</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Indent Width</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Indent First Paragraph</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Text Margins</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Title and Partition</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Heading 1 and Chapter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Heading 2 and Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Heading 3 and Section</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Heading 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Text Paragraph</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Scene Separator</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Page Layout</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Unit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Page Size</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Page Margins</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Document Style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Page Header</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Page Counter Offset</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Add Colors to Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Increase Size of Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Bold Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>HTML Options</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>Add CSS Styles</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Preserve Tab Characters</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>in the future</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>just now</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>a minute ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>{0} minutes ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>an hour ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>{0} hours ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>a day ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>{0} days ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>a week ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>{0} weeks ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>a month ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>{0} months ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>a year ago</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>{0} years ago</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Title</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Heading 1 (Partition)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Heading 2 (Chapter)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Heading 3 (Scene)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Heading 4 (Section)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Text Paragraph</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Scene Separator</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>None</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Novel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Plot</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Characters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Locations</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Timeline</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Objects</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Entities</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Custom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Archive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Templates</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Trash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Novel Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Project Note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Root Folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Novel Title Page</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Novel Chapter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Novel Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Novel Section</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>Active</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Inactive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Tag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Point of View</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>Story</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Mentions</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Level</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Line</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Chars</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Words</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Pars</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>POV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Synopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Microsoft Word Document (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter Markup (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Standard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Extended Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portable Document Format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter Markup (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Square</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Triangle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Diamond</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Pentagon</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Hexagon</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Star</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>1/4 Circle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Half Circle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4 Circle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Full Circle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 Bar</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 Bars</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 Bars</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 Bars</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 Block</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 Blocks</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 Blocks</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 Blocks</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>Text files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>Markdown files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>novelWriter files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>CSV files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>All files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Millimeters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Centimeters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Inches</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Straight single quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Straight double quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Left single quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Right single quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Single low-9 quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Single high-reversed-9 quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Left double quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Right double quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Double low-9 quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Double high-reversed-9 quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Double low-reversed-9 quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Single left-pointing angle quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>Single right-pointing angle quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Double left-pointing angle quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>Double right-pointing angle quotation mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Left corner bracket</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Right corner bracket</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Left white corner bracket</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Right white corner bracket</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>About novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>This application is licensed under {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Credits</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Manuscript Build Settings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>General</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Selection</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formatting</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Add Dictionaries</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Download a dictionary from one of the links, and add it below.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Add Dictionary</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Dictionary install location</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Additional dictionaries found: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Free or Libre Office extension</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Browse Files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>Could not process dictionary file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Added: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Line: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Words: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Words: {0} selected</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Toggle Tool Bar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Outline</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Toggle Focus Mode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Close</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Search for</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Replace with</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Case Sensitive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Whole Words Only</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>RegEx Mode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Loop Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Search Next File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Preserve Case</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Close Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Find in current document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Find and replace in current document</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Opened Document: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>Could not save document.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Saved Document: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Spell checking requires the package PyEnchant. It does not appear to be installed.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Spell check complete</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Document Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Created: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Updated: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>File Location: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Set as Document Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>Open URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Follow Tag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Create Note for Tag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Cut</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Copy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Paste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Select All</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Select Word</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Select Paragraph</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Spelling Suggestion(s)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>No Suggestions</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Ignore Word</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Add Word to Dictionary</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Please select some text before calling replace quotes.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Do you want to create a new project note for the tag '{0}'?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Merge Documents</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Documents to Merge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Drag and drop items to change the order, or uncheck to exclude.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Move merged items to Trash</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Split Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Document Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Select the maximum level to split into files.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Split on Heading Level 1 (Partition)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Split up to Heading Level 2 (Chapter)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Split up to Heading Level 3 (Scene)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Split up to Heading Level 4 (Section)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>Split into a new folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Create document hierarchy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Move split document to Trash</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Markdown Bold</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Markdown Italic</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Markdown Strikethrough</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Shortcode Bold</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Shortcode Italic</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Shortcode Strikethrough</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Shortcode Underline</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Shortcode Highlight</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Shortcode Superscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Shortcode Subscript</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Show/Hide Viewer Panel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Comments</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Show Comments</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Synopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Show Synopsis Comments</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Outline</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Go Backward</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Go Forward</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Open in Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Reload</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Close</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>An error occurred while generating the preview.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Copy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Select All</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Select Word</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Select Paragraph</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Hide Inactive Tags</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>References</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Item Label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Label</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Class</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Usage</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Insert Placeholder Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Insert Lorem Ipsum Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Number of paragraphs</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Randomize order</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Insert</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter is ready ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>You are now running novelWriter version {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Please check the {0}release notes{1} for further details.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>Close the current project?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Changes are saved automatically.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>Backup the current project?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>The project index is outdated or broken. Rebuilding index.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Import File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>Could not read file. The file must be an existing text file.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Please open a document to import the text file into.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>Importing the file will overwrite the current content of the document. Do you want to proceed?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Indexing completed in {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>The project index has been successfully rebuilt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>Could not initialize the dialog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>Do you want to exit novelWriter?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Some changes will not be applied until novelWriter has been restarted.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Create or Open Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Save Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Close Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Project Settings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Novel Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Rename Item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Delete Item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Empty Trash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Exit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Open Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Save Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Close Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>View Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Close Document View</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Show File Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Import Text from File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Edit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Undo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Redo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Cut</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Copy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Paste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Select All</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Select Paragraph</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;View</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Go to Tree View</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Go to Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Go to Outline</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Navigate Backward</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Navigate Forward</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Focus Mode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Full Screen Mode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>&amp;Insert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Dashes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Short Dash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Long Dash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Horizontal Bar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Figure Dash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Quote Marks</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Left Single Quote</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Right Single Quote</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Left Double Quote</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Right Double Quote</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Alternative Apostrophe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>General Punctuation</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Ellipsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Prime</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Double Prime</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>White Spaces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Non-Breaking Space</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Thin Space</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Thin Non-Breaking Space</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Other Symbols</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>List Bullet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Hyphen Bullet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Flower Mark</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Per Mille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Degree Symbol</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Minus Sign</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Times Sign</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Division Sign</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Tags and References</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Special Comments</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Synopsis Comment</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Short Description Comment</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Word/Character Count</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Breaks and Vertical Space</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Page Break</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Forced Line Break</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Vertical Space (Single)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Vertical Space (Multi)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Placeholder Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Footnote</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Bold</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Italic</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Strikethrough</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Wrap Double Quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Wrap Single Quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>More Formats ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Bold (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Italics (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Strikethrough (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Underline</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Highlight</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Superscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Subscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Novel Title</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Unnumbered Chapter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Alternative Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Align Left</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Align Center</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Align Right</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Indent Left</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Indent Right</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Toggle Comment</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Toggle Ignore Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Remove Block Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Replace Straight Single Quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Replace Straight Double Quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Remove In-Paragraph Breaks</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Find</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Replace</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Find Next</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Find Previous</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Replace Next</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Find in Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;Tools</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Check Spelling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Spell Check Language</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Default</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Re-Run Spell Check</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Project Word List</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Add Dictionaries</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Rebuild Index</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Backup Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Build Manuscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Writing Statistics</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Preferences</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>&amp;Help</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>About novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>About Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>User Manual (Online)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>User Manual (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Report an Issue (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Ask a Question (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>The novelWriter Website</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>None</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Session Time</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Words: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Project word count (session change)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Novel word count (session change)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Build Manuscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Add New Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Delete Selected Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Duplicate Selected Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Edit Selected Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Builds</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Outline</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Preview</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Print</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Close</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Show Page Breaks</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>My Manuscript</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Build Manuscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Output Format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Table of Contents</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Path</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>File Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Reset file name to default</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Open Folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Select Folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>Output folder does not exist.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>The file already exists. Do you want to overwrite it?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Novel Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Overview</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Contents</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Outline of {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Novel Root</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Refresh</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Last Column</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Hidden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Point of View Character</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Focus Character</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Novel Plot</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Column Size</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>More Options</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Maximum column size in %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>No meta data</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Title</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Chapter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Section</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Synopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Title Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Reference Tags</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Select Columns</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Outline of</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Refresh</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>Export CSV</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Save Outline As</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Preferences</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>General</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Appearance</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Display language</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>Requires restart to take effect.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Color theme</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>General color theme and icons.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Application font</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Hide vertical scroll bars in main windows</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Scrolling available with mouse wheel and keys only.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Hide horizontal scroll bars in main windows</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Use the system's font selection dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Turn off to use the Qt font dialog, which may have more options.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Document Style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Document color theme</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Color theme for the editor and viewer.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Document font</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>Applies to both document editor and viewer.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Emphasize partition and chapter labels</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Makes them stand out in the project tree.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Show full path in document header</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Add the parent folder names to the header.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Include project notes in status bar word count</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Behavior</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Save document interval</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>How often the document is automatically saved.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>seconds</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Save project interval</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>How often the project is automatically saved.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Ask before exiting novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Only applies when a project is open.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Project Backup</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Browse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Backup storage location</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Path: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Run backup when the project is closed</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Can be overridden for individual projects in Project Settings.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Ask before running backup</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>If off, backups will run in the background.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Session Timer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Pause the session timer when not writing</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Also pauses when the application window does not have focus.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Editor inactive time before pausing timer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>User activity includes typing and changing the content.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>minutes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Writing</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Text Flow</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Maximum text width in "Normal Mode"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>Set to 0 to disable this feature.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Maximum text width in "Focus Mode"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>The maximum width cannot be disabled.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Hide document footer in "Focus Mode"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Hide the information bar in the document editor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Justify the text margins</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Minimum text margin</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Tab width</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>The width of a tab key press in the editor and viewer.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Text Editing</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Spell check language</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Available languages are determined by your system.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Auto-select word under cursor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>Apply formatting to word under cursor if no selection is made.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Show tabs and spaces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Show line endings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Editor Scrolling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Scroll past end of the document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>Also centers the cursor when scrolling.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Typewriter style scrolling when you type</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Keeps the cursor at a fixed vertical position.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Minimum position for Typewriter scrolling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>Percentage of the editor height from the top.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Text Highlighting</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>None</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>Single Quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>Double Quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>Both</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Highlight dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Applies to the selected quote styles.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Alternative dialog symbols</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Custom highlighting of dialog text.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Allow open-ended dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Highlight dialog line with no closing quote.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Dialog line symbols</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Lines starting with any of these symbols are dialog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Narrator break symbol</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Symbol to indicate a narrator break in dialog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Alternating dialog/narration symbol</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Alternates dialog highlighting within any paragraph.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Add highlight color to emphasised text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Applies to the document editor only.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Highlight multiple or trailing spaces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Text Automation</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Auto-replace text as you type</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Allow the editor to replace symbols as you type.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Auto-replace single quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Try to guess which is an opening or a closing quote.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Auto-replace double quotes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Auto-replace dashes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>Double and triple hyphens become short and long dashes.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Auto-replace dots</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Three consecutive dots become ellipsis.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Insert non-breaking space before</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Automatically add space before any of these symbols.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Insert non-breaking space after</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Automatically add space after any of these symbols.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Use thin space instead</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Inserts a thin space instead of a regular space.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Quotation Style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Single quote open style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>The symbol to use for a leading single quote.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Single quote close style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>The symbol to use for a trailing single quote.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Double quote open style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>The symbol to use for a leading double quote.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Double quote close style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>The symbol to use for a trailing double quote.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Backup Directory</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Project Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Case Sensitive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Whole Words Only</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>RegEx Mode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Search for</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Project Settings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Settings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Importance</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Auto-Replace</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Project Content</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Quick Links</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Move Up</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Move Down</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Add Item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Expand All</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Collapse All</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Empty Trash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>More Options</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Did not find anywhere to add the file or folder!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Cannot add new files or folders to the Trash folder.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>New Note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>New Chapter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>New Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>New Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>New Folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>No documents selected for merging.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Merged</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>Could not write document content.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>Do you want to duplicate this document?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Do you want to duplicate this item and all child items?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>Could not duplicate all items.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Root folders can only be deleted when they are empty.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>Permanently delete selected item(s)?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>Move selected item(s) to Trash?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>The Trash folder is already empty.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Permanently delete {0} file(s) from Trash?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Select Quote Style</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Project Tree View</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Novel Tree View</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Project Search</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Novel Outline View</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Build Manuscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Novel Details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Writing Statistics</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Settings</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Welcome</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>List</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>New</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Browse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Cancel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Create</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Open</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Project Word List</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Import words from text file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Export words to text file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Add Word</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Remove Word</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Import File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Export File</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Writing Statistics</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Session Start</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Length</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Idle</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Words</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Histogram</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Sum Totals</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Total Time:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Idle Time:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Filtered Time:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Novel Word Count:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Notes Word Count:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Total Word Count:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Count novel files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Count note files</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>Hide zero word count</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>Hide negative word count</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Group entries by day</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Show idle time</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Word count cap for the histogram</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Save As</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>JSON Data File (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>CSV Data File (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>JSON Data File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>CSV Data File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Save Data As</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>{0} file successfully written to:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Failed to write {0} file.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>Could not delete document file.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Not a known project file format.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Path: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>Project file not found.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Failed to open project.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Unknown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>Project file does not appear to be a novelWriterXML file.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>Failed to parse project xml.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Recovered</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Opened Project: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>There is no project open.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Failed to save project.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Saved Project: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Backing up project ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>Could not create backup folder.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Created a backup of your project of size {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>Could not write backup archive.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Project backed up to '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>New</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Draft</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Finished</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Minor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Major</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Main</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>All Novel Folders</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>The target folder is not empty. Please choose another folder.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>An error occurred while trying to create the project.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>New Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Title Page</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Address</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>By</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Word Count</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Summary of the chapter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Summary of the scene.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>A short description.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Chapter {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Scene {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Main Plot</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonist</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Main Location</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>The target folder already exists. Please choose another folder.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>Could not copy project files.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Failed to create a new example project.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Save</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Cancel</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;Close</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Close without Saving</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Save</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Save All</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Open</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Yes</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Yes to &amp;All</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;No</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>N&amp;o to All</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Abort</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Retry</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Ignore</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Close</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>Cancel</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Discard</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Help</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Apply</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Reset</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Restore Defaults</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Square</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Triangle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Diamond</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Pentagon</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Hexagon</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Star</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>1/4 Circle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Half Circle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4 Circle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Full Circle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 Bar</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 Bars</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 Bars</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 Bars</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 Block</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 Blocks</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 Blocks</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 Blocks</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>novelWriter Project File or Zip File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>novelWriter Project File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Open Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Select Font</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Characters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Characters in Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Characters in Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Paragraphs</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Characters, No Spaces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Characters in Text, No Spaces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Characters in Headings, No Spaces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Words</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Words in Text</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Words in Headings</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Latest Version: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Checking ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Download from {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Version</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Released on</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Release Notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>Check Now</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>Failed</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Table of Contents</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Title</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Words</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Pages</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Page</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Progress</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Words per page</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>First page offset</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Chapters on odd pages</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Untitled</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>END</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Setting</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Value</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Selection</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Title</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Hidden</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>Included in manuscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>Excluded from manuscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Always included</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Always excluded</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Reset to default</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Mark selection as</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Select Root Folders</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Information</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Warning</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Error</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Question</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Hide</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Editing: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>None</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Title</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Chapter Number</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Chapter Number (Word)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Chapter Number (Upper Case Roman)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Chapter Number (Lower Case Roman)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Scene Number (In Chapter)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Scene Number (Absolute)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Point of View Character</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Focus Character</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Insert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Apply</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Center</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Page Break</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Required</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Optional</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Create a fresh project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Create an example project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Copy an existing project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Project Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Author</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Project Path</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Prefill Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Set to 0 to only add scenes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>Add {0} chapter documents</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>Add {0} scene documents (to each chapter)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Add a folder for plot notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Add a folder for character notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Add a folder for location notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Add example notes to the above</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Chapters and Scenes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Project Notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Create New Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Select Project Folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Fresh Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Example Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Template: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>A project name is required.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>The project path is not reachable.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Path</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>Remove '{0}' from the recent projects list? The project files will not be deleted.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Open Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Remove Project</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Revisions</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Editing Time</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Word Count</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>In Novels</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>In Notes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Selected Novel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Chapters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Scenes</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Press the "Preview" button to generate ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>Processing ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Done</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Built</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>No Preview</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Word Count</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Last Opened</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Text Auto-Replace for Preview and Build</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Keyword</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Replace With</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Select item to edit</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Project name</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Changing this will affect the backup path.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Author(s)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Only used when building the manuscript.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Project language</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Default</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Spell check language</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Overrides main preferences.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>Disable backup on close</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Novel Document Status Levels</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Importance</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Project Note Importance Levels</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>Not in use</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Used once</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>Used by {0} items</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Select Color</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Usage</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Add Label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Delete Label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Move Up</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Move Down</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Import Labels</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Export Labels</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Select item to edit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Color</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Circles ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Bars ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Blocks ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Shape</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>New Item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>Cannot delete a status item that is in use.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Import File</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Export File</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Empty Trash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Rename</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Duplicate</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Open Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>View Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Create New ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Rename to Heading</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Set Active to ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Toggle Active</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Set Status to ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Manage Labels ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Set Importance to ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Transform ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Convert to {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Merge Child Items into Self</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Merge Child Items into New</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Merge Documents in Folder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Split Document by Headings</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Expand All</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Collapse All</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Delete Permanently</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>Move to Trash</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Do you want to convert the folder to a {0}? This action cannot be reversed.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>From Template</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>First Heading</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Tag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Importance</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Heading</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Short Description</translation>
     </message>

--- a/i18n/nw_es_419.ts
+++ b/i18n/nw_es_419.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Filtrado de Documentos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Documentos de Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Notas del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Documentos Excluidos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Títulación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Formato para Particiones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Formato para Capítulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Formato Sin Numeración</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Formato para Escenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Formato Alternativo para Escenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Formato para Secciones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Estilo de Títulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Estilo de Particiones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Estilo de Capítulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Estilo de Escenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Contenido Textual</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Incluir las Sinopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Incluir los Comentarios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Incluir las Palabras Clave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Incluir el Texto Base</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Ignorar estas palabras clave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Añadir Títulos a las Notas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Formato del Texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Tipografía del Texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Altura de Línea</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Justificar los Márgenes del Texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Reemplazar Caracteres Unicode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Reemplazar Tabulaciones por Espacios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Conservar Saltos de Línea Forzados</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Aplicar Resaltado sobre el Diálogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>Sangría en Línea Inicial</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Habilitar Sangría</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Ancho de Sangría</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Sangría en el Primer Párrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Márgenes del texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Título de novela y Partición</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Título 1 y Capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Título 2 y Escena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Título 3 y Sección</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Título 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Párrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Separador de escenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Diseño de Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Unidades</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Tamaño de Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Márgenes de página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Estilo del Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Encabezado de Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Desfase del Número de Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Añadir colores a los títulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Aumentar el tamaño de los títulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Títulos en negrita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>Opciones de HTML</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>Añadir Estilos CSS</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Preservar Caracteres de Tabulación</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>en el futuro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>ahora mismo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>hace un minuto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>hace {0} minutos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>hace una hora</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>hace {0} horas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>hace un día</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>hace {0} días</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>hace una semana</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>hace {0} semanas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>hace un mes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>hace {0} meses</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>hace un año</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>hace {0} años</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Título 1 (Partición)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Título 2 (Capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Título 3 (Escena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Título 4 (Sección)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Párrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Separador de escenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>Ninguno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Argumento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Personajes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Lugares</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Línea de Tiempo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Objetos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Entidades</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Personalizado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Plantillas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Papelera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Documento de Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Nota del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Carpeta Raíz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Carpeta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Portada de Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Capítulo de Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Escena de Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Sección Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>En uso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Sin uso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Punto de Vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Foco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>Historia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Menciones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Nivel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Línea</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Caract.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Palab.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Párrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>Perspectiva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Sinopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Documento de Microsoft Word (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>Etiquetado de novelWriter (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Markdown Estándar (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Markdown Ampliado (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portable Document Format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + Etiquetado de novelWriter (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Cuadrado</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Triángulo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Diamante</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Pentágono</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Hexágono</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Estrella</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>Cuarto de Círculo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Semicírculo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4 de Círculo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Círculo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 Barra</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 Barras</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 Barras</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 Barras</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 Bloque</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 Bloques</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 Bloques</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 Bloques</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>Archivos de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>Archivos de Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>Archivos de novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>Archivos CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>Todos los archivos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Milímetros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Centímetros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Pulgadas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>Legal / Oficio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>Letter / Carta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Apóstrofo adireccional</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Comillas adireccionales</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Comilla simple de apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Comilla simple de cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Comilla baja simple de cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Comilla alta simple de apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Comilla doble de apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Comilla doble de cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Comilla baja doble de cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Comilla alta doble de apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Comilla baja doble de apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Comilla angular simple de apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>Comilla angular simple de cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Comilla angular de apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>Comilla angular de cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Soporte de la esquina izquierda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Soporte de la esquina derecha</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Soporte de esquina blanco izquierdo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Soporte de equina blanco derecho</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>Acerca de novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>Esta aplicación se encuentra bajo licencia {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Créditos</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Opciones de Compilación del Manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Nombre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>Generales</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Selección</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Títulación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formato</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Agregar Diccionarios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Descargue un diccionario desde uno de estos enlaces, y localícelo a continuación.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Agregar el Diccionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Ubicación para instalar el diccionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Diccionarios encontrados: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Extensión de Free o Libre Office</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Explorar Archivos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>No se pudo procesar el archivo de diccionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Agregado: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Línea: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Palabras: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Palabras: {0} seleccionadas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Alternar Barra de Herramientas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Estructura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Buscar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Alternar el Modo Enfocado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Cerrar</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Buscar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Reemplazar con</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Buscar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Sensibilidad a Mayúsculas y Minúsculas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Sólo Palabras Enteras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>Modo ExReg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Reiniciar la Búsqueda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Buscar en el Siguiente Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Conservar Mayúsculas y Minúsculas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Cerrar la Búsqueda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Buscar en el documento actual</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Buscar y reemplazar en el documento actual</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Se Abrió el Documento: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Este documento ha cambiado por fuera de novelWriter estando abierto. ¿Sobreescribir en el disco?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>No se puedo guardar el documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Documento Guardado: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Para la corrección ortográfica se requiere del paquete PyEnchant. Parece que no se encuentra instalado.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Se completó la comprobación ortográfica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Detalles del Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Creación: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Actualizado en: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>Ubicación del Archivo: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Elegir como Nombre del Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>Abrir URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Continuar a Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Crear Nota para la Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Cortar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Copiar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Pegar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Seleccionar Todo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Seleccionar Palabra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Seleccionar Párrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Sugerencia(s) de Ortografía</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>No Hay Sugerencias</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Ignorar la palabra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Añadir Palabra al Diccionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Por favor seleccione algo del texto antes de intentar reemplazar las comillas.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>¿Desea crear una nueva nota del proyecto para la etiqueta '{0}'?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Combinar Documentos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Documentos a Combinar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Arrastre y suelte ítems para cambiar su orden, o desmárquelos para excluirlos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Mover ítems combinados a la papelera</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Separar el Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Títulación de Documentos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Elija el nivel máximo a separar en archivos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Separar por el Nivel de Título 1 (Partición)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Separar hasta el Nivel de Título 2 (Capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Separar hasta el Nivel de Título 3 (Escena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Separar hasta el Nivel de Título 4 (Sección)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>Separar en una nueva carpeta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Crear un árbol de documentos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Mover el documento separado a la Papelera</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Negrita (de Markdown)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Cursiva (de Markdown)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Tachado (de Markdown)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Negrita (en código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Cursiva (en código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Tachado (en código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Subrayado (en código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Resaltado (en código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Superíndice (en código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Subíndice (en código)</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Mostrar / Ocultar Panel del Visualizador</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Comentarios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Mostrar los Comentarios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Sinopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Mostrar las Sinopsis</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Estructura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Ir Atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Ir Adelante</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Abrir en el Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Actualizar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Cerrar</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>Ocurrió un error al generar la vista previa.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Copiar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Seleccionar Todo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Seleccionar Palabra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Seleccionar Párrafo</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Ocultar las Etiquetas Inactivas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>Referencias</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Rótulo del Ítem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Rótulo</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Rótulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Clase</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Uso</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Insertar Texto para Rellenar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Insertar texto Lorem Ipsum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Número de párrafos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Orden aleatorio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Insertar</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter ya está listo...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>Está usando la versión {0} de novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Por favor, revise las {0}notas de la versión{1} para más detalles.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>¿Cerrar el proyecto actual?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Los cambios se guardan automáticamente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>¿Respaldar datos del proyecto actual?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>El proyecto ya se ha abierto en otra instancia de novelWriter, y por lo tanto está bloqueado. ¿Interrumpir el bloqueo y continuar de todos modos?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Nota: Si el programa o la computadora dejaron de funcionar, se puede quitar el bloqueo con toda seguridad. No se recomienda en el caso de que otra instancia activa de novelWriter haya abierto el proyecto. En tal caso éste podrá entrar en corrupción.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>El proyecto fue bloqueado por el equipo '{0}' ({1} {2}), por última vez activo el {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>El índice del proyecto está dañado o desactualizado. Recomponiendo el índice.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Importar un Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>No se pudo leer el archivo. El archivo debe ser un archivo de texto existente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Por favor abra un documento en el cual importar el archivo de texto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>El contenido actual del documento será sobrescrito al importar el archivo. ¿Desea continuar?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Se completó el indexado en {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>El índice del proyecto se ha reconstruido con éxito.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>No se pudo inicializar el diálogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>¿Desea salir de novelWriter?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Algunos cambios no se aplicarán hasta haber reiniciado novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>No se pudo encontrar la referencia para la etiqueta '{0}'. O no existe, o se ha desactualizado el índice. Éste se puede actualizar desde el menú Herramientas, o presionando {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Crear o Abrir un Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Guardar Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Cerrar Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Configuración del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Detalles de la Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Renombrar Ítem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Eliminar Ítem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Vaciar la Papelera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Salir</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Abrir Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Guardar Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Cerrar Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>Visualizar Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Cerrar Visualización</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Mostrar Detalles del Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Importar Texto desde un Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Editar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Deshacer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Rehacer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Cortar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Copiar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Pegar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Seleccionar Todo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Seleccionar Párrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;Ver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Ir a Vista de Árbol</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Ir al Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Ir a la Estructura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Navegar hacia atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Navegar hacia adelante</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Modo Enfocado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Modo Pantalla Completa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>&amp;Insertar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Rayas y Guiones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Guion</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Raya</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Barra Horizontal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Guion de Combinación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Comillas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Comilla Simple de Apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Comilla Simple de Cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Comilla Doble de Apertura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Comilla Doble de Cierre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Apóstrofo Alternativo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>Puntuación General</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Puntos Suspensivos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Prima</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Doble Prima</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>Espacio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Espacio Duro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Espacio Angosto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Espacio Duro Angosto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Otros Signos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>Viñeta de Lista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Viñeta Guion</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Signo Flor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Por Mil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Signo de Grado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Signo Menos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Signo de Multiplicación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Signo de División</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Etiquetas y Referencias</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Comentarios Especiales</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Comentario de Sinopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Breve Comentario Descriptivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Conteo de palabras/caracteres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Saltos y Espacio vertical</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Salto de Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Salto de línea forzado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Salto Vertical (Único)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Salto Vertical (Múltiple)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Texto para Rellenar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Nota al pie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Formato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Negrita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Cursiva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Tachado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Envolver con Comillas Dobles</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Envolver con Comillas Simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>Más Formatos...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Negrita (Código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Cursiva (Código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Tachado (Código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Subrayado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Resaltar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Superíndice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Subíndice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Título de la Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Capítulo Sin Número</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Escena Alternativa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Alinear a la Izquierda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Alinear al Centro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Alinear a la Derecha</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Indentar a la Izquierda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Indentar a la Derecha</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Alternar a Comentario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Ignorar Texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Quitar Formato del Bloque</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Reemplazar Apóstrofos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Reemplazar Comillas ASCII</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Quitar los Quiebres de Párrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;Búsqueda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Buscar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Reemplazar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Buscar Siguiente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Buscar Anterior</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Reemplazar Siguiente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Buscar en el Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;Herramientas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Comprobar la Ortografía</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Idioma de la Comprobación Ortográfica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Por defecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Reiniciar la Comprobación Ortográfica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Lista de Palabras del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Agregar Diccionarios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Reconstruir el Índice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Crea una copia de seguridad del proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Compilar el Manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Estadísticas de Redacción</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Preferencias</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>&amp;Ayuda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>Acerca de novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>Acerca de Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>Manual de Usuario (En línea)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>Manual de Usuario (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Reportar un Problema (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Hacer una Pregunta (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>El Sitio Web de novelWriter</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>Ninguno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Tiempo de la Sesión</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Palabras: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Total de palabras del proyecto (y variación por la sesión actual)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Total de palabras de la novela (y variación por la sesión actual)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Compilar Manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Añadir una Nueva Compilación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Eliminar la Compilación Seleccionada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Duplicar la compilación seleccionada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Editar la Compilación Seleccionada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Compilaciones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Detalles</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Estructura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Vista Previa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Imprimir</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Compilar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Cerrar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Mostrar saltos de página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>Mi Manuscrito</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Compilar el Manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Grabar al Siguiente Formato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Tabla de Contenidos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Ruta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>Nombre del Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Restablecer al Nombre de Archivo Por Defecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Abrir la Carpeta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>C&amp;ompilar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Seleccionar una Carpeta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>La carpeta destino no existe en la ruta definida.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>El archivo ya existe. ¿Desea sobrescribirlo?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Detalles de la Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Resumen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Contenido</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Estructura de {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Raíz de la Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Actualizar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Última Columna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Ocultar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Personaje Vehículo del Punto de Vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Personaje bajo Enfoque</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Argumento de la Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Tamaño de Columna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>Más Opciones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Tamaño de columna máximo en %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>Sin metadatos</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Escena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Sección</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Sinopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Detalles del Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Etiquetado</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Escoger Columnas</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Estructura de</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Actualizar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>Exportar a CSV</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Guardar Estructura Como</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Preferencias</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Buscar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>General</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Apariencia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Idioma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>Se requiere reiniciar la aplicación para surtir efecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Tema de colores</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>Tema general de colores y de íconos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Tipografía de la Aplicación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Esconder las barras de desplazamiento vertical en las ventanas principales</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Se podrá desplazar solamente por medio del ratón y de las teclas.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Esconder las barras de desplazamiento horizontal en las ventanas principales</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Seleccionar tipografías con el cuadro de diálogo del sistema</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Desactive para seleccionar tipografías por medio de Qt, que puede ofrecer más opciones.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Estilo del Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Tema de colores del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Tema de colores del editor y del visualizador.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Tipografía del Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>A usar tanto en el editor como en el visualizador de documentos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Enfatizar etiquetado de particiones y capítulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Se las destaca en el árbol del proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Mostrar la ruta completa del documento en el encabezado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Añade los nombres de carpetas superiores al encabezado.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Incluir a las notas del proyecto en el total de palabras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Comportamiento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Intervalo para guardar el documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>Con qué frecuencia se guardará automáticamente el documento actual.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>segundos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Intervalo para guardar el proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>Con qué frecuencia se guardará automáticamente el proyecto actual.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Preguntar antes de salir de novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Solo cuando hay un proyecto abierto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Respaldado de Datos del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Abrir ubicación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Ubicación de la copia de seguridad</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Ruta destino: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Crear una copia de seguridad cuando se cierre el proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Puede anularse para un proyecto individual en la Configuración del Proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Preguntar antes de respaldar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>De lo contrario se crearán las copias de seguridad en segundo plano.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Tiempo de la Sesión</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Poner el tiempo de la sesión en pausa cuando no se esté escribiendo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Además lo pone en pausa cuando la ventana de la aplicación no tenga el foco.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Lapso de inacción antes de poner el tiempo en pausa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>Las acciones incluyen tipear y modificar el contenido.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>minutos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Escritura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Flujo del Texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Anchura máxima del texto en "Modo Normal"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>Establecer en 0 para desactivar esta función.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Anchura máxima del texto en "Modo Enfocado"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>La anchura máxima no se puede desactivar.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Ocultar el pie del documento en el "Modo Enfocado"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Oculta la barra de información del editor del documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Justificar los márgenes del texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Margen mínimo del texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Anchura de la tabulación por tecla Tab</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>El ancho de una tabulación producido en el editor y el visualizador.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Edición</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Idioma a comprobar la ortografía</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Su sistema determinará los idiomas disponibles.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Seleccionar la palabra bajo el cursor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>De no haber selección se aplicará el formato a la palabra situada bajo el cursor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Mostrar tabulaciones y espacios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Mostrar fin de línea</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Desplazamiento del Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Desplazar más allá del final del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>También centra el cursor al desplazarse.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Desplazamiento estilo "máquina de escribir" cuando teclea</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Conservará el cursor de texto en una posición vertical fija.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Posicionamiento mínimo para desplazar tipo "Máquina de escribir"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>Un porcentaje de la altura del editor desde el tope.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Resaltado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>En ningún caso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>En Comillas Simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>En Comillas Dobles</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>En ambos casos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Resaltar diálogos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Se aplica a los estilos de comillas seleccionados.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Símbolos de diálogo alternativos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Personaliza el resaltado de diálogos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Permitir diálogos en continuado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Se resaltarán líneas del diálogo sin símbolo de cierre.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Símbolos de línea de diálogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Las líneas que empiecen con uno de estos símbolos serán diálogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Símbolo de comentario del narrador</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Símbolo que indica una interrupción del diálogo por parte del narrador.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Símbolo alternante entre diálogo y narración</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Proporciona resaltado del diálogo en medio de un párrafo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Añadir resalte de color al texto enfatizado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Se usará solo en el editor de documentos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Resaltar espacios múltiples o finales</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Automatización</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Reemplazar el texto mientras se escribe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Permite al editor reemplazar símbolos mientras tipea.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Reemplazar comillas simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Se intentará adivinar cuáles comillas son de apertura o de cierre.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Reemplazar comillas dobles</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Reemplazar guiones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>Los guiones dobles y triples se convertirán en rayas cortas y largas.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Reemplazar puntos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Tres puntos consecutivos se convierten en el carácter de puntos suspensivos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Insertar un espacio duro previo a</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Añade un espacio indivisible automáticamente delante de un símbolo de esta lista.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Insertar un espacio duro posterior a</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Añade un espacio indivisible automáticamente detrás de un símbolo de esta lista.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Pero espaciar con un espacio duro fino</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Inserta un espacio indivisible más estrecho en lugar de un espacio duro regular.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Empleo de Comillas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Estilo de comilla de apertura simple</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>El símbolo a usar para una comilla de apertura simple.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Estilo de comilla de cierre simple</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>El símbolo a usar para una comilla de cierre simple.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Estilo de comilla de apertura doble</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>El símbolo a usar para una comilla de apertura doble.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Estilo de comilla de cierre doble</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>El símbolo a usar para una comilla de cierre doble.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Directorio de la Copia de Seguridad</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Búsqueda en Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Sensibilidad a Mayúsculas y Minúsculas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Sólo Palabras Enteras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>Modo ExReg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Buscar</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Configuración del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Configuración</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Importancia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Reemplazos</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Contenido del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Enlaces Rápidos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Mover Arriba</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Mover Abajo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Añadir Ítem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Expandir Todo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Contraer Todo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Vaciar la Papelera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>Más Opciones</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>¡No se encontró dónde añadir el archivo o carpeta!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>No se puede añadir nuevos archivos o carpetas a la carpeta Papelera.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>Nota nueva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>Capítulo Nuevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>Escena Nueva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>Documento Nuevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>Nueva Carpeta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>No se han seleccionado documentos para combinar.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Combinado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>No se pudo escribir el contenido del documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>¿Desea duplicar este documento?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>¿Desea duplicar este ítem y todos sus ítems secundarios?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>No se ha podido duplicar todos los ítems.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Las carpetas raíz sólo pueden eliminarse si están vacías.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>¿Eliminar permanentemente el/los elemento(s) seleccionado(s)?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>¿Mover elemento(s) seleccionado(s) a la Papelera?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>La carpeta Papelera ya está vacía.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>¿Eliminar {0} archivo(s) permanentemente de la Papelera?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Seleccionar estilo de entrecomillado</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Vista de Árbol del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Vista de Árbol de Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Búsqueda en Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Vista de Estructura de la Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Compilar el Manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Detalles de la Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Estadísticas de Redacción</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Configuración</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Bienvenida</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>Lista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>Nuevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Abrir ubicación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Cancelar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Crear</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Abrir</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Lista de Palabras del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Importar palabras desde un archivo de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Exportar palabras a un archivo de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Agregar palabra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Quitar palabra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Nota: El archivo a importar debe ser un archivo de texto plano (codificación UTF-8 o ASCII).</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Importar desde Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Exportar a Archivo</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Estadísticas de Redacción</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Inicio de la Sesión</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Duración</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Inactividad</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Palabras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Histograma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Totales Agregados</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Tiempo Total:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Tiempo de Inactividad:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Tiempo con Filtros:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Total de Palabras de Novela:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Total de Palabras de Notas:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Total de Palabras:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filtros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Contar archivos de novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Contar archivos de notas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>No mostrar totales en cero</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>No mostrar totales negativos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Agrupar entradas por día</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Mostrar tiempo de inactividad</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Límite de total de palabras para el histograma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Guardar Como</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>Archivo de Datos JSON (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>Archivo de Datos CSV (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>Archivo de Datos JSON</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>Archivo de Datos CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Guardar Datos Como</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>El archivo {0} se ha guardado con éxito en:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Hubo una falla al escribir el archivo {0}.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>No se puedo eliminar el archivo de documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Formato de archivo de proyecto desconocido.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Ruta destino: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>No se ha encontrado el archivo de proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Hubo una falla al abrir el proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Desconocido</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>Aparentemente el archivo del proyecto no es un archivo novelWriterXML.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Formato de archivo de proyecto novelWriter desconocido, o no soportado. Esta versión de novelWriter no puede abrir el proyecto. El archivo se guardó con la versión {0} de novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>Hubo una falla al procesar el xml del proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>Se está por actualizar el formato de archivo de su proyecto. De continuar, ninguna versión anterior de novelWriter podrá abrir este proyecto. ¿Continuar?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>Este proyecto se ha guardado en una versión nueva de novelWriter, la versión {0}. Ésta es la versión {1}. Si procede a abrir el proyecto, algunos atributos y opciones no serán preservadas, pero en general el proyecto no presentará problemas. ¿Continuar abriendo el proyecto?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Restaurado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Se ha(n) encontrado {0} archivo(s) sin vinculación en el proyecto. Se ha(n) recuperado {1} archivo(s).</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Se Abrió el Proyecto: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>No hay ningún proyecto abierto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Hubo una falla al guardar el proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Proyecto Guardado: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Respaldando el proyecto...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>No se puede crear una copia de seguridad porque no se estableció el nombre del proyecto. Por favor escoja un Nombre de Proyecto en la Configuración del Proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>No se pudo crear la carpeta de respaldo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Se ha creado una copia de seguridad del proyecto de {0}B de tamaño.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>No se puedo escribir el archivo de respaldo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Se ha respaldado el proyecto en '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>Nuevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Nota</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Borrador</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Terminado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Menor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Mayor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Principal</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>Todas las Carpetas de Novela</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>La carpeta de destino no está vacía. Por favor, elija otra.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>Ocurrió un error mientras se intentaba crear el proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>Proyecto Nuevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Título de la Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Dirección</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>Por</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Total de Palabras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Resumen del capítulo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Resumen de la escena.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>Una breve descripción.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Capítulo {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Escena {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Argumento Principal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Lugar Principal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>La carpeta de destino ya existe. Por favor, elija otra.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>No se han podido copiar los archivos del proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Hubo una falla al crear un nuevo proyecto de ejemplo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Hubo una falla al crear un nuevo proyecto de ejemplo. No se pudieron encontrar los archivos necesarios. Aparentemente esta instalación carece de ellos.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Guardar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Cancelar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;Cerrar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Cerrar sin Guardar</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Guardar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Guardar Todo</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Abrir</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Sí</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Sí a &amp;Todo</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;No</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>N&amp;o a Todo</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Abortar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Reintentar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Ignorar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Cerrar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>Cancelar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Descartar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Ayuda</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Aplicar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Restablecer</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Restaurar valores predeterminados</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Cuadrado</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Triángulo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Diamante</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Pentágono</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Hexágono</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Estrella</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>Cuarto de Círculo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Semicírculo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4 de Círculo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Círculo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 Barra</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 Barras</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 Barras</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 Barras</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 Bloque</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 Bloques</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 Bloques</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 Bloques</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>Archivo de proyecto de novelWriter o archivo Zip</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>Archivo de Proyecto de novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Abrir un Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Seleccionar Tipografía</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Caracteres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Caracteres en el Texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Caracteres en los Títulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Párrafos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Títulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Caracteres, sin Espacios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Caracteres en el Texto, sin Espacios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Caracteres en los Títulos, sin Espacios</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Palabras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Palabras en el Texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Palabras en los Titulos</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Última versión: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Comprobando...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Descargar de {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Versión</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Publicado el</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Notas de la Versión</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>Verificar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>Hubo una falla</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Tabla de Contenido</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Palabras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Páginas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Progreso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Palabras por página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>Desfase de la primera página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Capítulos en páginas impares</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Sin Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>FIN</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Opciones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Valores Definidos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Nombre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Selecciones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Oculto</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>A incluir en el manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>A excluir del manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Incluir de todos modos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Excluir de todos modos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Restablecer a por defecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Ajustar la selección a:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Carpetas Raíz a Seleccionar</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Información</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Advertencia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Error</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Pregunta</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Omitir</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Editando: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>Ninguno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Numeral del Capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Numeral del Capítulo (En Palabras)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Numeral Romano del Capítulo (Mayúsculas)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Numeral Romano del Capítulo (Minúsculas)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Numeral de la Escena (En el Capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Numeral de la Escena (Valor Absoluto)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Perspectiva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Personaje Central</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Insertar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Aplicar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Centrado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Salto de Página</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Requerido</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Opcional</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Crear un nuevo proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Crear un ejemplo de proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Copiar un proyecto existente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Nombre del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Autor(es)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Ruta del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Rellenar el Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Escoger 0 para solo añadir escenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>Incluir {0} capítulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>Incluir {0} escenas (a cada capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Añadir una carpeta para notas argumentales</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Añadir una carpeta para notas sobre los personajes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Añadir una carpeta para notas acerca de los lugares</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Añadir ejemplos de notas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Capítulos y Escenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Notas del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Crear un Proyecto Nuevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Escoger la Carpeta del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Proyecto vacío</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Ejemplo de Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Plantilla: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>Se requiere un nombre de proyecto.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>No se puede acceder a la ruta del proyecto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Ruta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>¿Eliminar '{0}' de la lista de proyectos recientes? Los archivos del proyecto no se eliminarán.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Abrir un Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Eliminar Proyecto</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Nombre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Revisiones</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Tiempo de Edición</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Total de Palabras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>En Novelas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>En Notas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Novela seleccionada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Capítulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Escenas</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Pulse el botón "Vista Previa" para así generarla...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>Procesando...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Hecho</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Compilado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>Sin Vista Previa</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Total de Palabras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Abierto por última vez</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Lista de Reemplazos de Texto para Previsualizar y Compilar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Palabra Clave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Reemplazar Por</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Seleccionar el ítem a editar</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Nombre del proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Cambiar esto afectará a la ruta de la copia de seguridad.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Autores</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Se utiliza solo al compilar el manuscrito.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Idioma del proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Por defecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Idioma a comprobar la ortografía</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Anulará a la configuración principal.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>No crear copia de seguridad al cerrar</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Estados de los Documentos de Novela</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Importancia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Prioridades de las Notas del Proyecto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>No está en uso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Un ítem lo usa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>{0} ítems lo usan</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Escoger un Color</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Rótulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Uso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Añadir Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Eliminar Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Mover arriba</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Mover abajo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Importar etiquetas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Exportar etiquetas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Seleccionar el ítem a editar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Color</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Círculos...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Barras...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Bloques...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Forma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>Nuevo Ítem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>No se puede eliminar un ítem de estado actualmente en uso.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Importar desde Archivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Exportar a Archivo</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Vaciar la Papelera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Renombrar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Duplicar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Abrir el Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>Visualizar el Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Crear Nuevo...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Renombrar a Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Inclusión...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Alternar su Inclusión</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Cambiar el Estado a...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Administrar las Etiquetas...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Importancia...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Transformar...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Convertir a {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Combinar Ítems Descendientes con sí mismo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Combinar los Ítems Descendientes en uno Nuevo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Combinar los Documentos de la Carpeta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Separar el Documento según Titulación</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Expandir Todo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Contraer Todo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Eliminar Permanentemente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>Mover a la Papelera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>¿Desea convertir la carpeta a {0}? Esta acción es irreversible.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>A partir de Plantilla</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>Primer Título</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Importancia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Breve Descripción</translation>
     </message>

--- a/i18n/nw_fr_FR.ts
+++ b/i18n/nw_fr_FR.ts
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="310" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="117" />
       <source>Title</source>
       <translation>Titre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118" />
       <source>Heading 1 (Partition)</source>
       <translation>Titre 1 (Partie)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119" />
       <source>Heading 2 (Chapter)</source>
       <translation>Titre 2 (Chapitre)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120" />
       <source>Heading 3 (Scene)</source>
       <translation>Titre 3 (Scène)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121" />
       <source>Heading 4 (Section)</source>
       <translation>Titre 4 (Section)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122" />
       <source>Text Paragraph</source>
       <translation>Paragraphe de texte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123" />
       <source>Scene Separator</source>
       <translation>Séparateur de scène</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="267" />
-      <location filename="../novelwriter/constants.py" line="262" />
-      <location filename="../novelwriter/constants.py" line="234" />
+      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="240" />
       <source>None</source>
       <translation>Sans</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="235" />
+      <location filename="../novelwriter/constants.py" line="241" />
       <source>Novel</source>
       <translation>Roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
-      <location filename="../novelwriter/constants.py" line="236" />
+      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="242" />
       <source>Plot</source>
       <translation>Intrigue</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="285" />
-      <location filename="../novelwriter/constants.py" line="237" />
+      <location filename="../novelwriter/constants.py" line="291" />
+      <location filename="../novelwriter/constants.py" line="243" />
       <source>Characters</source>
       <translation>Personnages</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="288" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="294" />
+      <location filename="../novelwriter/constants.py" line="244" />
       <source>Locations</source>
       <translation>Lieux</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="245" />
       <source>Timeline</source>
       <translation>Chronologie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="295" />
+      <location filename="../novelwriter/constants.py" line="246" />
       <source>Objects</source>
       <translation>Objets</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="247" />
       <source>Entities</source>
       <translation>Entités</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="425" />
+      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="248" />
       <source>Custom</source>
       <translation>Personnalisé</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="249" />
       <source>Archive</source>
       <translation>Archive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="250" />
       <source>Templates</source>
       <translation>Modèles</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="251" />
       <source>Trash</source>
       <translation>Corbeille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="270" />
-      <location filename="../novelwriter/constants.py" line="263" />
+      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="269" />
       <source>Novel Document</source>
       <translation>Document du roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
-      <location filename="../novelwriter/constants.py" line="264" />
+      <location filename="../novelwriter/constants.py" line="281" />
+      <location filename="../novelwriter/constants.py" line="270" />
       <source>Project Note</source>
       <translation>Note du projet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="274" />
       <source>Root Folder</source>
       <translation>Dossier racine</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="269" />
+      <location filename="../novelwriter/constants.py" line="275" />
       <source>Folder</source>
       <translation>Dossier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
+      <location filename="../novelwriter/constants.py" line="277" />
       <source>Novel Title Page</source>
       <translation>Page de titre du roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="278" />
       <source>Novel Chapter</source>
       <translation>Chapitre du roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="279" />
       <source>Novel Scene</source>
       <translation>Scène du roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
+      <location filename="../novelwriter/constants.py" line="280" />
       <source>Novel Section</source>
       <translation>Section de roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="284" />
       <source>Active</source>
       <translation>Actif</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
+      <location filename="../novelwriter/constants.py" line="285" />
       <source>Inactive</source>
       <translation>Inactif</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="288" />
       <source>Tag</source>
       <translation>Étiquette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="289" />
       <source>Point of View</source>
       <translation>Point de vue</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
-      <location filename="../novelwriter/constants.py" line="284" />
+      <location filename="../novelwriter/constants.py" line="325" />
+      <location filename="../novelwriter/constants.py" line="290" />
       <source>Focus</source>
       <translation>Focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="298" />
       <source>Story</source>
       <translation>Histoire</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="299" />
       <source>Mentions</source>
       <translation>Mentions</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="311" />
+      <location filename="../novelwriter/constants.py" line="317" />
       <source>Level</source>
       <translation>Niveau</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="312" />
+      <location filename="../novelwriter/constants.py" line="318" />
       <source>Document</source>
       <translation>Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="313" />
+      <location filename="../novelwriter/constants.py" line="319" />
       <source>Line</source>
       <translation>Ligne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
+      <location filename="../novelwriter/constants.py" line="320" />
       <source>Status</source>
       <translation>État</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="321" />
       <source>Chars</source>
       <translation>Caractères</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="322" />
       <source>Words</source>
       <translation>Mots</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="323" />
       <source>Pars</source>
       <translation>Parties</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="324" />
       <source>POV</source>
       <translation>PDV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="329" />
+      <location filename="../novelwriter/constants.py" line="335" />
       <source>Synopsis</source>
       <translation>Synopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="351" />
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="352" />
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="347" />
+      <location filename="../novelwriter/constants.py" line="353" />
       <source>Microsoft Word Document (.docx)</source>
       <translation>Document Microsoft Word (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="348" />
+      <location filename="../novelwriter/constants.py" line="354" />
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="355" />
       <source>novelWriter Markup (.txt)</source>
       <translation>Marquage novelWriter (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="356" />
       <source>Standard Markdown (.md)</source>
       <translation>Markdown standard (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="357" />
       <source>Extended Markdown (.md)</source>
       <translation>Markdown étendu (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="358" />
       <source>Portable Document Format (.pdf)</source>
       <translation>Format de document portable (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="359" />
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="360" />
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + marquage novelWriter (.json)</translation>
     </message>
     <message>
+      <location filename="../novelwriter/constants.py" line="375" />
+      <source>Square</source>
+      <translation type="unfinished">Carré</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376" />
+      <source>Triangle</source>
+      <translation type="unfinished">Triangle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377" />
+      <source>Nabla</source>
+      <translation type="unfinished">Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378" />
+      <source>Diamond</source>
+      <translation type="unfinished">Losange</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379" />
+      <source>Pentagon</source>
+      <translation type="unfinished">Pentagone</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380" />
+      <source>Hexagon</source>
+      <translation type="unfinished">Hexagone</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381" />
+      <source>Star</source>
+      <translation type="unfinished">Étoile</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382" />
+      <source>Pacman</source>
+      <translation type="unfinished">Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385" />
+      <source>1/4 Circle</source>
+      <translation type="unfinished">Quart de cercle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386" />
+      <source>Half Circle</source>
+      <translation type="unfinished">Demi-cercle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387" />
+      <source>3/4 Circle</source>
+      <translation type="unfinished">Trois-quarts de cercle</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388" />
+      <source>Full Circle</source>
+      <translation type="unfinished">Cercle entier</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391" />
+      <source>1 Bar</source>
+      <translation type="unfinished">Une barre</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392" />
+      <source>2 Bars</source>
+      <translation type="unfinished">Deux barres</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393" />
+      <source>3 Bars</source>
+      <translation type="unfinished">Trois barres</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394" />
+      <source>4 Bars</source>
+      <translation type="unfinished">Quatre barres</translation>
+    </message>
+    <message>
       <location filename="../novelwriter/constants.py" line="397" />
+      <source>1 Block</source>
+      <translation type="unfinished">Un bloc</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398" />
+      <source>2 Blocks</source>
+      <translation type="unfinished">Deux blocs</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399" />
+      <source>3 Blocks</source>
+      <translation type="unfinished">Trois blocs</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400" />
+      <source>4 Blocks</source>
+      <translation type="unfinished">Quatre blocs</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403" />
       <source>Text files</source>
       <translation>Fichiers texte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="398" />
+      <location filename="../novelwriter/constants.py" line="404" />
       <source>Markdown files</source>
       <translation>Fichiers Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="399" />
+      <location filename="../novelwriter/constants.py" line="405" />
       <source>novelWriter files</source>
       <translation>Fichiers novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="400" />
+      <location filename="../novelwriter/constants.py" line="406" />
       <source>CSV files</source>
       <translation>Fichiers CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="407" />
       <source>All files</source>
       <translation>Tous les fichiers</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="410" />
       <source>Millimetres</source>
       <translation>Millimètres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="411" />
       <source>Centimetres</source>
       <translation>Centimètres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="406" />
+      <location filename="../novelwriter/constants.py" line="412" />
       <source>Inches</source>
       <translation>Pouces</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="414" />
+      <location filename="../novelwriter/constants.py" line="420" />
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="415" />
+      <location filename="../novelwriter/constants.py" line="421" />
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="416" />
+      <location filename="../novelwriter/constants.py" line="422" />
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="417" />
+      <location filename="../novelwriter/constants.py" line="423" />
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="424" />
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="461" />
+      <location filename="../novelwriter/constants.py" line="467" />
       <source>Straight single quotation mark</source>
       <translation>apostrophe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="462" />
+      <location filename="../novelwriter/constants.py" line="468" />
       <source>Straight double quotation mark</source>
       <translation>guillemet anglais</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="464" />
+      <location filename="../novelwriter/constants.py" line="470" />
       <source>Left single quotation mark</source>
       <translation>guillemet-apostrophe culbuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="471" />
       <source>Right single quotation mark</source>
       <translation>guillemet-apostrophe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="472" />
       <source>Single low-9 quotation mark</source>
       <translation>guillemet-virgule inférieur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="467" />
+      <location filename="../novelwriter/constants.py" line="473" />
       <source>Single high-reversed-9 quotation mark</source>
       <translation>guillemet-virgule supérieur culbuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="474" />
       <source>Left double quotation mark</source>
       <translation>guillemet-apostrophe double culbuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="475" />
       <source>Right double quotation mark</source>
       <translation>guillemet-apostrophe double</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="476" />
       <source>Double low-9 quotation mark</source>
       <translation>guillemet-virgule double inférieur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="477" />
       <source>Double high-reversed-9 quotation mark</source>
       <translation>guillemet-virgule double supérieur culbuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="478" />
       <source>Double low-reversed-9 quotation mark</source>
       <translation>guillemet-virgule double inférieur culbuté</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="480" />
       <source>Single left-pointing angle quotation mark</source>
       <translation>guillemet simple vers la gauche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="481" />
       <source>Single right-pointing angle quotation mark</source>
       <translation>guillemet simple vers la droite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="482" />
       <source>Double left-pointing angle quotation mark</source>
       <translation>guillemet gauche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="477" />
+      <location filename="../novelwriter/constants.py" line="483" />
       <source>Double right-pointing angle quotation mark</source>
       <translation>guillemet droit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="485" />
       <source>Left corner bracket</source>
       <translation>crochet en angle à gauche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="486" />
       <source>Right corner bracket</source>
       <translation>crochet en angle à droite</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="487" />
       <source>Left white corner bracket</source>
       <translation>crochet en angle à gauche blanc</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="482" />
+      <location filename="../novelwriter/constants.py" line="488" />
       <source>Right white corner bracket</source>
       <translation>crochet en angle à droite blanc</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3072" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
       <source>Line: {0} ({1})</source>
       <translation>Ligne : {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3073" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
       <source>Words: {0} ({1})</source>
       <translation>Mots : {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3074" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
       <source>Words: {0} selected</source>
       <translation>Mots sélectionnés : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3086" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
       <source>Status</source>
       <translation>État</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2865" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
       <source>Toggle Tool Bar</source>
       <translation>Afficher/Masquer la barre d'outils</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2870" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
       <source>Outline</source>
       <translation>Plan</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2875" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
       <source>Search</source>
       <translation>Chercher</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2880" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
       <source>Toggle Focus Mode</source>
       <translation>Basculer le mode focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2885" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
       <source>Close</source>
       <translation>Fermer</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
       <source>Search for</source>
       <translation>Rechercher</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2487" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
       <source>Replace with</source>
       <translation>Remplacer par</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2495" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
       <source>Search</source>
       <translation>Chercher</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2500" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
       <source>Case Sensitive</source>
       <translation>Sensible à la casse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2506" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
       <source>Whole Words Only</source>
       <translation>Mots entiers uniquement</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2512" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
       <source>RegEx Mode</source>
       <translation>Expressions régulières</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2518" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
       <source>Loop Search</source>
       <translation>Recherche en boucle</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2524" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
       <source>Search Next File</source>
       <translation>Chercher dans le fichier suivant</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2532" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
       <source>Preserve Case</source>
       <translation>Conserver la casse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
       <source>Close Search</source>
       <translation>Terminer la recherche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2551" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
       <source>Find in current document</source>
       <translation>Chercher dans le document actuel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2555" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
       <source>Find and replace in current document</source>
       <translation>Chercher et remplacer dans le document actuel</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="436" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443" />
       <source>Opened Document: {0}</source>
       <translation>Document ouvert : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="474" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481" />
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Ce document a été modifié en dehors de novelWriter pendant qu'il était ouvert. Écraser le fichier sur le disque ?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490" />
       <source>Could not save document.</source>
       <translation>Impossible d'enregistrer le document.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="508" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515" />
       <source>Saved Document: {0}</source>
       <translation>Document enregistré : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="677" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684" />
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>La vérification orthographique nécessite PyEnchant qui ne semble pas installé ici.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="703" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710" />
       <source>Spell check complete</source>
       <translation>La vérification orthographique est terminée</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="823" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830" />
       <source>Document Details</source>
       <translation>Détails du document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="825" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832" />
       <source>Created: {0}</source>
       <translation>Créé : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="826" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833" />
       <source>Updated: {0}</source>
       <translation>Mis à jour : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="828" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835" />
       <source>File Location: {0}</source>
       <translation>Emplacement du fichier : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1149" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
       <source>Set as Document Name</source>
       <translation>Définir comme nom du document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1155" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
       <source>Open URL</source>
       <translation>Ouvrir une URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
       <source>Follow Tag</source>
       <translation>Suivre cette étiquette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1166" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
       <source>Create Note for Tag</source>
       <translation>Créer une note pour l'étiquette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1172" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
       <source>Cut</source>
       <translation>Couper</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1174" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
       <source>Copy</source>
       <translation>Copier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1177" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
       <source>Paste</source>
       <translation>Coller</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1182" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
       <source>Select All</source>
       <translation>Sélectionner tout</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
       <source>Select Word</source>
       <translation>Sélectionner le mot</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1188" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
       <source>Select Paragraph</source>
       <translation>Sélectionner le paragraphe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1204" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
       <source>Spelling Suggestion(s)</source>
       <translation>Orthographe suggérée</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1209" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
       <source>No Suggestions</source>
       <translation>Pas de suggestion</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1213" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
       <source>Ignore Word</source>
       <translation>Ignorer le mot</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1215" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
       <source>Add Word to Dictionary</source>
       <translation>Ajouter ce mot au dictionnaire</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1619" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
       <source>Please select some text before calling replace quotes.</source>
       <translation>Veuillez sélectionner du texte avant de demander le remplacement des guillemets.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1974" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Voulez-vous créer une nouvelle note de projet pour l'étiquette '{0}' ?</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2346" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
       <source>Markdown Bold</source>
       <translation>Markdown gras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2352" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
       <source>Markdown Italic</source>
       <translation>Markdown italique</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2358" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
       <source>Markdown Strikethrough</source>
       <translation>Markdown barré</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2364" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
       <source>Shortcode Bold</source>
       <translation>Code court gras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2370" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
       <source>Shortcode Italic</source>
       <translation>Code court italique</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2376" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
       <source>Shortcode Strikethrough</source>
       <translation>Code court barré</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2382" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
       <source>Shortcode Underline</source>
       <translation>Code court souligné</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2388" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
       <source>Shortcode Highlight</source>
       <translation>Surligner les codes courts</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2394" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
       <source>Shortcode Superscript</source>
       <translation>Code court exposant</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2400" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
       <source>Shortcode Subscript</source>
       <translation>Code court indice</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="213" />
-      <location filename="../novelwriter/gui/statusbar.py" line="64" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212" />
+      <location filename="../novelwriter/gui/statusbar.py" line="63" />
       <source>None</source>
       <translation>Sans</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="72" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71" />
       <source>Editor</source>
       <translation>Éditeur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="80" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79" />
       <source>Project</source>
       <translation>Projet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="100" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99" />
       <source>Session Time</source>
       <translation>Durée de la session</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="179" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178" />
       <source>Words: {0} ({1})</source>
       <translation>Mots : {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="181" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180" />
       <source>Project word count (session change)</source>
       <translation>Nombre de mots du projet (changement durant cette session)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="183" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182" />
       <source>Novel word count (session change)</source>
       <translation>Nombre de mots du roman (changement durant cette session)</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253" />
       <source>Project Content</source>
       <translation>Contenu du projet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262" />
       <source>Quick Links</source>
       <translation>Liens rapides</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268" />
       <source>Move Up</source>
       <translation>Déplacer vers le haut</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272" />
       <source>Move Down</source>
       <translation>Déplacer vers le bas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312" />
       <source>Add Item</source>
       <translation>Ajouter un élément</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319" />
       <source>Expand All</source>
       <translation>Tout développer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322" />
       <source>Collapse All</source>
       <translation>Tout replier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325" />
       <source>Empty Trash</source>
       <translation>Vider la corbeille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329" />
       <source>More Options</source>
       <translation>Autres options</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626" />
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Pas trouvé d'emplacement pour y ajouter le fichier ou le dossier !</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630" />
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Impossible d'ajouter de nouveaux fichiers ou dossiers dans le dossier Corbeille.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644" />
       <source>New Note</source>
       <translation>Nouvelle note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647" />
       <source>New Chapter</source>
       <translation>Nouveau chapitre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650" />
       <source>New Scene</source>
       <translation>Nouvelle scène</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653" />
       <source>New Document</source>
       <translation>Nouveau document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656" />
       <source>New Folder</source>
       <translation>Nouveau dossier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706" />
       <source>No documents selected for merging.</source>
       <translation>Aucun document n'a été sélectionné pour la fusion.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714" />
       <source>Merged</source>
       <translation>Fusionné</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772" />
+      <location filename="../novelwriter/gui/projtree.py" line="728" />
       <source>Could not write document content.</source>
       <translation>Impossible d'écrire le contenu du document.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787" />
       <source>Do you want to duplicate this document?</source>
       <translation>Voulez-vous dupliquer ce document ?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789" />
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Voulez-vous dupliquer cet élément et tous ceux qu'il contient ?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794" />
       <source>Could not duplicate all items.</source>
       <translation>Impossible de dupliquer tous les éléments.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910" />
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Les dossiers racines ne peuvent être supprimés que s'ils sont vides.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914" />
       <source>Permanently delete selected item(s)?</source>
       <translation>Supprimer définitivement le(s) élément(s) sélectionné(s) ?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924" />
       <source>Move selected item(s) to Trash?</source>
       <translation>Déplacer le(s) élément(s) sélectionné(s) vers la corbeille ?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939" />
       <source>The Trash folder is already empty.</source>
       <translation>Le dossier Corbeille est déjà vide.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942" />
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Effacer définitivement {0} fichier(s) dans la Corbeille ?</translation>
     </message>
@@ -3637,7 +3737,7 @@
       <translation>Le format de ce fichier de projet n'est pas reconnu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="475" />
+      <location filename="../novelwriter/core/project.py" line="471" />
       <location filename="../novelwriter/core/project.py" line="288" />
       <location filename="../novelwriter/core/project.py" line="283" />
       <location filename="../novelwriter/core/project.py" line="278" />
@@ -3685,98 +3785,98 @@
       <translation>Ce projet a été enregistré par une version plus récente de novelWriter, la version {0}. Ceci est la version {1}. Si vous ouvrez quand même ce projet, certaines propriétés ou certains réglages risquent d'être perdus, toutefois le projet dans son ensemble devrait être intact. Voulez-vous quand même ouvrir ce projet ?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="360" />
       <source>Recovered</source>
       <translation>Récupéré</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="364" />
+      <location filename="../novelwriter/core/project.py" line="362" />
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>{0} fichier(s) orphelin(s) trouvé(s) dans le projet, dont {1} récupéré(s).</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="380" />
+      <location filename="../novelwriter/core/project.py" line="378" />
       <source>Opened Project: {0}</source>
       <translation>Projet ouvert : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="391" />
+      <location filename="../novelwriter/core/project.py" line="389" />
       <source>There is no project open.</source>
       <translation>Aucun projet n'est ouvert.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="414" />
+      <location filename="../novelwriter/core/project.py" line="412" />
       <source>Failed to save project.</source>
       <translation>Impossible d'enregistrer le projet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="428" />
+      <location filename="../novelwriter/core/project.py" line="424" />
       <source>Saved Project: {0}</source>
       <translation>Projet enregistré : {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="450" />
+      <location filename="../novelwriter/core/project.py" line="446" />
       <source>Backing up project ...</source>
       <translation>Sauvegarde du projet en cours ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="453" />
+      <location filename="../novelwriter/core/project.py" line="449" />
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Il est impossible de sauvegarder le projet car il n'a pas reçu de nom. Veuillez remplir le nom dans les paramètres du projet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="465" />
+      <location filename="../novelwriter/core/project.py" line="461" />
       <source>Could not create backup folder.</source>
       <translation>Il n'a pas été possible de créer le répertoire de sauvegarde.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="470" />
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Une sauvegarde de votre projet a été créée, de taille {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="478" />
+      <location filename="../novelwriter/core/project.py" line="474" />
       <source>Could not write backup archive.</source>
       <translation>Il n'a pas été possible d'écrire l'archive de sauvegarde.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="481" />
+      <location filename="../novelwriter/core/project.py" line="477" />
       <source>Project backed up to '{0}'</source>
       <translation>Projet sauvegardé dans {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="495" />
       <location filename="../novelwriter/core/project.py" line="491" />
+      <location filename="../novelwriter/core/project.py" line="487" />
       <source>New</source>
       <translation>Nouveau</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="488" />
       <source>Note</source>
       <translation>Note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="489" />
       <source>Draft</source>
       <translation>Brouillon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="490" />
       <source>Finished</source>
       <translation>Terminé</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="496" />
+      <location filename="../novelwriter/core/project.py" line="492" />
       <source>Minor</source>
       <translation>Mineur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="497" />
+      <location filename="../novelwriter/core/project.py" line="493" />
       <source>Major</source>
       <translation>Majeur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="498" />
+      <location filename="../novelwriter/core/project.py" line="494" />
       <source>Main</source>
       <translation>Principal</translation>
     </message>
@@ -4019,109 +4119,6 @@
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="369" />
-      <source>Square</source>
-      <translation>Carré</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="370" />
-      <source>Triangle</source>
-      <translation>Triangle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="371" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="372" />
-      <source>Diamond</source>
-      <translation>Losange</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Pentagon</source>
-      <translation>Pentagone</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Hexagon</source>
-      <translation>Hexagone</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Star</source>
-      <translation>Étoile</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>1/4 Circle</source>
-      <translation>Quart de cercle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Half Circle</source>
-      <translation>Demi-cercle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="381" />
-      <source>3/4 Circle</source>
-      <translation>Trois-quarts de cercle</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="382" />
-      <source>Full Circle</source>
-      <translation>Cercle entier</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>1 Bar</source>
-      <translation>Une barre</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>2 Bars</source>
-      <translation>Deux barres</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="387" />
-      <source>3 Bars</source>
-      <translation>Trois barres</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="388" />
-      <source>4 Bars</source>
-      <translation>Quatre barres</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>1 Block</source>
-      <translation>Un bloc</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>2 Blocks</source>
-      <translation>Deux blocs</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="393" />
-      <source>3 Blocks</source>
-      <translation>Trois blocs</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="394" />
-      <source>4 Blocks</source>
-      <translation>Quatre blocs</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
       <location filename="../novelwriter/shared.py" line="278" />
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="332" />
+      <location filename="../novelwriter/constants.py" line="338" />
       <source>Characters</source>
-      <translation>Personnages</translation>
+      <translation>Signes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="339" />
       <source>Characters in Text</source>
       <translation>Signes dans le texte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="334" />
+      <location filename="../novelwriter/constants.py" line="340" />
       <source>Characters in Headings</source>
       <translation>Signes dans les titres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="335" />
+      <location filename="../novelwriter/constants.py" line="341" />
       <source>Paragraphs</source>
       <translation>Paragraphes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="342" />
       <source>Headings</source>
       <translation>En-têtes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="343" />
       <source>Characters, No Spaces</source>
       <translation>Signes, espaces exclus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="344" />
       <source>Characters in Text, No Spaces</source>
       <translation>Signes dans le texte, espaces exclus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="345" />
       <source>Characters in Headings, No Spaces</source>
       <translation>Signes dans les titres, espaces exclus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="346" />
       <source>Words</source>
       <translation>Mots</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="347" />
       <source>Words in Text</source>
       <translation>Mots dans le texte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="348" />
       <source>Words in Headings</source>
       <translation>Mots dans les titres</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134" />
       <source>Empty Trash</source>
       <translation>Vider la corbeille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155" />
       <source>Rename</source>
       <translation>Renommer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170" />
       <source>Duplicate</source>
       <translation>Dupliquer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190" />
       <source>Open Document</source>
       <translation>Ouvrir le document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195" />
       <source>View Document</source>
       <translation>Afficher le document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204" />
       <source>Create New ...</source>
       <translation>Créer un nouveau...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216" />
       <source>Rename to Heading</source>
       <translation>Renommer comme en-tête</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225" />
       <source>Set Active to ...</source>
       <translation>Définir Actif à ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231" />
       <source>Toggle Active</source>
       <translation>Activer/Désactiver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238" />
       <source>Set Status to ...</source>
       <translation>Définir le statut à ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268" />
+      <location filename="../novelwriter/gui/projtree.py" line="1250" />
       <source>Manage Labels ...</source>
       <translation>Gérer les étiquettes...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256" />
       <source>Set Importance to ...</source>
       <translation>Définir l'Importance à ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277" />
       <source>Transform ...</source>
       <translation>Transformer ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299" />
+      <location filename="../novelwriter/gui/projtree.py" line="1295" />
+      <location filename="../novelwriter/gui/projtree.py" line="1291" />
+      <location filename="../novelwriter/gui/projtree.py" line="1287" />
       <source>Convert to {0}</source>
       <translation>Convertir en {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303" />
       <source>Merge Child Items into Self</source>
       <translation>Intégrer les éléments enfants</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305" />
       <source>Merge Child Items into New</source>
       <translation>Créer une fusion des éléments enfants</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309" />
       <source>Merge Documents in Folder</source>
       <translation>Fusionner les documents du dossier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313" />
       <source>Split Document by Headings</source>
       <translation>Découper le document selon les titres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320" />
       <source>Expand All</source>
       <translation>Tout développer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322" />
       <source>Collapse All</source>
       <translation>Tout replier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332" />
       <source>Delete Permanently</source>
       <translation>Supprimer définitivement</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334" />
       <source>Move to Trash</source>
       <translation>Déplacer vers la corbeille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410" />
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Voulez-vous convertir le dossier en {0} ? Cette action est irréversible.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048" />
       <source>From Template</source>
       <translation>Depuis le modèle</translation>
     </message>

--- a/i18n/nw_it_IT.ts
+++ b/i18n/nw_it_IT.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Filtri del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Documenti del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Note del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Documenti inattivi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Intestazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Formato della Partizione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Formato del Capitolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Formato non numerato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Formato della Scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Formato scena alt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Formato della Sezione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Stile del titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Stile della partizione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Stile del capitolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Stile della scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Contenuto del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Includi sinossi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Includi commenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Includi parole chiave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Includi il corpo del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Ignora queste parole chiave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Aggiungi i titoli per le note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Formato del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Carattere del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Altezza della riga</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Giustifica i margini del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Sostituisci Caratteri Unicode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Sostituisci le tabulazioni con gli spazi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Conserva le interruzioni di linea</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Applica evidenziazione dialogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>Rientro della prima linea</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Abilita l'ndentazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Larghezza dell'indentazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Indenta il primo paragrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Margini del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Titolo e partizione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Intestazione 1 e Capitolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Intestazione 2 e Scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Intestazione 3 e Sezione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Intestazione 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Paragrafo di testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Separatore di scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Impaginazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Unità</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Dimensioni pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Margini della pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Stile del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Intestazione della pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Scostamento del contatore di pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Aggiungi colori ai titoli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Aumenta la dimensione dei titoli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Titoli in grassetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>Opzioni HTML</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>Aggiungi stile CSS</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Conserva gli spazi di tabulazione</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>in futuro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>ora</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>un minuto fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>{0} minuti fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>un ora fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>{0} ore fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>un giorno fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>{0} giorni fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>una settimana fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>{0} settimane fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>un mese fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>{0} mesi fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>un anno fa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>{0} anni fa</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Titolo 1 (Partizione)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Titolo 2 (Capitolo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Titolo 3 (Scena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Titolo 4 (Sezione)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Paragrafo di testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Separatore di scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>Nessuno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Trama</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Personaggi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Luoghi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Sequenza temporale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Oggetti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Entità</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Personalizzato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Archivio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Modelli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Cestino</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Documento del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Nota del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Cartella principale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Cartella</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Pagina del titolo del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Capitolo del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Scena del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Sezione del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>Attivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Inattivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Etichetta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Punto di vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>Storia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Menzioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Livello</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Righe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Stato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Caratteri</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Parole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Paragrafi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>POV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Sommario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Documento Aperto (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Apri documento piatto (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Documento Microsoft Word (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter Markup (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Standard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Extended Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portable Document Format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter Markup (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Quadrato</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Triangolo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Triangolo capovolto</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Diamante</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Pentagono</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Esagono</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Stella</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>1/4 di cerchio</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Mezzo cerchio</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4 di cerchio</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Cerchio intero</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 barra</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 barre</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 barre</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 barre</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 blocco</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 blocchi</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 blocchi</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 blocchi</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>File di testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>File Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>File di novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>File CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>Tutti i file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Millimetri</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Centimetri</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Pollici</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>US Legale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>US Lettera</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Virgoletta singola diritta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Virgolette doppie diritte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Virgoletta singola a sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Virgoletta singola a destra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Singola virgoletta bassa 9</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Singola virgoletta alta inversa-9</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Virgolette doppie a sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Virgolette doppie a destra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Doppie virgolette basse 9</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Doppie virgolette alte inverse 9</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Doppie virgolette basse inverse 9</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Virgoletta singola ad angolo sinistro (&lt;)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
-      <translation>Virgoletta singola ad angolo destro (&gt;)</translation>
+      <translation>Virgoletta singola ad angolo destro (>)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Virgolette doppie ad angolo sinistro (&lt;&lt;)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
-      <translation>Virgolette doppie ad angolo destro (&gt;&gt;)</translation>
+      <translation>Virgolette doppie ad angolo destro (>>)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Staffa angolare sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Staffa angolare destra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Staffa angolare bianca sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Staffa angolare bianca destra</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>A proposito di novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>Questa applicazione è concessa in licenza sotto {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Riconoscimenti</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Impostazioni di creazione del manoscritto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>Generale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Selezione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Intestazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formattazione</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Aggiungi dizionari</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Scarica un dizionario da uno dei link e aggiungilo qui sotto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Aggiungi dizionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Posizione installazione del dizionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Dizionari aggiuntivi trovati: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Estensione di Free o Libre Office</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Sfoglia i file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>Impossibile elaborare il file del dizionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Aggiunto: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Riga: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Parole: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Parole: {0} selezionate</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Stato</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Attiva/disattiva la Barra degli strumenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Struttura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Cerca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Attiva/Disattiva modalità Focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Chiudi</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Ricerca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Sostituisci con</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Cerca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Considera maiuscole/minuscole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Solo parole intere</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>Modalità RegEx</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Ricerca a ciclo continuo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Cerca nel file successivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Non considerare maiuscole/minuscole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Chiudi ricerca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Trova nel documento corrente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Trova e sostituisci nel documento corrente</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Documento aperto: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Questo documento è stato cambiato al di fuori di novelWriter mentre era aperto. Sovrascrivere il file su disco?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>Impossibile salvare il documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Documento salvato: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Il controllo ortografico richiede il pacchetto PyEnchant. Non sembra essere installato.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Controllo ortografico completo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Dettagli del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Creato: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Aggiornato: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>Posizione del file: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Imposta come nome del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>Apri URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Segui i Tag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Crea una nota per il Tag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Taglia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Copia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Incolla</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Seleziona tutto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Seleziona parola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Seleziona paragrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Suggerimento(i) ortografico(i)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>Nessun suggerimento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Ignora parola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Aggiungi parola al dizionario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Per favore seleziona del testo prima di chiedere il cambio di virgolette.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Vuoi creare una nuova nota di progetto per il tag '{0}'?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Unisci i documenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Documenti da unire</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Trascina e rilascia gli elementi per cambiare l'ordine, o deseleziona per escludere.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Sposta gli elementi uniti nel cestino</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Dividi il documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Intestazioni del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Seleziona il livello massimo da dividere in file separati.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Dividi sul livello d'intestazione 1 (Partizione)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Dividi sul livello d'intestazione 2 (Capitolo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Dividi sul livello d'intestazione 3 (Scena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Dividi sul livello d'intestazione 4 (Sezione)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>Dividi in una nuova cartella</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Crea gerarchia dei documenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Sposta il documento diviso nel cestino</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Markdown grassetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Markdown corsivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Markdown barrato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Shortcode grassetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Shortcode corsivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Shortcode barrato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Shortcode sottolineato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Evidenziazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Shortcode apice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Shortcode pendice</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Mostra/Nascondi il Pannello di visualizzazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Commenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Mostra i commenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Sinossi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Mostra i commenti relativi alla sinossi</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Struttura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Vai Indietro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Vai Avanti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Apri nell'editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Ricarica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Chiudi</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>Si è verificato un errore durante la generazione dell'anteprima.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Copia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Seleziona tutto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Seleziona parola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Seleziona paragrafo</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Nascondi le etichette inattive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>Riferimenti</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Etichetta dell'elemento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Etichetta</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Etichetta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Stato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Classe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Utilizzo</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Inserisci testo segnaposto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Inserisci testo Lorem Ipsum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Numero dei paragrafi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Ordine casuale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Inserisci</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter è pronto...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>Stai ora eseguendo la versione {0} di novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Per favore controlla le {0}note di rilascio{1} per ulteriori dettagli.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>Chiudere il progetto attuale?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Le modifiche vengono salvate automaticamente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>Eseguire il backup del progetto corrente?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>Il progetto è già aperto da un'altra istanza di novelWriter, ed è quindi bloccato. Scavalcare il blocco e continuare comunque?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Nota: Se il programma o il computer in precedenza si è bloccato, il blocco può essere superato in modo sicuro. Tuttavia, non è consigliabile sovrascrivere se il progetto è aperto in un'altra istanza di novelWriter. Facendolo si potrebbe danneggiare il progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>Il progetto è stato bloccato dal computer '{0}' ({1} {2}), ultimo attivo su {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>L'indice del progetto è obsoleto o rotto. Ricostruzione dell'indice.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Importa file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>Impossibile leggere il file. Il file deve essere un file di testo esistente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Si prega di aprire un documento in cui importare il file di testo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>L'importazione del file sovrascriverà il contenuto corrente del documento. Vuoi procedere?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Indicizzazione completata in {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>L'indice del progetto è stato ricostruito con successo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>Impossibile inizializzare il dialogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>Vuoi uscire da novelWriter?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Alcune modifiche non saranno applicate fino al riavvio di novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>Impossibile trovare il riferimento per il tag '{0}'. O non esiste, o l'indice è obsoleto. L'indice può essere aggiornato dal menu Strumenti, o premendo {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Crea o apri un progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Salva progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Chiudi progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Impostazioni del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Dettagli del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Rinomina l'elemento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Elimina l'elemento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Svuota il cestino</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Esci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Apri documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Salva documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Chiudi documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>Visualizza documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Chiudi visualizzazione documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Mostra dettagli del file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Importa testo da file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Modifica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Annulla</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Ripristina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Taglia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Copia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Incolla</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Seleziona tutto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Seleziona paragrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;Visualizza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Vai alla vista ad albero</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Vai al documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Vai allo schema riassuntivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Naviga indietro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Naviga avanti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Modalità Focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Modalità a schermo intero</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>&amp;Inserisci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Trattini</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Trattino breve</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Trattino lungo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Barra orizzontale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Simbolo 'Tilde'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Marcatori di citazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Virgoletta singola a sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Virgoletta singola a destra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Virgolette doppie a sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Virgolette doppie a destra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Apostrofo alternativo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>Punteggiatura generica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Ellisse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Apostrofo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Doppie virgolette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>Spazi bianchi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Spaziatura larga</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Spaziatura sottile</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Spaziatura media</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Altri simboli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>Elenco puntato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Elenco listato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Asterisco a forma di fiore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Per mille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Simbolo di grado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Segno meno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Segno di moltiplicazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Segno di divisione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Etichette e riferimenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Commenti speciali</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Commenti relativi alla sinossi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Breve commento descrittivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Conteggio Parole/Caratteri</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Interruzioni e spazio verticale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Interruzione di pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Interruzione di riga forzata</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Spazio verticale (Singolo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Spazio verticale (Multiplo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Testo segnaposto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Nota a piè pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Formato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Grassetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Corsivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Barrato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Doppie virgolette automatiche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Singole virgolette automatiche</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>Altri formati ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Grassetto (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Corsivi (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Barrato (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Sottolineato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Evidenzia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Apice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Pedice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Titolo del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Capitolo non numerato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Scena alternativa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Allineamento a sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Centrato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Allineamento a destra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Rientro a sinistra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Rientro a destra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Attiva/Disattiva commento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Attiva/disattiva ignora testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Rimuovi il formato blocco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Sostituisci le singole virgolette dritte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Sostituisci le doppie virgolette dritte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Rimuovi le interruzioni di paragrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;Cerca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Trova</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Sostituisci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Trova successivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Trova precedente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Sostituisci successivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Trova nel progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;Strumenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Controllo ortografico</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Lingua per il controllo ortografico</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Predefinito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Riavvia il controllo ortografico</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Elenco delle parole del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Aggiungi dizionari</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Ricostruisci l'indice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Crea una copia di backup</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Compila manoscritto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Statistiche di scrittura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Preferenze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>&amp;Aiuto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>A proposito di novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>A proposito di Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>Manuale utente (Online)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>Manuale utente (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Segnala un problema (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Fai una domanda (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>Il sito web di novelWriter</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>Nessuno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Durata della sessione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Parole: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Conteggio parole del progetto (modifica sessione)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Conteggio parole del romanzo (modifica sessione)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Compila manoscritto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Aggiungi nuova compilazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Elimina la compilazione selezionata</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Duplica la costruzione selezionata</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Modifica la compilazione selezionata</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Compilazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Dettagli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Struttura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Anteprima</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Stampa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Compila</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Chiudi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Mostra interruzione di pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>Il mio manoscritto</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Compila manoscritto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Formato di output</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Tavola dei contenuti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Percorso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>Nome file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Ripristina il nome del file predefinito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Apri cartella</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;Compila</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Seleziona cartella</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>La cartella di output non esiste.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>Questo file esiste già. Vuoi sovrascriverlo?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Dettagli del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Panoramica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Contenuti</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Schema di {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Radice del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Aggiorna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Ultima colonna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Nascosto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Personaggio con punto di vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Personaggio oggetto del focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Trama del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Dimensione della colonna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>Altre opzioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Dimensione massima della colonna in %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>Nessun metadato</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Capitolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Sezione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Stato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Sinossi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Dettagli Titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Riferimenti</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Seleziona colonne</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Struttura di</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Aggiorna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>Esporta in formato CSV</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Salva lo schema come</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Preferenze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Cerca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>Generale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Aspetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Lingua dell'interfaccia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>Richiede il riavvio per avere effetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Tema colore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>Colore del tema generale e icone.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Carattere dell'applicazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Nascondi le barre di scorrimento verticali nelle finestre principali</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Scorrimento disponibile solo con la rotellina del mouse e i tasti.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Nascondi le barre di scorrimento orizzontali nelle finestre principali</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Usa la finestra di selezione dei caratteri del sistema</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Disattiva per usare la finestra di dialogo dei caratteri Qt, che potrebbe avere più opzioni.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Stile del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Tema colore del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Colore del tema per l'editor e il visualizzatore.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Carattere del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>Si applica sia all'editor di documenti che al visualizzatore.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Evidenzia le etichette delle partizioni e dei capitoli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Le fa risaltare nell'albero del progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Mostra il percorso completo nell'intestazione del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Aggiunge i nomi delle cartelle di livello superiore all'intestazione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Includi le note del progetto nel conteggio delle parole della barra di stato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Comportamento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Intervallo di salvataggio del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>Quante volte il documento viene salvato automaticamente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>secondi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Intervallo di salvataggio del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>Quante volte il progetto viene salvato automaticamente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Chiedi prima di uscire da novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Si applica solo quando il progetto è aperto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Backup del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Sfoglia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Posizione di archiviazione del backup</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Percorso: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Esegui il backup quando il progetto è chiuso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Può essere sovrascritto per singoli progetti nelle Impostazioni del progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Chiedi prima di eseguire il backup</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>Se disattivato, i backup verranno eseguiti in background.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Timer della sessione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Metti in pausa il timer di sessione quando non si scrive</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Inoltre si interrompe quando la finestra dell'applicazione non ha focus.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Tempo d'inattività dell'editor prima di mettere in pausa il timer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>L'attività dell'utente include la digitazione e la modifica del contenuto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>minuti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Scrittura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Flusso del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Larghezza massima del testo in "Modalità normale"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>Impostare a 0 per disabilitare questa funzione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Larghezza massima del testo in "Modalità Focus"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>La larghezza massima non può essere disabilitata.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Nascondi piè di pagina del documento in "Modalità Focus"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Nascondi la barra delle informazioni nell'editor dei documenti.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Giustifica i margini del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Dimensione minima del margine del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Larghezza di tabulazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>La larghezza ottenibile con una pressione sul tasto TAB nell'editor e nel visualizzatore.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Modifica del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Lingua per il controllo ortografico</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Le lingue disponibili sono determinate dal tuo sistema.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Seleziona automaticamente la parola sotto il cursore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>Applica la formattazione alla parola sotto il cursore se non viene effettuata alcuna selezione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Mostra tabulazioni e spazi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Mostra terminazioni di riga</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Scorrimento dell'editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Scorri alla fine del documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>Centra anche il cursore durante lo scorrimento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Scorrimento stile macchina da scrivere quando si digita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Mantiene il cursore in posizione verticale fissa.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Posizione minima per lo scorrimento della macchina da scrivere</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>Percentuale dell'altezza dell'editor dall'alto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Evidenziazione del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>Nessuno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>Singole virgolette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>Doppie virgolette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>Entrambe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Evidenzia il dialogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Si applica agli stili di virgolette selezionati.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Simboli di dialogo alternativi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Evidenziazione personalizzata del testo del dialogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Consenti dialogo aperto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Evidenzia la linea di dialogo senza virgolette di chiusura.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Simboli delle righe di dialogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Le linee che iniziano con uno di questi simboli sono dialogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Simbolo per gli interventi del narratore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Simbolo che indica l'intervento del narratore nel dialogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Simbolo alternativo di dialogo/narrazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Alterna l'evidenziazione dei dialoghi all'interno di qualsiasi paragrafo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Aggiungi un colore per evidenziare ed enfatizzare il testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Si applica solo all'editor dei documenti.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Evidenzia spazi multipli o finali</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Automatismi del testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Sostituisci automaticamente il testo mentre digiti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Consenti all'editor di sostituire i simboli durante la digitazione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Sostituisci automaticamente le virgolette singole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Prova a indovinare quale sia l'inizio o la fine di una citazione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Sostituisci automaticamente le virgolette doppie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Sostituisci automaticamente i trattini</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>I trattini doppi e tripli diventano brevi e lunghi trattini.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Sostituisci automaticamente i puntini</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Tre punti consecutivi diventano puntini di sospensione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Inserisci uno spazio prima di</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Aggiungi automaticamente spazio prima di uno di questi simboli.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Inserisci uno spazio dopo di</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Aggiungi automaticamente uno spazio dopo uno di questi simboli.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Usa invece uno spazio sottile</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Inserisce uno spazio sottile invece di uno spazio regolare.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Stile delle citazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Singola virgoletta aperta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>Il simbolo da usare per una singola virgoletta iniziale.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Singola virgoletta chiusa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>Il simbolo da usare per una singola virgoletta finale.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Doppie virgolette aperte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>Il simbolo da usare per avere doppie virgolette iniziali.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Doppie virgolette chiuse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>Il simbolo da usare per avere doppie virgolette finali.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Percorso di backup</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Ricerca nel progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Considera maiuscole/minuscole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Solo parole intere</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>Modalità RegEx</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Ricerca</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Impostazioni del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Impostazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Stato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Importanza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Auto - sostituisci</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="253" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Contenuto del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="262" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Collegamenti rapidi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="268" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Sposta su</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="272" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Sposta giù</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="312" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Aggiungi elemento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="319" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Espandi tutto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="322" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Collassa tutto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="325" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Svuota il cestino</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="329" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>Altre opzioni</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="626" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Non è stato trovato alcun posto dove aggiungere il file o la cartella!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="630" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Impossibile aggiungere nuovi file o cartelle alla cartella Cestino.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="644" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>Nuova nota</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="647" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>Nuovo capitolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="650" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>Nuova scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="653" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>Nuovo documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="656" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>Nuova cartella</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="706" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>Nessun documento selezionato per la fusione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="714" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Uniti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="772" />
-      <location filename="../novelwriter/gui/projtree.py" line="728" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>Impossibile scrivere il contenuto del documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="787" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>Vuoi duplicare questo documento?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="789" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Vuoi duplicare questo elemento e tutti gli elementi figli?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="794" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>Impossibile duplicare tutti gli elementi.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="910" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Le cartelle radice possono essere eliminate solo quando sono vuote.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="914" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>Eliminare permanentemente gli elementi selezionati?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="924" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>Spostare gli elementi selezionati nel cestino?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="939" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>La cartella Cestino è già vuota.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="942" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Eliminare definitivamente {0} file(s) dal cestino?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Seleziona lo stile delle virgolette</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Vista ad albero del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Vista ad albero del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Ricerca nel progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Vista della struttura del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Genera manoscritto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Dettagli del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Statistiche di scrittura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Opzioni</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Benvenuto/a</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>Elenco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>Nuovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Sfoglia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Cancella</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Crea</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Apri</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Elenco delle parole del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Importa parole da un file di testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Esporta le parole in file di testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Aggiungi parola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Rimuovi parola</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Nota: il file da importare deve essere un file di testo semplice con codifica UTF-8 o ASCII.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Importa file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Esporta file</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Statistiche di scrittura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Avvii di sessione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Durata</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Inattività</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Parole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Istogramma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Totalizzazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Tempo totale:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Tempo d'inattività:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Tempo filtrato:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Conteggio parole del romanzo:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Conteggio parole delle note:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Conteggio parole totali:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filtri</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Conteggio file del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Conteggio file delle note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>Nascondi il conteggio parole se a zero</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>Nascondi il conteggio parole se negativo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Raggruppa le voci per giorno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Mostra tempo d'inattività</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Max n° di parole per l'istogramma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Salva come</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>File di dati JSON (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>File di dati CSV (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>File di dati JSON</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>File di dati CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Salva dati come</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>{0} file scritto correttamente in:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Scrittura file {0} non riuscita.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>Impossibile eliminare il file del documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Non è un formato conosciuto di file di progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Percorso: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>File di progetto non trovato.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Impossibile aprire il progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Sconosciuto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>Il file del progetto non sembra essere un file novelWriterXML.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Formato file di progetto di novelWriter sconosciuto o non supportato. Il progetto non può essere aperto da questa versione di novelWriter. Il file è stato salvato con la versione {0} di novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>Impossibile analizzare il progetto xml.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>Il formato del file del tuo progetto sta per essere aggiornato. Scegliendo di procedere, le versioni più vecchie di novelWriter non saranno più in grado di aprire questo progetto. Continuare?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>Questo progetto è stato salvato da una versione più recente di novelWriter, versione {0}. Questa è la versione {1}. Se si continua ad aprire il progetto, alcuni attributi e impostazioni potrebbero non essere preservati, ma il progetto complessivo dovrebbe andare bene. Continuare ad aprire il progetto?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Ripristinato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Trovati {0} file orfani nel progetto. {1} file sono stati recuperati ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Progetto aperto: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>Non c'è nessun progetto aperto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Salvataggio del progetto non riuscito.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Progetto salvato: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Crea una copia di backup ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Impossibile eseguire il backup del progetto perché nessun nome del progetto è impostato. Si prega di impostare un nome del progetto nelle impostazioni del progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>Impossibile creare la cartella di backup.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Creato un backup del progetto di dimensione {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>Impossibile scrivere l'archivio di backup.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Eseguito il backup del progetto su '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>Nuovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Nota</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Bozza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Finito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Minore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Maggiore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Principale</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>Tutte le cartelle del romanzo</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>La cartella di destinazione non è vuota. Per favore scegli un'altra cartella.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>Si è verificato un errore durante il tentativo di creare il progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>Nuovo progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Pagina del titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Indirizzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>Di</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Conteggio delle parole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Riassunto del capitolo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Riassunto della scena.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>Una breve descrizione.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Capitolo {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Scena {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Trama principale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Località principale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>La cartella di destinazione esiste già. Si prega di scegliere un'altra cartella.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>Impossibile copiare i file del progetto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Impossibile creare un nuovo progetto di esempio.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Impossibile creare un nuovo progetto di esempio. Impossibile trovare i file necessari. Sembrano mancanti da questa installazione.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Salva</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Cancella</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;Chiudi</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Chiudi senza salvare</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Salva</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Salva tutto</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Apri</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Sì</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Sì a &amp;tutto</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;No</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>N&amp;o a tutto</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Interrompi</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Riprova</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Ignora</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Chiudi</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>Cancella</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Scarta</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Aiuto</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Applica</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Ripristina</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Ripristina predefiniti</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Quadrato</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Triangolo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Triangolo capovolto</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Diamante</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Pentagono</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Esagono</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Stella</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>1/4 di cerchio</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Mezzo cerchio</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4 di cerchio</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Cerchio intero</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 barra</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 barre</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 barre</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 barre</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 blocco</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 blocchi</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 blocchi</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 blocchi</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>File di progetto di novelWriter o file Zip</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>File di progetto di novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Apri progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Seleziona il tipo di carattere</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Caratteri</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Caratteri nel testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Caratteri nelle intestazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Paragrafi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Intestazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Caratteri, esclusi gli spazi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Caratteri nel testo, esclusi gli spazi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Caratteri nelle intestazioni, esclusi gli spazi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Parole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Parole nel testo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Parole nelle intestazioni</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Ultima versione: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Controllo in corso...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Scarica da {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Versione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Rilasciata il</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Note di rilascio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>Controlla adesso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>Tentativo non riuscito</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Tavola dei contenuti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Parole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Pagine</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Avanzamento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Parole per pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>Scostamento prima pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Capitoli su pagine dispari</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Senza titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>FINE</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Impostazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Valore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Selezione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Nascosto</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>Incluso nel manoscritto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>Escluso dal manoscritto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Sempre incluso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Sempre escluso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Ripristina predefinito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Segna la selezione come</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Seleziona cartelle radice</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Informazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Attenzione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Errore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Domanda</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Nascondi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Modifiche: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>Nessuno</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Titolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Numero capitolo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Numero capitolo (in lettere)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Numero capitolo (numeri romani maiuscoli)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Numero capitolo (numeri romani minuscoli)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Numero scena (nel capitolo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Numero scena (assoluto)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Personaggio con punto di vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Personaggio oggetto del focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Inserisci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Applica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Centro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Interruzione di pagina</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Necessario</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Facoltativo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Crea un nuovo progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Crea un progetto di esempio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Copia un progetto esistente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Nome del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Autore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Percorso del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Tipo di progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Imposta a 0 per aggiungere solo scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>Aggiungi {0} capitoli come documenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>Aggiungi {0} scene come documenti (a ogni capitolo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Aggiungi una cartella per le note sulla trama</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Aggiungi una cartella per le note sui personaggi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Aggiungi una cartella per le note sulle località</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Aggiungi note di esempio alle precedenti</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Capitoli e scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Note del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Crea un nuovo progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Seleziona la cartella del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Nuovo progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Progetto di esempio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Modello: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>È richiesto un nome di progetto.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>Il percorso del progetto non è raggiungibile.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Percorso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>Rimuovere '{0}' dalla lista dei progetti recenti? I file del progetto non verranno eliminati.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Apri il progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Rimuovi il progetto</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Revisioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Tempo di lavorazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Conteggio delle parole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>nel romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>nelle note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Romanzo selezionato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Capitoli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Scene</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Premi il tasto "Anteprima" per compilarla ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>In elaborazione ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Fatto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Realizzata</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>Nessuna anteprima</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Conteggio delle parole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Ultima apertura</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Sostituzione automatica del testo per l'anteprima e la generazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Parola chiave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Sostituisci con</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Seleziona elemento da modificare</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Nome del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Questo cambiamento influirà sul percorso di backup.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Autore(i)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Usato solo durante la costruzione del manoscritto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Lingua del progetto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Predefinita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Lingua per il controllo ortografico</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Sovrascrive i valori predefiniti.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>Disabilita il backup alla chiusura</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Stato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Livelli di avanzamento dei file del romanzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Importanza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Livelli d'importanza dei file delle note</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>Non utilizzato</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Usato una volta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>Usato da {0} elementi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Seleziona colore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Etichetta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Utilizzo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Aggiungi etichetta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Elimina etichetta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Sposta su</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Sposta giù</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Importa etichette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Esporta etichette</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Seleziona elemento da modificare</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Colore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Cerchi...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Barre ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Blocchi ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Forma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>Nuovo elemento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>Impossibile eliminare un elemento di stato in uso.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Importa file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Esporta file</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1134" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Svuota il cestino</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1155" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Rinomina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1170" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Duplica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1190" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Apri documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1195" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>Visualizza documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1204" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Crea nuovo ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1216" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Rinomina nell'intestazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1225" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Imposta attività su ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1231" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Commuta Attiva/Disattiva</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1238" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Imposta lo stato su ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1268" />
-      <location filename="../novelwriter/gui/projtree.py" line="1250" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Gestisci Etichette ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1256" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Imposta l'importanza su ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1277" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Trasforma ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1299" />
-      <location filename="../novelwriter/gui/projtree.py" line="1295" />
-      <location filename="../novelwriter/gui/projtree.py" line="1291" />
-      <location filename="../novelwriter/gui/projtree.py" line="1287" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Converti in {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1303" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Fondi elementi figli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1305" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Fondi elementi figli in uno nuovo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1309" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Fondi i documenti nella cartella</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1313" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Dividi il documento alle intestazioni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1320" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Espandi tutto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1322" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Collassa tutto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1332" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Elimina definitivamente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1334" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>Sposta nel cestino</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1410" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Vuoi convertire la cartella in un {0}? Questa azione non può essere annullata.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1048" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>Dal modello</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>Prima intestazione</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Etichetta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Importanza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Intestazione</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Breve descrizione</translation>
     </message>

--- a/i18n/nw_ja_JP.ts
+++ b/i18n/nw_ja_JP.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>ドキュメントフィルター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>小説ドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>プロジェクトノート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>非アクティブなドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>見出し</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>パーティション書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>チャプター書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>番号なし書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>シーン書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>代替シーン書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>セクション書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>タイトルのスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>パーティションのスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>チャプターのスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>シーンのスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>テキストコンテンツ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>あらすじを含める</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>コメントを含める</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>キーワードを含める</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>本文テキストを含める</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>これらのキーワードを無視</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>ノートにタイトルを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>テキストの書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>テキストのフォント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>行の高さ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>テキストの余白を揃える</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Unicode文字を置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>タブをスペースで置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>ハードラインブレイクを保持</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>ダイアログにハイライトを適用</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>最初の行のインデント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>インデントを有効</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>インデントの幅</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>最初の段落をインデント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>テキストの余白</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>タイトルおよびパーティション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>見出し 1 およびチャプター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>見出し 2 およびシーン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>見出し 3 およびセクション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>見出し 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>テキスト段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>シーンセパレーター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>ページレイアウト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>ユニット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>ページサイズ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>ページの余白</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>ドキュメントスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>ページヘッダー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>ページカウンターオフセット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>見出しに色を追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>見出しのサイズを拡大</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>太字の見出し</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>HTMLオプション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>CSSスタイルを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>タブ文字を保持</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>未来</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>現在</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>1 分前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>{0} 分前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>1 時間前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>{0} 時間前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>1 日前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>{0} 日前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>1 週間前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>{0} 週間前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>1 ヶ月前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>{0} ヶ月前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>1 年前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>{0} 年前</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>タイトル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>見出し 1 (パーティション)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>見出し 2 (チャプター)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>見出し 3 (シーン)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>見出し 4 (セクション)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>テキスト段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>シーンセパレーター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>なし</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>小説</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>プロット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>登場人物</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>場所</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>タイムライン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>オブジェクト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>エンティティ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>カスタム</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>アーカイブ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>テンプレート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>ごみ箱</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>小説のドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>プロジェクトノート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>ルートフォルダー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>フォルダー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>小説のタイトルページ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>小説のチャプター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>小説のシーン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>小説のセクション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>アクティブ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>非アクティブ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>タグ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>視点</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>焦点</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>ストーリー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>メンション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>階層</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>ドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>行</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>ステータス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>文字</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>単語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>視点</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>あらすじ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>オープンドキュメント (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>フラットオープンドキュメント (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Microsoft Word 文書 (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriterマークアップ (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>標準マークダウン (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>拡張マークダウン (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>ポータブルドキュメントフォーマット (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter マークアップ (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>正方形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>三角形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>逆三角形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>菱形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>五角形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>六角形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>星</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>パックマン</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>1/4の円</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>半円</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4の円</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>全円</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1バー</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2バー</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3バー</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4バー</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1ブロック</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2ブロック</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3ブロック</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4ブロック</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>テキストファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>マークダウンファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>novelWriterファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>CSVファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>すべてのファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>ミリメートル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>センチメートル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>インチ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>US リーガル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>US レター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>直線形シングルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>直線形ダブルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>左シングルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>右シングルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>シングルローナインクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>上反転シングルローナインクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>左ダブルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>右ダブルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>ダブルローナインクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>上反転ダブルローナインクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>下反転ダブルローナインクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>左フレンチシングルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>右フレンチシングルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>左フレンチダブルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>右フレンチダブルクォーテーション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>左鉤括弧</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>右鉤括弧</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>左二重鉤括弧</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>右二重鉤括弧</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>novelWriterについて</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>このアプリケーションは {0} でライセンスされています</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>クレジット</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>原稿のビルド設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>名前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>一般</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>見出し</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>書式設定</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>辞書を追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>いずれかのリンクから辞書をダウンロードして、以下に追加します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>辞書を追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>辞書のインストール場所</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>追加の辞書が見つかりました: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Free または Libre Office拡張</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>ファイルを参照</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>辞書ファイルを処理できませんでした</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>追加: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>行: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>単語: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>単語: {0} 選択済み</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>ステータス</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>ツールバーの切り替え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>アウトライン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>フォーカスモードの切り替え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>閉じる</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>置換候補</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>大文字と小文字を区別</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>完全一致のみ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>正規表現モード</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>ループ検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>次のファイルを検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>大文字と小文字を保持</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>検索を閉じる</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>現在のドキュメント内を検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>現在のドキュメント内を検索して置き換え</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>開かれたドキュメント： {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>このドキュメントは、開いている間にnovelWriter以外で変更されました。ディスクにファイルを上書きしますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>ドキュメントを保存できませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>保存済みドキュメント: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>スペルチェックにはPyEnchantパッケージが必要ですが、インストールされていないようです。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>スペルチェック完了</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>ドキュメントの詳細</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>作成済み: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>更新: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>ファイル場所: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>ドキュメント名として設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>URLを開く</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>タグをフォロー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>タグのメモを作成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>切り取り</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>コピー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>貼り付け</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>すべて選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>単語を選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>段落を選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>スペルの提案</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>候補なし</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>単語を無視</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>単語を辞書に追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>置き換え引用符を呼び出す前にテキストを選択してください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>タグ '{0}' の新規プロジェクトノートを作成しますか？</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>ドキュメントを結合</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>結合するドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>アイテムをドラッグ&amp;ドロップして順序を変更するか、チェックを外して除外します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>結合したアイテムをごみ箱に移動</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>ドキュメントを分割</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>ドキュメントの見出し</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>ファイルに分割する最大階層を選択します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>見出し階層1 (パーティション) で分割</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>見出し階層2 (チャプター) で分割</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>見出し階層3 (シーン) で分割</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>見出し階層4 (セクション) で分割</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>新規フォルダーに分割</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>ドキュメント階層を作成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>分割したドキュメントをごみ箱に移動</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>マークダウン 太字</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>マークダウン 斜体</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>マークダウン 取り消し線</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>ショートコード 太字</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>ショートコード 斜体</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>ショートコード 取り消し線</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>ショートコード 下線</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>ショートコードハイライト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>ショートコード 上付き文字</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>ショートコード 下付き文字</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>ビューアーパネルの表示/非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>コメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>コメントを表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>あらすじ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>あらすじコメントを表示</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>アウトライン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>戻る</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>進む</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>エディターで開く</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>リロード</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>閉じる</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>プレビューの生成中にエラーが発生しました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>コピー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>すべて選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>単語を選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>段落を選択</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>非アクティブなタグを非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>参照</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>アイテムラベル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>ラベル</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>ラベル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>ステータス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>クラス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>用途</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>プレースホルダーテキスト (ダミーテキスト) を挿入</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>ロレム・イプサムテキストを挿入</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>段落数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>順番をランダム化</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>挿入</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriterの準備ができました...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>novelWriter バージョン {0} を実行しています。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>詳細については、 {0}リリース ノート{1} を確認してください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>現在のプロジェクトを閉じますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>変更は自動的に保存されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>現在のプロジェクトをバックアップしますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>プロジェクトは既に別のnovelWriterのインスタンスによって開かれているためロックされています。無視して続行しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>注意: プログラムまたはコンピュータが以前にクラッシュした場合、ロックを無視しても安全に続行することができます。 ただし、novelWriterの別のインスタンスでプロジェクトが開いている場合は、無視して続行することは推奨されません。プロジェクトが破損する可能性があります。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>このプロジェクトは、コンピューター '{0}' ({1} {2}) によってロックされました。最後に有効になったのは {3} です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>プロジェクトインデックスが古くなっているか、破損しています。インデックスを再構築します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>ファイルをインポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>ファイルを読み込めませんでした。ファイルは既存のテキストファイルである必要があります。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>テキストファイルをインポートするには、ドキュメントを開いてください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>ファイルをインポートするとドキュメントの現在の内容が上書きされます。続行しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>インデックス作成は {0} ミリ秒で完了しました</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>プロジェクト インデックスが正常に再構築されました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>ダイアログを初期化できませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>novelWriterを終了しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>いくつかの変更は、novelWriterが再起動されるまで適用されません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>タグ '{0}' の参照が見つかりませんでした。タグが存在しないか、インデックスが古いかのどちらかです。インデックスはツールメニューから更新するか、{1} を押して更新することができます。</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;プロジェクト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>プロジェクトを作成または開く</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>プロジェクトを保存</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>プロジェクトを閉じる</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>プロジェクト設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>小説の詳細</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>アイテム名を変更</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>アイテムを削除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>ごみ箱を空にする</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>終了</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;ドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>ドキュメントを開く...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>ドキュメントを保存</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>ドキュメントを閉じる</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>ドキュメントを表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>ドキュメント表示を閉じる</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>ファイルの詳細を表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>ファイルからテキストをインポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;編集</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>元に戻す</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>やり直す</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>切り取り</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>コピー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>貼り付け</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>すべて選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>段落を選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>ツリー ビューへ移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>ドキュメントへ移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>アウトラインへ移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>前に戻る</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>次に進む</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>フォーカスモード</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>フルスクリーンモード</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>&amp;挿入</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>ダッシュ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>enダッシュ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>emダッシュ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>水平線</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>フィギュアダッシュ	</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>引用符</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>左シングルクォート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>右シングルクォート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>左ダブルクォート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>右ダブルクォート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>代替アポストロフ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>一般的な句読点</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>省略記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>プライム</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>ダブルプライム</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>空白</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>ノーブレークスペース</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>細いスペース</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>細いノーブレークスペース</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>その他の記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>箇条書きリスト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>ハイフンリスト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>花記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>パーミル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>度記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>引き算記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>掛け算記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>割り算記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>タグと参照</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>特殊コメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>あらすじコメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>短文説明コメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>単語/文字数カウント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>区切りと垂直スペース</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>改ページ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>強制的な改行</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>垂直スペース (シングル)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>垂直スペース (マルチ)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>プレースホルダーテキスト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>脚注</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;書式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>太字</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>斜体</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>取り消し線</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>ダブルクォートで包む</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>シングルクォートで包む</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>より多くのフォーマット...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>太字(ショートコード)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>斜体 (ショートコード)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>取り消し線 (ショートコード)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>下線</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>ハイライト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>上付き文字</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>下付き文字</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>小説のタイトル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>番号なしチャプター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>代替シーン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>左揃え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>中央揃え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>右揃え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>左側をインデント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>右側をインデント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>コメントの切り替え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>無視テキストの切り替え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>ブロック形式を削除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>直線シングルクォートを置き換え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>直線ダブルクォートを置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>段落内の改行を削除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>置き換え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>次を検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>前を検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>次を置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>プロジェクト内を検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;ツール</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>スペルチェック</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>スペルチェック言語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>既定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>スペルチェックを再実行</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>プロジェクト単語リスト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>辞書を追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>インデックスを再構築</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>プロジェクトをバックアップ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>原稿をビルド</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>統計の作成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>環境設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>&amp;ヘルプ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>novelWriterについて</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>Qt5について</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>ユーザーマニュアル (オンライン)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>ユーザーマニュアル (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>問題を報告 (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>質問する (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>novelWriterのウェブサイト</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>なし</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>エディター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>プロジェクト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>セッション時間</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>単語: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>プロジェクト単語数 (セッション中の変更)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>小説の単語数 (セッション中の変更)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>原稿をビルド</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>新規ビルドを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>選択したビルドを削除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>選択したビルドを複製</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>選択したビルドを編集</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>ビルド</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>詳細</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>アウトライン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>プレビュー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>印刷</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>ビルド</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>閉じる</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>改ページを表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>私の原稿</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>原稿をビルド</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>出力形式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>目次</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>パス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>ファイル名</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>ファイル名をデフォルトにリセット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>フォルダーを開く</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;ビルド</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>フォルダーを選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>出力フォルダが存在しません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>このファイルはすでに存在します。上書きしますか?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>小説の詳細</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>概要</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>内容</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>{0} のアウトライン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>小説のルート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>更新</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>最後の列</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>視点人物</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>焦点人物</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>小説のプロット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>列のサイズ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>その他の設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>列の最大サイズ (%)</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>メタデータなし</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>タイトル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>チャプター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>シーン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>セクション</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>ドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>ステータス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>あらすじ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>タイトルの詳細</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>参照タグ</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>列の選択</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>アウトライン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>更新</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>CSVを出力</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>アウトラインを名前を付けて保存</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>環境設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>一般</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>外観</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>表示言語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>有効にするには再起動が必要です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>カラーテーマ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>一般的なカラーテーマとアイコン。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>アプリケーションのフォント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>メインウィンドウの垂直スクロールバーを非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>スクロールはマウスホイールとキーでのみ利用可能です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>メインウィンドウの横スクロールバーを非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>システムのフォント選択ダイアログを使用</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Qt フォントダイアログを使用するにはオフにしてください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>ドキュメントスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>ドキュメントのカラーテーマ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>エディタとビューアーのカラーテーマ。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>ドキュメントのフォント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>ドキュメントエディターとビューアーの両方に適用されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>パーティションとチャプターラベルを強調</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>プロジェクトツリーで目立つようにします。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>ドキュメントヘッダーにフルパスを表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>親フォルダ名をヘッダーに追加します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>ステータスバーの単語数にプロジェクトノートを含める</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>動作</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>ドキュメントの保存間隔</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>ドキュメントが自動的に保存される頻度。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>秒</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>プロジェクトの保存間隔</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>プロジェクトが自動的に保存される頻度。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>ノベルライターを終了する前に確認する</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>プロジェクトが開いているときにのみ適用されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>プロジェクトのバックアップ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>ブラウズ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>バックアップストレージの場所</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>パス: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>プロジェクトを閉じたときにバックアップを実行</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>プロジェクト設定で個々のプロジェクトに対して上書きできます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>バックアップを実行する前に確認</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>オフの場合、バックアップはバックグラウンドで実行されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>セッションタイマー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>書き込んでいない時にセッションタイマーを一時停止</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>また、アプリケーションウィンドウにフォーカスがない場合は一時停止します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>タイマーを一時停止するまでのエディターの非アクティブ時間</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>ユーザーアクティビティには、入力とコンテンツの変更が含まれます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>分</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>執筆</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>テキストフロー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>"ノーマルモード"でのテキストの最大幅</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>この機能を無効にするには0に設定してください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>"フォーカスモード"でのテキストの最大幅</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>最大幅を無効にすることはできません</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>"フォーカスモード"でドキュメントのフッターを非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>ドキュメントエディターで情報バーを非表示にします。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>テキストの余白を揃える</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>テキストの最小マージン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>タブの幅</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>タブキーを押した時のエディターとプレービューでの幅。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>テキスト編集</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>スペルチェック言語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>利用可能な言語はシステムによって決定されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>カーソルの下にある単語を自動選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>選択が行われていない場合は、カーソルの下にある単語に書式を適用します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>タブとスペースを表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>行末を表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>エディタースクロール</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>ドキュメントの最後までスクロール</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>また、スクロール時にカーソルを中央に移動します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>入力時にタイプライタースタイルスクロール</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>カーソルを固定の垂直位置に維持します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>タイプライタースクロールの最小位置</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>エディタの高さの上からの割合。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>テキストのハイライト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>なし</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>シングルクォート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>ダブルクォート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>両方</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>ダイアログのハイライト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>選択したクォートスタイルに適用されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>代替ダイアログ記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>ダイアログテキストのカスタムハイライト。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>閉じないダイアログを許可</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>終了引用符の無いダイアログ行を強調表示します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>ダイアログ行記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>これらの記号で始まる行はダイアログとなります。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>ナレーター区切り記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>ダイアログ内のナレーターの区切りを示すシンボルです。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>ダイアログ/ナレーションの切替記号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>任意の段落内の会話の強調表示を切り替えます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>強調テキストにハイライト色を追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>ドキュメントエディターにのみ適用されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>複数または末尾のスペースをハイライト表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>テキストの自動化</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>入力時にテキストを自動的に置き換え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>入力時にエディタが記号を置き換えることを許可します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>シングルクォートの自動置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>引用符が開始と終了のどちらかを推測する</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>ダブルクォートの自動置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>ダッシュの自動置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>二重および三重のハイフンはenおよびemダッシュに置き換えらます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>ドットの自動置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>３つ連続したドットは省略記号に置き換えられます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>ノーブレークスペースを前に挿入</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>これらの記号の前にスペースを自動的に追加します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>ノーブレークスペースを後に挿入</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>これらの記号の後にスペースを自動的に追加します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>細いスペースを代わりに使用</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>通常のスペースの代わりに細いスペースを挿入します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>クォーテーションスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>シングルクォートオープンスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>先頭のシングルクォートに使用する記号です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>シングルクォートクローズスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>末尾のシングルクォートに使用する記号です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>ダブルクォートオープンスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>先頭のダブルクォートに使用する記号です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>シングルクォートクローズスタイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>末尾のダブルクォートに使用する記号です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>バックアップディレクトリー</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>プロジェクト検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>大文字と小文字を区別</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>完全一致のみ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>正規表現モード</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>検索</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>プロジェクト設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>ステータス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>重要度</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>自動置換</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>プロジェクトの内容</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>クイックリンク</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>上へ移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>下へ移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>アイテムを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>すべて展開</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>すべて折りたたむ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>ごみ箱を空にする</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>その他の設定</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>ファイルまたはフォルダを追加する場所が見つかりませんでした！</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>ごみ箱フォルダには新規ファイルやフォルダを追加できません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>新規ノート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>新規チャプター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>新規シーン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>新規ドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>新規フォルダー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>結合するドキュメントが選択されていません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>結合された</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>ドキュメントの内容を書き込めませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>このドキュメントを複製しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>このアイテムとすべての子アイテムを複製しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>すべてのアイテムを複製できませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>ルートフォルダーは空の場合にのみ削除できます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>選択したアイテムを完全に削除しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>選択したアイテムをごみ箱に移動しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>ごみ箱フォルダーはすでに空です。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>ごみ箱から {0} 個のファイルを完全に削除しますか？</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>クォートスタイルを選択</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>プロジェクトツリービュー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>小説ツリービュー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>プロジェクト検索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>小説アウトラインビュー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>原稿をビルド</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>小説の詳細</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>執筆の統計</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>設定</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>ようこそ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>一覧</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>新規</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>ブラウズ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>キャンセル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>作成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>開く</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>プロジェクト単語リスト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>テキストファイルから単語をインポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>単語をテキストファイルにエクスポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>単語を追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>単語を削除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>注: インポート ファイルは、UTF-8 または ASCII エンコーディングのプレーンテキストファイルである必要があります。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>ファイルをインポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>ファイルをエクスポート</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>執筆の統計</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>セッション開始</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>長さ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>アイドル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>単語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>ヒストグラム</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>合計</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>合計時間:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>アイドル時間:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>フィルター時間:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>小説の単語数:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>ノートの単語数:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>合計単語数:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>フィルター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>小説ファイルをカウント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>ノートファイルをカウント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>単語数0を非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>負の単語数を非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>日毎にグループ化</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>アイドル時間の表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>ヒストグラムの単語数上限</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>名前を付けて保存</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>JSON データファイル (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>CSV データファイル (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>JSON データファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>CSV データファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>名前を付けてデータを保存</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>{0} ファイルの書き込みに成功しました:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>{0} ファイルの書き込みに失敗しました。</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>ドキュメントファイルを削除できませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>既知のプロジェクトファイル形式ではありません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>パス: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>プロジェクトファイルが見つかりません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>プロジェクトを開けませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>不明</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>プロジェクトファイルがnovelWriter XMLファイルではないようです。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>不明な、またはサポートされていないnovelWriterプロジェクトファイル形式です。このバージョンのnovelWriterではプロジェクトを開くことはできません。 ファイルは、novelWriterのバージョン {0} で保存されました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>プロジェクトxmlの解析に失敗しました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>プロジェクトのファイル形式を更新しようとしています。 続行すると、古いバージョンのnovelWriterはこのプロジェクトを開くことができなくなります。続行しますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>このプロジェクトは、新しいバージョンのnovelWriter、バージョン {0} によって保存されました。 このインスタンスはバージョン {1} です。 プロジェクトを開くと、いくつかの属性や設定は保持されませんが、プロジェクト全体は問題ありません。 プロジェクトを開きますか？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>復元されました</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>プロジェクト内に孤立している {0} ファイルが見つかりました。 {1} ファイルを復元しました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>開いたプロジェクト: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>プロジェクトが開かれていません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>プロジェクトを保存できませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>保存されたプロジェクト: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>プロジェクトをバックアップ中...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>プロジェクト名が設定されていないため、プロジェクトをバックアップできません。プロジェクト設定でプロジェクト名を設定してください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>バックアップフォルダーを作成できませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>プロジェクトサイズ {0}Bのバックアップを作成しました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>バックアップアーカイブを書き込めませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>プロジェクトはバックアップされました '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>新規</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>ノート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>下書き</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>終了</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>マイナー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>メジャー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>メイン</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>すべての小説フォルダー</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>ターゲットフォルダが空ではありません。別のフォルダを選択してください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>プロジェクトの作成中にエラーが発生しました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>新規プロジェクト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>タイトルページ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>アドレス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>作</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>単語カウント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>チャプターの概要。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>シーンの概要。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>簡潔な説明。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>チャプター {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>シーン {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>メインプロット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>主人公</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>メインの場所</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>ターゲットフォルダは既に存在します。別のフォルダを選択してください。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>プロジェクトファイルをコピーできませんでした。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>新規サンプルプロジェクトの作成に失敗しました。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>新規サンプルプロジェクトの作成に失敗しました。必要なファイルが見つかりませんでした。インストール時に欠落しているようです。</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;保存</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;キャンセル</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;閉じる</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>保存せずに閉じる</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>保存</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>すべて保存</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>開く</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;はい</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>&amp;すべて はい</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;いいえ</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>&amp;すべて いいえ</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>中止</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>再試行</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>無視</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>閉じる</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>キャンセル</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>破棄</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>ヘルプ</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>適用</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>リセット</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>既定値に戻す</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>正方形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>三角形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>逆三角形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>菱形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>五角形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>六角形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>星</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>パックマン</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>1/4の円</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>半円</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4の円</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>全円</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1バー</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2バー</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3バー</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4バー</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1ブロック</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2ブロック</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3ブロック</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4ブロック</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>novelWriterプロジェクトファイルまたはZipファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>novelWriterプロジェクトファイル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>プロジェクトを開く</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>フォントを選択</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>文字数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>テキスト内の文字数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>見出し内の文字数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>見出し</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>スペースなし文字数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>テキスト内のスペースなし文字数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>見出し内のスペースなし文字数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>単語数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>テキスト内の単語数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>見出し内の単語数</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>最新バージョン: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>確認しています...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>ここからダウンロード: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>バージョン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>リリース日</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>更新履歴</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>今すぐ確認</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>失敗</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>目次</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>タイトル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>単語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>ページ数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>ページ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>進捗</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>1ページあたりの単語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>最初のページオフセット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>奇数ページ上のチャプター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>無題</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>END</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>値</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>名前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>タイトル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>非表示</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>原稿に含む</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>原稿から除外</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>常に含む</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>常に除外</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>デフォルトにリセット</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>選択範囲を次としてマーク</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>ルートフォルダーを選択</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>情報</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>警告</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>エラー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>質問</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>非表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>編集中: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>なし</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>タイトル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>チャプター番号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>チャプター番号 (文章)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>チャプター番号 (大文字のローマ字)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>チャプター番号 (小文字のローマ字)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>シーン番号 (チャプター内)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>シーン番号 (絶対)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>視点人物</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>焦点人物</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>挿入</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>適用</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>中央</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>改ページ</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>必須</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>任意</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>新鮮なプロジェクトを作成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>サンプルプロジェクトを作成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>既存のプロジェクトをコピー</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>プロジェクト名</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>著者</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>プロジェクトパス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>プロジェクトのプリフィル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>シーンのみを追加するには0に設定してください</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>{0} チャプタードキュメントを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>{0} シーンドキュメントを追加(各チャプターに)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>プロットノート用のフォルダーを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>登場人物ノート用のフォルダーを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>場所ノート用のフォルダーを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>上記にノートの例を追加する</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>チャプターとシーン</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>プロジェクトノート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>新規プロジェクトを作成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>プロジェクトフォルダーを選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>新鮮なプロジェクト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>サンプルプロジェクト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>テンプレート: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>プロジェクト名は必須です。</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>プロジェクトパスに到達できません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>パス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>'{0}' を最近のプロジェクトリストから削除しますか？　プロジェクトファイルは削除されません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>プロジェクトを開く</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>プロジェクトを削除</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>プロジェクト</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>名前</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>修正</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>編集時間</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>単語カウント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>小説内</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>ノート内</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>選択した小説</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>チャプター</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>シーン</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>"プレビュー" ボタンを押して生成します ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>処理中…</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>完了</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>ビルドされた</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>プレビューなし</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>単語カウント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>最後に開いた</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>プレビューとビルドのためのテキスト自動置換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>キーワード</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>置換候補</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>編集するアイテムを選択</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>プロジェクト名</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>これを変更すると、バックアップパスに影響します。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>著者</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>原稿の作成時にのみ使用されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>プロジェクトの言語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>既定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>スペルチェック言語</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>メイン設定よりも優先されます。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>終了時にバックアップを無効にする</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>ステータス</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>小説のドキュメントの状態レベル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>重要度</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>プロジェクトノートの重要度レベル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>使用されていません</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>一度だけ使用</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>{0} 個のアイテムで使用</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>色を選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>ラベル</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>用途</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>ラベルを追加</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>ラベルを削除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>上へ移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>下へ移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>ラベルをインポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>ラベルをエクスポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>編集するアイテムを選択</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>色</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>円...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>バー...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>ブロック...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>形状</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>新規アイテム</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>使用中のステータスアイテムは削除できません。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>ファイルをインポート</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>ファイルをエクスポート</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>ごみ箱を空にする</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>名前を変更</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>複製</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>ドキュメントを開く</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>ドキュメントを表示</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>新規作成...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>見出し名に変更</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>アクティブに設定...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>アクティブを切り替え</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>ステータスを... に設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>ラベルを管理...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>重要度を... に設定</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>変換...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>{0} へ変換</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>子アイテムを自分に結合</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>子アイテムを新規アイテムに結合</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>フォルダ内のドキュメントを結合</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>見出しでドキュメントを分割</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>すべて展開</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>すべて折りたたむ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>完全に削除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>ごみ箱に移動</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>フォルダーを {0} に変換しますか？　この操作は元に戻せません。</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>テンプレートから</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>ドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>最初の見出し</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>タグ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>重要度</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>ドキュメント</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>見出し</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>短い説明</translation>
     </message>

--- a/i18n/nw_nb_NO.ts
+++ b/i18n/nw_nb_NO.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Dokumentfiltre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Romandokumenter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Prosjektnotater</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Inaktive dokumenter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Tittelformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Kapittelformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Unummerert format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Sceneformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Alt. sceneformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Seksjonformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Tittel-stil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Partisjon-stil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Kapittel-stil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Scene-stil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Tekstinnhold</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Inkluder sammendrag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Inkluder kommentarer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Inkluder kodeord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Inkluder tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Ignorer disse nøkkelordene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Legg til titler for notater</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Tekstformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Skrifttype</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Linjehøyde</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Juster tekstmarginer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Erstatt unicode-tegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Erstatt tabulator med mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Bevar harde linjeskift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Fremhev dialogtekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>Innrykk på første linje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Aktiver innrykk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Innrykkets bredde</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Innrykk på første avsnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Tekstmarg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Tittel og partisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Overskrift 1 og kapittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Overskrift 2 og scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Overskrift 3 og seksjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Overskrift 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Tekstavsnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Scene-separator</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Sideoppsett</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Enhet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Sidestørrelse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Sidemarg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Dokumentets stil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Topptekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Første side for sideteller</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Bruk farge på overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Bruk større skrift for overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Uthev overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>HTML-instillinger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>Legg til CSS style</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Bevar tabulatorer</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>i fremtiden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>nå nettopp</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>for et minutt siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>for {0} minutter siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>for en time siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>for {0} timer siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>for en dag siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>for {0} dager siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>for en uke siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>for {0} uker siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>for en måned siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>for {0} måneder siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>for et år siden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>for {0} år siden</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Tittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Overskrift 1 (inndeling)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Overskrift 2 (kapittel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Overskrift 3 (scene)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Overskrift 4 (seksjon)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Tekstavsnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Scene-separator</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>Ingen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Plott</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Karakterer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Lokasjoner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Tidslinje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Objekter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Enheter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Annet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Arkiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Maler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Søppel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Romandokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Prosjektnotat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Hovedmappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Mappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Tittelside</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Kapittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Seksjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>Aktiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Inaktiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Knagg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Perspektiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Fokus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>Fortelling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Nevnt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Nivå</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Linje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Tegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Avsnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>Persp.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Sammendrag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Microsoft Word-dokument (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter Markup (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Standard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Utvidet Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portabelt dokument-format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter Markup (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Firkant</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Trekant</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Diamant</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Pentagon</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Heksagon</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Stjerne</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>1/4 sirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Halvsirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4 sirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Helsirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 strek</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 streker</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 streker</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 streker</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 kloss</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 klosser</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 klosser</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 klosser</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>Tekstfiler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>Markdown-filer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>novelWriter-filer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>CSV-filer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>Alle filer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Millimeter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Centimeter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Tommer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Rett, enkelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Rett, dobbelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Venstre, enkelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Høyre, enkelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Enkelt, lavt-9 sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Enkelt, høyt, reversert-9 sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Venstre, dobbelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Høyre, dobbelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Dobbelt, lavt-9 sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Dobbelt, høyt, reversert-9 sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Dobbelt, lavt, reversert-9 sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Enkelt, venstre, angulært sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>Enkelt, høyre, angulært sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Dobbelt, venstre, angulært sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>Dobbelt, høyre, angulært sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Venstre hjørnevinkel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Høyre hjørnevinkel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Venstre, hvit hjørnevinkel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Høyre, hvit hjørnevinkel</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>Om novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>Denne applikasjonen er lisensiert under {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Krediteringer</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Byggeinnstillinger for manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>Generelt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Utvalg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formattering</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Legg til ordbøker</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Last ned en ordbok fra en av lenkene, og legg den til nedenfor.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Legg til ordbok</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Mappe hvor ordbøkene er installert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Ordbøker funnet: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Free- eller Libre Office-utvidelse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Bla gjennom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>Kunne ikke behandle ordbokfilen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Lagt til: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Linje: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Ord: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Ord: {0} valgt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Vis/skjul verktøylinje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Disposisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Søk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Slå av/på "Fokus-modus"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Lukk</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Søketekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Erstatt med</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Søk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Skill store/små bokstaver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Kun hele ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>RegEx-modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Søk rundt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Søk i neste file</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Behold store/små bokstaver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Lukk søk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Søk i det åpne dokumentet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Søk og erstatt i det åpne dokumentet</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Åpnet dokument: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Dette dokumentet er endret utenfor novelWriter mens det var åpent. Overskrive filen på disken?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>Kunne ikke lagre dokumentet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Lagret dokument: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Stavekontroll krever at pakken PyEnchant er installert. Det ser det ikke ut til at den er.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Stavekontrollen er ferdig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Dokumentdetaljer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Opprettet: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Oppdatert: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>Filplassering: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Sett som dokumentnavn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>Åpne lenke</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Følg knagg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Opprett notat for knagg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Klipp</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Kopier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Lim inn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Velg hele teksten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Velg hele ordet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Velg hele avsnittet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Forslag fra stavekontrollen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>Ingen forslag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Ignorer ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Legg til ord i ordbok</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Venligst velg en del av teksten før du velger å erstatte sitattegn.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Vil du opprette et nytt prosjektnotat for knaggen '{0}'?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Slå sammen dokumenter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Dokumenter som skal slås sammen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Dra og slipp elementer for å endre rekkefølgen, eller fjern merking for å ekskludere.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Flytt sammenslåtte elementer til papirkurven</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Del opp dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Dokumentets overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Velg hvilket nivå av overskrifter å dele opp til.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Splitt på overskrifter på nivå 1 (titler)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Splitt på overskrifter opp til nivå 2 (kapitler)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Splitt på overskrifter opp til nivå 3 (scener)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Splitt på overskrifter opp til nivå 4 (seksjoner)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>Del inn i en ny mappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Opprett dokumenthierarki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Flytt splittet element til papirkurven</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Fet skrift med Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Kursiv med Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Gjennomstrek med Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Fet skrift med kortkode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Kursiv med kortkode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Gjennomstrek med kortkode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Understrek med kortkode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Tekstutheving med kortkode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Hevet skrift med kortkode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Senket skrift med kortkode</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Vis/skjul visningspanelet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Kommentarer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Vis kommentarer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Sammendrag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Vis sammendrag</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Disposisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Gå bakover</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Gå fremover</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Åpne i editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Oppdater</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Lukk</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>Det har oppstått en feil under genereringen av visningen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Kopier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Velg hele teksten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Velg hele ordet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Velg hele avsnittet</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Skjul inaktive knagger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>Referanser</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Enhetens navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Navn</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Klasse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Formål</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Sett inn midlertidig tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Sett inn Lorem Ipsum-tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Antall avsnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Tilfeldig rekkefølge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Sett inn</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter er klar ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>Du kjører nå novelWriter versjon {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Sjekk {0}utgivelsesnotater{1} for mer informasjon.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>Ønsker du å lukke dette prosjektet?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Endringer lagres automatisk.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>Ønsker du å ta sikkerhetskopi av dette prosjektet?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>Prosjektet er allerede åpent av en annen instans av novelWriter, og er derfor låst. Vil du overstyre denne låsen og fortsette likevel?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Merk: Hvis programmet eller datamaskinen tidligere krasjet, kan fil-låsen trygt overstyres. Det anbefales imidlertid ikke å overstyre den hvis prosjektet er åpent i en annen instans av novelWriter. Å gjøre det kan skape konflikter i prosjektets filer.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>Prosjektet er låst av datamaskinen {0} ({1} {2}), siste registrerte aktivitet var {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>Prosjektets indeks er utdatert eller skadet. Bygger indeksen på nytt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Importer fil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>Kunne ikke lese filen. Filen må eksistere fra før av.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Vennligst åpne et dokument hvor teksten i filen kan importeres.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>Å importere filen vil overskrive all eksisterende tekst i dokumentet. Ønsker du å fortsette?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Indekseringen tok {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>Prosjektets indeks har blitt bygget på nytt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>Kunne ikke initialisere dialogen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>Ønsker du å avslutte novelWriter?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Noen endringer vil ikke tas i bruk før neste gang novelWriter startes.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>Kunne ikke finne referansen til knagg {0}. Enten finnes den ikke, eller så er prosjektets indeks ikke oppdatert. Indeksen kan oppdateres fra Verktøy-menyen eller ved å trykke på {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Opprett eller åpne prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Lagre prosjektet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Lukk prosjektet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Prosjektinnstillinger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Roman-detaljer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Endre navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Slett enhet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Tøm søppel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Avslutt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Åpne dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Lagre dokumentet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Lukk dokumentet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>Vis dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Lukk dokumentvisning</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Vis filinformasjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Importer tekst fra fil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Rediger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Angre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Gjenopprett</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Klipp</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Kopier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Lim inn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Velg hele teksten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Velg hele avsnittet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;Vis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Gå til prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Gå til dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Gå til disposisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Navigere bakover</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Navigere fremover</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Focus-modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Fullskjerm-modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>Sett &amp;inn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Bindestreker</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Kort bindestrek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Lang bindestrek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Horisontal strek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Tallstrek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Venstre, enkelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Høyre, enkelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Venstre, dobbelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Høyre, dobbelt sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Alternativ apostrof</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>Generell tegnsetting</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Ellipsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Primtegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Dobbelt primtegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>Mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Hardt mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Kort mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Hardt, kort mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Andre symboler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>Kulepunkt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Bindestrekpunkt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Blomsterpunkt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Promille</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Gradertegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Minustegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Gangetegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Deletegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Knagger og referanser</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Andre kommentartyper</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Kommentar med sammendrag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Kommentar for kort beskrivelse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Statistikk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Linjeskift og avstand</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Sideskift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Tvunget linjeskift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Vertikal avstand (enkel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Vertikal avstand (flere)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Midlertidig tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Fotnote</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Formattering</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Fet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Kursiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Gjennomstrek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Sett i doble sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Sett i enkle sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>Flere formater ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Fet (kortkode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Kursiv (kortkode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Gjennomstrek (Kortkode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Understrek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Tekstutheving</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Hevet skrift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Senket skrift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Boktittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Unumrert kapittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Alternativ scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Venstrejuster</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Sentrer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Høyrejuster</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Innrykk fra venstre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Innrykk fra høyre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Veksle kommentar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Aktiver/deaktiver ignorert tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Fjern formattering</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Erstatt enkle sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Erstatt doble sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Fjern linjeskift i avsnittet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;Søk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Søk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Erstatt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Finn neste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Finn forrige</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Erstatt neste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Søk i prosjektet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;Verktøy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Stavekontroll</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Språk for stavekontroll</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Ingen valg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Kjør stavekontroll</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Prosjektets ordliste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Legg til ordbøker</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Bygg indeks</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Lag sikkerhetskopi av prosjektets mappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Bygg manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Statistikk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Innstillinger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>&amp;Hjelp</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>Om novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>Om Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>Brukermanual (på nett)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>Brukermanual (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Rapporter en feil (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Still et spørsmål (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>novelWriters nettside</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>Ingen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Tid brukt i gjeldende sesjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Ord: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Antall ord i prosjektet (endring i denne sesjonen)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Antall ord i roman-teksten (endring i denne sesjonen)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Bygg manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Legg til ny byggedefinisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Slett valgte byggedefinisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Dupliser byggedefinisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Rediger valgte byggedefinisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Byggedefinisjoner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Detaljer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Disposisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Forhåndsvis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Skriv ut</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Bygg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Lukk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Vis markør for ny side</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>Mitt manuskript</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Bygg manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Dokumentformat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Innholdsfortegnelse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Filbane</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>Filnavn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Tilbakestill filnavn til standard</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Åpne mappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;Bygg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Velg mappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>Mappen eksisterer ikke.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>Filen eksisterer allerede. Vil du overskrive den?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Roman-detaljer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Oversikt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Innhold</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Innhold i {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Roman-mappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Oppdatér</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Siste kolonne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Skjult</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Synsvinkel-karakter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Fokus-karakter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Roman-plott</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Kolonnebredde</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>Flere valg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Maksimal kolonnebredde i %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>Ingen meta-data</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Tittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Kapittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Seksjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Sammendrag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Oversikt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Referanser</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Velg kolonner</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Disposisjon for</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Oppdatér</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>Eksporter CSV</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Lagre disposisjon som</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Innstillinger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Søk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>Generelt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Utseende</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Visningspråk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>Krever omstart for å tre i kraft.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Fargetema</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>Generelt fargetema og ikoner.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Applikasjonens skrifttype</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Skjul vertikale rullefelt i hovedvinduer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Rulling kan bare gjøres med mus og tastatur.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Skjul horisontale rullefelt i hovedvinduer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Bruk operativsystemets dialog for skriftvalg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Slå av for istedet bruker Qt sin dialog for skrifttype, som kan ha flere valg.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Dokumentets stil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Dokumentets fargetema</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Fargetema for redigering og visning.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Dokumentets skrifttype</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>Gjelder både redigerings- og visningsvindu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Fremhev filnavn for inndeling og kapitler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Får dem til å skille seg ut i prosjekttreet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Vis full prosjektbane i dokumenthoder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Legger til mappene foran dokumentets navn.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Inkluder prosjektnotater i antallet ord i statuslinjen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Funksjonalitet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Intervall for lagring av dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>Hvor ofte dokumentet lagres automatisk.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>sekunder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Intervall for lagring av prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>Hvor ofte prosjektet lagres automatisk.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Spør før novelWriter lukkes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Gjelder bare når et prosjekt er åpent.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Sikkerhetskopi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Bla</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Filbane for sikkerhetskopi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Filbane: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Lag sikkerhetskopi når prosjektet lukkes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Kan overstyres fra individuelle prosjektinnstillinger.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Spør før sikkerhetskopi tas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>Hvis avslått, tas sikkerhetskopi automatisk.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Sesjons-klokke</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Sett klokka på pause når du er inaktiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Pauses også når du ikke jobber i applikasjonens vindu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Tid uten skriving før klokka settes på pause</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>Dette måler kun endringer i teksteditoren.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>minutter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Skriving</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Tekstflyt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Maks tekstbredde i "Normal-modus"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>Sett til 0 for å deaktivere denne funksjonen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Maks tekstbredde i "Fokus-modus"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>Denne maks-bredden kan ikke deaktiveres.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Gjem dokumentets bunnlinje i "Fokus-modus"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Skjul informasjonslinjen i dokumenteditoren.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Juster tekstmarginer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Minimum tekstmargin</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Tabulatorens bredde</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>Hvor langt tabulatoren hopper i editor og visning.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Redigering av tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Språk for stavekontroll</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Tilgjengelige språk hentes fra operativystemet ditt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Auto-velg ord under markør</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>Hvis ingen tekst er valgt, formatter ordet hvor markøren står.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Synlige tabulatorer og mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Synlige linjeender</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Tekstbehandler rulling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Tillat å rulle forbi slutten av dokumentet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>Sentrerer også markøren når man ruller.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Skrivemaskin-liknende rulling mens du skriver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Holder markøren på samme sted vertikalt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Minste avstand for skrivemaskin-rulling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>I prosent fra toppen av editor-vinduet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Fremheving</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>Ingen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>Enkle anførselstegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>Doble anførselstegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>Begge typer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Fremhev dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Gjelder alle de valgte anførselstegn.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Symboler for alternativ dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Egendefinert fremheving av dialog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Tillat anførselstegn som ikke lukkes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Fremhev dialog som ikke er lukket i samme avsnitt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Symbol for dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Linjer som begynner med dette symbolet er ansett som dialog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Symbol for forteller-innslag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Bytt til fortellerstemme i dialog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Symbol for dialog/forteller-skifte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Veksler mellom dialog og forteller i alle typer avsnitt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Fremhev formattert tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Gjelder bare for redigeringsvindu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Fremhev flere eller etterfølgende mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Tekstautomatisering</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Erstatt mens du skriver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Erstatt symboler mens du skriver.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Erstatt enkle sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Prøv å gjette om det er et åpne- eller lukketegn.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Erstatt doble sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Erstatt bindestreker</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>To og tre bindestreker erstattes med kort og lang bindestrek.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Erstatt tre punktum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Tre punktum på rad erstattes med ellipsis.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Sett inn hardt mellomrom foran</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Legg til mellomrom automatisk foran disse tegnene.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Sett inn hardt mellomrom etter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Legg til mellomrom automatisk etter disse tegnene.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Bruk tynt mellomrom istedet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Sett inn et tynt mellomrom istedenfor et vanlig et.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Sitattegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Enkelt sitat, venstre side</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>Symbol for enkelt sitattegn før et sitat.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Enkelt sitat, høyre side</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>Symbol for enkelt sitattegn etter et sitat.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Dobbelt sitat, venstre side</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>Symbol for dobbelt sitattegn før et sitat.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Dobbelt sitat, høyre side</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>Symbol for dobbelt sitattegn etter et sitat.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Mappe for sikkerhetskopi</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Søk i prosjektet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Skill store/små bokstaver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Kun hele ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>RegEx-modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Søketekst</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Prosjektinnstillinger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Innstillinger</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Viktighet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Autoerstatt</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Prosjektets innhold</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Hurtiglenker</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Flytt opp</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Flytt ned</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Legg til element</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Utvid alle</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Lukk alle</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Tøm papirkurven</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>Flere valg</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Fant ikke noe sted å legge til filen eller mappen!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Kan ikke legge til nye filer eller mapper i papirkurvmappen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>Nytt notat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>Nytt kapittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>Ny scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>Nytt dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>Ny mappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>Ingen dokumenter er valgt for sammenslåing.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Sammenslått</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>Kan ikke skrive til dokumentet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>Vil du duplisere dette dokumentet?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Vil du duplisere dette elementet og alle underelementer?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>Kunne ikke duplisere alle elementer.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Rotmapper kan bare slettes når de er tomme.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>Slett merkede elementer permanent?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>Flytte valgte elementer til papirkurven?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>Papirkurven er allerede tom.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Vil du slette {0} filer i papirkurven for godt?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Velg anførselstegn</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Prosjektoversikt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Romanoversikt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Søk i prosjektet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Disposisjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Bygg manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Roman-detaljer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Statistikk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Oppsett</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Velkommen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>Liste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>Nytt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Bla gjennom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Avbryt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Opprett</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Åpne</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Prosjektets ordliste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Importer ord fra tekstfil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Eksporter ord til tekstfil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Legg til ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Fjern ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Merk: Importfilen må være en standard tekstfil med UTF-8 eller ASCII-koding.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Importer fil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Eksporter fil</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Statistikk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Starttid</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Lengde</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Inaktiv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Histogram</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Totalsummer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Totaltid:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Inaktiv tid:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Filtrert tid:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Ord i roman:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Ord i notater:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Ord totalt:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filtre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Tell i romanfiler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Tell i notatfiler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>Skjul null-verdier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>Skjul negative verdier</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Samle rader per dag</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Vis inaktiv som tid</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Maks antall ord for histogram</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Lagre som</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>JSON-format (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>CSV-format (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>JSON-format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>CSV-format</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Lagre data som</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>{0}-filen ble skrevet til:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Kunne ikke skrive {0}-filen.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>Kunne ikke slette dokumentets fil.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Ikke et kjent prosjektfilformat.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Filbane: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>Prosjektfilen finnes ikke.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Kunne ikke åpne prosjektet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Ukjent</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>Prosjektfilen later ikke til å være en novelWriterXML-fil.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Prosjektfilen har et ukjent eller ikke støttet format, og kan ikke åpnes med denne versjonen av novelWriter. Prosjektet ble lagret av novelWriter versjon {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>Kunne ikke lese prosjektets xml-data.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>Filformatet til prosjektet ditt er i ferd med å bli oppdatert. Hvis du fortsetter, vil ikke eldre versjoner av novelWriter lenger kunne åpne dette prosjektet. Fortsette?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>Dette prosjektet ble lagret av en nyere versjon av novelWriter, versjon {0}. Dette er versjon {1}. Hvis du ønsker å fortsette med å åpne prosjektet, kan noen av innstillingene bli borte, men selve prosjektet vil være i orden. Vil du fortsatt åpne prosjektet?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Gjennopprettet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>{0} foreldreløse fil(er) ble funnet i prosjektet. {1} fil(er) ble gjenopprettet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Åpnet prosjekt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>Det er ikke noe prosjekter åpent.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Kunne ikke lagre prosjektet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Lagret prosjekt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Lager sikkerhetskopi ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Kan ikke ta sikkerhetskopi av prosjektet da prosjektnavn ikke er satt. Du må først sette et prosjektnavn i Prosjektinnstillinger.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>Kunne ikke lage mappe til sikkerhetskopi.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Opprettet en sikkerhetskopi av prosjektet med størrelse {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>Kunne ikke lage sikkerhetskopi.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Sikkerhetskopi skrevet til '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>Ny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Notat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Utkast</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Ferdig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Mindre</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Større</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Hoved</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>Alle roman-mapper</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>Den valgte mappen er ikke tom. Vennligst velg en annen mappe.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>Det oppsto en feil under forsøk på å opprette prosjektet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>Nytt prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Tittelside</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Adresse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>Av</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Antall ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Sammendrag av kapittelet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Sammendrag av scenen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>En kort beskrivelse.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Kapittel {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Scene {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Hovedplott</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonist</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Hovedlokasjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>Den valgte mappen finnes allerede. Vennligst velg en annen mappe.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>Kunne ikke kopiere prosjektfiler.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Kunne ikke lage nytt eksempel-prosjekt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Kunne ikke lage nytt eksempel-prosjekt. Kunne ikke finne de nødvendige filene. De ser ut til å mangle i denne installasjonen.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Lagre</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Avbryt</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;Lukk</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Lukk uten å lagre</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Lagre</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Lagre alle</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Åpne</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Ja</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Ja til &amp;alle</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;Nei</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>N&amp;ei til alle</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Avbryt</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Prøv igjen</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Ignorer</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Lukk</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>Avbryt</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Forkast</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Hjelp</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Anvend</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Nullstill</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Gjennopprett standard</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Firkant</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Trekant</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Diamant</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Pentagon</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Heksagon</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Stjerne</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>1/4 sirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Halv sirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4 sirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Hel sirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 strek</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 streker</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 streker</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 streker</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 kloss</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 klosser</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 klosser</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 klosser</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>novelWriter prosjektfil eller Zip-fil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>novelWriter prosjektfil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Åpne prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Velg skrifttype</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Tegn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Tegn i tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Tegn i overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Avsnitt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Tegn, utenom mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Tegn i tekst, utenom mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Tegn i overskrifter, utenom mellomrom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Ord i tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Ord i overskrifter</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Siste versjon: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Sjekker ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Last ned fra {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Versjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Utgitt den</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Lanseringsnotater</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>Sjekk nå</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>Mislyktes</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Innholdsfortegnelse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Tittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Sider</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Side</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Fremdrift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Ord per side</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>Første side forskjøvet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Kapittel på oddetall-sider</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Uten tittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>SLUTT</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Innstilling</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Verdi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Utvalg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Tittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Skjult</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>Inkludert i manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>Ekskludert fra manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Alltid inkludert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Alltid ekskludert</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Tilbakestill til standard</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Merk utvalg som</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Velg hovedmapper</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Informasjon</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Advarsel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Feil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Spørsmål</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Skjul</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Redigerer: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>Ingen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Tittel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Kapittelnummer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Kapittelnummer (som ord)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Kapittelnummer (store romertall)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Kapittelnummer (små romertall)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Scenenummer (i kapittel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Scenenummer (absolutt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Synsvinkel-karakter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Fokus-karakter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Sett inn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Anvend</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Sentrer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Sideskift</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Påkrevd</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Valgfritt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Opprett et nytt prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Opprett et eksempelprosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Kopier et eksisterende prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Prosjektnavn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Forfatter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Filbane</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Forhåndsfyll prosjektet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Satt til 0 for bare å legge til scener</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>Legg til {0} kapitteldokumenter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>Legg til {0} scenedokumenter (til hvert kapittel)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Legg til en mappe for plott-notater</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Legg til en mappe for karakterer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Legg til en mappe for lokasjoner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Lag eksempelfiler til ovennevnte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Kapittel og scener</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Prosjektnotater</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Opprett nytt prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Velg prosjektmappe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Nytt prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Eksempelprosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Mal: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>Vennligst oppgi et prosjektnavn.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>Prosjektets bane er ikke tilgjengelig.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Filbane</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>Vil du fjerne {0} fra listen over tidligere åpnede prosjekter? Selve prosjektfilene blir ikke slettet.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Åpne prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Fjern prosjekt</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Prosjekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Revisjoner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Redigeringstid</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Antall ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>I romaner</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>I notater</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Velg roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Kapitler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Scener</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Trykk på "Forhåndsvisning"-knappen for å generere ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>Behandler ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Ferdig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Bygget</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>Ingen forhåndsvisning</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Antall ord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Sist åpnet</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Erstatt automatisk for forhåndsvisning og manuskript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Nøkkelord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Erstatt med</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Velg enhet å redigere</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Prosjektnavn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Å endring denne vil påvirke banen til sikkerhetskopier.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Forfatter(e)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Brukes kun ved bygging av manuskript.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Prosjektets språk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Ingen valg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Språk for stavekontroll</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Overstyrer valg i innstillinger.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>Ikke lag sikkerhetskopi når prosjektet lukkes</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Statusnivåer i roman-filer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Viktighet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Viktighetsnivåer i notatfiler</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>Ikke i bruk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Brukt ett sted</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>Brukt {0} steder</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Velg farge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Bruk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Legg til</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Slett</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Flytt opp</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Flytt ned</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Importer fra fil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Eksporter til fil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Velg enhet å redigere</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Farge</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Sirkler ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Streker ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Klosser ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Former</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>Legg til</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>Kan ikke slette status som er i bruk.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Importer fil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Eksporter fil</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Tøm papirkurven</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Endre navn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Dupliser</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Åpne dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>Vis dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Opprett ny ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Endre navn til overskriften</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Sett aktiv til ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Aktiver/deaktiver</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Sett status til ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Administrer etiketter ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Sett viktighetsnivå til ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Endre ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Konverter til {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Lim inn underelementer i dette dokumentet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Lim inn underelementer i nytt dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Slå sammen dokumenter i mappen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Splitt dokumentet etter overskrifter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Utvid alle</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Lukk alle</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Slett permanent</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>Flytt til papirkurv</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Vil du konvertere mappen til et {0}? Denne handlingen kan ikke angres.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>Fra mal</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>Første overskrift</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Knagg</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Viktighet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Overskrift</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Kort beskrivelse</translation>
     </message>

--- a/i18n/nw_nl_NL.ts
+++ b/i18n/nw_nl_NL.ts
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="310" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="117" />
       <source>Title</source>
       <translation>Titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118" />
       <source>Heading 1 (Partition)</source>
       <translation type="unfinished">Kop 1 (Partitie)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119" />
       <source>Heading 2 (Chapter)</source>
       <translation type="unfinished">Kop 2 (Hoofdstuk)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120" />
       <source>Heading 3 (Scene)</source>
       <translation type="unfinished">Kop 3 (Scène)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121" />
       <source>Heading 4 (Section)</source>
       <translation type="unfinished">Kop 4 (Sectie)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122" />
       <source>Text Paragraph</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123" />
       <source>Scene Separator</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="267" />
-      <location filename="../novelwriter/constants.py" line="262" />
-      <location filename="../novelwriter/constants.py" line="234" />
+      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="240" />
       <source>None</source>
       <translation>Geen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="235" />
+      <location filename="../novelwriter/constants.py" line="241" />
       <source>Novel</source>
       <translation type="unfinished">Roman</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
-      <location filename="../novelwriter/constants.py" line="236" />
+      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="242" />
       <source>Plot</source>
       <translation type="unfinished">Plot</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="285" />
-      <location filename="../novelwriter/constants.py" line="237" />
+      <location filename="../novelwriter/constants.py" line="291" />
+      <location filename="../novelwriter/constants.py" line="243" />
       <source>Characters</source>
       <translation type="unfinished">Personages</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="288" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="294" />
+      <location filename="../novelwriter/constants.py" line="244" />
       <source>Locations</source>
       <translation type="unfinished">Locaties</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="245" />
       <source>Timeline</source>
       <translation type="unfinished">Tijdslijn</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="295" />
+      <location filename="../novelwriter/constants.py" line="246" />
       <source>Objects</source>
       <translation type="unfinished">Objecten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="247" />
       <source>Entities</source>
       <translation type="unfinished">Entiteiten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="425" />
+      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="248" />
       <source>Custom</source>
       <translation>Custom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="249" />
       <source>Archive</source>
       <translation type="unfinished">Archief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="250" />
       <source>Templates</source>
       <translation type="unfinished">Templates</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="251" />
       <source>Trash</source>
       <translation type="unfinished">Prullenbak</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="270" />
-      <location filename="../novelwriter/constants.py" line="263" />
+      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="269" />
       <source>Novel Document</source>
       <translation>Roman Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
-      <location filename="../novelwriter/constants.py" line="264" />
+      <location filename="../novelwriter/constants.py" line="281" />
+      <location filename="../novelwriter/constants.py" line="270" />
       <source>Project Note</source>
       <translation>Project Notitie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="274" />
       <source>Root Folder</source>
       <translation>Hoofdmap</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="269" />
+      <location filename="../novelwriter/constants.py" line="275" />
       <source>Folder</source>
       <translation>Map</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
+      <location filename="../novelwriter/constants.py" line="277" />
       <source>Novel Title Page</source>
       <translation>Roman Titel Pagina</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="278" />
       <source>Novel Chapter</source>
       <translation>Roman Hoofdstuk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="279" />
       <source>Novel Scene</source>
       <translation>Roman Scene</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
+      <location filename="../novelwriter/constants.py" line="280" />
       <source>Novel Section</source>
       <translation>Roman Sectie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="284" />
       <source>Active</source>
       <translation type="unfinished">Actief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
+      <location filename="../novelwriter/constants.py" line="285" />
       <source>Inactive</source>
       <translation type="unfinished">Inactief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="288" />
       <source>Tag</source>
       <translation type="unfinished">Label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="289" />
       <source>Point of View</source>
       <translation type="unfinished">Perspectief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
-      <location filename="../novelwriter/constants.py" line="284" />
+      <location filename="../novelwriter/constants.py" line="325" />
+      <location filename="../novelwriter/constants.py" line="290" />
       <source>Focus</source>
       <translation>Focus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="298" />
       <source>Story</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="299" />
       <source>Mentions</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="311" />
+      <location filename="../novelwriter/constants.py" line="317" />
       <source>Level</source>
       <translation>Niveau</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="312" />
+      <location filename="../novelwriter/constants.py" line="318" />
       <source>Document</source>
       <translation>Document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="313" />
+      <location filename="../novelwriter/constants.py" line="319" />
       <source>Line</source>
       <translation>Regel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
+      <location filename="../novelwriter/constants.py" line="320" />
       <source>Status</source>
       <translation type="unfinished">Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="321" />
       <source>Chars</source>
       <translation>Tekens</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="322" />
       <source>Words</source>
       <translation>Woorden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="323" />
       <source>Pars</source>
       <translation>Par.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="324" />
       <source>POV</source>
       <translation>Perspectief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="329" />
+      <location filename="../novelwriter/constants.py" line="335" />
       <source>Synopsis</source>
       <translation>Synopsis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="351" />
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="352" />
       <source>Flat Open Document (.fodt)</source>
       <translation>Plat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="347" />
+      <location filename="../novelwriter/constants.py" line="353" />
       <source>Microsoft Word Document (.docx)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="348" />
+      <location filename="../novelwriter/constants.py" line="354" />
       <source>HTML 5 (.html)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="355" />
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter Opmaak (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="356" />
       <source>Standard Markdown (.md)</source>
       <translation>Standaard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="357" />
       <source>Extended Markdown (.md)</source>
       <translation>Uitgebreide Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="358" />
       <source>Portable Document Format (.pdf)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="359" />
       <source>JSON + HTML 5 (.json)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="360" />
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter Opmaak (.json)</translation>
     </message>
     <message>
+      <location filename="../novelwriter/constants.py" line="375" />
+      <source>Square</source>
+      <translation type="unfinished">Vierkant</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376" />
+      <source>Triangle</source>
+      <translation type="unfinished">Driehoek</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377" />
+      <source>Nabla</source>
+      <translation type="unfinished">Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378" />
+      <source>Diamond</source>
+      <translation type="unfinished">Diamant</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379" />
+      <source>Pentagon</source>
+      <translation type="unfinished">Pentagon</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380" />
+      <source>Hexagon</source>
+      <translation type="unfinished">Zeshoek</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381" />
+      <source>Star</source>
+      <translation type="unfinished">Ster</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382" />
+      <source>Pacman</source>
+      <translation type="unfinished">Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385" />
+      <source>1/4 Circle</source>
+      <translation type="unfinished">1/4 cirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386" />
+      <source>Half Circle</source>
+      <translation type="unfinished">Halve cirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387" />
+      <source>3/4 Circle</source>
+      <translation type="unfinished">3/4 cirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388" />
+      <source>Full Circle</source>
+      <translation type="unfinished">Volledige cirkel</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391" />
+      <source>1 Bar</source>
+      <translation type="unfinished">1 staaf</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392" />
+      <source>2 Bars</source>
+      <translation type="unfinished">2 staven</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393" />
+      <source>3 Bars</source>
+      <translation type="unfinished">3 staven</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394" />
+      <source>4 Bars</source>
+      <translation type="unfinished">4 staven</translation>
+    </message>
+    <message>
       <location filename="../novelwriter/constants.py" line="397" />
+      <source>1 Block</source>
+      <translation type="unfinished">1 blok</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398" />
+      <source>2 Blocks</source>
+      <translation type="unfinished">2 blokken</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399" />
+      <source>3 Blocks</source>
+      <translation type="unfinished">3 blokken</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400" />
+      <source>4 Blocks</source>
+      <translation type="unfinished">4 blokken</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403" />
       <source>Text files</source>
       <translation>Tekst bestanden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="398" />
+      <location filename="../novelwriter/constants.py" line="404" />
       <source>Markdown files</source>
       <translation>Markdown bestanden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="399" />
+      <location filename="../novelwriter/constants.py" line="405" />
       <source>novelWriter files</source>
       <translation>novelWriter bestanden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="400" />
+      <location filename="../novelwriter/constants.py" line="406" />
       <source>CSV files</source>
       <translation>CSV bestanden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="407" />
       <source>All files</source>
       <translation>Alle bestanden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="410" />
       <source>Millimetres</source>
       <translation>Millimeters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="411" />
       <source>Centimetres</source>
       <translation>Centimeters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="406" />
+      <location filename="../novelwriter/constants.py" line="412" />
       <source>Inches</source>
       <translation>Inches</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="414" />
+      <location filename="../novelwriter/constants.py" line="420" />
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="415" />
+      <location filename="../novelwriter/constants.py" line="421" />
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="416" />
+      <location filename="../novelwriter/constants.py" line="422" />
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="417" />
+      <location filename="../novelwriter/constants.py" line="423" />
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="424" />
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="461" />
+      <location filename="../novelwriter/constants.py" line="467" />
       <source>Straight single quotation mark</source>
       <translation>Recht enkel aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="462" />
+      <location filename="../novelwriter/constants.py" line="468" />
       <source>Straight double quotation mark</source>
       <translation>Recht dubbel aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="464" />
+      <location filename="../novelwriter/constants.py" line="470" />
       <source>Left single quotation mark</source>
       <translation>Linker enkel aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="471" />
       <source>Right single quotation mark</source>
       <translation>Rechter enkel aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="472" />
       <source>Single low-9 quotation mark</source>
       <translation>Enkel lage-9 aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="467" />
+      <location filename="../novelwriter/constants.py" line="473" />
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Enkel hoog-omgekeerd-9 aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="474" />
       <source>Left double quotation mark</source>
       <translation>Linker dubbel aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="475" />
       <source>Right double quotation mark</source>
       <translation>Rechter dubbel aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="476" />
       <source>Double low-9 quotation mark</source>
       <translation>Dubbel lage-9 aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="477" />
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Dubbel hoog-omgekeerd-9 aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="478" />
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Dubbel laag-omgekeerd-9 aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="480" />
       <source>Single left-pointing angle quotation mark</source>
       <translation>Enkel links-wijzende hoek aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="481" />
       <source>Single right-pointing angle quotation mark</source>
       <translation>Enkel rechts-wijzende hoek aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="482" />
       <source>Double left-pointing angle quotation mark</source>
       <translation>Dubbel links-wijzende hoek aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="477" />
+      <location filename="../novelwriter/constants.py" line="483" />
       <source>Double right-pointing angle quotation mark</source>
       <translation>Dubbel rechts-wijzende hoek aanhalingsteken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="485" />
       <source>Left corner bracket</source>
       <translation>Linker hoekbeugel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="486" />
       <source>Right corner bracket</source>
       <translation>Rechter hoekbeugel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="487" />
       <source>Left white corner bracket</source>
       <translation>Linker holle hoekbeugel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="482" />
+      <location filename="../novelwriter/constants.py" line="488" />
       <source>Right white corner bracket</source>
       <translation>Rechter holle hoekbeugel</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3072" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
       <source>Line: {0} ({1})</source>
       <translation>Regel: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3073" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
       <source>Words: {0} ({1})</source>
       <translation>Woorden: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3074" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
       <source>Words: {0} selected</source>
       <translation>Woorden: {0} geselecteerd</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3086" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
       <source>Status</source>
       <translation>Status</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2865" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
       <source>Toggle Tool Bar</source>
       <translation>Toon/verberg werkbalk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2870" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
       <source>Outline</source>
       <translation>Samenvatting</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2875" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
       <source>Search</source>
       <translation>Zoek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2880" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
       <source>Toggle Focus Mode</source>
       <translation>Schakel focus modus in/uit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2885" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
       <source>Close</source>
       <translation>Sluiten</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
       <source>Search for</source>
       <translation>Zoek naar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2487" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
       <source>Replace with</source>
       <translation>Vervang door</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2495" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
       <source>Search</source>
       <translation>Zoek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2500" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
       <source>Case Sensitive</source>
       <translation>Hoofdlettergevoelig</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2506" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
       <source>Whole Words Only</source>
       <translation>Alleen hele woorden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2512" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
       <source>RegEx Mode</source>
       <translation>RegEx modus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2518" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
       <source>Loop Search</source>
       <translation>Zoekopdracht lus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2524" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
       <source>Search Next File</source>
       <translation>Doorzoek volgend bestand</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2532" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
       <source>Preserve Case</source>
       <translation>Behoud hoofd/kleine letters</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
       <source>Close Search</source>
       <translation>Zoekopdracht afsluiten</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2551" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
       <source>Find in current document</source>
       <translation>Zoeken in huidige document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2555" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
       <source>Find and replace in current document</source>
       <translation>Zoek en vervang in huidig document</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="436" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443" />
       <source>Opened Document: {0}</source>
       <translation>Geopend document: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="474" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481" />
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Dit document is gewijzigd buiten de openstaande novelWriter instantie. Het bestand op de schijf overschrijven?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490" />
       <source>Could not save document.</source>
       <translation>Kon document niet opslaan.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="508" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515" />
       <source>Saved Document: {0}</source>
       <translation>Document opgeslagen: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="677" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684" />
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Spellingscontrole vereist het pakket PyEnchant. Het lijkt niet geïnstalleerd te zijn.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="703" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710" />
       <source>Spell check complete</source>
       <translation>Spellingscontrole compleet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="823" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830" />
       <source>Document Details</source>
       <translation>Document details</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="825" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832" />
       <source>Created: {0}</source>
       <translation>Aangemaakt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="826" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833" />
       <source>Updated: {0}</source>
       <translation>Bijgewerkt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="828" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835" />
       <source>File Location: {0}</source>
       <translation>Bestandslocatie: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1149" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
       <source>Set as Document Name</source>
       <translation>Instellen als documentnaam</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1155" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
       <source>Open URL</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
       <source>Follow Tag</source>
       <translation>Volg label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1166" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
       <source>Create Note for Tag</source>
       <translation>Creëer notitie voor label</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1172" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
       <source>Cut</source>
       <translation>Knippen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1174" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
       <source>Copy</source>
       <translation>Kopiëren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1177" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
       <source>Paste</source>
       <translation>Plakken</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1182" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
       <source>Select All</source>
       <translation>Selecteer alles</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
       <source>Select Word</source>
       <translation>Selecteer woord</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1188" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
       <source>Select Paragraph</source>
       <translation>Selecteer paragraaf</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1204" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
       <source>Spelling Suggestion(s)</source>
       <translation>Spelling suggestie(s)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1209" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
       <source>No Suggestions</source>
       <translation>Geen suggesties</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1213" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
       <source>Ignore Word</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1215" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
       <source>Add Word to Dictionary</source>
       <translation>Woord toevoegen aan woordenboek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1619" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
       <source>Please select some text before calling replace quotes.</source>
       <translation>Selecteer a.u.b. een tekst voordat u vervang aanhalingstekens aanroept.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1974" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Wilt u een nieuwe project notitie maken voor het label '{0}'?</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2346" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
       <source>Markdown Bold</source>
       <translation>Markdown vet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2352" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
       <source>Markdown Italic</source>
       <translation>Markdown cursief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2358" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
       <source>Markdown Strikethrough</source>
       <translation>Markdown doorstrepen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2364" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
       <source>Shortcode Bold</source>
       <translation>Korte code vet</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2370" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
       <source>Shortcode Italic</source>
       <translation>Korte code cursief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2376" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
       <source>Shortcode Strikethrough</source>
       <translation>Korte code doorstrepen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2382" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
       <source>Shortcode Underline</source>
       <translation>Korte code onderstrepen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2388" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
       <source>Shortcode Highlight</source>
       <translation>Snelkoppeling accentuering</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2394" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
       <source>Shortcode Superscript</source>
       <translation>Korte code superscript</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2400" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
       <source>Shortcode Subscript</source>
       <translation>Korte code subscript</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="213" />
-      <location filename="../novelwriter/gui/statusbar.py" line="64" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212" />
+      <location filename="../novelwriter/gui/statusbar.py" line="63" />
       <source>None</source>
       <translation>Geen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="72" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71" />
       <source>Editor</source>
       <translation>Tekstbewerker</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="80" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79" />
       <source>Project</source>
       <translation>Project</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="100" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99" />
       <source>Session Time</source>
       <translation>Sessieduur</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="179" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178" />
       <source>Words: {0} ({1})</source>
       <translation>Woorden: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="181" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180" />
       <source>Project word count (session change)</source>
       <translation>Aantal projectwoorden (verandering sessie)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="183" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182" />
       <source>Novel word count (session change)</source>
       <translation>Roman woord telling (sessie verandering)</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253" />
       <source>Project Content</source>
       <translation>Project Inhoud</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262" />
       <source>Quick Links</source>
       <translation>Snelle Koppelingen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268" />
       <source>Move Up</source>
       <translation>Omhoog Schuiven</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272" />
       <source>Move Down</source>
       <translation>Omlaag Schuiven</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312" />
       <source>Add Item</source>
       <translation>Item Toevoegen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319" />
       <source>Expand All</source>
       <translation>Alles Uitklappen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322" />
       <source>Collapse All</source>
       <translation>Alles Samenvouwen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325" />
       <source>Empty Trash</source>
       <translation>Leeg Prullenbak</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329" />
       <source>More Options</source>
       <translation>Meer Opties</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626" />
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Kon geen plek vinden om het bestand of de map aan toe te voegen!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630" />
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Kan geen nieuwe bestanden of mappen toevoegen aan de Prullenbak map.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644" />
       <source>New Note</source>
       <translation>Nieuwe notitie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647" />
       <source>New Chapter</source>
       <translation>Nieuw Hoofdstuk</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650" />
       <source>New Scene</source>
       <translation>Nieuwe Scène</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653" />
       <source>New Document</source>
       <translation>Nieuw document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656" />
       <source>New Folder</source>
       <translation>Nieuwe map</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706" />
       <source>No documents selected for merging.</source>
       <translation>Geen documenten geselecteerd voor samenvoegen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714" />
       <source>Merged</source>
       <translation>Samengevoegd</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772" />
+      <location filename="../novelwriter/gui/projtree.py" line="728" />
       <source>Could not write document content.</source>
       <translation>Kon documenteninhoud niet schrijven.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787" />
       <source>Do you want to duplicate this document?</source>
       <translation>Wilt u dit document dupliceren?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789" />
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Wilt u dit item en alle onderliggende items dupliceren?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794" />
       <source>Could not duplicate all items.</source>
       <translation>Kon niet alle items dupliceren.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910" />
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Root mappen kunnen alleen verwijderd worden wanneer ze leeg zijn.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914" />
       <source>Permanently delete selected item(s)?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924" />
       <source>Move selected item(s) to Trash?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939" />
       <source>The Trash folder is already empty.</source>
       <translation>De Prullenbak map is al leeg.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942" />
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>{0} bestand(en) permanent verwijderen uit de prullenbak?</translation>
     </message>
@@ -3637,7 +3737,7 @@
       <translation>Niet een bekend project bestandsformaat.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="475" />
+      <location filename="../novelwriter/core/project.py" line="471" />
       <location filename="../novelwriter/core/project.py" line="288" />
       <location filename="../novelwriter/core/project.py" line="283" />
       <location filename="../novelwriter/core/project.py" line="278" />
@@ -3685,98 +3785,98 @@
       <translation>Dit project was aangemaakt door een nieuwere versie van novelWriter, versie {0}. Dit is versie {1}. Als je het project blijft openen, kunnen sommige kenmerken en instellingen niet worden behouden, maar over het algemeen moet het project goed zijn. Doorgaan met het openen van het project?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="360" />
       <source>Recovered</source>
       <translation>Hersteld</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="364" />
+      <location filename="../novelwriter/core/project.py" line="362" />
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Gevonden {0} weesbestand(en) in het project. {1} bestand(en) werd(en) hersteld.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="380" />
+      <location filename="../novelwriter/core/project.py" line="378" />
       <source>Opened Project: {0}</source>
       <translation>Geopend project: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="391" />
+      <location filename="../novelwriter/core/project.py" line="389" />
       <source>There is no project open.</source>
       <translation>Er is geen project open.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="414" />
+      <location filename="../novelwriter/core/project.py" line="412" />
       <source>Failed to save project.</source>
       <translation>Opslaan project mislukt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="428" />
+      <location filename="../novelwriter/core/project.py" line="424" />
       <source>Saved Project: {0}</source>
       <translation>Project opgeslagen: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="450" />
+      <location filename="../novelwriter/core/project.py" line="446" />
       <source>Backing up project ...</source>
       <translation>Reservekopie van project wordt gemaakt...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="453" />
+      <location filename="../novelwriter/core/project.py" line="449" />
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Kan geen back-up maken van het project omdat er geen projectnaam is ingesteld. Stel een projectnaam in in Projectinstellingen.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="465" />
+      <location filename="../novelwriter/core/project.py" line="461" />
       <source>Could not create backup folder.</source>
       <translation>Kon de reservekopie map niet maken.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="470" />
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Een back-up gemaakt van je project van grootte {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="478" />
+      <location filename="../novelwriter/core/project.py" line="474" />
       <source>Could not write backup archive.</source>
       <translation>Kon reservekopie archief niet wegschrijven.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="481" />
+      <location filename="../novelwriter/core/project.py" line="477" />
       <source>Project backed up to '{0}'</source>
       <translation>Project reservekopie gemaakt naar '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="495" />
       <location filename="../novelwriter/core/project.py" line="491" />
+      <location filename="../novelwriter/core/project.py" line="487" />
       <source>New</source>
       <translation>Nieuw</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="488" />
       <source>Note</source>
       <translation>Notitie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="489" />
       <source>Draft</source>
       <translation>Concept</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="490" />
       <source>Finished</source>
       <translation>Voltooid</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="496" />
+      <location filename="../novelwriter/core/project.py" line="492" />
       <source>Minor</source>
       <translation>Klein</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="497" />
+      <location filename="../novelwriter/core/project.py" line="493" />
       <source>Major</source>
       <translation>Groot</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="498" />
+      <location filename="../novelwriter/core/project.py" line="494" />
       <source>Main</source>
       <translation>Hoofd</translation>
     </message>
@@ -4019,109 +4119,6 @@
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="369" />
-      <source>Square</source>
-      <translation type="unfinished">Vierkant</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="370" />
-      <source>Triangle</source>
-      <translation type="unfinished">Driehoek</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="371" />
-      <source>Nabla</source>
-      <translation type="unfinished">Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="372" />
-      <source>Diamond</source>
-      <translation type="unfinished">Diamant</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Pentagon</source>
-      <translation type="unfinished">Pentagon</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Hexagon</source>
-      <translation type="unfinished">Zeshoek</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Star</source>
-      <translation type="unfinished">Ster</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Pacman</source>
-      <translation type="unfinished">Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>1/4 Circle</source>
-      <translation type="unfinished">1/4 cirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Half Circle</source>
-      <translation type="unfinished">Halve cirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="381" />
-      <source>3/4 Circle</source>
-      <translation type="unfinished">3/4 cirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="382" />
-      <source>Full Circle</source>
-      <translation type="unfinished">Volledige cirkel</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>1 Bar</source>
-      <translation type="unfinished">1 staaf</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>2 Bars</source>
-      <translation type="unfinished">2 staven</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="387" />
-      <source>3 Bars</source>
-      <translation type="unfinished">3 staven</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="388" />
-      <source>4 Bars</source>
-      <translation type="unfinished">4 staven</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>1 Block</source>
-      <translation type="unfinished">1 blok</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>2 Blocks</source>
-      <translation type="unfinished">2 blokken</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="393" />
-      <source>3 Blocks</source>
-      <translation type="unfinished">3 blokken</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="394" />
-      <source>4 Blocks</source>
-      <translation type="unfinished">4 blokken</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
       <location filename="../novelwriter/shared.py" line="278" />
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="332" />
+      <location filename="../novelwriter/constants.py" line="338" />
       <source>Characters</source>
-      <translation type="unfinished">Personages</translation>
+      <translation type="unfinished">Tekens</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="339" />
       <source>Characters in Text</source>
       <translation type="unfinished">Tekens in tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="334" />
+      <location filename="../novelwriter/constants.py" line="340" />
       <source>Characters in Headings</source>
       <translation type="unfinished">Tekens in koppen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="335" />
+      <location filename="../novelwriter/constants.py" line="341" />
       <source>Paragraphs</source>
       <translation type="unfinished">Paragrafen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="342" />
       <source>Headings</source>
       <translation type="unfinished">Koppen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="343" />
       <source>Characters, No Spaces</source>
       <translation type="unfinished">Tekens, geen spaties</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="344" />
       <source>Characters in Text, No Spaces</source>
       <translation type="unfinished">Tekens in tekst, geen spaties</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="345" />
       <source>Characters in Headings, No Spaces</source>
       <translation type="unfinished">Tekens in koppen, geen spaties</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="346" />
       <source>Words</source>
       <translation type="unfinished">Woorden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="347" />
       <source>Words in Text</source>
       <translation type="unfinished">Woorden in tekst</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="348" />
       <source>Words in Headings</source>
       <translation type="unfinished">Woorden in koppen</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134" />
       <source>Empty Trash</source>
       <translation>Prullenbak legen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155" />
       <source>Rename</source>
       <translation>Hernoemen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170" />
       <source>Duplicate</source>
       <translation>Dupliceren</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190" />
       <source>Open Document</source>
       <translation>Document openen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195" />
       <source>View Document</source>
       <translation>Bekijk document</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204" />
       <source>Create New ...</source>
       <translation>Nieuwe aanmaken...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216" />
       <source>Rename to Heading</source>
       <translation>Hernoemen naar titel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225" />
       <source>Set Active to ...</source>
       <translation>Stel Actief in op...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231" />
       <source>Toggle Active</source>
       <translation>Schakel actief</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238" />
       <source>Set Status to ...</source>
       <translation>Status instellen op ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268" />
+      <location filename="../novelwriter/gui/projtree.py" line="1250" />
       <source>Manage Labels ...</source>
       <translation>Labels beheren ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256" />
       <source>Set Importance to ...</source>
       <translation>Belangrijkheid instellen op ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277" />
       <source>Transform ...</source>
       <translation>Transformeren ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299" />
+      <location filename="../novelwriter/gui/projtree.py" line="1295" />
+      <location filename="../novelwriter/gui/projtree.py" line="1291" />
+      <location filename="../novelwriter/gui/projtree.py" line="1287" />
       <source>Convert to {0}</source>
       <translation>Converteer naar {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303" />
       <source>Merge Child Items into Self</source>
       <translation>Onderliggende items samenvoegen in zelf</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305" />
       <source>Merge Child Items into New</source>
       <translation>Onderliggende items samenvoegen in nieuw</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309" />
       <source>Merge Documents in Folder</source>
       <translation>Documenten in Map Samenvoegen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313" />
       <source>Split Document by Headings</source>
       <translation>Document splitsen op koppen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320" />
       <source>Expand All</source>
       <translation>Alles Uitklappen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322" />
       <source>Collapse All</source>
       <translation>Alles Samenvouwen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332" />
       <source>Delete Permanently</source>
       <translation>Permanent Verwijderen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334" />
       <source>Move to Trash</source>
       <translation>Verplaatsen naar Prullenbak</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410" />
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Wilt u de map converteren naar een {0}? Deze actie kan niet ongedaan worden gemaakt.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048" />
       <source>From Template</source>
       <translation>Van sjabloon</translation>
     </message>

--- a/i18n/nw_pl_PL.ts
+++ b/i18n/nw_pl_PL.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Filtry dokumentów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Dokumenty powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Notatki projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Dokumenty nieaktywne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Nagłówki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Formatowanie części</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Formatowanie rozdziału</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Formatowanie rozdziału nienumerowanego</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Formatowanie sceny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Formatowanie sceny alternatywnej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Formatowanie sekcji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Formatowanie tytułu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Formatowanie części</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Formatowanie rozdziału</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Formatowanie sceny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Zawartość tekstowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Uwzględnij streszczenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Uwzględnij komentarze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Uwzględnij słowa kluczowe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Uwzględnij tekst główny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Ignoruj następujące słowa kluczowe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Dodaj tytuły notatek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Format tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Czcionka tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Wysokość wiersza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Wyjustuj marginesy tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Zastąp znaki Unicode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Zastąp znaki tabulacji spacjami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Zachowaj przełamania wiersza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Zastosuj wyróżnianie dialogów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>Wcięcie pierwszego wiersza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Stosuj wcięcia wiersza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Szerokość wcięcia wiersza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Wcięcie pierwszego akapitu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Marginesy tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Tytuł i część</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Nagłówek 1 i rozdział</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Nagłówek 2 i scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Nagłówek 3 i sekcja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Nagłówek 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Akapit tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Odstęp między scenami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Układ strony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Jednostka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Wielkość strony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Marginesy strony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Styl dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Nagłówek strony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Przesunięcie licznika stron</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Dodaj kolory do nagłówków</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Zwiększ rozmiar nagłówków</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Pogrubienie nagłówków</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>Opcje HTML</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>Dodaj style CSS</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Zachowaj znaki tabulacji</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>w przyszłości</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>teraz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>minutę temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>{0} minut temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>godzinę temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>{0} godzin temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>poprzedniego dnia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>{0} dni temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>tydzień temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>{0} tygodni temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>miesiąc temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>{0} miesięcy temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>rok temu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>{0} lat temu</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Tytuł</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Nagłówek 1 (część)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Nagłówek 2 (rozdział)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Nagłówek 3 (scena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Nagłówek 4 (sekcja)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Akapit tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Odstęp między scenami</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>NIC</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Powieść</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Fabuła</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Postacie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Miejsca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Linia czasu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Obiekty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Podmioty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Różne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Archiwum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Szablony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Kosz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Dokument powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Notatka projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Katalog bazowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Katalog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Strona tytułowa powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Rozdział powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Sekcja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>Aktywny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Nieaktywny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Znacznik</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Punkt widzenia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Skupienie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>Historia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Wzmianka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Poziom</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Wiersz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Znaki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Słowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Akapity</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>Punkt widzenia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Streszczenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Dokument Word Microsoft (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter Markup (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Standard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Extended Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portable Document Format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter Markup (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Kwadrat</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Trójkąt</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Diament</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Pięciokąt</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Sześciokąt</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Gwiazda</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>Ćwierć koła</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Pół koła</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4 koła</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Pełne koło</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 pasek</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 paski</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 paski</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 paski</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 bloczek</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 bloczki</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 bloczki</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 bloczki</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>Pliki tekstowe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>Pliki Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>Pliki novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>Pliki CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>Wszystkie pliki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Milimetry</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Centymetry</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Cale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Amerykański cudzysłów pojedynczy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Amerykański cudzysłów podwójny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Cudzysłów definicyjny lewy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Cudzysłów definicyjny prawy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Polski cudzysłów pojedynczy lewy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Polski cudzysłów definicyjny lewy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Cudzysłów amerykański lewy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Cudzysłów apostrofowy prawy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Cudzysłów apostrofowy lewy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Podwójny odwrócony cudzysłów górny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Podwójny odwrócony cudzysłów dolny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Pojedynczy cudzysłów ostrokątny lewy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>Pojedynczy cudzysłów ostrokątny prawy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Podwójny cudzysłów ostrokątny lewy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>Podwójny cudzysłów ostrokątny prawy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Lewy nawias narożnikowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Prawy nawias narożnikowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Lewy nawias narożnikowy biały</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Prawy nawias narożnikowy biały</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>O programie novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>Ta aplikacja podlega licencji {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Twórcy</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Ustawienia budowy manuskryptu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Nazwa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>Podstawowe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Wybór</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Nagłówki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formatowanie</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Dodaj słowniki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Pobierz słownik z jednego z linków i dodaj poniżej.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Dodaj słownik</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Lokalizacja instalacji słownika</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Znaleziono dodatkowe słowniki: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Rozszerzenie Free lub Libre Office</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Przeglądaj pliki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>Nie można przetworzyć pliku słownika</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Dodano: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Wiersz: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Słowa: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Słowa: {0} wybranych</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Przełącz pasek narzędzi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Zarys</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Szukaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Przełącz tryb skupienia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Zamknij</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Wyszukaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Zastąp przez</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Szukaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Wielkość znaków</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Tylko pełne słowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>Wyrażenia regularne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Wyszukiwanie w pętli</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Przeszukuj następny plik</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Zachowaj wielkość liter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Zamknij wyszukiwanie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Znajdź w bieżącym dokumencie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Znajdź i zastąp w bieżącym dokumencie</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Otwarto dokument: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Dokument został zmieniony poza programem, kiedy ten był otwarty. Czy nadpisać plik na dysku?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>Nie można zapisać dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Zapisano dokument: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Sprawdzanie pisowni wymaga pakietu PyEnchant. Wygląda na to, że nie jest on zainstalowany.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Sprawdzanie pisowni zakończone</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Szczegóły dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Utworzono: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Zaktualizowano: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>Lokalizacja pliku: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Ustaw jako nazwę dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>Otwórz adres URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Podążaj za znacznikiem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Stwórz notatkę dla znacznika</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Wytnij</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Kopiuj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Wklej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Zaznacz słowo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Zaznacz akapit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Podpowiedzi pisowni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>Brak podpowiedzi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Ignoruj słowo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Dodaj słowo do słownika</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Zaznacz tekst przed wywołaniem zastępowania cudzysłowów.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Czy chcesz stworzyć nową notatkę dla znacznika '{0}'?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Połącz dokumenty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Dokumenty do połączenia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Przeciągnij i upuść, aby zmienić kolejność, albo odznacz, żeby wykluczyć.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Przesuń połączone pliki do kosza</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Podziel dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Nagłówki dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Wybierz maksymalny poziom dla podziału na pliki.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Dziel na nagłówkach poziomu 1 (część)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Dziel do nagłówków poziomu 2 (rozdział)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Dziel do nagłówków poziomu 3 (scena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Dziel do nagłówków poziomu 4 (sekcja)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>Dziel w nowym katalogu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Utwórz hierarchię dokumentów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Przenieś podzielony dokument do kosza</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Pogrubienie Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Kursywa Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Przekreślenie Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Pogrubienie Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Kursywa Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Przekreślenie Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Podkreślenie Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Podświetlenie Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Indeks górny Shortcode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Indeks dolny Shortcode</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Pokaż/Ukryj panel podglądu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Komentarze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Pokaż komentarze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Streszczenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Pokaż komentarze streszczenia</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Zarys</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Zobacz poprzedni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Zobacz następny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Otwórz w edytorze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Odśwież</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Zamknij</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>Podczas generowania podglądu pojawił się błąd.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Kopiuj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Zaznacz słowo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Zaznacz akapit</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Ukryj nieaktywne znaczniki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>Odnośniki</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Etykieta elementu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Etykieta</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Etykieta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Klasa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Użycie</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Wstaw tekst zastępczy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Wstaw tekst Lorem Ipsum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Liczba akapitów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Ustaw losową kolejność</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Wstaw</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter jest gotowy...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>Uruchomiona wersja noveWriter to {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Sprawdź {0} uwagi do wydania {1}, aby uzyskać więcej szczegółów.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>Zamknąć bieżący projekt?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Zmiany są zapisywane automatycznie.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>Zapisać kopię zapasową projektu?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>Projekt jest już otwarty w innej instancji novelWriter i został zablokowany. Czy pominąć blokadę i kontynuować mimo to?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Uwaga: jeśli program lub komputer wcześniej zawiesił się, blokada może zostać bezpiecznie pominięta. Mimo to pomijanie nie jest zalecane, jeśli projekt jest otwarty w innej instancji programu novelWriter. Takie postępowanie może doprowadzić do uszkodzenia projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>Projekt został zablokowany na komputerze '{0}' ({1} {2}), ostatnio aktywny {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>Indeks projektu jest nieaktualny lub uszkodzony. Odświeżanie indeksu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Importuj plik</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>Nie można odczytać pliku. Plik powinien być istniejącym plikiem tekstowym.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Otwórz dokument, do którego ma zostać zaimportowany plik tekstowy.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>Zaimportowanie pliku nadpisze obecną treść dokumentu. Czy chcesz kontynuować?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Indeksowanie zakończone w ciągu {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>Indeks projektu został z sukcesem odświeżony.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>Nie można uruchomić dialogu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>Czy chcesz opuścić novelWriter?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Niektóre zmiany nie zostaną zastosowane, dopóki novelWriter nie zostanie uruchomiony ponownie.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>Nie mogę znaleźć odnośnika do znacznika '{0}'. Znacznik nie istnieje lub indeks jest nieaktualny. Indeks można zaktualizować poprzez menu Narzędzia lub wciskając {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Stwórz lub otwórz projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Zapisz projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Zamknij projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Ustawienia projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Szczegóły powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Zmień nazwę elementu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Usuń element</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Opróżnij kosz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Wyjdź</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Otwórz dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Zapisz dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Zamknij dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>Podgląd dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Zamknij podgląd dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Pokaż szczegóły pliku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Importuj tekst z pliku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Edycja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Cofnij</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Ponów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Wytnij</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Kopiuj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Wklej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Zaznacz akapit</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;Widok</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Idź do widoku drzewa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Idź do dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Idź do zarysu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Przejdź do poprzedniego</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Przejdź do następnego</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Tryb skupienia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Tryb pełnoekranowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>Ws&amp;taw</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Myślniki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Półpauza (myślnik)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Pauza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Długa pauza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Kreska liczbowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Znaki cudzysłowu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Lewy pojedynczy cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Prawy pojedynczy cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Lewy podwójny cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Prawy podwójny cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Apostrof alternatywny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>Ogólna interpunkcja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Wielokropek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Prim</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Bis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>Spacje</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Spacja niełamiąca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Wąska spacja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Wąska spacja niełamiąca</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Pozostałe symbole</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>Punktor okrągły</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Punktor dywiz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Punktor kwiat</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Promil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Stopień (symbol)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Znak minus</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Znak mnożenia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Znak dzielenia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Znaczniki i odnośniki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Komentarze specjalne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Streszczenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Krótki opis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Ilość słów/znaków</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Wcięcia i odstępy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Podział strony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Ręczny podział wiersza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Odstęp pionowy (pojedynczy)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Odstęp pionowy (wielokrotny)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Tekst zastępczy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Przypis</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Formatowanie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Pogrubienie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Kursywa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Przekreślenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Dodaj podwójny cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Dodaj pojedynczy cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>Więcej formatów...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Pogrubienie (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Kursywa (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Przekreślenie (Shortcode)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Podkreślenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Podświetlenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Indeks górny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Indeks dolny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Tytuł powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Rozdział nienumerowany</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Scena alternatywna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Wyrównaj do lewej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Wyrównaj do środka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Wyrównaj do prawej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Wcięcie z lewej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Wcięcie z prawej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Przełącz komentarz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Przełącz tekst ignorowany</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Usuń formatowanie blokowe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Zastąp pojedyncze cudzysłowy proste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Zastąp podwójne cudzysłowy proste</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Usuń podziały wewnątrz akapitu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>&amp;Szukaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Znajdź</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Zastąp</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Znajdź następny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Znajdź poprzedni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Zastąp następny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Znajdź w projekcie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>&amp;Narzędzia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Sprawdź pisownię</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Język sprawdzania pisowni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Domyślny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Uruchom ponownie sprawdzanie pisowni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Lista słów dla projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Dodaj słowniki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Odśwież indeks</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Wykonaj kopię zapasową projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Buduj manuskrypt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Statystyka pisania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Ustawienia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>Po&amp;moc</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>O programie novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>O bibliotece Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>Podręcznik użytkownika (online)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>Podręcznik użytkownika (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Zgłoś błąd (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Zadaj pytanie (GitHub)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>Strona novelWriter</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>Żaden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Edytor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Czas sesji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Słowa: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Ilość słów w projekcie (zmiana w czasie sesji)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Ilość słów w powieści (zmiana w czasie sesji)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Buduj manuskrypt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Dodaj nowy wzorzec</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Usuń wybrany wzorzec</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Duplikuj wybrany wzorzec</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Edytuj wybrany wzorzec</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Wzorce budowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Szczegóły</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Zarys</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Podgląd</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Drukuj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Buduj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Zamknij</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Pokazuj podziały stron</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>Mój manuskrypt</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Buduj manuskrypt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Format wyjściowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Spis treści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Ścieżka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>Nazwa pliku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Przywróć domyślną nazwę pliku</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Otwórz katalog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;Buduj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Wybierz katalog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>Katalog docelowy nie istnieje.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>Ten plik już istnieje. Czy chcesz go nadpisać?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Szczegóły powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Ogólne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Zawartość</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Zarys {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Katalog bazowy powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Odśwież</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Ostatnia kolumna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Ukryta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Punkt widzenia postaci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Skupienie na postaci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Wątek powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Rozmiar kolumny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>Więcej opcji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Maksymalny rozmiar kolumny w %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>Brak metadanych</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Tytuł</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Rozdział</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Sekcja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Streszczenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Szczegóły tytułu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Odnośniki do znaczników</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Wybierz kolumny</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Zarys</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Odśwież</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>Eksport CSV</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Zapisz zarys jako</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Ustawienia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Szukaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>Podstawowe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Wygląd</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Język interfejsu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>Zmiana wymaga ponownego uruchomienia programu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Motyw kolorystyczny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>Ogólny motyw kolorystyczny oraz ikony.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Czcionka interfejsu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Ukryj pionowe paski przewijania w oknach głównych</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Przewijanie będzie możliwe tylko przy pomocy kółka myszy i klawiszy.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Ukryj poziome paski przewijania w oknach głównych</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Używaj systemowego dialogu wyboru czcionki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Wyłącz, aby używać dialogu czcionek Qt, w którym może być więcej opcji.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Styl dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Motyw kolorystyczny dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Motyw kolorystyczny dla edytora i okna podglądu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Czcionka dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>Dotyczy zarówno edytora, jak i okna podglądu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Wytłuść etykiety części i rozdziałów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Wyróżnia je w drzewie projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Pokaż pełną ścieżkę w pasku tytułowym dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Pokaż nazwy katalogów nadrzędnych w pasku tytułowym.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Uwzględnij notatki projektu w ilości słów w pasku statusu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Zachowanie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Częstotliwość autozapisu dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>Jak często dokument ma być zapisywany automatycznie.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>sekundy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Częstotliwość autozapisu projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>Jak często projekt ma być zapisywany automatycznie.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Zapytaj przed wyjściem z programu novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Dotyczy tylko sytuacji, kiedy jest otwarty projekt.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Kopia zapasowa projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Przeglądaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Lokalizacja kopii zapasowych</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Ścieżka: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Wykonuj kopię zapasową podczas zamykania projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Może zostać zmienione dla konkretnych projektów w ustawieniach projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Zapytaj przed stworzeniem kopii zapasowej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>Jeśli wyłączone, to kopie zapasowe będą tworzone w tle.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Licznik sesji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Zatrzymaj licznik sesji, gdy pisanie jest przerwane</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Licznik zatrzymuje się również, kiedy okno programu jest nieaktywne.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Czas nieaktywności edytora przed zatrzymaniem licznika</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>Aktywność użytkownika oznacza pisanie oraz zmianę zawartości.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>minuty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Pisanie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Przepływ tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Maksymalna szerokość tekstu w trybie normalnym</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>Ustaw jako 0, żeby wyłączyć tę opcję.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Maksymalna szerokość tekstu w trybie skupienia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>Maksymalna szerokość nie może być wyłączona.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Ukryj dolny pasek dokumentu w trybie skupienia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Ukryj pasek informacji w edytorze dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Wyjustuj marginesy tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Minimalny margines tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Szerokość tabulatora</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>Szerokość znaku tabulacji w edytorze i oknie podglądu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Edycja tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Język sprawdzania pisowni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Dostępne języki zależą od twojego systemu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Automatycznie wybieraj słowo pod kursorem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>Nadaj formatowanie słowu pod kursorem, jeśli nic nie zostało zaznaczone.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Pokazuj spacje i znaki tabulacji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Pokazuj znaki końca wiersza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Przewijanie w edytorze</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Przewijaj poza koniec dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>Również wyśrodkowuje kursor podczas przewijania.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Przewijanie w stylu maszyny do pisania podczas wprowadzania tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Utrzymuje kursor w na stałej pozycji w pionie.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Minimalna pozycja do przewijania w stylu maszyny do pisania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>Procentowa wysokość od góry edytora.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Wyróżnianie tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>Żaden</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>Pojedynczy cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>Podwójny cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>Obydwa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Wyróżniaj dialogi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Dotyczy wybranych stylów cudzysłowu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Alternatywne symbole kwestii dialogowych</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Niestandardowe wyróżnienie kwestii dialogowej.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Zezwalaj na otwarty dialog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Wyróżniaj dialog bez cudzysłowu zamykającego.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Symbol kwestii dialogowej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Wiersze zaczynające się od tego symbolu są dialogiem.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Symbol wtrącenia narratora</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Symbol wskazujący na wtrącenie narratora w dialogu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Symbol przeplatania dialogu i narracji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Zmienia wyróżnianie dialogu w dowolnym akapicie.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Nadaj kolor wyróżnionemu tekstowi</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Dotyczy tylko edytora dokumentów.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Wyświetlaj spacje wielokrotne lub znajdujące się na końcu linii</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Automatyzacja tekstu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Automatycznie zastępuj tekst podczas pisania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Pozwól, żeby edytor zastępował symbole w trakcie ich wprowadzania.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Automatycznie zastępuj pojedyncze cudzysłowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Próbuj zgadnąć, czy cudzysłów jest otwierający czy zamykający.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Automatycznie zastępuj podwójne cudzysłowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Automatycznie zastępuj myślniki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>Podwójne i potrójne dywizy są zamieniane na półpauzy i pauzy.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Automatycznie zastępuj kropki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Trzy kolejne kropki zamieniane są na wielokropek.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Wstawiaj spację niełamiącą przed</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Automatycznie dodawaj spację przed jednym z tych znaków.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Wstawiaj spację niełamiącą po</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Automatycznie dodawaj spację po jednym z tych znaków.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Używaj wąskiej spacji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Wstawia wąską spację zamiast zwykłej.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Style znaków cytowania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Pojedynczy otwierający cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>Symbol używany jako początkowy znak cytowania.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Pojedynczy zamykający cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>Symbol używany jako końcowy znak cytowania.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Podwójny otwierający cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>Symbol używany jako początkowy znak cytowania.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Podwójny zamykający cudzysłów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>Symbol używany jako końcowy znak cytowania.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Katalog kopii zapasowych</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Przeszukiwanie projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Wielkość znaków</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Tylko pełne słowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>Wyrażenia regularne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Wyszukaj</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Ustawienia projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Ustawienia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Ważność</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Autozastępowanie</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="253" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Zawartość projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="262" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Szybkie linki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="268" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Przenieś wyżej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="272" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Przenieś niżej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="312" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Dodaj element</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="319" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Maksymalizuj wszystko</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="322" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Minimalizuj wszystko</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="325" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Opróżnij kosz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="329" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>Więcej opcji</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="626" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Nie można znaleźć miejsca na dodanie pliku lub katalogu!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="630" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Nie można dodawać nowych plików ani katalogów do katalogu Kosz.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="644" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>Nowa notatka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="647" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>Nowy rozdział</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="650" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>Nowa scena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="653" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>Nowy dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="656" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>Nowy katalog</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="706" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>Nie wybrano dokumentów do połączenia.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="714" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Połączono</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="772" />
-      <location filename="../novelwriter/gui/projtree.py" line="728" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>Nie można zapisać zawartości dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="787" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>Czy chcesz powielić ten dokument?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="789" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Czy chcesz powielić ten element i wszystkie elementy podrzędne?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="794" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>Nie można powielić wszystkich elementów.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="910" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Katalogi bazowe mogą być usuwane tylko wtedy, gdy są puste.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="914" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>Trwale usunąć zaznaczone element(y)?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="924" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>Przenieść zaznaczone element(y) do kosza?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="939" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>Katalog Kosz jest już pusty.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="942" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Trwale usunąć {0} plik(ów) z kosza?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Wybierz styl cudzysłowu</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Widok drzewa projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Widok drzewa powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Przeszukiwanie projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Widok zarysu powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Buduj manuskrypt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Szczegóły powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Statystyka pisania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Ustawienia</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Witaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>Lista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>Nowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Przeglądaj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Anuluj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Utwórz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Otwórz</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Lista słów dla projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Importuj słowa z pliku tekstowego</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Eksportuj słowa do pliku tekstowego</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Dodaj słowo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Usuń słowo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Uwaga: plik do importu musi być zwykłym plikiem tekstowym z kodowaniem UTF-8 lub ASCII.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Importuj plik</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Eksportuj plik</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Statystyka pisania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Start sesji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Długość</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Bezczynność</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Słowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Histogram</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Całkowite sumy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Czas całkowity:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Czas bezczynności:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Czas netto:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Ilość słów w powieściach:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Ilość słów w notatkach:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Całkowita ilość słów:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filtry</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Wliczaj pliki powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Wliczaj pliki notatek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>Ukryj zerową ilość słów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>Ukryj negatywną ilość słów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Grupuj pozycje według dni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Pokazuj czas bezczynności</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Limit ilości słów dla histogramu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Zapisz jako</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>Plik JSON (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>Plik CSV (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>Plik JSON</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>Plik CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Zapisz dane jako</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>{0} plik pomyślnie zapisany w:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Nie udało się zapisać pliku {0}.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>Nie można usunąć pliku dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Nieznany format pliku dokumentu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Ścieżka: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>Plik projektu nie został znaleziony.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Nie udało się otworzyć projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Nieznany</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>Plik projektu nie wygląda na plik novelWriterXML.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Nieznany lub nieobsługiwany format projektu. Projekt nie może zostać otwarty w tej wersji novelWriter. Plik został zapisany przez novelWriter w wersji {0}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>Nie udało się przetworzyć pliku xml projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>Format plików projektu zostanie uaktualniony. Jeśli będziesz kontynuować, starsze wersje novelWriter nie będą już mogły otworzyć tego projektu. Czy kontynuować?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>Ten projekt został zapisany w nowszej wersji novelWriter, wersja {0}. To jest wersja {1}. Jeśli będziesz kontynuować, niektóre właściwości i ustawienia mogą nie zostać zachowane, ale cały projekt nie powinie ulec uszkodzeniu. Czy kontynuować otwieranie projektu?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Przywrócono</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Znaleziono {0} osierocony(ch) plik(ów). Przywrócono {1} plik(ów).</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Otwarto projekt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>Żaden projekt nie jest otwarty.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Nie udało się zapisać projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Zapisano projekt: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Wykonywanie kopii zapasowej projektu...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Nie można wykonać kopii zapasowej projektu, ponieważ nie została ustawiona nazwa projektu. Proszę podać nazwę projektu w ustawieniach projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>Nie można utworzyć katalogu kopii zapasowych.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Utworzono kopię zapasową projektu o rozmiarze {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>Nie można zapisać archiwum kopii zapasowej.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Kopia zapasowa projektu utworzona w '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>Nowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Notatka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Szkic</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Ukończony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Poboczny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Ważny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Główny</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>Wszystkie katalogi powieści</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>Katalog docelowy nie jest pusty. Proszę wybrać inny katalog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>Podczas tworzenia projektu wystąpił błąd.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>Nowy projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Strona tytułowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Adres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
-      <translation />
+      <translation/>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Ilość słów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Podsumowanie rozdziału.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Podsumowanie strony.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>Krótki opis.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Rozdział {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Scena {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Główny wątek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Główna lokacja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>Katalog docelowy już istnieje. Proszę wybrać inny katalog.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>Nie można skopiować plików projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Nie udało się stworzyć nowego przykładowego projektu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Nie udało się stworzyć nowego przykładowego projektu. Nie można odnaleźć potrzebnych plików. Wydaje się, że nie ma ich w tej instalacji.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Zapisz</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Anuluj</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>Za&amp;mknij</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Zamknij bez zapisywania</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Zapisz</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Zapisz wszystko</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Otwórz</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Tak</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Tak na &amp;wszystko</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;Nie</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>N&amp;ie na wszystko</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Przerwij</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Spróbuj ponownie</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Zignoruj</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Zamknij</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>Anuluj</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Odrzuć</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Pomoc</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Zastosuj</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Resetuj</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Przywróć domyślne</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Kwadrat</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Trójkąt</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Diament</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Pięciokąt</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Sześciokąt</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Gwiazda</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>Ćwierć koła</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Pół koła</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4 koła</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Pełne koło</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 pasek</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 paski</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 paski</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 paski</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 bloczek</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 bloczki</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 bloczki</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 bloczki</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>Plik projektu novelWriter lub zip</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>Plik projektu novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Otwórz projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Wybierz czcionkę</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Znaki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Znaki w tekście</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Znaki w nagłówkach</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Akapity</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Nagłówki</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Znaki bez spacji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Znaki w tekście bez spacji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Znaki w nagłówkach bez spacji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Słowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Słowa w tekście</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Słowa w nagłówkach</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Najnowsza wersja: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Sprawdzanie...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Pobierz z {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Wersja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Opublikowana</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Uwagi do wydania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>Sprawdź teraz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>Sprawdzanie nie powiodło się</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Spis treści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Tytuł</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Słowa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Strony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Strona</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Stopień zaawansowania</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Słowa na stronę</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>Przesunięcie pierwszej strony</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Rozdziały na stronach nieparzystych</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Bez tytułu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>KONIEC</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Ustawienie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Wartość</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Nazwa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Wybór</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Tytuł</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Ukryte</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>Uwzględnione w manuskrypcie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>Wyłączone z manuskryptu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Zawsze uwzględniane</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Zawsze wyłączane</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Przywróć ustawienia domyślne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Zaznacz wybrane jako</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Wybierz katalogi bazowe</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Informacja</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Ostrzeżenie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Błąd</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Pytanie</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Ukryj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Edytowanie: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>Nic</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Tytuł</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Numer rozdziału</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Numer rozdziału (słownie)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Numer rozdziału (liczba rzymska duża)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Numer rozdziału (liczba rzymska mała)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Numer sceny (w rozdziale)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Numer sceny (ciągły)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Punkt widzenia postaci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Skupienie na postaci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Wstaw</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Zastosuj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Wyśrodkuj</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Podział strony</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Wymagane</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Opcjonalnie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Stwórz świeży projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Stwórz przykładowy projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Kopiuj istniejący projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Nazwa projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Autor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Ścieżka do projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Wypełnij projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Ustaw 0 aby dodać tylko sceny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>Dodaj {0} dokumentów rozdziałów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>Dodaj {0} dokumentów scen (do każdego rozdziału)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Dodaj katalog na notatki fabuły</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Dodaj katalog na notatki postaci</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Dodaj katalog na notatki lokacji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Dodaj przykładowe notatki do wszystkich powyższych</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Rozdziały i sceny</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Notatki projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Utwórz nowy projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Wybierz katalog projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Świeży projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Przykładowy projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Szablon: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>Wymagana jest nazwa dla projektu.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>Ta ścieżka projektu jest niedostępna.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Ścieżka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>Usunąć '{0}' z listy ostatnio używanych projektów? Pliki projektu nie zostaną usunięte.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Otwórz projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Usuń projekt</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Projekt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Nazwa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Korekty</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Czas edycji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Ilość słów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>W powieściach</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>W notatkach</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Wybrana powieść</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Rozdziały</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Sceny</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Naciśnij przycisk "Podgląd", aby wygenerować...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>Przetwarzanie...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Wykonano</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Zbudowano</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>Brak podglądu</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Ilość słów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Ostatnio otwarty</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Autozastępowanie tekstu dla podglądu i budowy</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Słowo kluczowe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Zastąp przez</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Wybierz element do edycji</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Nazwa projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Ta zmiana będzie miała wpływ na ścieżkę do kopii zapasowej.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Autor(zy)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Używane jedynie podczas budowy manuskryptu.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Język projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Domyślne</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Język sprawdzania pisowni</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Zmienia ustawienia ogólne.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>Wyłącz tworzenie kopii zapasowej przy zamykaniu</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Status</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Poziomy statusów dokumentów powieści</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Ważność</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Poziomy ważności notatek projektu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>Nieużywany</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Użyty raz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>Używany przez {0} elementów</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Wybierz kolor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Etykieta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Użycie</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Dodaj etykietę</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Usuń etykietę</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Przenieś wyżej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Przenieś niżej</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Importuj etykiety</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Importuj etykiety</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Wybierz element do edycji</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Kolor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Kółka ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Paski ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Bloki ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Kształt</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>Nowy element</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>Nie można usunąć elementu, który jest używany.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Importuj plik</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Eksportuj plik</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1134" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Opróżnij kosz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1155" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Zmień nazwę</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1170" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Powiel</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1190" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Otwórz dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1195" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>Podgląd dokumentu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1204" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Utwórz nowy...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1216" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Zmień na nazwę nagłówka</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1225" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Ustaw aktywność jako...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1231" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Przełącz aktywność</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1238" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Ustaw status jako...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1268" />
-      <location filename="../novelwriter/gui/projtree.py" line="1250" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Zarządzaj etykietami...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1256" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Ustaw ważność jako...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1277" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Przekształć...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1299" />
-      <location filename="../novelwriter/gui/projtree.py" line="1295" />
-      <location filename="../novelwriter/gui/projtree.py" line="1291" />
-      <location filename="../novelwriter/gui/projtree.py" line="1287" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Zmień na {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1303" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Połącz elementy podrzędne razem</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1305" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Połącz elementy podrzędne jako nowy dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1309" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Połącz dokumenty w katalogu</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1313" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Podziel dokument według nagłówków</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1320" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Maksymalizuj wszystko</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1322" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Minimalizuj wszystko</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1332" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Usuń trwale</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1334" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>Przenieś do kosza</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1410" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Czy chcesz przekształcić katalog na {0}? Tego działania nie można cofnąć.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1048" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>Z szablonu</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>Pierwszy nagłówek</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Znacznik</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Ważność</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Dokument</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Nagłówek</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Krótki opis</translation>
     </message>

--- a/i18n/nw_pt_BR.ts
+++ b/i18n/nw_pt_BR.ts
@@ -4,277 +4,277 @@
   <context>
     <name>Builds</name>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="122" />
+      <location filename="../novelwriter/core/buildsettings.py" line="122"/>
       <source>Document Filters</source>
       <translation>Filtros de documentos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="123" />
+      <location filename="../novelwriter/core/buildsettings.py" line="123"/>
       <source>Novel Documents</source>
       <translation>Documentos do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="124" />
+      <location filename="../novelwriter/core/buildsettings.py" line="124"/>
       <source>Project Notes</source>
       <translation>Notas do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="125" />
+      <location filename="../novelwriter/core/buildsettings.py" line="125"/>
       <source>Inactive Documents</source>
       <translation>Documentos inativos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="127" />
+      <location filename="../novelwriter/core/buildsettings.py" line="127"/>
       <source>Headings</source>
       <translation>Cabeçalhos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="128" />
+      <location filename="../novelwriter/core/buildsettings.py" line="128"/>
       <source>Partition Format</source>
       <translation>Parte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="129" />
+      <location filename="../novelwriter/core/buildsettings.py" line="129"/>
       <source>Chapter Format</source>
       <translation>Capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="130" />
+      <location filename="../novelwriter/core/buildsettings.py" line="130"/>
       <source>Unnumbered Format</source>
       <translation>Capítulo sem número</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="131" />
+      <location filename="../novelwriter/core/buildsettings.py" line="131"/>
       <source>Scene Format</source>
       <translation>Cena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="132" />
+      <location filename="../novelwriter/core/buildsettings.py" line="132"/>
       <source>Alt. Scene Format</source>
       <translation>Cena (variação)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="133" />
+      <location filename="../novelwriter/core/buildsettings.py" line="133"/>
       <source>Section Format</source>
       <translation>Seção</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="134" />
+      <location filename="../novelwriter/core/buildsettings.py" line="134"/>
       <source>Title Styling</source>
       <translation>Estilo do título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="135" />
+      <location filename="../novelwriter/core/buildsettings.py" line="135"/>
       <source>Partition Styling</source>
       <translation>Estilo de parte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="136" />
+      <location filename="../novelwriter/core/buildsettings.py" line="136"/>
       <source>Chapter Styling</source>
       <translation>Estilo do capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="137" />
+      <location filename="../novelwriter/core/buildsettings.py" line="137"/>
       <source>Scene Styling</source>
       <translation>Estilo da cena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="139" />
+      <location filename="../novelwriter/core/buildsettings.py" line="139"/>
       <source>Text Content</source>
       <translation>Conteúdo do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="140" />
+      <location filename="../novelwriter/core/buildsettings.py" line="140"/>
       <source>Include Synopsis</source>
       <translation>Incluir sinopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="141" />
+      <location filename="../novelwriter/core/buildsettings.py" line="141"/>
       <source>Include Comments</source>
       <translation>Incluir comentários</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="142" />
+      <location filename="../novelwriter/core/buildsettings.py" line="142"/>
       <source>Include Keywords</source>
       <translation>Incluir palavras-chave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="143" />
+      <location filename="../novelwriter/core/buildsettings.py" line="143"/>
       <source>Include Body Text</source>
       <translation>Incluir corpo do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="144" />
+      <location filename="../novelwriter/core/buildsettings.py" line="144"/>
       <source>Ignore These Keywords</source>
       <translation>Ignorar estas palavras-chave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="145" />
+      <location filename="../novelwriter/core/buildsettings.py" line="145"/>
       <source>Add Titles for Notes</source>
       <translation>Adicionar títulos às notas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="147" />
+      <location filename="../novelwriter/core/buildsettings.py" line="147"/>
       <source>Text Format</source>
       <translation>Formatação do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="148" />
+      <location filename="../novelwriter/core/buildsettings.py" line="148"/>
       <source>Text Font</source>
       <translation>Fonte do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="149" />
+      <location filename="../novelwriter/core/buildsettings.py" line="149"/>
       <source>Line Height</source>
       <translation>Altura da linha</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="150" />
+      <location filename="../novelwriter/core/buildsettings.py" line="150"/>
       <source>Justify Text Margins</source>
       <translation>Justificar margens do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="151" />
+      <location filename="../novelwriter/core/buildsettings.py" line="151"/>
       <source>Replace Unicode Characters</source>
       <translation>Substituir caracteres unicode</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="152" />
+      <location filename="../novelwriter/core/buildsettings.py" line="152"/>
       <source>Replace Tabs with Spaces</source>
       <translation>Substituir tabulações por espaços</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="153" />
+      <location filename="../novelwriter/core/buildsettings.py" line="153"/>
       <source>Preserve Hard Line Breaks</source>
       <translation>Manter quebras de linha manuais</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="154" />
+      <location filename="../novelwriter/core/buildsettings.py" line="154"/>
       <source>Apply Dialogue Highlighting</source>
       <translation>Aplicar destaque de diálogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="156" />
+      <location filename="../novelwriter/core/buildsettings.py" line="156"/>
       <source>First Line Indent</source>
       <translation>Recuo da primeira linha</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="157" />
+      <location filename="../novelwriter/core/buildsettings.py" line="157"/>
       <source>Enable Indent</source>
       <translation>Habilitar recuo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="158" />
+      <location filename="../novelwriter/core/buildsettings.py" line="158"/>
       <source>Indent Width</source>
       <translation>Largura do recuo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="159" />
+      <location filename="../novelwriter/core/buildsettings.py" line="159"/>
       <source>Indent First Paragraph</source>
       <translation>Recuar primeiro parágrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="161" />
+      <location filename="../novelwriter/core/buildsettings.py" line="161"/>
       <source>Text Margins</source>
       <translation>Margem do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="162" />
+      <location filename="../novelwriter/core/buildsettings.py" line="162"/>
       <source>Title and Partition</source>
       <translation>Título e parte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="163" />
+      <location filename="../novelwriter/core/buildsettings.py" line="163"/>
       <source>Heading 1 and Chapter</source>
       <translation>Cabeçalho 1 e capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="164" />
+      <location filename="../novelwriter/core/buildsettings.py" line="164"/>
       <source>Heading 2 and Scene</source>
       <translation>Cabeçalho 2 e cena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="165" />
+      <location filename="../novelwriter/core/buildsettings.py" line="165"/>
       <source>Heading 3 and Section</source>
       <translation>Cabeçalho 3 e seção</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="166" />
+      <location filename="../novelwriter/core/buildsettings.py" line="166"/>
       <source>Heading 4</source>
       <translation>Cabeçalho 4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="167" />
+      <location filename="../novelwriter/core/buildsettings.py" line="167"/>
       <source>Text Paragraph</source>
       <translation>Parágrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="168" />
+      <location filename="../novelwriter/core/buildsettings.py" line="168"/>
       <source>Scene Separator</source>
       <translation>Separador de cena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="170" />
+      <location filename="../novelwriter/core/buildsettings.py" line="170"/>
       <source>Page Layout</source>
       <translation>Formato da página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="171" />
+      <location filename="../novelwriter/core/buildsettings.py" line="171"/>
       <source>Unit</source>
       <translation>Unidade</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="172" />
+      <location filename="../novelwriter/core/buildsettings.py" line="172"/>
       <source>Page Size</source>
       <translation>Tamanho da página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="173" />
+      <location filename="../novelwriter/core/buildsettings.py" line="173"/>
       <source>Page Margins</source>
       <translation>Margens da página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="175" />
+      <location filename="../novelwriter/core/buildsettings.py" line="175"/>
       <source>Document Style</source>
       <translation>Estilo do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="176" />
+      <location filename="../novelwriter/core/buildsettings.py" line="176"/>
       <source>Page Header</source>
       <translation>Cabeçalho da página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="177" />
+      <location filename="../novelwriter/core/buildsettings.py" line="177"/>
       <source>Page Counter Offset</source>
       <translation>Deslocamento da numeração de página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="178" />
+      <location filename="../novelwriter/core/buildsettings.py" line="178"/>
       <source>Add Colours to Headings</source>
       <translation>Colorir cabeçalhos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="179" />
+      <location filename="../novelwriter/core/buildsettings.py" line="179"/>
       <source>Increase Size of Headings</source>
       <translation>Aumentar tamanho dos cabeçalhos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="180" />
+      <location filename="../novelwriter/core/buildsettings.py" line="180"/>
       <source>Bold Headings</source>
       <translation>Cabeçalhos em negrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="182" />
+      <location filename="../novelwriter/core/buildsettings.py" line="182"/>
       <source>HTML Options</source>
       <translation>Opções de HTML</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="183" />
+      <location filename="../novelwriter/core/buildsettings.py" line="183"/>
       <source>Add CSS Styles</source>
       <translation>Adicionar estilos CSS</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/buildsettings.py" line="184" />
+      <location filename="../novelwriter/core/buildsettings.py" line="184"/>
       <source>Preserve Tab Characters</source>
       <translation>Manter caracteres de tabulação</translation>
     </message>
@@ -282,72 +282,72 @@
   <context>
     <name>Common</name>
     <message>
-      <location filename="../novelwriter/common.py" line="338" />
+      <location filename="../novelwriter/common.py" line="338"/>
       <source>in the future</source>
       <translation>no futuro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="342" />
+      <location filename="../novelwriter/common.py" line="342"/>
       <source>just now</source>
       <translation>agora</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="346" />
+      <location filename="../novelwriter/common.py" line="346"/>
       <source>a minute ago</source>
       <translation>um minuto atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="350" />
+      <location filename="../novelwriter/common.py" line="350"/>
       <source>{0} minutes ago</source>
       <translation>{0} minutos atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="354" />
+      <location filename="../novelwriter/common.py" line="354"/>
       <source>an hour ago</source>
       <translation>uma hora atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="358" />
+      <location filename="../novelwriter/common.py" line="358"/>
       <source>{0} hours ago</source>
       <translation>{0} horas atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="362" />
+      <location filename="../novelwriter/common.py" line="362"/>
       <source>a day ago</source>
       <translation>um dia atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="366" />
+      <location filename="../novelwriter/common.py" line="366"/>
       <source>{0} days ago</source>
       <translation>{0} dias atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="370" />
+      <location filename="../novelwriter/common.py" line="370"/>
       <source>a week ago</source>
       <translation>uma semana atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="374" />
+      <location filename="../novelwriter/common.py" line="374"/>
       <source>{0} weeks ago</source>
       <translation>{0} semanas atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="378" />
+      <location filename="../novelwriter/common.py" line="378"/>
       <source>a month ago</source>
       <translation>um mês atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="382" />
+      <location filename="../novelwriter/common.py" line="382"/>
       <source>{0} months ago</source>
       <translation>{0} meses atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="386" />
+      <location filename="../novelwriter/common.py" line="386"/>
       <source>a year ago</source>
       <translation>um ano atrás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/common.py" line="390" />
+      <location filename="../novelwriter/common.py" line="390"/>
       <source>{0} years ago</source>
       <translation>{0} anos atrás</translation>
     </message>
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316"/>
+      <location filename="../novelwriter/constants.py" line="117"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118"/>
       <source>Heading 1 (Partition)</source>
       <translation>Cabeçalho 1 (parte)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119"/>
       <source>Heading 2 (Chapter)</source>
       <translation>Cabeçalho 2 (capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120"/>
       <source>Heading 3 (Scene)</source>
       <translation>Cabeçalho 3 (cena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121"/>
       <source>Heading 4 (Section)</source>
       <translation>Cabeçalho 4 (seção)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122"/>
       <source>Text Paragraph</source>
       <translation>Parágrafo de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123"/>
       <source>Scene Separator</source>
       <translation>Separador de cena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
-      <location filename="../novelwriter/constants.py" line="266" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="273"/>
+      <location filename="../novelwriter/constants.py" line="268"/>
+      <location filename="../novelwriter/constants.py" line="240"/>
       <source>None</source>
       <translation>Nenhum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="241"/>
       <source>Novel</source>
       <translation>Livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="292"/>
+      <location filename="../novelwriter/constants.py" line="242"/>
       <source>Plot</source>
       <translation>Enredo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="291"/>
+      <location filename="../novelwriter/constants.py" line="243"/>
       <source>Characters</source>
       <translation>Personagens</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="294"/>
+      <location filename="../novelwriter/constants.py" line="244"/>
       <source>Locations</source>
       <translation>Lugares</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="293"/>
+      <location filename="../novelwriter/constants.py" line="245"/>
       <source>Timeline</source>
       <translation>Linha do tempo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="295"/>
+      <location filename="../novelwriter/constants.py" line="246"/>
       <source>Objects</source>
       <translation>Objetos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="294" />
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="296"/>
+      <location filename="../novelwriter/constants.py" line="247"/>
       <source>Entities</source>
       <translation>Entidades</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="423" />
-      <location filename="../novelwriter/constants.py" line="295" />
-      <location filename="../novelwriter/constants.py" line="246" />
+      <location filename="../novelwriter/constants.py" line="425"/>
+      <location filename="../novelwriter/constants.py" line="297"/>
+      <location filename="../novelwriter/constants.py" line="248"/>
       <source>Custom</source>
       <translation>Outros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="247" />
+      <location filename="../novelwriter/constants.py" line="249"/>
       <source>Archive</source>
       <translation>Arquivados</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="248" />
+      <location filename="../novelwriter/constants.py" line="250"/>
       <source>Templates</source>
       <translation>Modelos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="249" />
+      <location filename="../novelwriter/constants.py" line="251"/>
       <source>Trash</source>
       <translation>Lixeira</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
-      <location filename="../novelwriter/constants.py" line="267" />
+      <location filename="../novelwriter/constants.py" line="276"/>
+      <location filename="../novelwriter/constants.py" line="269"/>
       <source>Novel Document</source>
       <translation>Documento do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="281"/>
+      <location filename="../novelwriter/constants.py" line="270"/>
       <source>Project Note</source>
       <translation>Notas do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="274"/>
       <source>Root Folder</source>
       <translation>Diretório-raiz</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="275"/>
       <source>Folder</source>
       <translation>Diretório</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
+      <location filename="../novelwriter/constants.py" line="277"/>
       <source>Novel Title Page</source>
       <translation>Folha de rosto do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="278"/>
       <source>Novel Chapter</source>
       <translation>Capítulo do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="277" />
+      <location filename="../novelwriter/constants.py" line="279"/>
       <source>Novel Scene</source>
       <translation>Cena do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="280"/>
       <source>Novel Section</source>
       <translation>Seção do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="284"/>
       <source>Active</source>
       <translation>Ativo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="285"/>
       <source>Inactive</source>
       <translation>Inativo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
+      <location filename="../novelwriter/constants.py" line="288"/>
       <source>Tag</source>
       <translation>Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
+      <location filename="../novelwriter/constants.py" line="289"/>
       <source>Point of View</source>
       <translation>Ponto de vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="323" />
-      <location filename="../novelwriter/constants.py" line="288" />
+      <location filename="../novelwriter/constants.py" line="325"/>
+      <location filename="../novelwriter/constants.py" line="290"/>
       <source>Focus</source>
       <translation>Foco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="298"/>
       <source>Story</source>
       <translation>História</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="299"/>
       <source>Mentions</source>
       <translation>Menções</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="317"/>
       <source>Level</source>
       <translation>Nível</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="318"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="319"/>
       <source>Line</source>
       <translation>Linha</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="320"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
+      <location filename="../novelwriter/constants.py" line="321"/>
       <source>Chars</source>
       <translation>Caracteres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="320" />
+      <location filename="../novelwriter/constants.py" line="322"/>
       <source>Words</source>
       <translation>Palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="321" />
+      <location filename="../novelwriter/constants.py" line="323"/>
       <source>Pars</source>
       <translation>Parágrafos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="322" />
+      <location filename="../novelwriter/constants.py" line="324"/>
       <source>POV</source>
       <translation>Ponto de vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="335"/>
       <source>Synopsis</source>
       <translation>Sinopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="351"/>
       <source>Open Document (.odt)</source>
       <translation>Open Document (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="352"/>
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="353"/>
       <source>Microsoft Word Document (.docx)</source>
       <translation>Documento do Microsoft Word (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="354"/>
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="355"/>
       <source>novelWriter Markup (.txt)</source>
       <translation>Markup do novelWriter (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="356"/>
       <source>Standard Markdown (.md)</source>
       <translation>Markdown padrão (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="355" />
+      <location filename="../novelwriter/constants.py" line="357"/>
       <source>Extended Markdown (.md)</source>
       <translation>Markdown estendido (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="356" />
+      <location filename="../novelwriter/constants.py" line="358"/>
       <source>Portable Document Format (.pdf)</source>
       <translation>Portable Document Format (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="357" />
+      <location filename="../novelwriter/constants.py" line="359"/>
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="358" />
+      <location filename="../novelwriter/constants.py" line="360"/>
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + Markup do novelWriter (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="375"/>
+      <source>Square</source>
+      <translation>Quadrado</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376"/>
+      <source>Triangle</source>
+      <translation>Triângulo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377"/>
+      <source>Nabla</source>
+      <translation>Nabla</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378"/>
+      <source>Diamond</source>
+      <translation>Diamante</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379"/>
+      <source>Pentagon</source>
+      <translation>Pentágono</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380"/>
+      <source>Hexagon</source>
+      <translation>Hexágono</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381"/>
+      <source>Star</source>
+      <translation>Estrela</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382"/>
+      <source>Pacman</source>
+      <translation>Pacman</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385"/>
+      <source>1/4 Circle</source>
+      <translation>1/4 de círculo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386"/>
+      <source>Half Circle</source>
+      <translation>Meio círculo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387"/>
+      <source>3/4 Circle</source>
+      <translation>3/4 de círculo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388"/>
+      <source>Full Circle</source>
+      <translation>Círculo completo</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391"/>
+      <source>1 Bar</source>
+      <translation>1 barra</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392"/>
+      <source>2 Bars</source>
+      <translation>2 barras</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393"/>
+      <source>3 Bars</source>
+      <translation>3 barras</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394"/>
+      <source>4 Bars</source>
+      <translation>4 barras</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="397"/>
+      <source>1 Block</source>
+      <translation>1 bloco</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398"/>
+      <source>2 Blocks</source>
+      <translation>2 blocos</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399"/>
+      <source>3 Blocks</source>
+      <translation>3 blocos</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400"/>
+      <source>4 Blocks</source>
+      <translation>4 blocos</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403"/>
       <source>Text files</source>
       <translation>Arquivos de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="402" />
+      <location filename="../novelwriter/constants.py" line="404"/>
       <source>Markdown files</source>
       <translation>Arquivos Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="403" />
+      <location filename="../novelwriter/constants.py" line="405"/>
       <source>novelWriter files</source>
       <translation>Arquivos do novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="406"/>
       <source>CSV files</source>
       <translation>Arquivos CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="407"/>
       <source>All files</source>
       <translation>Todos os arquivos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="408" />
+      <location filename="../novelwriter/constants.py" line="410"/>
       <source>Millimetres</source>
       <translation>Milímetros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="409" />
+      <location filename="../novelwriter/constants.py" line="411"/>
       <source>Centimetres</source>
       <translation>Centímetros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="410" />
+      <location filename="../novelwriter/constants.py" line="412"/>
       <source>Inches</source>
       <translation>Polegadas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="420"/>
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
+      <location filename="../novelwriter/constants.py" line="421"/>
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="420" />
+      <location filename="../novelwriter/constants.py" line="422"/>
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="421" />
+      <location filename="../novelwriter/constants.py" line="423"/>
       <source>US Legal</source>
       <translation>Ofício</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="422" />
+      <location filename="../novelwriter/constants.py" line="424"/>
       <source>US Letter</source>
       <translation>Carta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="467"/>
       <source>Straight single quotation mark</source>
       <translation>Aspas simples retas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="468"/>
       <source>Straight double quotation mark</source>
       <translation>Aspas duplas retas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="470"/>
       <source>Left single quotation mark</source>
       <translation>Aspas simples à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="471"/>
       <source>Right single quotation mark</source>
       <translation>Aspas simples à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="472"/>
       <source>Single low-9 quotation mark</source>
       <translation>Aspas 9-baixo simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="473"/>
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Aspas 9-alto-invertido simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="474"/>
       <source>Left double quotation mark</source>
       <translation>Aspas duplas à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="473" />
+      <location filename="../novelwriter/constants.py" line="475"/>
       <source>Right double quotation mark</source>
       <translation>Aspas duplas à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="476"/>
       <source>Double low-9 quotation mark</source>
       <translation>Aspas 9-baixo duplas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="477"/>
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Aspas 9-alto-invertido duplas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="478"/>
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Aspas 9-baixo-invertido duplas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="478" />
+      <location filename="../novelwriter/constants.py" line="480"/>
       <source>Single left-pointing angle quotation mark</source>
       <translation>Aspas angulares simples à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="481"/>
       <source>Single right-pointing angle quotation mark</source>
       <translation>Aspas angulares simples à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="482"/>
       <source>Double left-pointing angle quotation mark</source>
       <translation>Aspas angulares duplas apontando à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="483"/>
       <source>Double right-pointing angle quotation mark</source>
       <translation>Aspas angulares duplas apontando à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="483" />
+      <location filename="../novelwriter/constants.py" line="485"/>
       <source>Left corner bracket</source>
       <translation>Colchete de canto à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="484" />
+      <location filename="../novelwriter/constants.py" line="486"/>
       <source>Right corner bracket</source>
       <translation>Right corner bracket</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="485" />
+      <location filename="../novelwriter/constants.py" line="487"/>
       <source>Left white corner bracket</source>
       <translation>Colchete branco de canto à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="486" />
+      <location filename="../novelwriter/constants.py" line="488"/>
       <source>Right white corner bracket</source>
       <translation>Colchete branco de canto à direita</translation>
     </message>
@@ -797,17 +897,17 @@
   <context>
     <name>GuiAbout</name>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="51" />
+      <location filename="../novelwriter/dialogs/about.py" line="51"/>
       <source>About novelWriter</source>
       <translation>Sobre o novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="71" />
+      <location filename="../novelwriter/dialogs/about.py" line="71"/>
       <source>This application is licenced under {0}</source>
       <translation>Este programa está licenciado sob {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/about.py" line="78" />
+      <location filename="../novelwriter/dialogs/about.py" line="78"/>
       <source>Credits</source>
       <translation>Créditos</translation>
     </message>
@@ -815,33 +915,33 @@
   <context>
     <name>GuiBuildSettings</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="99" />
-      <location filename="../novelwriter/tools/manussettings.py" line="85" />
+      <location filename="../novelwriter/tools/manussettings.py" line="99"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="85"/>
       <source>Manuscript Build Settings</source>
       <translation>Opções de compilação do manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="104" />
+      <location filename="../novelwriter/tools/manussettings.py" line="104"/>
       <source>Name</source>
       <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="111" />
+      <location filename="../novelwriter/tools/manussettings.py" line="111"/>
       <source>General</source>
       <translation>Geral</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="112" />
+      <location filename="../novelwriter/tools/manussettings.py" line="112"/>
       <source>Selection</source>
       <translation>Seleção</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="113" />
+      <location filename="../novelwriter/tools/manussettings.py" line="113"/>
       <source>Headings</source>
       <translation>Cabeçalhos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="114" />
+      <location filename="../novelwriter/tools/manussettings.py" line="114"/>
       <source>Formatting</source>
       <translation>Formatação</translation>
     </message>
@@ -849,47 +949,47 @@
   <context>
     <name>GuiDictionaries</name>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="54" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="54"/>
       <source>Add Dictionaries</source>
       <translation>Adicionar dicionários</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="71" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="71"/>
       <source>Download a dictionary from one of the links, and add it below.</source>
       <translation>Baixe um dicionário de um dos links e adicione-o abaixo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="80" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="80"/>
       <source>Add Dictionary</source>
       <translation>Adicionar dicionário</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="93" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="93"/>
       <source>Dictionary install location</source>
       <translation>Local de instalação do dicionário</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="159" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="159"/>
       <source>Additional dictionaries found: {0}</source>
       <translation>Dicionários adicionais encontrados: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="186" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="186"/>
       <source>Free or Libre Office extension</source>
       <translation>Extensão de Free ou Libre Office</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="189" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="189"/>
       <source>Browse Files</source>
       <translation>Explorar arquivos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="199" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="199"/>
       <source>Could not process dictionary file</source>
       <translation>Não foi possível processar o arquivo do dicionário</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/dictionaries.py" line="243" />
+      <location filename="../novelwriter/tools/dictionaries.py" line="243"/>
       <source>Added: {0} [{1}B]</source>
       <translation>Adicionado: {0} [{1}B]</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088"/>
       <source>Line: {0} ({1})</source>
       <translation>Linha: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089"/>
       <source>Words: {0} ({1})</source>
       <translation>Palavras: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090"/>
       <source>Words: {0} selected</source>
       <translation>Palavras: {0} selecionadas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881"/>
       <source>Toggle Tool Bar</source>
       <translation>Exibir/ocultar barra de ferramentas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886"/>
       <source>Outline</source>
       <translation>Estrutura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891"/>
       <source>Search</source>
       <translation>Pesquisa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896"/>
       <source>Toggle Focus Mode</source>
       <translation>Alternar o modo de foco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901"/>
       <source>Close</source>
       <translation>Fechar</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499"/>
       <source>Search for</source>
       <translation>Pesquisar por</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503"/>
       <source>Replace with</source>
       <translation>Substituir por</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511"/>
       <source>Search</source>
       <translation>Pesquisa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516"/>
       <source>Case Sensitive</source>
       <translation>Diferenciar maiúsculas e minúsculas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522"/>
       <source>Whole Words Only</source>
       <translation>Apenas palavras inteiras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528"/>
       <source>RegEx Mode</source>
       <translation>Expressão regular</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534"/>
       <source>Loop Search</source>
       <translation>Pesquisa iterativa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540"/>
       <source>Search Next File</source>
       <translation>Pesquisar no documento seguinte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548"/>
       <source>Preserve Case</source>
       <translation>Preservar maiúsculas e minúsculas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556"/>
       <source>Close Search</source>
       <translation>Fechar pesquisa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567"/>
       <source>Find in current document</source>
       <translation>Encontrar no documento atual</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571"/>
       <source>Find and replace in current document</source>
       <translation>Encontrar e substituir no documento atual</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="443" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443"/>
       <source>Opened Document: {0}</source>
       <translation>Documento aberto: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="481" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481"/>
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Este documento foi alterado fora do novelWriter enquanto estava aberto. Sobrescrever o arquivo no disco?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="490" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490"/>
       <source>Could not save document.</source>
       <translation>Não foi possível salvar o documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="515" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515"/>
       <source>Saved Document: {0}</source>
       <translation>Documento salvo: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="684" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684"/>
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>A verificação ortográfica requer o pacote PyEnchant. Ele não parece estar instalado.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="710" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710"/>
       <source>Spell check complete</source>
       <translation>Verificação ortográfica concluída</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="830" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830"/>
       <source>Document Details</source>
       <translation>Detalhes do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="832" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832"/>
       <source>Created: {0}</source>
       <translation>Criado em: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="833" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833"/>
       <source>Updated: {0}</source>
       <translation>Atualizado em: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="835" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835"/>
       <source>File Location: {0}</source>
       <translation>Caminho do arquivo: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156"/>
       <source>Set as Document Name</source>
       <translation>Definir como nome do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162"/>
       <source>Open URL</source>
       <translation>Abrir URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169"/>
       <source>Follow Tag</source>
       <translation>Seguir etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173"/>
       <source>Create Note for Tag</source>
       <translation>Criar nota para a etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179"/>
       <source>Cut</source>
       <translation>Recortar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181"/>
       <source>Copy</source>
       <translation>Copiar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184"/>
       <source>Paste</source>
       <translation>Colar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189"/>
       <source>Select All</source>
       <translation>Selecionar tudo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191"/>
       <source>Select Word</source>
       <translation>Selecionar palavra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195"/>
       <source>Select Paragraph</source>
       <translation>Selecionar parágrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211"/>
       <source>Spelling Suggestion(s)</source>
       <translation>Sugestão(ões) de ortografia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216"/>
       <source>No Suggestions</source>
       <translation>Sem sugestões</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220"/>
       <source>Ignore Word</source>
       <translation>Ignorar palavra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222"/>
       <source>Add Word to Dictionary</source>
       <translation>Adicionar palavra ao dicionário</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626"/>
       <source>Please select some text before calling replace quotes.</source>
       <translation>Por favor, selecione algum texto antes de usar a substituição de aspas.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992"/>
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Deseja criar uma nova nota de projeto para a etiqueta '{0}'?</translation>
     </message>
@@ -1144,22 +1244,22 @@
   <context>
     <name>GuiDocMerge</name>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="53" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="53"/>
       <source>Merge Documents</source>
       <translation>Combinar documentos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="57" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="57"/>
       <source>Documents to Merge</source>
       <translation>Documentos para combinar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="60" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="60"/>
       <source>Drag and drop items to change the order, or uncheck to exclude.</source>
       <translation>Arraste e solte itens para alterar a ordem, ou desmarque para excluí-los.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docmerge.py" line="79" />
+      <location filename="../novelwriter/dialogs/docmerge.py" line="79"/>
       <source>Move merged items to Trash</source>
       <translation>Mover arquivos combinados para a lixeira</translation>
     </message>
@@ -1167,52 +1267,52 @@
   <context>
     <name>GuiDocSplit</name>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="59" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="59"/>
       <source>Split Document</source>
       <translation>Dividir documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="61" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="61"/>
       <source>Document Headings</source>
       <translation>Cabeçalhos do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="64" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="64"/>
       <source>Select the maximum level to split into files.</source>
       <translation>Selecione o nível máximo para dividir em arquivos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="86" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="86"/>
       <source>Split on Heading Level 1 (Partition)</source>
       <translation>Dividir nos cabeçalhos de nível 1 (título)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="87" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="87"/>
       <source>Split up to Heading Level 2 (Chapter)</source>
       <translation>Dividir até os cabeçalhos de nível 2 (capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="88" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="88"/>
       <source>Split up to Heading Level 3 (Scene)</source>
       <translation>Dividir até os cabeçalhos de nível 3 (cena)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="89" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="89"/>
       <source>Split up to Heading Level 4 (Section)</source>
       <translation>Dividir até os cabeçalhos de nível 4 (seção)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="96" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="96"/>
       <source>Split into a new folder</source>
       <translation>Dividir em um novo diretório</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="100" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="100"/>
       <source>Create document hierarchy</source>
       <translation>Criar hierarquia do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/docsplit.py" line="104" />
+      <location filename="../novelwriter/dialogs/docsplit.py" line="104"/>
       <source>Move split document to Trash</source>
       <translation>Mover documento dividido para a lixeira</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362"/>
       <source>Markdown Bold</source>
       <translation>Negrito (em Markdown)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368"/>
       <source>Markdown Italic</source>
       <translation>Itálico (em Markdown)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374"/>
       <source>Markdown Strikethrough</source>
       <translation>Tachado (em Markdown)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380"/>
       <source>Shortcode Bold</source>
       <translation>Negrito (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386"/>
       <source>Shortcode Italic</source>
       <translation>Itálico (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392"/>
       <source>Shortcode Strikethrough</source>
       <translation>Tachado (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398"/>
       <source>Shortcode Underline</source>
       <translation>Sublinhado (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404"/>
       <source>Shortcode Highlight</source>
       <translation>Destaque (em código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410"/>
       <source>Shortcode Superscript</source>
       <translation>Sobrescrito (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416"/>
       <source>Shortcode Subscript</source>
       <translation>Subscrito (código)</translation>
     </message>
@@ -1273,27 +1373,27 @@
   <context>
     <name>GuiDocViewFooter</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="895" />
+      <location filename="../novelwriter/gui/docviewer.py" line="895"/>
       <source>Show/Hide Viewer Panel</source>
       <translation>Exibir/ocultar painel de visualização</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="899" />
+      <location filename="../novelwriter/gui/docviewer.py" line="899"/>
       <source>Comments</source>
       <translation>Comentários</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="905" />
+      <location filename="../novelwriter/gui/docviewer.py" line="905"/>
       <source>Show Comments</source>
       <translation>Exibir comentários</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="909" />
+      <location filename="../novelwriter/gui/docviewer.py" line="909"/>
       <source>Synopsis</source>
       <translation>Sinopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="915" />
+      <location filename="../novelwriter/gui/docviewer.py" line="915"/>
       <source>Show Synopsis Comments</source>
       <translation>Exibir comentários de sinopse</translation>
     </message>
@@ -1301,32 +1401,32 @@
   <context>
     <name>GuiDocViewHeader</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="660" />
+      <location filename="../novelwriter/gui/docviewer.py" line="660"/>
       <source>Outline</source>
       <translation>Estrutura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="665" />
+      <location filename="../novelwriter/gui/docviewer.py" line="665"/>
       <source>Go Backward</source>
       <translation>Voltar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="670" />
+      <location filename="../novelwriter/gui/docviewer.py" line="670"/>
       <source>Go Forward</source>
       <translation>Avançar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="675" />
+      <location filename="../novelwriter/gui/docviewer.py" line="675"/>
       <source>Open in Editor</source>
       <translation>Abrir no editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="680" />
+      <location filename="../novelwriter/gui/docviewer.py" line="680"/>
       <source>Reload</source>
       <translation>Recarregar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="685" />
+      <location filename="../novelwriter/gui/docviewer.py" line="685"/>
       <source>Close</source>
       <translation>Fechar</translation>
     </message>
@@ -1334,27 +1434,27 @@
   <context>
     <name>GuiDocViewer</name>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="241" />
+      <location filename="../novelwriter/gui/docviewer.py" line="241"/>
       <source>An error occurred while generating the preview.</source>
       <translation>Ocorreu um erro ao gerar a pré-visualização.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="403" />
+      <location filename="../novelwriter/gui/docviewer.py" line="403"/>
       <source>Copy</source>
       <translation>Copiar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="409" />
+      <location filename="../novelwriter/gui/docviewer.py" line="409"/>
       <source>Select All</source>
       <translation>Selecionar tudo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="413" />
+      <location filename="../novelwriter/gui/docviewer.py" line="413"/>
       <source>Select Word</source>
       <translation>Selecionar palavra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewer.py" line="419" />
+      <location filename="../novelwriter/gui/docviewer.py" line="419"/>
       <source>Select Paragraph</source>
       <translation>Selecionar parágrafo</translation>
     </message>
@@ -1362,12 +1462,12 @@
   <context>
     <name>GuiDocViewerPanel</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="66" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="66"/>
       <source>Hide Inactive Tags</source>
       <translation>Ocultar etiquetas inativas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="75" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="75"/>
       <source>References</source>
       <translation>Referências</translation>
     </message>
@@ -1375,12 +1475,12 @@
   <context>
     <name>GuiEditLabel</name>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="44" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="44"/>
       <source>Item Label</source>
       <translation>Rótulo do item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/editlabel.py" line="63" />
+      <location filename="../novelwriter/dialogs/editlabel.py" line="63"/>
       <source>Label</source>
       <translation>Rótulo</translation>
     </message>
@@ -1388,22 +1488,22 @@
   <context>
     <name>GuiItemDetails</name>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="73" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="73"/>
       <source>Label</source>
       <translation>Rótulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="86" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="86"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="99" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="99"/>
       <source>Class</source>
       <translation>Classe</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/itemdetails.py" line="111" />
+      <location filename="../novelwriter/gui/itemdetails.py" line="111"/>
       <source>Usage</source>
       <translation>Uso</translation>
     </message>
@@ -1411,27 +1511,27 @@
   <context>
     <name>GuiLipsum</name>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="51" />
+      <location filename="../novelwriter/tools/lipsum.py" line="51"/>
       <source>Insert Placeholder Text</source>
       <translation>Inserir texto de preenchimento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="72" />
+      <location filename="../novelwriter/tools/lipsum.py" line="72"/>
       <source>Insert Lorem Ipsum Text</source>
       <translation>Inserir texto fictício (Lorem Ipsum)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="75" />
+      <location filename="../novelwriter/tools/lipsum.py" line="75"/>
       <source>Number of paragraphs</source>
       <translation>Quantidade de parágrafos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="81" />
+      <location filename="../novelwriter/tools/lipsum.py" line="81"/>
       <source>Randomise order</source>
       <translation>Ordem aleatória</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/lipsum.py" line="101" />
+      <location filename="../novelwriter/tools/lipsum.py" line="101"/>
       <source>Insert</source>
       <translation>Inserir</translation>
     </message>
@@ -1439,103 +1539,103 @@
   <context>
     <name>GuiMain</name>
     <message>
-      <location filename="../novelwriter/guimain.py" line="324" />
+      <location filename="../novelwriter/guimain.py" line="324"/>
       <source>novelWriter is ready ...</source>
       <translation>novelWriter está pronto ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="356" />
+      <location filename="../novelwriter/guimain.py" line="356"/>
       <source>You are now running novelWriter version {0}.</source>
       <translation>Você está executando a versão {0} do novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="359" />
+      <location filename="../novelwriter/guimain.py" line="359"/>
       <source>Please check the {0}release notes{1} for further details.</source>
       <translation>Por favor, verifique as {0}notas da versão{1} para mais detalhes.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="381" />
+      <location filename="../novelwriter/guimain.py" line="381"/>
       <source>Close the current project?</source>
       <translation>Fechar o projeto atual?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="857" />
-      <location filename="../novelwriter/guimain.py" line="382" />
+      <location filename="../novelwriter/guimain.py" line="857"/>
+      <location filename="../novelwriter/guimain.py" line="382"/>
       <source>Changes are saved automatically.</source>
       <translation>Alterações são salvas automaticamente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="393" />
+      <location filename="../novelwriter/guimain.py" line="393"/>
       <source>Backup the current project?</source>
       <translation>Criar cópia de segurança do projeto atual?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="440" />
+      <location filename="../novelwriter/guimain.py" line="440"/>
       <source>The project is already open by another instance of novelWriter, and is therefore locked. Override lock and continue anyway?</source>
       <translation>O projeto já está aberto em outra instância do novelWriter, e portanto foi bloqueado. Deseja sobrescrever o bloqueio e continuar mesmo assim?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="445" />
+      <location filename="../novelwriter/guimain.py" line="445"/>
       <source>Note: If the program or the computer previously crashed, the lock can safely be overridden. However, overriding it is not recommended if the project is open in another instance of novelWriter. Doing so may corrupt the project.</source>
       <translation>Nota: se o programa ou o computador travaram anteriormente, o bloqueio pode ser substituído com segurança. No entanto, sobrescrevê-lo não é recomendado se o projeto estiver aberto em outra instância do novelWriter. Fazer isso pode corromper o projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="453" />
+      <location filename="../novelwriter/guimain.py" line="453"/>
       <source>The project was locked by the computer '{0}' ({1} {2}), last active on {3}.</source>
       <translation>O projeto foi bloqueado pelo computador '{0}' ({1} {2}), ativo pela última vez em {3}.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="498" />
+      <location filename="../novelwriter/guimain.py" line="498"/>
       <source>The project index is outdated or broken. Rebuilding index.</source>
       <translation>O índice do projeto está desatualizado ou quebrado. Reconstruindo o índice.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="666" />
+      <location filename="../novelwriter/guimain.py" line="666"/>
       <source>Import File</source>
       <translation>Importar arquivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="680" />
+      <location filename="../novelwriter/guimain.py" line="680"/>
       <source>Could not read file. The file must be an existing text file.</source>
       <translation>Não foi possível ler o arquivo. O arquivo deve ser um arquivo de texto existente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="686" />
+      <location filename="../novelwriter/guimain.py" line="686"/>
       <source>Please open a document to import the text file into.</source>
       <translation>Por favor, abra o documento no qual deseja importar o texto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="692" />
+      <location filename="../novelwriter/guimain.py" line="692"/>
       <source>Importing the file will overwrite the current content of the document. Do you want to proceed?</source>
       <translation>Importar o arquivo vai sobrescrever o conteúdo atual do documento. Deseja continuar?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="747" />
+      <location filename="../novelwriter/guimain.py" line="747"/>
       <source>Indexing completed in {0} ms</source>
       <translation>Indexação completa em {0} ms</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="753" />
+      <location filename="../novelwriter/guimain.py" line="753"/>
       <source>The project index has been successfully rebuilt.</source>
       <translation>O índice do projeto foi reconstruído com sucesso.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="846" />
+      <location filename="../novelwriter/guimain.py" line="846"/>
       <source>Could not initialise the dialog.</source>
       <translation>Não foi possível inicializar a caixa de diálogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="856" />
+      <location filename="../novelwriter/guimain.py" line="856"/>
       <source>Do you want to exit novelWriter?</source>
       <translation>Deseja sair do novelWriter?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1083" />
+      <location filename="../novelwriter/guimain.py" line="1083"/>
       <source>Some changes will not be applied until novelWriter has been restarted.</source>
       <translation>Algumas alterações não serão aplicadas enquanto o novelWriter não for reiniciado.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/guimain.py" line="1111" />
+      <location filename="../novelwriter/guimain.py" line="1111"/>
       <source>Could not find the reference for tag '{0}'. It either doesn't exist, or the index is out of date. The index can be updated from the Tools menu, or by pressing {1}.</source>
       <translation>Não foi possível encontrar a referência para a etiqueta '{0}'. Pode ser que ela não exista ou que o índice esteja desatualizado. O índice pode ser atualizado a partir do menu Ferramentas ou pressionando {1}.</translation>
     </message>
@@ -1543,652 +1643,652 @@
   <context>
     <name>GuiMainMenu</name>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="130" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="130"/>
       <source>&amp;Project</source>
       <translation>&amp;Projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="133" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="133"/>
       <source>Create or Open Project</source>
       <translation>Criar ou abrir projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="138" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="138"/>
       <source>Save Project</source>
       <translation>Salvar projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="144" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="144"/>
       <source>Close Project</source>
       <translation>Fechar projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="152" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="152"/>
       <source>Project Settings</source>
       <translation>Configurações do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="157" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="157"/>
       <source>Novel Details</source>
       <translation>Detalhes do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="165" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="165"/>
       <source>Rename Item</source>
       <translation>Renomear item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="169" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="169"/>
       <source>Delete Item</source>
       <translation>Remover item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="174" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="174"/>
       <source>Empty Trash</source>
       <translation>Esvaziar lixeira</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="184" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="184"/>
       <source>Exit</source>
       <translation>Sair</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="195" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="195"/>
       <source>&amp;Document</source>
       <translation>&amp;Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="198" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="198"/>
       <source>Open Document</source>
       <translation>Abrir documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="203" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="203"/>
       <source>Save Document</source>
       <translation>Salvar documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="209" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="209"/>
       <source>Close Document</source>
       <translation>Fechar documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="218" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="218"/>
       <source>View Document</source>
       <translation>Ver documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="223" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="223"/>
       <source>Close Document View</source>
       <translation>Fechar a visualização do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="231" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="231"/>
       <source>Show File Details</source>
       <translation>Mostrar detalhes do arquivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="235" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="235"/>
       <source>Import Text from File</source>
       <translation>Importar texto de arquivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="243" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="243"/>
       <source>&amp;Edit</source>
       <translation>&amp;Editar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="246" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="246"/>
       <source>Undo</source>
       <translation>Desfazer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="254" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="254"/>
       <source>Redo</source>
       <translation>Refazer</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="265" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="265"/>
       <source>Cut</source>
       <translation>Recortar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="273" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="273"/>
       <source>Copy</source>
       <translation>Copiar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="281" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="281"/>
       <source>Paste</source>
       <translation>Colar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="292" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="292"/>
       <source>Select All</source>
       <translation>Selecionar tudo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="300" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="300"/>
       <source>Select Paragraph</source>
       <translation>Selecionar parágrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="312" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="312"/>
       <source>&amp;View</source>
       <translation>&amp;Visualizar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="315" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="315"/>
       <source>Go to Tree View</source>
       <translation>Ir para visualização em árvore</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="322" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="322"/>
       <source>Go to Document</source>
       <translation>Ir para o documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="329" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="329"/>
       <source>Go to Outline</source>
       <translation>Ir para a estrutura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="339" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="339"/>
       <source>Navigate Backward</source>
       <translation>Navegar para trás</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="346" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="346"/>
       <source>Navigate Forward</source>
       <translation>Navegar para frente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="356" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="356"/>
       <source>Focus Mode</source>
       <translation>Modo de foco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="362" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="362"/>
       <source>Full Screen Mode</source>
       <translation>Modo de tela cheia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="372" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="372"/>
       <source>&amp;Insert</source>
       <translation>&amp;Inserir</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="375" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="375"/>
       <source>Dashes</source>
       <translation>Travessões e traços</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="378" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="378"/>
       <source>Short Dash</source>
       <translation>Meia-risca (en dash)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="386" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="386"/>
       <source>Long Dash</source>
       <translation>Travessão (em dash)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="394" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="394"/>
       <source>Horizontal Bar</source>
       <translation>Barra horizontal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="402" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="402"/>
       <source>Figure Dash</source>
       <translation>Traço de figura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="410" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="410"/>
       <source>Quote Marks</source>
       <translation>Aspas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="413" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="413"/>
       <source>Left Single Quote</source>
       <translation>Aspas simples à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="421" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="421"/>
       <source>Right Single Quote</source>
       <translation>Aspas simples à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="429" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="429"/>
       <source>Left Double Quote</source>
       <translation>Aspas duplas à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="437" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="437"/>
       <source>Right Double Quote</source>
       <translation>Aspas duplas à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="445" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="445"/>
       <source>Alternative Apostrophe</source>
       <translation>Apóstrofo alternativo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="453" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="453"/>
       <source>General Punctuation</source>
       <translation>Pontuação geral</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="456" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="456"/>
       <source>Ellipsis</source>
       <translation>Reticências</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="464" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="464"/>
       <source>Prime</source>
       <translation>Plica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="472" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="472"/>
       <source>Double Prime</source>
       <translation>Dupla plica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="480" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="480"/>
       <source>White Spaces</source>
       <translation>Espaços em branco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="483" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="483"/>
       <source>Non-Breaking Space</source>
       <translation>Espaço não-separável</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="491" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="491"/>
       <source>Thin Space</source>
       <translation>Espaço estreito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="499" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="499"/>
       <source>Thin Non-Breaking Space</source>
       <translation>Espaço estreito não-separável</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="507" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="507"/>
       <source>Other Symbols</source>
       <translation>Outros símbolos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="510" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="510"/>
       <source>List Bullet</source>
       <translation>Marcador de lista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="518" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="518"/>
       <source>Hyphen Bullet</source>
       <translation>Marcador em hífen</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="526" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="526"/>
       <source>Flower Mark</source>
       <translation>Marcador em flor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="534" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="534"/>
       <source>Per Mille</source>
       <translation>Por mil</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="542" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="542"/>
       <source>Degree Symbol</source>
       <translation>Simbolo de grau</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="550" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="550"/>
       <source>Minus Sign</source>
       <translation>Sinal de subtração</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="558" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="558"/>
       <source>Times Sign</source>
       <translation>Sinal de multiplicação</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="566" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="566"/>
       <source>Division Sign</source>
       <translation>Sinal de divisão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="574" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="574"/>
       <source>Tags and References</source>
       <translation>Etiquetas e referências</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="582" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="582"/>
       <source>Special Comments</source>
       <translation>Comentários especiais</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="585" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="585"/>
       <source>Synopsis Comment</source>
       <translation>Comentário de sinopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="593" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="593"/>
       <source>Short Description Comment</source>
       <translation>Comentário descritivo breve</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="601" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="601"/>
       <source>Word/Character Count</source>
       <translation>Contagem de palavras/caracteres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="608" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="608"/>
       <source>Breaks and Vertical Space</source>
       <translation>Quebras e espaço vertical</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="611" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="611"/>
       <source>Page Break</source>
       <translation>Quebra de página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="617" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="617"/>
       <source>Forced Line Break</source>
       <translation>Quebra de linha forçada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="623" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="623"/>
       <source>Vertical Space (Single)</source>
       <translation>Espaço vertical (único)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="629" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="629"/>
       <source>Vertical Space (Multi)</source>
       <translation>Espaço vertical (múltiplo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="635" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="635"/>
       <source>Placeholder Text</source>
       <translation>Texto de preenchimento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="641" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="641"/>
       <source>Footnote</source>
       <translation>Notas de rodapé</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="651" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="651"/>
       <source>&amp;Format</source>
       <translation>&amp;Formatar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="654" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="654"/>
       <source>Bold</source>
       <translation>Negrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="662" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="662"/>
       <source>Italic</source>
       <translation>Itálico</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="670" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="670"/>
       <source>Strikethrough</source>
       <translation>Tachado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="681" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="681"/>
       <source>Wrap Double Quotes</source>
       <translation>Aspas duplas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="689" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="689"/>
       <source>Wrap Single Quotes</source>
       <translation>Aspas simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="700" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="700"/>
       <source>More Formats ...</source>
       <translation>Mais formatos...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="703" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="703"/>
       <source>Bold (Shortcode)</source>
       <translation>Negrito (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="709" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="709"/>
       <source>Italics (Shortcode)</source>
       <translation>Itálico (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="715" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="715"/>
       <source>Strikethrough (Shortcode)</source>
       <translation>Tachado (código)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="721" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="721"/>
       <source>Underline</source>
       <translation>Sublinhado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="727" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="727"/>
       <source>Highlight</source>
       <translation>Destaque</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="733" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="733"/>
       <source>Superscript</source>
       <translation>Sobrescrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="739" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="739"/>
       <source>Subscript</source>
       <translation>Subscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="783" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="783"/>
       <source>Novel Title</source>
       <translation>Título do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="789" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="789"/>
       <source>Unnumbered Chapter</source>
       <translation>Capítulo sem número</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="795" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="795"/>
       <source>Alternative Scene</source>
       <translation>Cena (variação)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="804" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="804"/>
       <source>Align Left</source>
       <translation>Alinhar à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="812" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="812"/>
       <source>Align Centre</source>
       <translation>Centralizar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="820" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="820"/>
       <source>Align Right</source>
       <translation>Alinhar à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="831" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="831"/>
       <source>Indent Left</source>
       <translation>Recuo à esquerda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="839" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="839"/>
       <source>Indent Right</source>
       <translation>Recuo à direita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="850" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="850"/>
       <source>Toggle Comment</source>
       <translation>Ativar/desativar comentário</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="858" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="858"/>
       <source>Toggle Ignore Text</source>
       <translation>Ativar/desativar texto ignorado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="865" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="865"/>
       <source>Remove Block Format</source>
       <translation>Limpar formatação do bloco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="876" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="876"/>
       <source>Replace Straight Single Quotes</source>
       <translation>Substituir aspas retas simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="882" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="882"/>
       <source>Replace Straight Double Quotes</source>
       <translation>Substituir aspas retas duplas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="888" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="888"/>
       <source>Remove In-Paragraph Breaks</source>
       <translation>Remover quebras no parágrafo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="898" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="898"/>
       <source>&amp;Search</source>
       <translation>Pe&amp;squisa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="901" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="901"/>
       <source>Find</source>
       <translation>Procurar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="907" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="907"/>
       <source>Replace</source>
       <translation>Substituir</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="913" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="913"/>
       <source>Find Next</source>
       <translation>Procurar seguinte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="919" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="919"/>
       <source>Find Previous</source>
       <translation>Procurar anterior</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="927" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="927"/>
       <source>Replace Next</source>
       <translation>Substituir seguinte</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="936" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="936"/>
       <source>Find in Project</source>
       <translation>Procurar no projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="945" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="945"/>
       <source>&amp;Tools</source>
       <translation>Ferramen&amp;tas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="948" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="948"/>
       <source>Check Spelling</source>
       <translation>Verificar ortografia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="955" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="955"/>
       <source>Spell Check Language</source>
       <translation>Idioma da verificação ortográfica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="957" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="957"/>
       <source>Default</source>
       <translation>Padrão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="965" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="965"/>
       <source>Re-Run Spell Check</source>
       <translation>Refazer verificação ortográfica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="971" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="971"/>
       <source>Project Word List</source>
       <translation>Lista de palavras do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="976" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="976"/>
       <source>Add Dictionaries</source>
       <translation>Adicionar dicionários</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="983" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="983"/>
       <source>Rebuild Index</source>
       <translation>Reconstruir índice</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="991" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="991"/>
       <source>Backup Project</source>
       <translation>Cópia de segurança do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="995" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="995"/>
       <source>Build Manuscript</source>
       <translation>Compilar manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1000" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1000"/>
       <source>Writing Statistics</source>
       <translation>Estatísticas de escrita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1005" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1005"/>
       <source>Preferences</source>
       <translation>Preferências</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1016" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1016"/>
       <source>&amp;Help</source>
       <translation>A&amp;juda</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1019" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1019"/>
       <source>About novelWriter</source>
       <translation>Sobre o novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1024" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1024"/>
       <source>About Qt5</source>
       <translation>Sobre o Qt5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1032" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1032"/>
       <source>User Manual (Online)</source>
       <translation>Manual do usuário (online)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1039" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1039"/>
       <source>User Manual (PDF)</source>
       <translation>Manual do usuário (PDF)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1048" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1048"/>
       <source>Report an Issue (GitHub)</source>
       <translation>Reportar um problema (Github)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1052" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1052"/>
       <source>Ask a Question (GitHub)</source>
       <translation>Fazer uma pergunta (Github)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/mainmenu.py" line="1056" />
+      <location filename="../novelwriter/gui/mainmenu.py" line="1056"/>
       <source>The novelWriter Website</source>
       <translation>Página web do novelWriter</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="212" />
-      <location filename="../novelwriter/gui/statusbar.py" line="63" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212"/>
+      <location filename="../novelwriter/gui/statusbar.py" line="63"/>
       <source>None</source>
       <translation>Nenhum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="71" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71"/>
       <source>Editor</source>
       <translation>Editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="79" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79"/>
       <source>Project</source>
       <translation>Projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="99" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99"/>
       <source>Session Time</source>
       <translation>Duração da sessão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="178" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178"/>
       <source>Words: {0} ({1})</source>
       <translation>Palavras: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="180" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180"/>
       <source>Project word count (session change)</source>
       <translation>Contagem de palavras do projeto (alterações na sessão atual)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="182" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182"/>
       <source>Novel word count (session change)</source>
       <translation>Contagem de palavras do livro (alterações na sessão atual)</translation>
     </message>
@@ -2235,73 +2335,73 @@
   <context>
     <name>GuiManuscript</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="87" />
+      <location filename="../novelwriter/tools/manuscript.py" line="87"/>
       <source>Build Manuscript</source>
       <translation>Compilar manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="112" />
+      <location filename="../novelwriter/tools/manuscript.py" line="112"/>
       <source>Add New Build</source>
       <translation>Adicionar uma nova compilação</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="117" />
+      <location filename="../novelwriter/tools/manuscript.py" line="117"/>
       <source>Delete Selected Build</source>
       <translation>Excluir a compilação selecionada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="122" />
+      <location filename="../novelwriter/tools/manuscript.py" line="122"/>
       <source>Duplicate Selected Build</source>
       <translation>Duplicar a compilação selecionada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="127" />
+      <location filename="../novelwriter/tools/manuscript.py" line="127"/>
       <source>Edit Selected Build</source>
       <translation>Editar a compilação selecionada</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="131" />
+      <location filename="../novelwriter/tools/manuscript.py" line="131"/>
       <source>Builds</source>
       <translation>Compilações</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="163" />
+      <location filename="../novelwriter/tools/manuscript.py" line="163"/>
       <source>Details</source>
       <translation>Detalhes</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="164" />
+      <location filename="../novelwriter/tools/manuscript.py" line="164"/>
       <source>Outline</source>
       <translation>Estrutura</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="178" />
+      <location filename="../novelwriter/tools/manuscript.py" line="178"/>
       <source>Preview</source>
       <translation>Pré-visualização</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="181" />
+      <location filename="../novelwriter/tools/manuscript.py" line="181"/>
       <source>Print</source>
       <translation>Imprimir</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="184" />
+      <location filename="../novelwriter/tools/manuscript.py" line="184"/>
       <source>Build</source>
       <translation>Compilar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="187" />
+      <location filename="../novelwriter/tools/manuscript.py" line="187"/>
       <source>Close</source>
       <translation>Fechar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="203" />
+      <location filename="../novelwriter/tools/manuscript.py" line="203"/>
       <source>Show Page Breaks</source>
       <translation>Mostrar quebras de página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="307" />
-      <location filename="../novelwriter/tools/manuscript.py" line="268" />
+      <location filename="../novelwriter/tools/manuscript.py" line="307"/>
+      <location filename="../novelwriter/tools/manuscript.py" line="268"/>
       <source>My Manuscript</source>
       <translation>Meu manuscrito</translation>
     </message>
@@ -2309,57 +2409,57 @@
   <context>
     <name>GuiManuscriptBuild</name>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="70" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="70"/>
       <source>Build Manuscript</source>
       <translation>Compilar manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="91" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="91"/>
       <source>Output Format</source>
       <translation>Formato de saída</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="117" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="117"/>
       <source>Table of Contents</source>
       <translation>Sumário</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="145" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="145"/>
       <source>Path</source>
       <translation>Caminho</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="155" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="155"/>
       <source>File Name</source>
       <translation>Nome do arquivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="158" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="158"/>
       <source>Reset file name to default</source>
       <translation>Restaurar o nome do arquivo para o padrão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="184" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="184"/>
       <source>Open Folder</source>
       <translation>Abrir diretório</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="189" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="189"/>
       <source>&amp;Build</source>
       <translation>&amp;Compilar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="285" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="285"/>
       <source>Select Folder</source>
       <translation>Selecionar diretório</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="323" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="323"/>
       <source>Output folder does not exist.</source>
       <translation>Diretório de destino não existe.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manusbuild.py" line="331" />
+      <location filename="../novelwriter/tools/manusbuild.py" line="331"/>
       <source>The file already exists. Do you want to overwrite it?</source>
       <translation>O arquivo já existe. Deseja sobrescrevê-lo?</translation>
     </message>
@@ -2367,18 +2467,18 @@
   <context>
     <name>GuiNovelDetails</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="71" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="60" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="71"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="60"/>
       <source>Novel Details</source>
       <translation>Detalhes do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="85" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="85"/>
       <source>Overview</source>
       <translation>Visão geral</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="86" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="86"/>
       <source>Contents</source>
       <translation>Conteúdo</translation>
     </message>
@@ -2386,58 +2486,58 @@
   <context>
     <name>GuiNovelToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="213" />
+      <location filename="../novelwriter/gui/noveltree.py" line="213"/>
       <source>Outline of {0}</source>
       <translation>Estrutura de {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="219" />
+      <location filename="../novelwriter/gui/noveltree.py" line="219"/>
       <source>Novel Root</source>
       <translation>Raiz do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="224" />
+      <location filename="../novelwriter/gui/noveltree.py" line="224"/>
       <source>Refresh</source>
       <translation>Atualizar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="230" />
+      <location filename="../novelwriter/gui/noveltree.py" line="230"/>
       <source>Last Column</source>
       <translation>Última coluna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="233" />
+      <location filename="../novelwriter/gui/noveltree.py" line="233"/>
       <source>Hidden</source>
       <translation>Ocultar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="234" />
+      <location filename="../novelwriter/gui/noveltree.py" line="234"/>
       <source>Point of View Character</source>
       <translation>Personagem do ponto de vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="235" />
+      <location filename="../novelwriter/gui/noveltree.py" line="235"/>
       <source>Focus Character</source>
       <translation>Personagem em foco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="236" />
+      <location filename="../novelwriter/gui/noveltree.py" line="236"/>
       <source>Novel Plot</source>
       <translation>Enredo do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
-      <location filename="../novelwriter/gui/noveltree.py" line="239" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
+      <location filename="../novelwriter/gui/noveltree.py" line="239"/>
       <source>Column Size</source>
       <translation>Tamanho da coluna</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="243" />
+      <location filename="../novelwriter/gui/noveltree.py" line="243"/>
       <source>More Options</source>
       <translation>Mais opções</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="333" />
+      <location filename="../novelwriter/gui/noveltree.py" line="333"/>
       <source>Maximum column size in %</source>
       <translation>Tamanho máximo da coluna em %</translation>
     </message>
@@ -2445,7 +2545,7 @@
   <context>
     <name>GuiNovelTree</name>
     <message>
-      <location filename="../novelwriter/gui/noveltree.py" line="760" />
+      <location filename="../novelwriter/gui/noveltree.py" line="760"/>
       <source>No meta data</source>
       <translation>Sem metadados</translation>
     </message>
@@ -2453,49 +2553,49 @@
   <context>
     <name>GuiOutlineDetails</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="978" />
-      <location filename="../novelwriter/gui/outline.py" line="823" />
-      <location filename="../novelwriter/gui/outline.py" line="794" />
+      <location filename="../novelwriter/gui/outline.py" line="978"/>
+      <location filename="../novelwriter/gui/outline.py" line="823"/>
+      <location filename="../novelwriter/gui/outline.py" line="794"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="795" />
+      <location filename="../novelwriter/gui/outline.py" line="795"/>
       <source>Chapter</source>
       <translation>Capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="796" />
+      <location filename="../novelwriter/gui/outline.py" line="796"/>
       <source>Scene</source>
       <translation>Cena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="797" />
+      <location filename="../novelwriter/gui/outline.py" line="797"/>
       <source>Section</source>
       <translation>Seção</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="824" />
+      <location filename="../novelwriter/gui/outline.py" line="824"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="825" />
+      <location filename="../novelwriter/gui/outline.py" line="825"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="861" />
+      <location filename="../novelwriter/gui/outline.py" line="861"/>
       <source>Synopsis</source>
       <translation>Sinopse</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="873" />
+      <location filename="../novelwriter/gui/outline.py" line="873"/>
       <source>Title Details</source>
       <translation>Detalhes do título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="898" />
+      <location filename="../novelwriter/gui/outline.py" line="898"/>
       <source>Reference Tags</source>
       <translation>Etiquetas de referência</translation>
     </message>
@@ -2503,7 +2603,7 @@
   <context>
     <name>GuiOutlineHeaderMenu</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="758" />
+      <location filename="../novelwriter/gui/outline.py" line="758"/>
       <source>Select Columns</source>
       <translation>Selecionar colunas</translation>
     </message>
@@ -2511,17 +2611,17 @@
   <context>
     <name>GuiOutlineToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="222" />
+      <location filename="../novelwriter/gui/outline.py" line="222"/>
       <source>Outline of</source>
       <translation>Estrutura de</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="232" />
+      <location filename="../novelwriter/gui/outline.py" line="232"/>
       <source>Refresh</source>
       <translation>Atualizar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="235" />
+      <location filename="../novelwriter/gui/outline.py" line="235"/>
       <source>Export CSV</source>
       <translation>Exportar CSV</translation>
     </message>
@@ -2529,7 +2629,7 @@
   <context>
     <name>GuiOutlineTree</name>
     <message>
-      <location filename="../novelwriter/gui/outline.py" line="546" />
+      <location filename="../novelwriter/gui/outline.py" line="546"/>
       <source>Save Outline As</source>
       <translation>Salvar estrutura como</translation>
     </message>
@@ -2537,609 +2637,609 @@
   <context>
     <name>GuiPreferences</name>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="66" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="60" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="66"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="60"/>
       <source>Preferences</source>
       <translation>Preferências</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="72" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="72"/>
       <source>Search</source>
       <translation>Pesquisa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="145" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="145"/>
       <source>General</source>
       <translation>Geral</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="150" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="150"/>
       <source>Appearance</source>
       <translation>Aparência</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="163" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="163"/>
       <source>Display language</source>
       <translation>Idioma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="189" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="164" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="189"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="164"/>
       <source>Requires restart to take effect.</source>
       <translation>É necessário reiniciar para ter efeito.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="175" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="175"/>
       <source>Colour theme</source>
       <translation>Tema do programa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="176" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="176"/>
       <source>General colour theme and icons.</source>
       <translation>Tema de cores e ícones gerais.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="188" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="188"/>
       <source>Application font</source>
       <translation>Fonte do programa</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="197" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="197"/>
       <source>Hide vertical scroll bars in main windows</source>
       <translation>Ocultar a barra de rolagem vertical nas janelas principais</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="206" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="198" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="206"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="198"/>
       <source>Scrolling available with mouse wheel and keys only.</source>
       <translation>Rolagem disponível apenas com a roda do mouse ou teclado.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="205" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="205"/>
       <source>Hide horizontal scroll bars in main windows</source>
       <translation>Ocultar a barra de rolagem horizontal nas janelas principais</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="213" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="213"/>
       <source>Use the system's font selection dialog</source>
       <translation>Usar o diálogo de seleção de fonte do sistema</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="214" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="214"/>
       <source>Turn off to use the Qt font dialog, which may have more options.</source>
       <translation>Desligue para usar o diálogo de fonte do Qt, que pode ter mais opções.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="220" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="220"/>
       <source>Document Style</source>
       <translation>Estilo do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="233" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="233"/>
       <source>Document colour theme</source>
       <translation>Tema de cores do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="234" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="234"/>
       <source>Colour theme for the editor and viewer.</source>
       <translation>Tema de cores do editor e da visualização.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="246" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="246"/>
       <source>Document font</source>
       <translation>Fonte do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="435" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="424" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="247" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="435"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="424"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="247"/>
       <source>Applies to both document editor and viewer.</source>
       <translation>Aplica-se ao editor e à visualização de documentos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="255" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="255"/>
       <source>Emphasise partition and chapter labels</source>
       <translation>Destacar rótulos de partes e capítulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="256" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="256"/>
       <source>Makes them stand out in the project tree.</source>
       <translation>Faz com que eles se destaquem na árvore do projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="263" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="263"/>
       <source>Show full path in document header</source>
       <translation>Mostrar caminho completo no cabeçalho</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="264" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="264"/>
       <source>Add the parent folder names to the header.</source>
       <translation>Inclui o nome dos diretórios superiores no cabeçalho do documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="271" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="271"/>
       <source>Include project notes in status bar word count</source>
       <translation>Incluir as notas do projeto na contagem de palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="277" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="277"/>
       <source>Behaviour</source>
       <translation>Comportamento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="289" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="289"/>
       <source>Save document interval</source>
       <translation>Intervalo de salvamento do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>How often the document is automatically saved.</source>
       <translation>Com qual frequência o documento é salvo automaticamente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="290" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="290"/>
       <source>seconds</source>
       <translation>segundos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="300" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="300"/>
       <source>Save project interval</source>
       <translation>Intervalo de salvamento do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="301" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="301"/>
       <source>How often the project is automatically saved.</source>
       <translation>Com qual frequência o projeto é salvo automaticamente.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="308" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="308"/>
       <source>Ask before exiting novelWriter</source>
       <translation>Perguntar antes de sair do novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="309" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="309"/>
       <source>Only applies when a project is open.</source>
       <translation>Só se aplica quando há um projeto aberto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="315" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="315"/>
       <source>Project Backup</source>
       <translation>Cópia de segurança</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="322" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="322"/>
       <source>Browse</source>
       <translation>Explorar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="326" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="326"/>
       <source>Backup storage location</source>
       <translation>Local da cópia de segurança</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="843" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="327" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="843"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="327"/>
       <source>Path: {0}</source>
       <translation>Caminho: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="335" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="335"/>
       <source>Run backup when the project is closed</source>
       <translation>Criar cópia de segurança quando o projeto é fechado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="336" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="336"/>
       <source>Can be overridden for individual projects in Project Settings.</source>
       <translation>Pode ser sobrescrito por projeto individual nas configurações do projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="345" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="345"/>
       <source>Ask before running backup</source>
       <translation>Perguntar antes de criar cópia de segurança</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="346" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="346"/>
       <source>If off, backups will run in the background.</source>
       <translation>Se desativado, cópias de segurança serão criadas em segundo plano.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="352" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="352"/>
       <source>Session Timer</source>
       <translation>Temporizador de sessão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="361" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="361"/>
       <source>Pause the session timer when not writing</source>
       <translation>Pausar o temporizador de sessão quando não estiver escrevendo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="362" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="362"/>
       <source>Also pauses when the application window does not have focus.</source>
       <translation>Também pausa quando a janela do programa não estiver em foco.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="373" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="373"/>
       <source>Editor inactive time before pausing timer</source>
       <translation>Tempo de inatividade do editor antes de pausar o temporizador</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="374" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="374"/>
       <source>User activity includes typing and changing the content.</source>
       <translation>Atividades de usuário incluem digitar e modificar o conteúdo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="375" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="375"/>
       <source>minutes</source>
       <translation>minutos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="379" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="379"/>
       <source>Writing</source>
       <translation>Escrita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="384" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="384"/>
       <source>Text Flow</source>
       <translation>Fluxo do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="396" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="396"/>
       <source>Maximum text width in "Normal Mode"</source>
       <translation>Largura máxima do texto no "Modo Normal"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>Set to 0 to disable this feature.</source>
       <translation>Use 0 para desativar esta função.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="448" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="436" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="397" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="448"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="436"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="397"/>
       <source>px</source>
       <translation>px</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="407" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="407"/>
       <source>Maximum text width in "Focus Mode"</source>
       <translation>Largura máxima do texto no "Modo Foco"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="408" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="408"/>
       <source>The maximum width cannot be disabled.</source>
       <translation>A largura máxima não pode ser desativada.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="415" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="415"/>
       <source>Hide document footer in "Focus Mode"</source>
       <translation>Ocultar o rodapé do documento no "Modo Foco"</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="416" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="416"/>
       <source>Hide the information bar in the document editor.</source>
       <translation>Ocultar a barra de informações do editor de documentos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="423" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="423"/>
       <source>Justify the text margins</source>
       <translation>Justificar as margens do texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="434" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="434"/>
       <source>Minimum text margin</source>
       <translation>Margem de texto mínima</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="446" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="446"/>
       <source>Tab width</source>
       <translation>Largura da tabulação</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="447" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="447"/>
       <source>The width of a tab key press in the editor and viewer.</source>
       <translation>Largura da tabulação no editor e visualizador.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="454" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="454"/>
       <source>Text Editing</source>
       <translation>Edição de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="474" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="474"/>
       <source>Spell check language</source>
       <translation>Idioma da verificação ortográfica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="475" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="475"/>
       <source>Available languages are determined by your system.</source>
       <translation>Os idiomas disponíveis são determinados pelo seu sistema.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="482" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="482"/>
       <source>Auto-select word under cursor</source>
       <translation>Selecionar automaticamente a palavra sob o cursor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="483" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="483"/>
       <source>Apply formatting to word under cursor if no selection is made.</source>
       <translation>Aplicar a formatação à palavra sob o cursor se nenhuma seleção for feita.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="490" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="490"/>
       <source>Show tabs and spaces</source>
       <translation>Mostrar tabulações e espaços</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="497" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="497"/>
       <source>Show line endings</source>
       <translation>Mostrar terminações de linha</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="503" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="503"/>
       <source>Editor Scrolling</source>
       <translation>Rolagem do editor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="512" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="512"/>
       <source>Scroll past end of the document</source>
       <translation>Rolar após o final do documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="513" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="513"/>
       <source>Also centres the cursor when scrolling.</source>
       <translation>Também centraliza o cursor ao rolar.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="520" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="520"/>
       <source>Typewriter style scrolling when you type</source>
       <translation>Rolagem no estilo de máquina de escrever ao digitar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="521" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="521"/>
       <source>Keeps the cursor at a fixed vertical position.</source>
       <translation>Mantém o cursor em uma posição vertical fixa.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="531" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="531"/>
       <source>Minimum position for Typewriter scrolling</source>
       <translation>Posição mínima para a rolagem de máquina de escrever</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="532" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="532"/>
       <source>Percentage of the editor height from the top.</source>
       <translation>Porcentagem da altura do editor desde o topo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="538" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="538"/>
       <source>Text Highlighting</source>
       <translation>Destaque de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="544" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="544"/>
       <source>None</source>
       <translation>Nenhum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="545" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="545"/>
       <source>Single Quotes</source>
       <translation>Aspas simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="546" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="546"/>
       <source>Double Quotes</source>
       <translation>Aspas duplas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="547" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="547"/>
       <source>Both</source>
       <translation>Ambos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="550" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="550"/>
       <source>Highlight dialogue</source>
       <translation>Destacar diálogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="551" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="551"/>
       <source>Applies to the selected quote styles.</source>
       <translation>Aplica-se aos estilos de aspas selecionados.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="567" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="567"/>
       <source>Alternative dialogue symbols</source>
       <translation>Símbolos de diálogos alternativos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="568" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="568"/>
       <source>Custom highlighting of dialogue text.</source>
       <translation>Destaque personalizado do texto do diálogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="574" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="574"/>
       <source>Allow open-ended dialogue</source>
       <translation>Permitir diálogo sem aspas de fechamento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="575" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="575"/>
       <source>Highlight dialogue line with no closing quote.</source>
       <translation>Destacar a linha de diálogo sem aspas de fechamento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="584" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="584"/>
       <source>Dialogue line symbols</source>
       <translation>Símbolos de diálogo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="585" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="585"/>
       <source>Lines starting with any of these symbols are dialogue.</source>
       <translation>Linhas que começam com qualquer um destes símbolos são diálogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="594" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="594"/>
       <source>Narrator break symbol</source>
       <translation>Símbolo de intervenção do narrador</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="595" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="595"/>
       <source>Symbol to indicate a narrator break in dialogue.</source>
       <translation>Símbolo para indicar a intervenção do narrador em uma linha de diálogo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="604" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="604"/>
       <source>Alternating dialogue/narration symbol</source>
       <translation>Símbolo de alternância diálogo/narração</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="605" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="605"/>
       <source>Alternates dialogue highlighting within any paragraph.</source>
       <translation>Alterna o destaque dos diálogos em um mesmo parágrafo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="611" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="611"/>
       <source>Add highlight colour to emphasised text</source>
       <translation>Adicionar cor de destaque ao texto enfatizado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="619" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="612" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="619"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="612"/>
       <source>Applies to the document editor only.</source>
       <translation>Aplica-se apenas ao editor de documentos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="618" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="618"/>
       <source>Highlight multiple or trailing spaces</source>
       <translation>Destacar espaços múltiplos ou finais</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="625" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="625"/>
       <source>Text Automation</source>
       <translation>Substituição ao digitar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="637" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="637"/>
       <source>Auto-replace text as you type</source>
       <translation>Substituir automaticamente o texto ao digitar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="638" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="638"/>
       <source>Allow the editor to replace symbols as you type.</source>
       <translation>Permite que o editor substitua símbolos conforme você digita.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="646" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="646"/>
       <source>Auto-replace single quotes</source>
       <translation>Substituir aspas simples automaticamente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="656" />
-      <location filename="../novelwriter/dialogs/preferences.py" line="647" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="656"/>
+      <location filename="../novelwriter/dialogs/preferences.py" line="647"/>
       <source>Try to guess which is an opening or a closing quote.</source>
       <translation>Tenta adivinhar se a aspa é de abertura ou de fechamento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="655" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="655"/>
       <source>Auto-replace double quotes</source>
       <translation>Substituir aspas duplas automaticamente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="664" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="664"/>
       <source>Auto-replace dashes</source>
       <translation>Substituir travessões automaticamente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="665" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="665"/>
       <source>Double and triple hyphens become short and long dashes.</source>
       <translation>Hífens duplos ou triplos são substituídos por travessões curtos (en dash) ou longos (em dash).</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="673" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="673"/>
       <source>Auto-replace dots</source>
       <translation>Substituir pontos automaticamente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="674" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="674"/>
       <source>Three consecutive dots become ellipsis.</source>
       <translation>Três pontos consecutivos são substituídos por reticências.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="683" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="683"/>
       <source>Insert non-breaking space before</source>
       <translation>Inserir espaço não-separável antes de</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="684" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="684"/>
       <source>Automatically add space before any of these symbols.</source>
       <translation>Adiciona automaticamente um espaço não-separável antes de cada um desses símbolos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="693" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="693"/>
       <source>Insert non-breaking space after</source>
       <translation>Inserir espaço não-separável após</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="694" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="694"/>
       <source>Automatically add space after any of these symbols.</source>
       <translation>Adiciona automaticamente um espaço não-separável após cada um desses símbolos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="702" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="702"/>
       <source>Use thin space instead</source>
       <translation>Usar espaço estreito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="703" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="703"/>
       <source>Inserts a thin space instead of a regular space.</source>
       <translation>Insere um espaço estreito em vez de um espaço regular.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="709" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="709"/>
       <source>Quotation Style</source>
       <translation>Estilo de aspas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="724" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="724"/>
       <source>Single quote open style</source>
       <translation>Estilo da aspa de abertura simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="725" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="725"/>
       <source>The symbol to use for a leading single quote.</source>
       <translation>Símbolo usado para a aspa simples à esquerda.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="738" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="738"/>
       <source>Single quote close style</source>
       <translation>Estilo da aspa de fechamento simples</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="739" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="739"/>
       <source>The symbol to use for a trailing single quote.</source>
       <translation>Símbolo usado para a aspa simples à direita.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="753" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="753"/>
       <source>Double quote open style</source>
       <translation>Estilo da aspa de abertura dupla</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="754" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="754"/>
       <source>The symbol to use for a leading double quote.</source>
       <translation>Símbolo usado para a aspa dupla à esquerda.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="767" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="767"/>
       <source>Double quote close style</source>
       <translation>Estilo da aspa de fechamento dupla</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="768" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="768"/>
       <source>The symbol to use for a trailing double quote.</source>
       <translation>Símbolo usado para a aspa dupla à direita.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/preferences.py" line="839" />
+      <location filename="../novelwriter/dialogs/preferences.py" line="839"/>
       <source>Backup Directory</source>
       <translation>Diretório da cópia de segurança</translation>
     </message>
@@ -3147,27 +3247,27 @@
   <context>
     <name>GuiProjectSearch</name>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="77" />
+      <location filename="../novelwriter/gui/search.py" line="77"/>
       <source>Project Search</source>
       <translation>Pesquisa no projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="87" />
+      <location filename="../novelwriter/gui/search.py" line="87"/>
       <source>Case Sensitive</source>
       <translation>Diferenciar maiúsculas e minúsculas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="92" />
+      <location filename="../novelwriter/gui/search.py" line="92"/>
       <source>Whole Words Only</source>
       <translation>Apenas palavras inteiras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="97" />
+      <location filename="../novelwriter/gui/search.py" line="97"/>
       <source>RegEx Mode</source>
       <translation>Expressão regular</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/search.py" line="104" />
+      <location filename="../novelwriter/gui/search.py" line="104"/>
       <source>Search for</source>
       <translation>Pesquisar por</translation>
     </message>
@@ -3175,28 +3275,28 @@
   <context>
     <name>GuiProjectSettings</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="82" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="71" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="82"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="71"/>
       <source>Project Settings</source>
       <translation>Configurações do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="89" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="89"/>
       <source>Settings</source>
       <translation>Configurações</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="90" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="90"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="91" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="91"/>
       <source>Importance</source>
       <translation>Importância</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="92" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="92"/>
       <source>Auto-Replace</source>
       <translation>Substituição automática</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="253" />
+      <location filename="../novelwriter/gui/projtree.py" line="253"/>
       <source>Project Content</source>
       <translation>Conteúdo do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="262" />
+      <location filename="../novelwriter/gui/projtree.py" line="262"/>
       <source>Quick Links</source>
       <translation>Ligações rápidas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="268" />
+      <location filename="../novelwriter/gui/projtree.py" line="268"/>
       <source>Move Up</source>
       <translation>Mover para cima</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="272" />
+      <location filename="../novelwriter/gui/projtree.py" line="272"/>
       <source>Move Down</source>
       <translation>Mover para baixo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="312" />
+      <location filename="../novelwriter/gui/projtree.py" line="312"/>
       <source>Add Item</source>
       <translation>Adicionar item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="319" />
+      <location filename="../novelwriter/gui/projtree.py" line="319"/>
       <source>Expand All</source>
       <translation>Expandir tudo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="322" />
+      <location filename="../novelwriter/gui/projtree.py" line="322"/>
       <source>Collapse All</source>
       <translation>Recolher tudo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="325" />
+      <location filename="../novelwriter/gui/projtree.py" line="325"/>
       <source>Empty Trash</source>
       <translation>Esvaziar a lixeira</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="329" />
+      <location filename="../novelwriter/gui/projtree.py" line="329"/>
       <source>More Options</source>
       <translation>Mais opções</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="626" />
+      <location filename="../novelwriter/gui/projtree.py" line="626"/>
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Não foi possível encontrar nenhum lugar para adicionar o arquivo ou diretório!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="630" />
+      <location filename="../novelwriter/gui/projtree.py" line="630"/>
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Não é possível adicionar novos arquivos ou diretórios à lixeira.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="644" />
+      <location filename="../novelwriter/gui/projtree.py" line="644"/>
       <source>New Note</source>
       <translation>Nova nota</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="647" />
+      <location filename="../novelwriter/gui/projtree.py" line="647"/>
       <source>New Chapter</source>
       <translation>Novo capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="650" />
+      <location filename="../novelwriter/gui/projtree.py" line="650"/>
       <source>New Scene</source>
       <translation>Nova cena</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="653" />
+      <location filename="../novelwriter/gui/projtree.py" line="653"/>
       <source>New Document</source>
       <translation>Novo documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="656" />
+      <location filename="../novelwriter/gui/projtree.py" line="656"/>
       <source>New Folder</source>
       <translation>Novo diretório</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="706" />
+      <location filename="../novelwriter/gui/projtree.py" line="706"/>
       <source>No documents selected for merging.</source>
       <translation>Nenhum documento selecionado para combinar.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="714" />
+      <location filename="../novelwriter/gui/projtree.py" line="714"/>
       <source>Merged</source>
       <translation>Combinado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="772" />
-      <location filename="../novelwriter/gui/projtree.py" line="728" />
+      <location filename="../novelwriter/gui/projtree.py" line="772"/>
+      <location filename="../novelwriter/gui/projtree.py" line="728"/>
       <source>Could not write document content.</source>
       <translation>Não foi possível escrever o conteúdo do documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="787" />
+      <location filename="../novelwriter/gui/projtree.py" line="787"/>
       <source>Do you want to duplicate this document?</source>
       <translation>Deseja duplicar este documento?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="789" />
+      <location filename="../novelwriter/gui/projtree.py" line="789"/>
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Deseja duplicar este item e todos seus subitens?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="794" />
+      <location filename="../novelwriter/gui/projtree.py" line="794"/>
       <source>Could not duplicate all items.</source>
       <translation>Não foi possível duplicar todos os itens.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="910" />
+      <location filename="../novelwriter/gui/projtree.py" line="910"/>
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Os diretórios-raiz só podem ser excluídos quando estiverem vazios.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="914" />
+      <location filename="../novelwriter/gui/projtree.py" line="914"/>
       <source>Permanently delete selected item(s)?</source>
       <translation>Excluir permanentemente o(s) item(ns) selecionado(s)?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="924" />
+      <location filename="../novelwriter/gui/projtree.py" line="924"/>
       <source>Move selected item(s) to Trash?</source>
       <translation>Mover item(ns) selecionado(s) para a lixeira?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="939" />
+      <location filename="../novelwriter/gui/projtree.py" line="939"/>
       <source>The Trash folder is already empty.</source>
       <translation>O diretório da lixeira já está vazio.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="942" />
+      <location filename="../novelwriter/gui/projtree.py" line="942"/>
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Permanentemente remover {0} arquivo(s) da lixeira?</translation>
     </message>
@@ -3346,7 +3446,7 @@
   <context>
     <name>GuiQuoteSelect</name>
     <message>
-      <location filename="../novelwriter/dialogs/quotes.py" line="57" />
+      <location filename="../novelwriter/dialogs/quotes.py" line="57"/>
       <source>Select Quote Style</source>
       <translation>Selecionar o estilo da citação</translation>
     </message>
@@ -3354,42 +3454,42 @@
   <context>
     <name>GuiSideBar</name>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="66" />
+      <location filename="../novelwriter/gui/sidebar.py" line="66"/>
       <source>Project Tree View</source>
       <translation>Exibição em árvore do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="70" />
+      <location filename="../novelwriter/gui/sidebar.py" line="70"/>
       <source>Novel Tree View</source>
       <translation>Visualização em árvore do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="74" />
+      <location filename="../novelwriter/gui/sidebar.py" line="74"/>
       <source>Project Search</source>
       <translation>Pesquisa no projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="78" />
+      <location filename="../novelwriter/gui/sidebar.py" line="78"/>
       <source>Novel Outline View</source>
       <translation>Visão da estrutura do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="82" />
+      <location filename="../novelwriter/gui/sidebar.py" line="82"/>
       <source>Build Manuscript</source>
       <translation>Compilar manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="86" />
+      <location filename="../novelwriter/gui/sidebar.py" line="86"/>
       <source>Novel Details</source>
       <translation>Detalhes do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="90" />
+      <location filename="../novelwriter/gui/sidebar.py" line="90"/>
       <source>Writing Statistics</source>
       <translation>Estatísticas de escrita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/sidebar.py" line="95" />
+      <location filename="../novelwriter/gui/sidebar.py" line="95"/>
       <source>Settings</source>
       <translation>Configurações</translation>
     </message>
@@ -3397,37 +3497,37 @@
   <context>
     <name>GuiWelcome</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="69" />
+      <location filename="../novelwriter/tools/welcome.py" line="69"/>
       <source>Welcome</source>
       <translation>Boas-vindas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="112" />
+      <location filename="../novelwriter/tools/welcome.py" line="112"/>
       <source>List</source>
       <translation>Lista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="117" />
+      <location filename="../novelwriter/tools/welcome.py" line="117"/>
       <source>New</source>
       <translation>Novo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="122" />
+      <location filename="../novelwriter/tools/welcome.py" line="122"/>
       <source>Browse</source>
       <translation>Explorar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="127" />
+      <location filename="../novelwriter/tools/welcome.py" line="127"/>
       <source>Cancel</source>
       <translation>Cancelar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="132" />
+      <location filename="../novelwriter/tools/welcome.py" line="132"/>
       <source>Create</source>
       <translation>Criar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="137" />
+      <location filename="../novelwriter/tools/welcome.py" line="137"/>
       <source>Open</source>
       <translation>Abrir</translation>
     </message>
@@ -3435,43 +3535,43 @@
   <context>
     <name>GuiWordList</name>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="72" />
-      <location filename="../novelwriter/dialogs/wordlist.py" line="56" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="72"/>
+      <location filename="../novelwriter/dialogs/wordlist.py" line="56"/>
       <source>Project Word List</source>
       <translation>Lista de palavras do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="77" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="77"/>
       <source>Import words from text file</source>
       <translation>Importar palavras de um arquivo de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="81" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="81"/>
       <source>Export words to text file</source>
       <translation>Exportar palavras para arquivo de texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="99" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="99"/>
       <source>Add Word</source>
       <translation>Adicionar palavra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="103" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="103"/>
       <source>Remove Word</source>
       <translation>Remover palavra</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="186" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="186"/>
       <source>Note: The import file must be a plain text file with UTF-8 or ASCII encoding.</source>
       <translation>Nota: o arquivo a ser importado deve ser um arquivo de texto simples com codificação UTF-8 ou ASCII.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="190" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="190"/>
       <source>Import File</source>
       <translation>Importar arquivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/wordlist.py" line="208" />
+      <location filename="../novelwriter/dialogs/wordlist.py" line="208"/>
       <source>Export File</source>
       <translation>Exportar arquivo</translation>
     </message>
@@ -3479,147 +3579,147 @@
   <context>
     <name>GuiWritingStats</name>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="85" />
+      <location filename="../novelwriter/tools/writingstats.py" line="85"/>
       <source>Writing Statistics</source>
       <translation>Estatísticas de escrita</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="109" />
+      <location filename="../novelwriter/tools/writingstats.py" line="109"/>
       <source>Session Start</source>
       <translation>Início da sessão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="110" />
+      <location filename="../novelwriter/tools/writingstats.py" line="110"/>
       <source>Length</source>
       <translation>Duração</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="111" />
+      <location filename="../novelwriter/tools/writingstats.py" line="111"/>
       <source>Idle</source>
       <translation>Inatividade</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="112" />
+      <location filename="../novelwriter/tools/writingstats.py" line="112"/>
       <source>Words</source>
       <translation>Palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="113" />
+      <location filename="../novelwriter/tools/writingstats.py" line="113"/>
       <source>Histogram</source>
       <translation>Histograma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="143" />
+      <location filename="../novelwriter/tools/writingstats.py" line="143"/>
       <source>Sum Totals</source>
       <translation>Soma dos totais</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="171" />
+      <location filename="../novelwriter/tools/writingstats.py" line="171"/>
       <source>Total Time:</source>
       <translation>Tempo total:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="172" />
+      <location filename="../novelwriter/tools/writingstats.py" line="172"/>
       <source>Idle Time:</source>
       <translation>Tempo de inatividade:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="173" />
+      <location filename="../novelwriter/tools/writingstats.py" line="173"/>
       <source>Filtered Time:</source>
       <translation>Tempo filtrado:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="174" />
+      <location filename="../novelwriter/tools/writingstats.py" line="174"/>
       <source>Novel Word Count:</source>
       <translation>Contagem de palavras do livro:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="175" />
+      <location filename="../novelwriter/tools/writingstats.py" line="175"/>
       <source>Notes Word Count:</source>
       <translation>Contagem de palavras das notas:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="176" />
+      <location filename="../novelwriter/tools/writingstats.py" line="176"/>
       <source>Total Word Count:</source>
       <translation>Contagem total de palavras:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="197" />
+      <location filename="../novelwriter/tools/writingstats.py" line="197"/>
       <source>Filters</source>
       <translation>Filtros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="237" />
+      <location filename="../novelwriter/tools/writingstats.py" line="237"/>
       <source>Count novel files</source>
       <translation>Contar documentos do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="238" />
+      <location filename="../novelwriter/tools/writingstats.py" line="238"/>
       <source>Count note files</source>
       <translation>Contar documentos de notas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="239" />
+      <location filename="../novelwriter/tools/writingstats.py" line="239"/>
       <source>Hide zero word count</source>
       <translation>Ocultar contagem zerada de palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="240" />
+      <location filename="../novelwriter/tools/writingstats.py" line="240"/>
       <source>Hide negative word count</source>
       <translation>Ocultar contagem negativa de palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="241" />
+      <location filename="../novelwriter/tools/writingstats.py" line="241"/>
       <source>Group entries by day</source>
       <translation>Agrupar entradas por dia</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="242" />
+      <location filename="../novelwriter/tools/writingstats.py" line="242"/>
       <source>Show idle time</source>
       <translation>Mostrar tempo de inatividade</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="263" />
+      <location filename="../novelwriter/tools/writingstats.py" line="263"/>
       <source>Word count cap for the histogram</source>
       <translation>Limite de quantidade de palavras no histograma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="273" />
+      <location filename="../novelwriter/tools/writingstats.py" line="273"/>
       <source>Save As</source>
       <translation>Salvar como</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="279" />
+      <location filename="../novelwriter/tools/writingstats.py" line="279"/>
       <source>JSON Data File (.json)</source>
       <translation>Arquivo de dados JSON (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="283" />
+      <location filename="../novelwriter/tools/writingstats.py" line="283"/>
       <source>CSV Data File (.csv)</source>
       <translation>Arquivo de dados CSV (.csv)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="379" />
+      <location filename="../novelwriter/tools/writingstats.py" line="379"/>
       <source>JSON Data File</source>
       <translation>Arquivo de dados JSON</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="382" />
+      <location filename="../novelwriter/tools/writingstats.py" line="382"/>
       <source>CSV Data File</source>
       <translation>Arquivo de dados CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="389" />
+      <location filename="../novelwriter/tools/writingstats.py" line="389"/>
       <source>Save Data As</source>
       <translation>Salvar dados como</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="432" />
+      <location filename="../novelwriter/tools/writingstats.py" line="432"/>
       <source>{0} file successfully written to:</source>
       <translation>Arquivo {0} escrito com sucesso em:</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/writingstats.py" line="437" />
+      <location filename="../novelwriter/tools/writingstats.py" line="437"/>
       <source>Failed to write {0} file.</source>
       <translation>Falha ao escrever o arquivo {0}.</translation>
     </message>
@@ -3627,156 +3727,156 @@
   <context>
     <name>NWProject</name>
     <message>
-      <location filename="../novelwriter/core/project.py" line="197" />
+      <location filename="../novelwriter/core/project.py" line="197"/>
       <source>Could not delete document file.</source>
       <translation>Não foi possível excluir o arquivo do documento.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="277" />
+      <location filename="../novelwriter/core/project.py" line="277"/>
       <source>Not a known project file format.</source>
       <translation>Não é um formato conhecido de arquivo de projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="471" />
-      <location filename="../novelwriter/core/project.py" line="288" />
-      <location filename="../novelwriter/core/project.py" line="283" />
-      <location filename="../novelwriter/core/project.py" line="278" />
+      <location filename="../novelwriter/core/project.py" line="471"/>
+      <location filename="../novelwriter/core/project.py" line="288"/>
+      <location filename="../novelwriter/core/project.py" line="283"/>
+      <location filename="../novelwriter/core/project.py" line="278"/>
       <source>Path: {0}</source>
       <translation>Caminho: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="282" />
+      <location filename="../novelwriter/core/project.py" line="282"/>
       <source>Project file not found.</source>
       <translation>Arquivo de projeto não encontrado.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="287" />
+      <location filename="../novelwriter/core/project.py" line="287"/>
       <source>Failed to open project.</source>
       <translation>Falha ao abrir projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="305" />
+      <location filename="../novelwriter/core/project.py" line="305"/>
       <source>Unknown</source>
       <translation>Desconhecido</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="308" />
+      <location filename="../novelwriter/core/project.py" line="308"/>
       <source>Project file does not appear to be a novelWriterXML file.</source>
       <translation>O arquivo do projeto não parece ser um arquivo XML do novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="312" />
+      <location filename="../novelwriter/core/project.py" line="312"/>
       <source>Unknown or unsupported novelWriter project file format. The project cannot be opened by this version of novelWriter. The file was saved with novelWriter version {0}.</source>
       <translation>Formato de arquivo de projeto do novelWriter desconhecido ou não-suportado. O projeto não pode ser aberto por essa versão do novelWriter. O arquivo foi salvo com a versão {0} do novelWriter.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="318" />
+      <location filename="../novelwriter/core/project.py" line="318"/>
       <source>Failed to parse project xml.</source>
       <translation>Houve uma falha ao interpretar o conteúdo XML do projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="325" />
+      <location filename="../novelwriter/core/project.py" line="325"/>
       <source>The file format of your project is about to be updated. If you proceed, older versions of novelWriter will no longer be able to open this project. Continue?</source>
       <translation>O formato do arquivo do seu projeto está prestes a ser atualizado. Se você continuar, as versões mais antigas do novelWriter não poderão mais abrir este projeto. Continuar?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="337" />
+      <location filename="../novelwriter/core/project.py" line="337"/>
       <source>This project was saved by a newer version of novelWriter, version {0}. This is version {1}. If you continue to open the project, some attributes and settings may not be preserved, but the overall project should be fine. Continue opening the project?</source>
       <translation>O projeto foi salvo por uma versão mais nova do novelWriter, versão {0}. Esta é a versão {1}. Caso deseje abrir o projeto, alguns atributos e configurações podem não ser preservados, mas o projeto deve funcionar corretamente. Continuar?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="360" />
+      <location filename="../novelwriter/core/project.py" line="360"/>
       <source>Recovered</source>
       <translation>Recuperado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="362"/>
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Encontrado(s) {0} arquivo(s) órfão(s) no projeto. {1} arquivo(s) recuperado(s).</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="378" />
+      <location filename="../novelwriter/core/project.py" line="378"/>
       <source>Opened Project: {0}</source>
       <translation>Projeto aberto: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="389" />
+      <location filename="../novelwriter/core/project.py" line="389"/>
       <source>There is no project open.</source>
       <translation>Não há um projeto aberto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="412" />
+      <location filename="../novelwriter/core/project.py" line="412"/>
       <source>Failed to save project.</source>
       <translation>Houve uma falha ao salvar o projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="424" />
+      <location filename="../novelwriter/core/project.py" line="424"/>
       <source>Saved Project: {0}</source>
       <translation>Projeto salvo: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="446" />
+      <location filename="../novelwriter/core/project.py" line="446"/>
       <source>Backing up project ...</source>
       <translation>Criando uma cópia de segurança do projeto...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="449" />
+      <location filename="../novelwriter/core/project.py" line="449"/>
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Não foi possível criar a cópia de segurança do projeto porque o nome do projeto não está definido. Por favor, defina-o nas configurações do projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="461" />
+      <location filename="../novelwriter/core/project.py" line="461"/>
       <source>Could not create backup folder.</source>
       <translation>Não foi possível criar o diretório da cópia de segurança.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="470" />
+      <location filename="../novelwriter/core/project.py" line="470"/>
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Foi criado uma cópia de segurança do seu projeto com {0}B de tamanho.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="474"/>
       <source>Could not write backup archive.</source>
       <translation>Não foi possível escrever o arquivo da cópia de segurança.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="477" />
+      <location filename="../novelwriter/core/project.py" line="477"/>
       <source>Project backed up to '{0}'</source>
       <translation>Cópia de segurança do projeto criada em '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="491" />
-      <location filename="../novelwriter/core/project.py" line="487" />
+      <location filename="../novelwriter/core/project.py" line="491"/>
+      <location filename="../novelwriter/core/project.py" line="487"/>
       <source>New</source>
       <translation>Novo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="488" />
+      <location filename="../novelwriter/core/project.py" line="488"/>
       <source>Note</source>
       <translation>Nota</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="489" />
+      <location filename="../novelwriter/core/project.py" line="489"/>
       <source>Draft</source>
       <translation>Rascunho</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="490" />
+      <location filename="../novelwriter/core/project.py" line="490"/>
       <source>Finished</source>
       <translation>Finalizado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="492"/>
       <source>Minor</source>
       <translation>Menor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="493"/>
       <source>Major</source>
       <translation>Maior</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="494"/>
       <source>Main</source>
       <translation>Principal</translation>
     </message>
@@ -3784,7 +3884,7 @@
   <context>
     <name>NovelSelector</name>
     <message>
-      <location filename="../novelwriter/extensions/novelselector.py" line="112" />
+      <location filename="../novelwriter/extensions/novelselector.py" line="112"/>
       <source>All Novel Folders</source>
       <translation>Todos os diretórios do livro</translation>
     </message>
@@ -3792,99 +3892,99 @@
   <context>
     <name>ProjectBuilder</name>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="402" />
+      <location filename="../novelwriter/core/coretools.py" line="402"/>
       <source>The target folder is not empty. Please choose another folder.</source>
       <translation>A pasta de destino não está vazia. Por favor, escolha outra pasta.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="408" />
+      <location filename="../novelwriter/core/coretools.py" line="408"/>
       <source>An error occurred while trying to create the project.</source>
       <translation>Ocorreu um erro durante a criação o projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="415" />
+      <location filename="../novelwriter/core/coretools.py" line="415"/>
       <source>New Project</source>
       <translation>Novo projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="416" />
+      <location filename="../novelwriter/core/coretools.py" line="416"/>
       <source>Title Page</source>
       <translation>Folha de rosto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="446" />
+      <location filename="../novelwriter/core/coretools.py" line="446"/>
       <source>Address</source>
       <translation>Endereço</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="448" />
+      <location filename="../novelwriter/core/coretools.py" line="448"/>
       <source>By</source>
       <translation>Por</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="449" />
+      <location filename="../novelwriter/core/coretools.py" line="449"/>
       <source>Word Count</source>
       <translation>Contagem de palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="461" />
+      <location filename="../novelwriter/core/coretools.py" line="461"/>
       <source>Summary of the chapter.</source>
       <translation>Resumo do capítulo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="462" />
+      <location filename="../novelwriter/core/coretools.py" line="462"/>
       <source>Summary of the scene.</source>
       <translation>Resumo da cena.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="463" />
+      <location filename="../novelwriter/core/coretools.py" line="463"/>
       <source>A short description.</source>
       <translation>Uma breve descrição.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="468" />
+      <location filename="../novelwriter/core/coretools.py" line="468"/>
       <source>Chapter {0}</source>
       <translation>Capítulo {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="484" />
-      <location filename="../novelwriter/core/coretools.py" line="476" />
+      <location filename="../novelwriter/core/coretools.py" line="484"/>
+      <location filename="../novelwriter/core/coretools.py" line="476"/>
       <source>Scene {0}</source>
       <translation>Cena {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="491" />
+      <location filename="../novelwriter/core/coretools.py" line="491"/>
       <source>Main Plot</source>
       <translation>Enredo principal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="492" />
+      <location filename="../novelwriter/core/coretools.py" line="492"/>
       <source>Protagonist</source>
       <translation>Protagonista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="493" />
+      <location filename="../novelwriter/core/coretools.py" line="493"/>
       <source>Main Location</source>
       <translation>Local principal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="583" />
-      <location filename="../novelwriter/core/coretools.py" line="531" />
+      <location filename="../novelwriter/core/coretools.py" line="583"/>
+      <location filename="../novelwriter/core/coretools.py" line="531"/>
       <source>The target folder already exists. Please choose another folder.</source>
       <translation>A pasta de destino já existe. Por favor, escolha outra pasta.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="558" />
+      <location filename="../novelwriter/core/coretools.py" line="558"/>
       <source>Could not copy project files.</source>
       <translation>Não foi possível copiar os arquivos do projeto.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="593" />
+      <location filename="../novelwriter/core/coretools.py" line="593"/>
       <source>Failed to create a new example project.</source>
       <translation>Houve uma falha ao criar um novo projeto de exemplo.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/coretools.py" line="596" />
+      <location filename="../novelwriter/core/coretools.py" line="596"/>
       <source>Failed to create a new example project. Could not find the necessary files. They seem to be missing from this installation.</source>
       <translation>Houve uma falha ao criar um novo projeto de exemplo. Não foi possível encontrar os arquivos necessários. Eles parecem estar faltando nesta instalação.</translation>
     </message>
@@ -3892,7 +3992,7 @@
   <context>
     <name>QDialogButtonBox</name>
     <message>
-      <location filename="qtbase.py" line="18" />
+      <location filename="qtbase.py" line="18"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
@@ -3900,27 +4000,27 @@
   <context>
     <name>QGnomeTheme</name>
     <message>
-      <location filename="qtbase.py" line="23" />
+      <location filename="qtbase.py" line="23"/>
       <source>&amp;OK</source>
       <translation>&amp;OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="24" />
+      <location filename="qtbase.py" line="24"/>
       <source>&amp;Save</source>
       <translation>&amp;Salvar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="25" />
+      <location filename="qtbase.py" line="25"/>
       <source>&amp;Cancel</source>
       <translation>&amp;Cancelar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="26" />
+      <location filename="qtbase.py" line="26"/>
       <source>&amp;Close</source>
       <translation>&amp;Fechar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="27" />
+      <location filename="qtbase.py" line="27"/>
       <source>Close without Saving</source>
       <translation>Fechar sem salvar</translation>
     </message>
@@ -3928,218 +4028,115 @@
   <context>
     <name>QPlatformTheme</name>
     <message>
-      <location filename="qtbase.py" line="32" />
+      <location filename="qtbase.py" line="32"/>
       <source>OK</source>
       <translation>OK</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="33" />
+      <location filename="qtbase.py" line="33"/>
       <source>Save</source>
       <translation>Salvar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="34" />
+      <location filename="qtbase.py" line="34"/>
       <source>Save All</source>
       <translation>Salvar tudo</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="35" />
+      <location filename="qtbase.py" line="35"/>
       <source>Open</source>
       <translation>Abrir</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="36" />
+      <location filename="qtbase.py" line="36"/>
       <source>&amp;Yes</source>
       <translation>&amp;Sim</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="37" />
+      <location filename="qtbase.py" line="37"/>
       <source>Yes to &amp;All</source>
       <translation>Sim para &amp;Tudo</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="38" />
+      <location filename="qtbase.py" line="38"/>
       <source>&amp;No</source>
       <translation>&amp;Não</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="39" />
+      <location filename="qtbase.py" line="39"/>
       <source>N&amp;o to All</source>
       <translation>Nã&amp;o para tudo</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="40" />
+      <location filename="qtbase.py" line="40"/>
       <source>Abort</source>
       <translation>Abortar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="41" />
+      <location filename="qtbase.py" line="41"/>
       <source>Retry</source>
       <translation>Tentar novamente</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="42" />
+      <location filename="qtbase.py" line="42"/>
       <source>Ignore</source>
       <translation>Ignorar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="43" />
+      <location filename="qtbase.py" line="43"/>
       <source>Close</source>
       <translation>Fechar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="44" />
+      <location filename="qtbase.py" line="44"/>
       <source>Cancel</source>
       <translation>Cancelar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="45" />
+      <location filename="qtbase.py" line="45"/>
       <source>Discard</source>
       <translation>Descartar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="46" />
+      <location filename="qtbase.py" line="46"/>
       <source>Help</source>
       <translation>Ajuda</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="47" />
+      <location filename="qtbase.py" line="47"/>
       <source>Apply</source>
       <translation>Aplicar</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="48" />
+      <location filename="qtbase.py" line="48"/>
       <source>Reset</source>
       <translation>Redefinir</translation>
     </message>
     <message>
-      <location filename="qtbase.py" line="49" />
+      <location filename="qtbase.py" line="49"/>
       <source>Restore Defaults</source>
       <translation>Restaurar valores padrão</translation>
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Square</source>
-      <translation>Quadrado</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Triangle</source>
-      <translation>Triângulo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Nabla</source>
-      <translation>Nabla</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Diamond</source>
-      <translation>Diamante</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="377" />
-      <source>Pentagon</source>
-      <translation>Pentágono</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="378" />
-      <source>Hexagon</source>
-      <translation>Hexágono</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>Star</source>
-      <translation>Estrela</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Pacman</source>
-      <translation>Pacman</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="383" />
-      <source>1/4 Circle</source>
-      <translation>1/4 de círculo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="384" />
-      <source>Half Circle</source>
-      <translation>Meio círculo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>3/4 Circle</source>
-      <translation>3/4 de círculo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>Full Circle</source>
-      <translation>Círculo completo</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="389" />
-      <source>1 Bar</source>
-      <translation>1 barra</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="390" />
-      <source>2 Bars</source>
-      <translation>2 barras</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>3 Bars</source>
-      <translation>3 barras</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>4 Bars</source>
-      <translation>4 barras</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="395" />
-      <source>1 Block</source>
-      <translation>1 bloco</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="396" />
-      <source>2 Blocks</source>
-      <translation>2 blocos</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="397" />
-      <source>3 Blocks</source>
-      <translation>3 blocos</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="398" />
-      <source>4 Blocks</source>
-      <translation>4 blocos</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="278" />
+      <location filename="../novelwriter/shared.py" line="278"/>
       <source>novelWriter Project File or Zip File</source>
       <translation>Arquivo de projeto do novelWriter ou arquivo Zip</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="279" />
+      <location filename="../novelwriter/shared.py" line="279"/>
       <source>novelWriter Project File</source>
       <translation>Arquivo do projeto novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="283" />
+      <location filename="../novelwriter/shared.py" line="283"/>
       <source>Open Project</source>
       <translation>Abrir projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="292" />
+      <location filename="../novelwriter/shared.py" line="292"/>
       <source>Select Font</source>
       <translation>Selecionar fonte</translation>
     </message>
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="338"/>
       <source>Characters</source>
       <translation>Caracteres</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="339"/>
       <source>Characters in Text</source>
       <translation>Caracteres no texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="340"/>
       <source>Characters in Headings</source>
       <translation>Caracteres em cabeçalhos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="341"/>
       <source>Paragraphs</source>
       <translation>Parágrafos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="342"/>
       <source>Headings</source>
       <translation>Cabeçalhos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="343"/>
       <source>Characters, No Spaces</source>
       <translation>Caracteres, sem espaços</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="344"/>
       <source>Characters in Text, No Spaces</source>
       <translation>Caracteres no texto, sem espaços</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="343" />
+      <location filename="../novelwriter/constants.py" line="345"/>
       <source>Characters in Headings, No Spaces</source>
       <translation>Caracteres em cabeçalhos, sem espaços</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="344" />
+      <location filename="../novelwriter/constants.py" line="346"/>
       <source>Words</source>
       <translation>Palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="347"/>
       <source>Words in Text</source>
       <translation>Palavras no texto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="348"/>
       <source>Words in Headings</source>
       <translation>Palavras em cabeçalhos</translation>
     </message>
@@ -4205,42 +4202,42 @@
   <context>
     <name>VersionInfoWidget</name>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="53" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="53"/>
       <source>Latest Version: {0}</source>
       <translation>Última versão: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="54" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="54"/>
       <source>Checking ...</source>
       <translation>Verificando ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="55" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="55"/>
       <source>Download from {0}</source>
       <translation>Baixar de {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="59" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="59"/>
       <source>Version</source>
       <translation>Versão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="60" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="60"/>
       <source>Released on</source>
       <translation>Lançado em</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="61" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="61"/>
       <source>Release Notes</source>
       <translation>Notas da versão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="65" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="65"/>
       <source>Check Now</source>
       <translation>verificar agora</translation>
     </message>
     <message>
-      <location filename="../novelwriter/extensions/versioninfo.py" line="111" />
+      <location filename="../novelwriter/extensions/versioninfo.py" line="111"/>
       <source>Failed</source>
       <translation>houve uma falha</translation>
     </message>
@@ -4248,57 +4245,57 @@
   <context>
     <name>_ContentsPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="318" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="318"/>
       <source>Table of Contents</source>
       <translation>Sumário</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="329" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="329"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="330" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="330"/>
       <source>Words</source>
       <translation>Palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="331" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="331"/>
       <source>Pages</source>
       <translation>Páginas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="332" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="332"/>
       <source>Page</source>
       <translation>Página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="333" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="333"/>
       <source>Progress</source>
       <translation>Progresso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="366" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="366"/>
       <source>Words per page</source>
       <translation>Palavras por página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="375" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="375"/>
       <source>First page offset</source>
       <translation>Deslocamento da primeira página</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="384" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="384"/>
       <source>Chapters on odd pages</source>
       <translation>Capítulos em páginas ímpares</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="483" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="483"/>
       <source>Untitled</source>
       <translation>Sem título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="521" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="521"/>
       <source>END</source>
       <translation>FIM</translation>
     </message>
@@ -4306,32 +4303,32 @@
   <context>
     <name>_DetailsWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Setting</source>
       <translation>Definição</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="526" />
+      <location filename="../novelwriter/tools/manuscript.py" line="526"/>
       <source>Value</source>
       <translation>Valor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="593" />
+      <location filename="../novelwriter/tools/manuscript.py" line="593"/>
       <source>Name</source>
       <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="599" />
+      <location filename="../novelwriter/tools/manuscript.py" line="599"/>
       <source>Selection</source>
       <translation>Seleção</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="615" />
+      <location filename="../novelwriter/tools/manuscript.py" line="615"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="616" />
+      <location filename="../novelwriter/tools/manuscript.py" line="616"/>
       <source>Hidden</source>
       <translation>Oculto</translation>
     </message>
@@ -4339,37 +4336,37 @@
   <context>
     <name>_FilterTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="295" />
+      <location filename="../novelwriter/tools/manussettings.py" line="295"/>
       <source>Included in manuscript</source>
       <translation>Incluído no manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="296" />
+      <location filename="../novelwriter/tools/manussettings.py" line="296"/>
       <source>Excluded from manuscript</source>
       <translation>Excluído do manuscrito</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="331" />
+      <location filename="../novelwriter/tools/manussettings.py" line="331"/>
       <source>Always included</source>
       <translation>Sempre incluído</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="336" />
+      <location filename="../novelwriter/tools/manussettings.py" line="336"/>
       <source>Always excluded</source>
       <translation>Sempre excluído</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="341" />
+      <location filename="../novelwriter/tools/manussettings.py" line="341"/>
       <source>Reset to default</source>
       <translation>Restaurar predefinição</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="345" />
+      <location filename="../novelwriter/tools/manussettings.py" line="345"/>
       <source>Mark selection as</source>
       <translation>Definir seleção como</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="483" />
+      <location filename="../novelwriter/tools/manussettings.py" line="483"/>
       <source>Select Root Folders</source>
       <translation>Selecionar diretórios-raiz</translation>
     </message>
@@ -4377,22 +4374,22 @@
   <context>
     <name>_GuiAlert</name>
     <message>
-      <location filename="../novelwriter/shared.py" line="489" />
+      <location filename="../novelwriter/shared.py" line="489"/>
       <source>Information</source>
       <translation>Informação</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="492" />
+      <location filename="../novelwriter/shared.py" line="492"/>
       <source>Warning</source>
       <translation>Alerta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="495" />
+      <location filename="../novelwriter/shared.py" line="495"/>
       <source>Error</source>
       <translation>Erro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/shared.py" line="498" />
+      <location filename="../novelwriter/shared.py" line="498"/>
       <source>Question</source>
       <translation>Pergunta</translation>
     </message>
@@ -4400,84 +4397,84 @@
   <context>
     <name>_HeadingsTab</name>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="564" />
+      <location filename="../novelwriter/tools/manussettings.py" line="564"/>
       <source>Hide</source>
       <translation>Ocultar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="865" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="865"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>Editing: {0}</source>
       <translation>Editando: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="862" />
-      <location filename="../novelwriter/tools/manussettings.py" line="670" />
+      <location filename="../novelwriter/tools/manussettings.py" line="862"/>
+      <location filename="../novelwriter/tools/manussettings.py" line="670"/>
       <source>None</source>
       <translation>Nenhum</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="679" />
+      <location filename="../novelwriter/tools/manussettings.py" line="679"/>
       <source>Title</source>
       <translation>Título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="680" />
+      <location filename="../novelwriter/tools/manussettings.py" line="680"/>
       <source>Chapter Number</source>
       <translation>Número do capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="681" />
+      <location filename="../novelwriter/tools/manussettings.py" line="681"/>
       <source>Chapter Number (Word)</source>
       <translation>Número do capítulo (por extenso)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="682" />
+      <location filename="../novelwriter/tools/manussettings.py" line="682"/>
       <source>Chapter Number (Upper Case Roman)</source>
       <translation>Número do capítulo (numeral romano, maiúsculas)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="683" />
+      <location filename="../novelwriter/tools/manussettings.py" line="683"/>
       <source>Chapter Number (Lower Case Roman)</source>
       <translation>Número do capítulo (numeral romano, minúsculas)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="684" />
+      <location filename="../novelwriter/tools/manussettings.py" line="684"/>
       <source>Scene Number (In Chapter)</source>
       <translation>Número da cena (no capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="685" />
+      <location filename="../novelwriter/tools/manussettings.py" line="685"/>
       <source>Scene Number (Absolute)</source>
       <translation>Número da cena (absoluto)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="686" />
+      <location filename="../novelwriter/tools/manussettings.py" line="686"/>
       <source>Point of View Character</source>
       <translation>Personagem do ponto de vista</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="687" />
+      <location filename="../novelwriter/tools/manussettings.py" line="687"/>
       <source>Focus Character</source>
       <translation>Personagem em foco</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="699" />
+      <location filename="../novelwriter/tools/manussettings.py" line="699"/>
       <source>Insert</source>
       <translation>Inserir</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="702" />
+      <location filename="../novelwriter/tools/manussettings.py" line="702"/>
       <source>Apply</source>
       <translation>Aplicar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="721" />
+      <location filename="../novelwriter/tools/manussettings.py" line="721"/>
       <source>Centre</source>
       <translation>Centralizado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manussettings.py" line="722" />
+      <location filename="../novelwriter/tools/manussettings.py" line="722"/>
       <source>Page Break</source>
       <translation>Quebra de página</translation>
     </message>
@@ -4485,117 +4482,117 @@
   <context>
     <name>_NewProjectForm</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="569" />
+      <location filename="../novelwriter/tools/welcome.py" line="569"/>
       <source>Required</source>
       <translation>Obrigatório</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="575" />
+      <location filename="../novelwriter/tools/welcome.py" line="575"/>
       <source>Optional</source>
       <translation>Opcional</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="596" />
+      <location filename="../novelwriter/tools/welcome.py" line="596"/>
       <source>Create a fresh project</source>
       <translation>Criar um projeto vazio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="600" />
+      <location filename="../novelwriter/tools/welcome.py" line="600"/>
       <source>Create an example project</source>
       <translation>Criar um projeto de exemplo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="604" />
+      <location filename="../novelwriter/tools/welcome.py" line="604"/>
       <source>Copy an existing project</source>
       <translation>Copiar um projeto existente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="617" />
+      <location filename="../novelwriter/tools/welcome.py" line="617"/>
       <source>Project Name</source>
       <translation>Nome do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="618" />
+      <location filename="../novelwriter/tools/welcome.py" line="618"/>
       <source>Author</source>
       <translation>Autor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="619" />
+      <location filename="../novelwriter/tools/welcome.py" line="619"/>
       <source>Project Path</source>
       <translation>Caminho do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="620" />
+      <location filename="../novelwriter/tools/welcome.py" line="620"/>
       <source>Prefill Project</source>
       <translation>Pré-preencher projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="628" />
+      <location filename="../novelwriter/tools/welcome.py" line="628"/>
       <source>Set to 0 to only add scenes</source>
       <translation>Defina como 0 para adicionar apenas cenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="631" />
+      <location filename="../novelwriter/tools/welcome.py" line="631"/>
       <source>Add {0} chapter documents</source>
       <translation>Adicionar {0} documentos de capítulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="640" />
+      <location filename="../novelwriter/tools/welcome.py" line="640"/>
       <source>Add {0} scene documents (to each chapter)</source>
       <translation>Adicionar {0} documentos de cena (por capítulo)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="668" />
+      <location filename="../novelwriter/tools/welcome.py" line="668"/>
       <source>Add a folder for plot notes</source>
       <translation>Adicionar um diretório para notas de enredo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="669" />
+      <location filename="../novelwriter/tools/welcome.py" line="669"/>
       <source>Add a folder for character notes</source>
       <translation>Adicionar um diretório para notas de personagens</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="670" />
+      <location filename="../novelwriter/tools/welcome.py" line="670"/>
       <source>Add a folder for location notes</source>
       <translation>Adicionar um diretório para notas de lugares</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="671" />
+      <location filename="../novelwriter/tools/welcome.py" line="671"/>
       <source>Add example notes to the above</source>
       <translation>Adicionar notas de exemplo aos itens acima</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="677" />
+      <location filename="../novelwriter/tools/welcome.py" line="677"/>
       <source>Chapters and Scenes</source>
       <translation>Capítulos e cenas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="680" />
+      <location filename="../novelwriter/tools/welcome.py" line="680"/>
       <source>Project Notes</source>
       <translation>Notas do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="689" />
+      <location filename="../novelwriter/tools/welcome.py" line="689"/>
       <source>Create New Project</source>
       <translation>Criar um novo projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="738" />
+      <location filename="../novelwriter/tools/welcome.py" line="738"/>
       <source>Select Project Folder</source>
       <translation>Selecione o diretório do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="794" />
+      <location filename="../novelwriter/tools/welcome.py" line="794"/>
       <source>Fresh Project</source>
       <translation>Projeto vazio</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="796" />
+      <location filename="../novelwriter/tools/welcome.py" line="796"/>
       <source>Example Project</source>
       <translation>Projeto de exemplo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="798" />
+      <location filename="../novelwriter/tools/welcome.py" line="798"/>
       <source>Template: {0}</source>
       <translation>Modelo: {0}</translation>
     </message>
@@ -4603,7 +4600,7 @@
   <context>
     <name>_NewProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="538" />
+      <location filename="../novelwriter/tools/welcome.py" line="538"/>
       <source>A project name is required.</source>
       <translation>O nome do projeto é obrigatório.</translation>
     </message>
@@ -4611,27 +4608,27 @@
   <context>
     <name>_OpenProjectPage</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="293" />
+      <location filename="../novelwriter/tools/welcome.py" line="293"/>
       <source>The project path is not reachable.</source>
       <translation>O caminho do projeto não pode ser acessado.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="340" />
+      <location filename="../novelwriter/tools/welcome.py" line="340"/>
       <source>Path</source>
       <translation>Caminho</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="360" />
+      <location filename="../novelwriter/tools/welcome.py" line="360"/>
       <source>Remove '{0}' from the recent projects list? The project files will not be deleted.</source>
       <translation>Remover '{0}' da lista de projetos recentes? Os arquivos do projeto não serão excluídos.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="374" />
+      <location filename="../novelwriter/tools/welcome.py" line="374"/>
       <source>Open Project</source>
       <translation>Abrir projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="376" />
+      <location filename="../novelwriter/tools/welcome.py" line="376"/>
       <source>Remove Project</source>
       <translation>Remover projeto</translation>
     </message>
@@ -4639,54 +4636,54 @@
   <context>
     <name>_OverviewPage</name>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="202" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="202"/>
       <source>Project</source>
       <translation>Projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="236" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="214" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="236"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="214"/>
       <source>Name</source>
       <translation>Nome</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="215" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="215"/>
       <source>Revisions</source>
       <translation>Revisões</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="216" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="216"/>
       <source>Editing Time</source>
       <translation>Tempo de edição</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="237" />
-      <location filename="../novelwriter/tools/noveldetails.py" line="217" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="237"/>
+      <location filename="../novelwriter/tools/noveldetails.py" line="217"/>
       <source>Word Count</source>
       <translation>Contagem de palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="218" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="218"/>
       <source>In Novels</source>
       <translation>em livros</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="219" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="219"/>
       <source>In Notes</source>
       <translation>nas notas</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="226" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="226"/>
       <source>Selected Novel</source>
       <translation>Livro selecionado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="238" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="238"/>
       <source>Chapters</source>
       <translation>Capítulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/noveldetails.py" line="239" />
+      <location filename="../novelwriter/tools/noveldetails.py" line="239"/>
       <source>Scenes</source>
       <translation>Cenas</translation>
     </message>
@@ -4694,27 +4691,27 @@
   <context>
     <name>_PreviewWidget</name>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="758" />
+      <location filename="../novelwriter/tools/manuscript.py" line="758"/>
       <source>Press the "Preview" button to generate ...</source>
       <translation>Clique em "Pré-visualização" para gerá-la ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="852" />
+      <location filename="../novelwriter/tools/manuscript.py" line="852"/>
       <source>Processing ...</source>
       <translation>Processando ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="862" />
+      <location filename="../novelwriter/tools/manuscript.py" line="862"/>
       <source>Done</source>
       <translation>Pronto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="920" />
+      <location filename="../novelwriter/tools/manuscript.py" line="920"/>
       <source>Built</source>
       <translation>Criado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/manuscript.py" line="924" />
+      <location filename="../novelwriter/tools/manuscript.py" line="924"/>
       <source>No Preview</source>
       <translation>Sem pré-visualização</translation>
     </message>
@@ -4722,12 +4719,12 @@
   <context>
     <name>_ProjectListModel</name>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="455" />
+      <location filename="../novelwriter/tools/welcome.py" line="455"/>
       <source>Word Count</source>
       <translation>Contagem de palavras</translation>
     </message>
     <message>
-      <location filename="../novelwriter/tools/welcome.py" line="456" />
+      <location filename="../novelwriter/tools/welcome.py" line="456"/>
       <source>Last Opened</source>
       <translation>Aberto pela última vez em</translation>
     </message>
@@ -4735,22 +4732,22 @@
   <context>
     <name>_ReplacePage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="686" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="686"/>
       <source>Text Auto-Replace for Preview and Build</source>
       <translation>Substituição automática de texto para a pré-visualização e compilação</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Keyword</source>
       <translation>Palavra-chave</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="692" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="692"/>
       <source>Replace With</source>
       <translation>Substituir por</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="715" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="715"/>
       <source>Select item to edit</source>
       <translation>Selecione um item para editar</translation>
     </message>
@@ -4758,49 +4755,49 @@
   <context>
     <name>_SettingsPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="246" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="246"/>
       <source>Project name</source>
       <translation>Nome do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="247" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="247"/>
       <source>Changing this will affect the backup path.</source>
       <translation>Alterar isso afetará o caminho da cópia de segurança.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="257" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="257"/>
       <source>Author(s)</source>
       <translation>Autor(es)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="271" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="258" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="271"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="258"/>
       <source>Only used when building the manuscript.</source>
       <translation>Usado apenas na compilação do manuscrito.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="270" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="270"/>
       <source>Project language</source>
       <translation>Idioma do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="278" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="278"/>
       <source>Default</source>
       <translation>Padrão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="283" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="283"/>
       <source>Spell check language</source>
       <translation>Idioma da verificação ortográfica</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="295" />
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="284" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="295"/>
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="284"/>
       <source>Overrides main preferences.</source>
       <translation>Sobrescreve as preferências globais.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="294" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="294"/>
       <source>Disable backup on close</source>
       <translation>Desativar criação de cópia de segurança ao fechar</translation>
     </message>
@@ -4808,132 +4805,132 @@
   <context>
     <name>_StatusPage</name>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="316" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="316"/>
       <source>Status</source>
       <translation>Estado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="318" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="318"/>
       <source>Novel Document Status Levels</source>
       <translation>Níveis de estado nos documentos do livro</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="321" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="321"/>
       <source>Importance</source>
       <translation>Importância</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="323" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="323"/>
       <source>Project Note Importance Levels</source>
       <translation>Níveis de importância nas notas do projeto</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="342" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="342"/>
       <source>Not in use</source>
       <translation>Não usado</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="343" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="343"/>
       <source>Used once</source>
       <translation>Usado uma vez</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="344" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="344"/>
       <source>Used by {0} items</source>
       <translation>Usado por {0} items</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="345" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="345"/>
       <source>Select Colour</source>
       <translation>Selecione uma cor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Label</source>
       <translation>Rótulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="355" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="355"/>
       <source>Usage</source>
       <translation>Uso</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="367" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="367"/>
       <source>Add Label</source>
       <translation>Adicionar rótulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="371" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="371"/>
       <source>Delete Label</source>
       <translation>Excluir rótulo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="375" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="375"/>
       <source>Move Up</source>
       <translation>Mover para cima</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="379" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="379"/>
       <source>Move Down</source>
       <translation>Mover para baixo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="383" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="383"/>
       <source>Import Labels</source>
       <translation>Importar rótulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="387" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="387"/>
       <source>Export Labels</source>
       <translation>Exportar rótulos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="393" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="393"/>
       <source>Select item to edit</source>
       <translation>Selecione um item para editar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="403" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="403"/>
       <source>Colour</source>
       <translation>Cor</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="418" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="418"/>
       <source>Circles ...</source>
       <translation>Círculos ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="419" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="419"/>
       <source>Bars ...</source>
       <translation>Barras ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="420" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="420"/>
       <source>Blocks ...</source>
       <translation>Blocos ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="424" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="424"/>
       <source>Shape</source>
       <translation>Forma</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="515" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="515"/>
       <source>New Item</source>
       <translation>Novo item</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="526" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="526"/>
       <source>Cannot delete a status item that is in use.</source>
       <translation>Não é possível remover um item de estado em uso.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="565" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="565"/>
       <source>Import File</source>
       <translation>Importar arquivo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/dialogs/projectsettings.py" line="584" />
+      <location filename="../novelwriter/dialogs/projectsettings.py" line="584"/>
       <source>Export File</source>
       <translation>Exportar arquivo</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1134" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134"/>
       <source>Empty Trash</source>
       <translation>Esvaziar a lixeira</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1155" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155"/>
       <source>Rename</source>
       <translation>Renomear</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1170" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170"/>
       <source>Duplicate</source>
       <translation>Duplicar</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1190" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190"/>
       <source>Open Document</source>
       <translation>Abrir documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1195" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195"/>
       <source>View Document</source>
       <translation>Ver documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1204" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204"/>
       <source>Create New ...</source>
       <translation>Criar novo ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1216" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216"/>
       <source>Rename to Heading</source>
       <translation>Renomear para título</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1225" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225"/>
       <source>Set Active to ...</source>
       <translation>Definir inclusão como...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1231" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231"/>
       <source>Toggle Active</source>
       <translation>Alternar inclusão</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1238" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238"/>
       <source>Set Status to ...</source>
       <translation>Definir estado como...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1268" />
-      <location filename="../novelwriter/gui/projtree.py" line="1250" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1250"/>
       <source>Manage Labels ...</source>
       <translation>Gerenciar rótulos ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1256" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256"/>
       <source>Set Importance to ...</source>
       <translation>Definir importância como...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1277" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277"/>
       <source>Transform ...</source>
       <translation>Transformar ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1299" />
-      <location filename="../novelwriter/gui/projtree.py" line="1295" />
-      <location filename="../novelwriter/gui/projtree.py" line="1291" />
-      <location filename="../novelwriter/gui/projtree.py" line="1287" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1295"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1291"/>
+      <location filename="../novelwriter/gui/projtree.py" line="1287"/>
       <source>Convert to {0}</source>
       <translation>Converter em {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1303" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303"/>
       <source>Merge Child Items into Self</source>
       <translation>Combinar subitens neste documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1305" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305"/>
       <source>Merge Child Items into New</source>
       <translation>Combinar subitens em um novo documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1309" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309"/>
       <source>Merge Documents in Folder</source>
       <translation>Combinar documentos no diretório</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1313" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313"/>
       <source>Split Document by Headings</source>
       <translation>Dividir documento por cabeçalhos</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1320" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320"/>
       <source>Expand All</source>
       <translation>Expandir tudo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1322" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322"/>
       <source>Collapse All</source>
       <translation>Recolher tudo</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1332" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332"/>
       <source>Delete Permanently</source>
       <translation>Excluir permanentemente</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1334" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334"/>
       <source>Move to Trash</source>
       <translation>Mover para a lixeira</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1410" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410"/>
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Deseja converter o diretório em {0}? Esta ação não pode ser desfeita.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1048" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048"/>
       <source>From Template</source>
       <translation>Do modelo</translation>
     </message>
@@ -5071,12 +5068,12 @@
   <context>
     <name>_ViewPanelBackRefs</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="252" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="252"/>
       <source>First Heading</source>
       <translation>Primeiro cabeçalho</translation>
     </message>
@@ -5084,27 +5081,27 @@
   <context>
     <name>_ViewPanelKeyWords</name>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Tag</source>
       <translation>Etiqueta</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Importance</source>
       <translation>Importância</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="390" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="390"/>
       <source>Document</source>
       <translation>Documento</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Heading</source>
       <translation>Cabeçalho</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/docviewerpanel.py" line="391" />
+      <location filename="../novelwriter/gui/docviewerpanel.py" line="391"/>
       <source>Short Description</source>
       <translation>Breve descrição</translation>
     </message>

--- a/i18n/nw_ru_RU.ts
+++ b/i18n/nw_ru_RU.ts
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="310" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="117" />
       <source>Title</source>
       <translation>Заголовок</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118" />
       <source>Heading 1 (Partition)</source>
       <translation type="unfinished">Заголовок 1 (Раздел)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119" />
       <source>Heading 2 (Chapter)</source>
       <translation type="unfinished">Заголовок 2 (Глава)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120" />
       <source>Heading 3 (Scene)</source>
       <translation type="unfinished">Заголовок 3 (Сцена)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121" />
       <source>Heading 4 (Section)</source>
       <translation type="unfinished">Заголовок 4 (Часть)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122" />
       <source>Text Paragraph</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123" />
       <source>Scene Separator</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="267" />
-      <location filename="../novelwriter/constants.py" line="262" />
-      <location filename="../novelwriter/constants.py" line="234" />
+      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="240" />
       <source>None</source>
       <translation>Пусто</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="235" />
+      <location filename="../novelwriter/constants.py" line="241" />
       <source>Novel</source>
       <translation type="unfinished">Роман</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
-      <location filename="../novelwriter/constants.py" line="236" />
+      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="242" />
       <source>Plot</source>
       <translation type="unfinished">Сюжет</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="285" />
-      <location filename="../novelwriter/constants.py" line="237" />
+      <location filename="../novelwriter/constants.py" line="291" />
+      <location filename="../novelwriter/constants.py" line="243" />
       <source>Characters</source>
       <translation type="unfinished">Персонажи</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="288" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="294" />
+      <location filename="../novelwriter/constants.py" line="244" />
       <source>Locations</source>
       <translation type="unfinished">Локации</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="245" />
       <source>Timeline</source>
       <translation type="unfinished">Хронология</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="295" />
+      <location filename="../novelwriter/constants.py" line="246" />
       <source>Objects</source>
       <translation type="unfinished">Объекты</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="247" />
       <source>Entities</source>
       <translation type="unfinished">Сущности</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="425" />
+      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="248" />
       <source>Custom</source>
       <translation>Другое</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="249" />
       <source>Archive</source>
       <translation type="unfinished">Архив</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="250" />
       <source>Templates</source>
       <translation type="unfinished">Шаблоны</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="251" />
       <source>Trash</source>
       <translation type="unfinished">Корзина</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="270" />
-      <location filename="../novelwriter/constants.py" line="263" />
+      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="269" />
       <source>Novel Document</source>
       <translation>Документ романа</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
-      <location filename="../novelwriter/constants.py" line="264" />
+      <location filename="../novelwriter/constants.py" line="281" />
+      <location filename="../novelwriter/constants.py" line="270" />
       <source>Project Note</source>
       <translation>Заметка проекта</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="274" />
       <source>Root Folder</source>
       <translation>Корневая папка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="269" />
+      <location filename="../novelwriter/constants.py" line="275" />
       <source>Folder</source>
       <translation>Папка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
+      <location filename="../novelwriter/constants.py" line="277" />
       <source>Novel Title Page</source>
       <translation>Титульный лист</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="278" />
       <source>Novel Chapter</source>
       <translation>Глава романа</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="279" />
       <source>Novel Scene</source>
       <translation>Сцена романа</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
+      <location filename="../novelwriter/constants.py" line="280" />
       <source>Novel Section</source>
       <translation>Раздел романа</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="284" />
       <source>Active</source>
       <translation type="unfinished">Активен</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
+      <location filename="../novelwriter/constants.py" line="285" />
       <source>Inactive</source>
       <translation type="unfinished">Неактивен</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="288" />
       <source>Tag</source>
       <translation type="unfinished">Тэг</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="289" />
       <source>Point of View</source>
       <translation type="unfinished">Точка зрения</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
-      <location filename="../novelwriter/constants.py" line="284" />
+      <location filename="../novelwriter/constants.py" line="325" />
+      <location filename="../novelwriter/constants.py" line="290" />
       <source>Focus</source>
       <translation>Фокус</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="298" />
       <source>Story</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="299" />
       <source>Mentions</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="311" />
+      <location filename="../novelwriter/constants.py" line="317" />
       <source>Level</source>
       <translation>Уровень</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="312" />
+      <location filename="../novelwriter/constants.py" line="318" />
       <source>Document</source>
       <translation>Документ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="313" />
+      <location filename="../novelwriter/constants.py" line="319" />
       <source>Line</source>
       <translation>Строка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
+      <location filename="../novelwriter/constants.py" line="320" />
       <source>Status</source>
       <translation type="unfinished">Статус</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="321" />
       <source>Chars</source>
       <translation>Символов</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="322" />
       <source>Words</source>
       <translation>Слов</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="323" />
       <source>Pars</source>
       <translation>Абзацев</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="324" />
       <source>POV</source>
       <translation>От лица</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="329" />
+      <location filename="../novelwriter/constants.py" line="335" />
       <source>Synopsis</source>
       <translation>Синопсис</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="351" />
       <source>Open Document (.odt)</source>
       <translation>Открыть документ (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="352" />
       <source>Flat Open Document (.fodt)</source>
       <translation>Открыть Документ Flat (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="347" />
+      <location filename="../novelwriter/constants.py" line="353" />
       <source>Microsoft Word Document (.docx)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="348" />
+      <location filename="../novelwriter/constants.py" line="354" />
       <source>HTML 5 (.html)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="355" />
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter разметка (.txt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="356" />
       <source>Standard Markdown (.md)</source>
       <translation>Стандартный Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="357" />
       <source>Extended Markdown (.md)</source>
       <translation>Расширенный Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="358" />
       <source>Portable Document Format (.pdf)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="359" />
       <source>JSON + HTML 5 (.json)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="360" />
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + novelWriter разметка (.json)</translation>
     </message>
     <message>
+      <location filename="../novelwriter/constants.py" line="375" />
+      <source>Square</source>
+      <translation type="unfinished">Квадрат</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376" />
+      <source>Triangle</source>
+      <translation type="unfinished">Треугольник</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377" />
+      <source>Nabla</source>
+      <translation type="unfinished">Набла</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378" />
+      <source>Diamond</source>
+      <translation type="unfinished">Ромб</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379" />
+      <source>Pentagon</source>
+      <translation type="unfinished">Пятиугольник</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380" />
+      <source>Hexagon</source>
+      <translation type="unfinished">Шестиугольник</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381" />
+      <source>Star</source>
+      <translation type="unfinished">Звезда</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382" />
+      <source>Pacman</source>
+      <translation type="unfinished">Пакман</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385" />
+      <source>1/4 Circle</source>
+      <translation type="unfinished">1/4 круга</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386" />
+      <source>Half Circle</source>
+      <translation type="unfinished">Половина круга</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387" />
+      <source>3/4 Circle</source>
+      <translation type="unfinished">3/4 круга</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388" />
+      <source>Full Circle</source>
+      <translation type="unfinished">Круг</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391" />
+      <source>1 Bar</source>
+      <translation type="unfinished">1 Колонка</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392" />
+      <source>2 Bars</source>
+      <translation type="unfinished">2 Колонки</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393" />
+      <source>3 Bars</source>
+      <translation type="unfinished">3 Колонки</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394" />
+      <source>4 Bars</source>
+      <translation type="unfinished">4 Колонки</translation>
+    </message>
+    <message>
       <location filename="../novelwriter/constants.py" line="397" />
+      <source>1 Block</source>
+      <translation type="unfinished">1 Блок</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398" />
+      <source>2 Blocks</source>
+      <translation type="unfinished">2 Блока</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399" />
+      <source>3 Blocks</source>
+      <translation type="unfinished">3 Блока</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400" />
+      <source>4 Blocks</source>
+      <translation type="unfinished">4 Блока</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403" />
       <source>Text files</source>
       <translation>Текстовые файлы</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="398" />
+      <location filename="../novelwriter/constants.py" line="404" />
       <source>Markdown files</source>
       <translation>Файлы Markdown</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="399" />
+      <location filename="../novelwriter/constants.py" line="405" />
       <source>novelWriter files</source>
       <translation>файлы novelWriter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="400" />
+      <location filename="../novelwriter/constants.py" line="406" />
       <source>CSV files</source>
       <translation>Файлы CSV</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="407" />
       <source>All files</source>
       <translation>Все файлы</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="410" />
       <source>Millimetres</source>
       <translation>Миллиметры</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="411" />
       <source>Centimetres</source>
       <translation>Сантиметры</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="406" />
+      <location filename="../novelwriter/constants.py" line="412" />
       <source>Inches</source>
       <translation>Дюймы</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="414" />
+      <location filename="../novelwriter/constants.py" line="420" />
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="415" />
+      <location filename="../novelwriter/constants.py" line="421" />
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="416" />
+      <location filename="../novelwriter/constants.py" line="422" />
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="417" />
+      <location filename="../novelwriter/constants.py" line="423" />
       <source>US Legal</source>
       <translation>US Legal</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="424" />
       <source>US Letter</source>
       <translation>US Letter</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="461" />
+      <location filename="../novelwriter/constants.py" line="467" />
       <source>Straight single quotation mark</source>
       <translation>Прямая одинарная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="462" />
+      <location filename="../novelwriter/constants.py" line="468" />
       <source>Straight double quotation mark</source>
       <translation>Прямая двойная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="464" />
+      <location filename="../novelwriter/constants.py" line="470" />
       <source>Left single quotation mark</source>
       <translation>Левая одинарная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="471" />
       <source>Right single quotation mark</source>
       <translation>Правая одинарная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="472" />
       <source>Single low-9 quotation mark</source>
       <translation>Нижняя одинарная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="467" />
+      <location filename="../novelwriter/constants.py" line="473" />
       <source>Single high-reversed-9 quotation mark</source>
       <translation>Верхняя одинарная обратная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="474" />
       <source>Left double quotation mark</source>
       <translation>Левая двойная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="475" />
       <source>Right double quotation mark</source>
       <translation>Правая двойная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="476" />
       <source>Double low-9 quotation mark</source>
       <translation>Нижняя двойная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="477" />
       <source>Double high-reversed-9 quotation mark</source>
       <translation>Верхняя двойная обратная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="478" />
       <source>Double low-reversed-9 quotation mark</source>
       <translation>Нижняя двойная обратная кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="480" />
       <source>Single left-pointing angle quotation mark</source>
       <translation>Одинарная открывающая угловая кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="481" />
       <source>Single right-pointing angle quotation mark</source>
       <translation>Одинарная закрывающая угловая кавычка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="482" />
       <source>Double left-pointing angle quotation mark</source>
       <translation>Открывающая кавычка «ёлочка»</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="477" />
+      <location filename="../novelwriter/constants.py" line="483" />
       <source>Double right-pointing angle quotation mark</source>
       <translation>Закрывающая правая кавычка «ёлочка»</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="485" />
       <source>Left corner bracket</source>
       <translation>Левая г-образная скобка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="486" />
       <source>Right corner bracket</source>
       <translation>Правая г-образная скобка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="487" />
       <source>Left white corner bracket</source>
       <translation>Левая г-образная скобка с обводкой</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="482" />
+      <location filename="../novelwriter/constants.py" line="488" />
       <source>Right white corner bracket</source>
       <translation>Правая г-образная скобка с обводкой</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3072" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
       <source>Line: {0} ({1})</source>
       <translation>Строка: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3073" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
       <source>Words: {0} ({1})</source>
       <translation>Слов: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3074" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
       <source>Words: {0} selected</source>
       <translation>Слов: {0} выбрано</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3086" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
       <source>Status</source>
       <translation>Статус</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2865" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
       <source>Toggle Tool Bar</source>
       <translation>Переключить панель инструментов</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2870" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
       <source>Outline</source>
       <translation>Обводка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2875" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
       <source>Search</source>
       <translation>Поиск</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2880" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
       <source>Toggle Focus Mode</source>
       <translation>Переключить режим концентрации</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2885" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
       <source>Close</source>
       <translation>Закрыть</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
       <source>Search for</source>
       <translation>Искать по</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2487" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
       <source>Replace with</source>
       <translation>Заменить на</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2495" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
       <source>Search</source>
       <translation>Поиск</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2500" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
       <source>Case Sensitive</source>
       <translation>Учитывать регистр</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2506" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
       <source>Whole Words Only</source>
       <translation>Только слова целиком</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2512" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
       <source>RegEx Mode</source>
       <translation>Режим RegEx</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2518" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
       <source>Loop Search</source>
       <translation>Циклический поиск</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2524" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
       <source>Search Next File</source>
       <translation>Поиск в следующем файле</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2532" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
       <source>Preserve Case</source>
       <translation>Сохранять регистр</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
       <source>Close Search</source>
       <translation>Закрыть поиск</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2551" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
       <source>Find in current document</source>
       <translation>Найти в текущем документе</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2555" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
       <source>Find and replace in current document</source>
       <translation>Найти и заменить в текущем документе</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="436" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443" />
       <source>Opened Document: {0}</source>
       <translation>Открытый документ: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="474" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481" />
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>Этот документ был изменен вне программы novelWriter, пока он был открыт. Перезаписать файл на диске?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490" />
       <source>Could not save document.</source>
       <translation>Не удалось сохранить документ.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="508" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515" />
       <source>Saved Document: {0}</source>
       <translation>Сохраненный документ: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="677" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684" />
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>Проверка орфографии требует пакет PyEnchant. Похоже, он не установлен.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="703" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710" />
       <source>Spell check complete</source>
       <translation>Проверка орфографии завершена</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="823" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830" />
       <source>Document Details</source>
       <translation>Детали документа</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="825" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832" />
       <source>Created: {0}</source>
       <translation>Создано: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="826" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833" />
       <source>Updated: {0}</source>
       <translation>Обновлено: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="828" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835" />
       <source>File Location: {0}</source>
       <translation>Расположение файла: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1149" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
       <source>Set as Document Name</source>
       <translation>Установить как Имя Документа</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1155" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
       <source>Open URL</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
       <source>Follow Tag</source>
       <translation>Перейти по метке</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1166" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
       <source>Create Note for Tag</source>
       <translation>Создать Заметку для Тега</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1172" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
       <source>Cut</source>
       <translation>Вырезать</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1174" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
       <source>Copy</source>
       <translation>Копировать</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1177" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
       <source>Paste</source>
       <translation>Вставить</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1182" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
       <source>Select All</source>
       <translation>Выбрать все</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
       <source>Select Word</source>
       <translation>Выбрать слово</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1188" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
       <source>Select Paragraph</source>
       <translation>Выбрать Абзац</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1204" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
       <source>Spelling Suggestion(s)</source>
       <translation>Предложения по орфографии</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1209" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
       <source>No Suggestions</source>
       <translation>Нет предложений</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1213" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
       <source>Ignore Word</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1215" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
       <source>Add Word to Dictionary</source>
       <translation>Добавить слово в словарь</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1619" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
       <source>Please select some text before calling replace quotes.</source>
       <translation>Пожалуйста, выберите текст перед заменой кавычек.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1974" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>Вы хотите создать новую заметку проекта для тега '{0}'?</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2346" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
       <source>Markdown Bold</source>
       <translation>Markdown жирный</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2352" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
       <source>Markdown Italic</source>
       <translation>Markdown курсив</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2358" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
       <source>Markdown Strikethrough</source>
       <translation>Markdown зачёркнутый</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2364" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
       <source>Shortcode Bold</source>
       <translation>Shortcode жирный</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2370" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
       <source>Shortcode Italic</source>
       <translation>Shortcode курсив</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2376" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
       <source>Shortcode Strikethrough</source>
       <translation>Shortcode зачёркнутый</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2382" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
       <source>Shortcode Underline</source>
       <translation>Shortcode подчёркнутый</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2388" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
       <source>Shortcode Highlight</source>
       <translation>Shortcode выделенный</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2394" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
       <source>Shortcode Superscript</source>
       <translation>Shortcode верхний индекс</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2400" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
       <source>Shortcode Subscript</source>
       <translation>Shortcode нижний индекс</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="213" />
-      <location filename="../novelwriter/gui/statusbar.py" line="64" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212" />
+      <location filename="../novelwriter/gui/statusbar.py" line="63" />
       <source>None</source>
       <translation>Нет</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="72" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71" />
       <source>Editor</source>
       <translation>Редактор</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="80" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79" />
       <source>Project</source>
       <translation>Проект</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="100" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99" />
       <source>Session Time</source>
       <translation>Время сеанса</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="179" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178" />
       <source>Words: {0} ({1})</source>
       <translation>Слов: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="181" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180" />
       <source>Project word count (session change)</source>
       <translation>Количество слов в проекте (за сессию)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="183" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182" />
       <source>Novel word count (session change)</source>
       <translation>Количество слов в романе (за сессию)</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253" />
       <source>Project Content</source>
       <translation>Содержание проекта</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262" />
       <source>Quick Links</source>
       <translation>Быстрые ссылки</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268" />
       <source>Move Up</source>
       <translation>Сдвинуть вверх</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272" />
       <source>Move Down</source>
       <translation>Сдвинуть вниз</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312" />
       <source>Add Item</source>
       <translation>Добавить элемент</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319" />
       <source>Expand All</source>
       <translation>Развернуть всё</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322" />
       <source>Collapse All</source>
       <translation>Свернуть все</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325" />
       <source>Empty Trash</source>
       <translation>Очистить корзину</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329" />
       <source>More Options</source>
       <translation>Дополнительные параметры</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626" />
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>Нигде не найдено для добавления файла или папки!</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630" />
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>Невозможно добавить новые файлы или папки в корзину.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644" />
       <source>New Note</source>
       <translation>Новая заметка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647" />
       <source>New Chapter</source>
       <translation>Новая глава</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650" />
       <source>New Scene</source>
       <translation>Новая сцена</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653" />
       <source>New Document</source>
       <translation>Новый Документ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656" />
       <source>New Folder</source>
       <translation>Новая папка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706" />
       <source>No documents selected for merging.</source>
       <translation>Не выбраны документы для слияния.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714" />
       <source>Merged</source>
       <translation>Объединено</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772" />
+      <location filename="../novelwriter/gui/projtree.py" line="728" />
       <source>Could not write document content.</source>
       <translation>Не удается записать содержимое документа.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787" />
       <source>Do you want to duplicate this document?</source>
       <translation>Вы хотите сделать копию этого документа?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789" />
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>Вы хотите сделать копию этого предмета и всех дочерних элементов?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794" />
       <source>Could not duplicate all items.</source>
       <translation>Не удалось дублировать все элементы.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910" />
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>Корневые папки могут быть удалены только когда они пусты.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914" />
       <source>Permanently delete selected item(s)?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924" />
       <source>Move selected item(s) to Trash?</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939" />
       <source>The Trash folder is already empty.</source>
       <translation>Корзина уже пуста.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942" />
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>Удалить навсегда {0} файл(ов) из корзины?</translation>
     </message>
@@ -3637,7 +3737,7 @@
       <translation>Неизвестный формат файла проекта.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="475" />
+      <location filename="../novelwriter/core/project.py" line="471" />
       <location filename="../novelwriter/core/project.py" line="288" />
       <location filename="../novelwriter/core/project.py" line="283" />
       <location filename="../novelwriter/core/project.py" line="278" />
@@ -3685,98 +3785,98 @@
       <translation>Этот проект был сохранен в новой версии novelWriter, версии {0}. Это версия {1}. Если вы продолжаете открывать проект, некоторые атрибуты и настройки не могут быть сохранены, но общий вид проекта должен быть хорошим. Продолжить открытие проекта?</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="360" />
       <source>Recovered</source>
       <translation>Восстановлено</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="364" />
+      <location filename="../novelwriter/core/project.py" line="362" />
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>Найдено {0} несохранённых файл(ы) в проекте. {1} файл(ов) были восстановлены.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="380" />
+      <location filename="../novelwriter/core/project.py" line="378" />
       <source>Opened Project: {0}</source>
       <translation>Открытый проект: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="391" />
+      <location filename="../novelwriter/core/project.py" line="389" />
       <source>There is no project open.</source>
       <translation>Нет открытого проекта.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="414" />
+      <location filename="../novelwriter/core/project.py" line="412" />
       <source>Failed to save project.</source>
       <translation>Не удалось сохранить проект.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="428" />
+      <location filename="../novelwriter/core/project.py" line="424" />
       <source>Saved Project: {0}</source>
       <translation>Сохраненный проект: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="450" />
+      <location filename="../novelwriter/core/project.py" line="446" />
       <source>Backing up project ...</source>
       <translation>Резервное копирование проекта...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="453" />
+      <location filename="../novelwriter/core/project.py" line="449" />
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>Не удается создать резервную копию проекта, потому что имя проекта не задано. Пожалуйста, задайте имя проекта в настройках проекта.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="465" />
+      <location filename="../novelwriter/core/project.py" line="461" />
       <source>Could not create backup folder.</source>
       <translation>Не удалось создать папку резервного копирования.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="470" />
       <source>Created a backup of your project of size {0}B.</source>
       <translation>Создана резервная копия вашего проекта размером {0}B.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="478" />
+      <location filename="../novelwriter/core/project.py" line="474" />
       <source>Could not write backup archive.</source>
       <translation>Не удалось записать резервный архив.</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="481" />
+      <location filename="../novelwriter/core/project.py" line="477" />
       <source>Project backed up to '{0}'</source>
       <translation>Резервное копирование проекта в '{0}'</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="495" />
       <location filename="../novelwriter/core/project.py" line="491" />
+      <location filename="../novelwriter/core/project.py" line="487" />
       <source>New</source>
       <translation>Новый</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="488" />
       <source>Note</source>
       <translation>Заметка</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="489" />
       <source>Draft</source>
       <translation>Черновик</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="490" />
       <source>Finished</source>
       <translation>Завершено</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="496" />
+      <location filename="../novelwriter/core/project.py" line="492" />
       <source>Minor</source>
       <translation>Незначительный</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="497" />
+      <location filename="../novelwriter/core/project.py" line="493" />
       <source>Major</source>
       <translation>Значительный</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="498" />
+      <location filename="../novelwriter/core/project.py" line="494" />
       <source>Main</source>
       <translation>Главный</translation>
     </message>
@@ -4019,109 +4119,6 @@
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="369" />
-      <source>Square</source>
-      <translation type="unfinished">Квадрат</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="370" />
-      <source>Triangle</source>
-      <translation type="unfinished">Треугольник</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="371" />
-      <source>Nabla</source>
-      <translation type="unfinished">Набла</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="372" />
-      <source>Diamond</source>
-      <translation type="unfinished">Ромб</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Pentagon</source>
-      <translation type="unfinished">Пятиугольник</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Hexagon</source>
-      <translation type="unfinished">Шестиугольник</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Star</source>
-      <translation type="unfinished">Звезда</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Pacman</source>
-      <translation type="unfinished">Пакман</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>1/4 Circle</source>
-      <translation type="unfinished">1/4 круга</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Half Circle</source>
-      <translation type="unfinished">Половина круга</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="381" />
-      <source>3/4 Circle</source>
-      <translation type="unfinished">3/4 круга</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="382" />
-      <source>Full Circle</source>
-      <translation type="unfinished">Круг</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>1 Bar</source>
-      <translation type="unfinished">1 Колонка</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>2 Bars</source>
-      <translation type="unfinished">2 Колонки</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="387" />
-      <source>3 Bars</source>
-      <translation type="unfinished">3 Колонки</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="388" />
-      <source>4 Bars</source>
-      <translation type="unfinished">4 Колонки</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>1 Block</source>
-      <translation type="unfinished">1 Блок</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>2 Blocks</source>
-      <translation type="unfinished">2 Блока</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="393" />
-      <source>3 Blocks</source>
-      <translation type="unfinished">3 Блока</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="394" />
-      <source>4 Blocks</source>
-      <translation type="unfinished">4 Блока</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
       <location filename="../novelwriter/shared.py" line="278" />
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="332" />
+      <location filename="../novelwriter/constants.py" line="338" />
       <source>Characters</source>
       <translation type="unfinished">Персонажи</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="339" />
       <source>Characters in Text</source>
       <translation type="unfinished">Символов в тексте</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="334" />
+      <location filename="../novelwriter/constants.py" line="340" />
       <source>Characters in Headings</source>
       <translation type="unfinished">Символов в заголовках</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="335" />
+      <location filename="../novelwriter/constants.py" line="341" />
       <source>Paragraphs</source>
       <translation type="unfinished">Абзацев</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="342" />
       <source>Headings</source>
       <translation type="unfinished">Заголовки</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="343" />
       <source>Characters, No Spaces</source>
       <translation type="unfinished">Символов, без пробелов</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="344" />
       <source>Characters in Text, No Spaces</source>
       <translation type="unfinished">Символов в тексте, без пробелов</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="345" />
       <source>Characters in Headings, No Spaces</source>
       <translation type="unfinished">Символов в заголовках, без пробелов</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="346" />
       <source>Words</source>
       <translation type="unfinished">Слов</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="347" />
       <source>Words in Text</source>
       <translation type="unfinished">Слов в тексте</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="348" />
       <source>Words in Headings</source>
       <translation type="unfinished">Слов в заголовках</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134" />
       <source>Empty Trash</source>
       <translation>Очистить корзину</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155" />
       <source>Rename</source>
       <translation>Переименовать</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170" />
       <source>Duplicate</source>
       <translation>Дублировать</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190" />
       <source>Open Document</source>
       <translation>Открыть документ</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195" />
       <source>View Document</source>
       <translation>Просмотр документа</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204" />
       <source>Create New ...</source>
       <translation>Создать новую...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216" />
       <source>Rename to Heading</source>
       <translation>Переименовать в заголовке</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225" />
       <source>Set Active to ...</source>
       <translation>Установить активность в ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231" />
       <source>Toggle Active</source>
       <translation>Переключить активность</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238" />
       <source>Set Status to ...</source>
       <translation>Установить статус на ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268" />
+      <location filename="../novelwriter/gui/projtree.py" line="1250" />
       <source>Manage Labels ...</source>
       <translation>Управление метками...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256" />
       <source>Set Importance to ...</source>
       <translation>Установить важность на...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277" />
       <source>Transform ...</source>
       <translation>Преобразовать ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299" />
+      <location filename="../novelwriter/gui/projtree.py" line="1295" />
+      <location filename="../novelwriter/gui/projtree.py" line="1291" />
+      <location filename="../novelwriter/gui/projtree.py" line="1287" />
       <source>Convert to {0}</source>
       <translation>Преобразовать в {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303" />
       <source>Merge Child Items into Self</source>
       <translation>Объединить дочерние элементы в Себя</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305" />
       <source>Merge Child Items into New</source>
       <translation>Объединить дочерние элементы в Новые</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309" />
       <source>Merge Documents in Folder</source>
       <translation>Объединение документов в Папку</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313" />
       <source>Split Document by Headings</source>
       <translation>Разделить документ по заголовкам</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320" />
       <source>Expand All</source>
       <translation>Развернуть всё</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322" />
       <source>Collapse All</source>
       <translation>Свернуть все</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332" />
       <source>Delete Permanently</source>
       <translation>Удалить безвозвратно</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334" />
       <source>Move to Trash</source>
       <translation>Переместить в корзину</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410" />
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>Вы хотите конвертировать папку в {0}? Это действие нельзя отменить.</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048" />
       <source>From Template</source>
       <translation>Из шаблона</translation>
     </message>

--- a/i18n/nw_zh_CN.ts
+++ b/i18n/nw_zh_CN.ts
@@ -355,441 +355,541 @@
   <context>
     <name>Constant</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="310" />
-      <location filename="../novelwriter/constants.py" line="115" />
+      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="117" />
       <source>Title</source>
       <translation>标题</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="116" />
+      <location filename="../novelwriter/constants.py" line="118" />
       <source>Heading 1 (Partition)</source>
       <translation>标题 1 (分区)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="117" />
+      <location filename="../novelwriter/constants.py" line="119" />
       <source>Heading 2 (Chapter)</source>
       <translation>标题2(章节)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="118" />
+      <location filename="../novelwriter/constants.py" line="120" />
       <source>Heading 3 (Scene)</source>
       <translation>标题 3 (场景)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="119" />
+      <location filename="../novelwriter/constants.py" line="121" />
       <source>Heading 4 (Section)</source>
       <translation>标题 4 (小节)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="120" />
+      <location filename="../novelwriter/constants.py" line="122" />
       <source>Text Paragraph</source>
       <translation>文本段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="121" />
+      <location filename="../novelwriter/constants.py" line="123" />
       <source>Scene Separator</source>
       <translation>场景分隔符</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="267" />
-      <location filename="../novelwriter/constants.py" line="262" />
-      <location filename="../novelwriter/constants.py" line="234" />
+      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="240" />
       <source>None</source>
       <translation>无</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="235" />
+      <location filename="../novelwriter/constants.py" line="241" />
       <source>Novel</source>
       <translation>小说</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="286" />
-      <location filename="../novelwriter/constants.py" line="236" />
+      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="242" />
       <source>Plot</source>
       <translation>情节</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="285" />
-      <location filename="../novelwriter/constants.py" line="237" />
+      <location filename="../novelwriter/constants.py" line="291" />
+      <location filename="../novelwriter/constants.py" line="243" />
       <source>Characters</source>
       <translation>角色</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="288" />
-      <location filename="../novelwriter/constants.py" line="238" />
+      <location filename="../novelwriter/constants.py" line="294" />
+      <location filename="../novelwriter/constants.py" line="244" />
       <source>Locations</source>
       <translation>位置</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="287" />
-      <location filename="../novelwriter/constants.py" line="239" />
+      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="245" />
       <source>Timeline</source>
       <translation>时间线</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="289" />
-      <location filename="../novelwriter/constants.py" line="240" />
+      <location filename="../novelwriter/constants.py" line="295" />
+      <location filename="../novelwriter/constants.py" line="246" />
       <source>Objects</source>
       <translation>物品</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="290" />
-      <location filename="../novelwriter/constants.py" line="241" />
+      <location filename="../novelwriter/constants.py" line="296" />
+      <location filename="../novelwriter/constants.py" line="247" />
       <source>Entities</source>
       <translation>条目</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="419" />
-      <location filename="../novelwriter/constants.py" line="291" />
-      <location filename="../novelwriter/constants.py" line="242" />
+      <location filename="../novelwriter/constants.py" line="425" />
+      <location filename="../novelwriter/constants.py" line="297" />
+      <location filename="../novelwriter/constants.py" line="248" />
       <source>Custom</source>
       <translation>自定义</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="243" />
+      <location filename="../novelwriter/constants.py" line="249" />
       <source>Archive</source>
       <translation>归档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="244" />
+      <location filename="../novelwriter/constants.py" line="250" />
       <source>Templates</source>
       <translation>模板</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="245" />
+      <location filename="../novelwriter/constants.py" line="251" />
       <source>Trash</source>
       <translation>回收站</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="270" />
-      <location filename="../novelwriter/constants.py" line="263" />
+      <location filename="../novelwriter/constants.py" line="276" />
+      <location filename="../novelwriter/constants.py" line="269" />
       <source>Novel Document</source>
       <translation>小说文档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="275" />
-      <location filename="../novelwriter/constants.py" line="264" />
+      <location filename="../novelwriter/constants.py" line="281" />
+      <location filename="../novelwriter/constants.py" line="270" />
       <source>Project Note</source>
       <translation>项目笔记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="268" />
+      <location filename="../novelwriter/constants.py" line="274" />
       <source>Root Folder</source>
       <translation>根文件夹</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="269" />
+      <location filename="../novelwriter/constants.py" line="275" />
       <source>Folder</source>
       <translation>文件夹</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="271" />
+      <location filename="../novelwriter/constants.py" line="277" />
       <source>Novel Title Page</source>
       <translation>小说标题页</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="272" />
+      <location filename="../novelwriter/constants.py" line="278" />
       <source>Novel Chapter</source>
       <translation>小说章节</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="273" />
+      <location filename="../novelwriter/constants.py" line="279" />
       <source>Novel Scene</source>
       <translation>小说场景</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="274" />
+      <location filename="../novelwriter/constants.py" line="280" />
       <source>Novel Section</source>
       <translation>小说章节</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="278" />
+      <location filename="../novelwriter/constants.py" line="284" />
       <source>Active</source>
       <translation>活跃</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="279" />
+      <location filename="../novelwriter/constants.py" line="285" />
       <source>Inactive</source>
       <translation>非活跃</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="282" />
+      <location filename="../novelwriter/constants.py" line="288" />
       <source>Tag</source>
       <translation>标签</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="283" />
+      <location filename="../novelwriter/constants.py" line="289" />
       <source>Point of View</source>
       <translation>视角</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="319" />
-      <location filename="../novelwriter/constants.py" line="284" />
+      <location filename="../novelwriter/constants.py" line="325" />
+      <location filename="../novelwriter/constants.py" line="290" />
       <source>Focus</source>
       <translation>聚焦</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="292" />
+      <location filename="../novelwriter/constants.py" line="298" />
       <source>Story</source>
       <translation>故事</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="293" />
+      <location filename="../novelwriter/constants.py" line="299" />
       <source>Mentions</source>
       <translation>提及</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="311" />
+      <location filename="../novelwriter/constants.py" line="317" />
       <source>Level</source>
       <translation>登记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="312" />
+      <location filename="../novelwriter/constants.py" line="318" />
       <source>Document</source>
       <translation>文档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="313" />
+      <location filename="../novelwriter/constants.py" line="319" />
       <source>Line</source>
       <translation>行</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="314" />
+      <location filename="../novelwriter/constants.py" line="320" />
       <source>Status</source>
       <translation>状态</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="315" />
+      <location filename="../novelwriter/constants.py" line="321" />
       <source>Chars</source>
       <translation>字母</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="316" />
+      <location filename="../novelwriter/constants.py" line="322" />
       <source>Words</source>
       <translation>单词</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="317" />
+      <location filename="../novelwriter/constants.py" line="323" />
       <source>Pars</source>
       <translation>段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="318" />
+      <location filename="../novelwriter/constants.py" line="324" />
       <source>POV</source>
       <translation>视角</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="329" />
+      <location filename="../novelwriter/constants.py" line="335" />
       <source>Synopsis</source>
       <translation>概要</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="345" />
+      <location filename="../novelwriter/constants.py" line="351" />
       <source>Open Document (.odt)</source>
       <translation>打开文档 (.odt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="346" />
+      <location filename="../novelwriter/constants.py" line="352" />
       <source>Flat Open Document (.fodt)</source>
       <translation>Flat Open Document (.fodt)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="347" />
+      <location filename="../novelwriter/constants.py" line="353" />
       <source>Microsoft Word Document (.docx)</source>
       <translation>Microsoft Word 文档 (.docx)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="348" />
+      <location filename="../novelwriter/constants.py" line="354" />
       <source>HTML 5 (.html)</source>
       <translation>HTML 5 (.html)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="349" />
+      <location filename="../novelwriter/constants.py" line="355" />
       <source>novelWriter Markup (.txt)</source>
       <translation>novelWriter Markdown (.nwd)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="350" />
+      <location filename="../novelwriter/constants.py" line="356" />
       <source>Standard Markdown (.md)</source>
       <translation>Standard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="351" />
+      <location filename="../novelwriter/constants.py" line="357" />
       <source>Extended Markdown (.md)</source>
       <translation>Standard Markdown (.md)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="352" />
+      <location filename="../novelwriter/constants.py" line="358" />
       <source>Portable Document Format (.pdf)</source>
       <translation>便携文档格式 (.pdf)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="353" />
+      <location filename="../novelwriter/constants.py" line="359" />
       <source>JSON + HTML 5 (.json)</source>
       <translation>JSON + HTML 5 (.json)</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="354" />
+      <location filename="../novelwriter/constants.py" line="360" />
       <source>JSON + novelWriter Markup (.json)</source>
       <translation>JSON + NovelWriter Markdown (.json)</translation>
     </message>
     <message>
+      <location filename="../novelwriter/constants.py" line="375" />
+      <source>Square</source>
+      <translation type="unfinished">正方形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="376" />
+      <source>Triangle</source>
+      <translation type="unfinished">三角形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="377" />
+      <source>Nabla</source>
+      <translation type="unfinished">倒三角形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="378" />
+      <source>Diamond</source>
+      <translation type="unfinished">菱形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="379" />
+      <source>Pentagon</source>
+      <translation type="unfinished">五边形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="380" />
+      <source>Hexagon</source>
+      <translation type="unfinished">六边形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="381" />
+      <source>Star</source>
+      <translation type="unfinished">星形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="382" />
+      <source>Pacman</source>
+      <translation type="unfinished">吃豆人形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="385" />
+      <source>1/4 Circle</source>
+      <translation type="unfinished">1/4 圆</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="386" />
+      <source>Half Circle</source>
+      <translation type="unfinished">半圆</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="387" />
+      <source>3/4 Circle</source>
+      <translation type="unfinished">3/4 圈</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="388" />
+      <source>Full Circle</source>
+      <translation type="unfinished">圆形</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="391" />
+      <source>1 Bar</source>
+      <translation type="unfinished">1 条</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="392" />
+      <source>2 Bars</source>
+      <translation type="unfinished">2 条</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="393" />
+      <source>3 Bars</source>
+      <translation type="unfinished">3 条</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="394" />
+      <source>4 Bars</source>
+      <translation type="unfinished">4 条</translation>
+    </message>
+    <message>
       <location filename="../novelwriter/constants.py" line="397" />
+      <source>1 Block</source>
+      <translation type="unfinished">1 块</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="398" />
+      <source>2 Blocks</source>
+      <translation type="unfinished">2 块</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="399" />
+      <source>3 Blocks</source>
+      <translation type="unfinished">3 块</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="400" />
+      <source>4 Blocks</source>
+      <translation type="unfinished">4 块</translation>
+    </message>
+    <message>
+      <location filename="../novelwriter/constants.py" line="403" />
       <source>Text files</source>
       <translation>文本文件</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="398" />
+      <location filename="../novelwriter/constants.py" line="404" />
       <source>Markdown files</source>
       <translation>Markdown 文件</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="399" />
+      <location filename="../novelwriter/constants.py" line="405" />
       <source>novelWriter files</source>
       <translation>novelWriter 文件</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="400" />
+      <location filename="../novelwriter/constants.py" line="406" />
       <source>CSV files</source>
       <translation>CSV 文件</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="401" />
+      <location filename="../novelwriter/constants.py" line="407" />
       <source>All files</source>
       <translation>所有文件</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="404" />
+      <location filename="../novelwriter/constants.py" line="410" />
       <source>Millimetres</source>
       <translation>毫米</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="405" />
+      <location filename="../novelwriter/constants.py" line="411" />
       <source>Centimetres</source>
       <translation>厘米</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="406" />
+      <location filename="../novelwriter/constants.py" line="412" />
       <source>Inches</source>
       <translation>英寸</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="414" />
+      <location filename="../novelwriter/constants.py" line="420" />
       <source>A4</source>
       <translation>A4</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="415" />
+      <location filename="../novelwriter/constants.py" line="421" />
       <source>A5</source>
       <translation>A5</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="416" />
+      <location filename="../novelwriter/constants.py" line="422" />
       <source>A6</source>
       <translation>A6</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="417" />
+      <location filename="../novelwriter/constants.py" line="423" />
       <source>US Legal</source>
       <translation>美国法律格式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="418" />
+      <location filename="../novelwriter/constants.py" line="424" />
       <source>US Letter</source>
       <translation>美国信件</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="461" />
+      <location filename="../novelwriter/constants.py" line="467" />
       <source>Straight single quotation mark</source>
       <translation>单引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="462" />
+      <location filename="../novelwriter/constants.py" line="468" />
       <source>Straight double quotation mark</source>
       <translation>双引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="464" />
+      <location filename="../novelwriter/constants.py" line="470" />
       <source>Left single quotation mark</source>
       <translation>左单引号标记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="465" />
+      <location filename="../novelwriter/constants.py" line="471" />
       <source>Right single quotation mark</source>
       <translation>右单引号标记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="466" />
+      <location filename="../novelwriter/constants.py" line="472" />
       <source>Single low-9 quotation mark</source>
       <translation>低单引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="467" />
+      <location filename="../novelwriter/constants.py" line="473" />
       <source>Single high-reversed-9 quotation mark</source>
       <translation>反转的高单引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="468" />
+      <location filename="../novelwriter/constants.py" line="474" />
       <source>Left double quotation mark</source>
       <translation>左双引号标记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="469" />
+      <location filename="../novelwriter/constants.py" line="475" />
       <source>Right double quotation mark</source>
       <translation>右双引号标记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="470" />
+      <location filename="../novelwriter/constants.py" line="476" />
       <source>Double low-9 quotation mark</source>
       <translation>低双引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="471" />
+      <location filename="../novelwriter/constants.py" line="477" />
       <source>Double high-reversed-9 quotation mark</source>
       <translation>反转的高双引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="472" />
+      <location filename="../novelwriter/constants.py" line="478" />
       <source>Double low-reversed-9 quotation mark</source>
       <translation>反转的低双引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="474" />
+      <location filename="../novelwriter/constants.py" line="480" />
       <source>Single left-pointing angle quotation mark</source>
       <translation>左单角引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="475" />
+      <location filename="../novelwriter/constants.py" line="481" />
       <source>Single right-pointing angle quotation mark</source>
       <translation>右单角引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="476" />
+      <location filename="../novelwriter/constants.py" line="482" />
       <source>Double left-pointing angle quotation mark</source>
       <translation>左双角引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="477" />
+      <location filename="../novelwriter/constants.py" line="483" />
       <source>Double right-pointing angle quotation mark</source>
       <translation>右双角引号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="479" />
+      <location filename="../novelwriter/constants.py" line="485" />
       <source>Left corner bracket</source>
       <translation>左角括号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="480" />
+      <location filename="../novelwriter/constants.py" line="486" />
       <source>Right corner bracket</source>
       <translation>右角括号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="481" />
+      <location filename="../novelwriter/constants.py" line="487" />
       <source>Left white corner bracket</source>
       <translation>白色左角括号</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="482" />
+      <location filename="../novelwriter/constants.py" line="488" />
       <source>Right white corner bracket</source>
       <translation>白色右角括号</translation>
     </message>
@@ -897,22 +997,22 @@
   <context>
     <name>GuiDocEditFooter</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3072" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3088" />
       <source>Line: {0} ({1})</source>
       <translation>行数: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3073" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3089" />
       <source>Words: {0} ({1})</source>
       <translation>单词树: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3074" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3090" />
       <source>Words: {0} selected</source>
       <translation>单词：{0} 已选</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="3086" />
+      <location filename="../novelwriter/gui/doceditor.py" line="3102" />
       <source>Status</source>
       <translation>状态</translation>
     </message>
@@ -920,27 +1020,27 @@
   <context>
     <name>GuiDocEditHeader</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2865" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2881" />
       <source>Toggle Tool Bar</source>
       <translation>切换工具栏</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2870" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2886" />
       <source>Outline</source>
       <translation>提纲</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2875" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2891" />
       <source>Search</source>
       <translation>搜索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2880" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2896" />
       <source>Toggle Focus Mode</source>
       <translation>切换聚焦模式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2885" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2901" />
       <source>Close</source>
       <translation>关闭</translation>
     </message>
@@ -948,62 +1048,62 @@
   <context>
     <name>GuiDocEditSearch</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2499" />
       <source>Search for</source>
       <translation>搜索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2487" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2503" />
       <source>Replace with</source>
       <translation>替换为</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2495" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2511" />
       <source>Search</source>
       <translation>搜索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2500" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2516" />
       <source>Case Sensitive</source>
       <translation>大小写敏感</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2506" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2522" />
       <source>Whole Words Only</source>
       <translation>匹配整个单词</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2512" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2528" />
       <source>RegEx Mode</source>
       <translation>正则表达式模式</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2518" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2534" />
       <source>Loop Search</source>
       <translation>循环搜索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2524" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
       <source>Search Next File</source>
       <translation>搜索下一个文件</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2532" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2548" />
       <source>Preserve Case</source>
       <translation>保留大小写</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2540" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2556" />
       <source>Close Search</source>
       <translation>关闭搜索</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2551" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2567" />
       <source>Find in current document</source>
       <translation>在当前文档中查找</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2555" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2571" />
       <source>Find and replace in current document</source>
       <translation>在当前文档中查找和替换</translation>
     </message>
@@ -1011,132 +1111,132 @@
   <context>
     <name>GuiDocEditor</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="436" />
+      <location filename="../novelwriter/gui/doceditor.py" line="443" />
       <source>Opened Document: {0}</source>
       <translation>已打开的文档: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="474" />
+      <location filename="../novelwriter/gui/doceditor.py" line="481" />
       <source>This document has been changed outside of novelWriter while it was open. Overwrite the file on disk?</source>
       <translation>当前文件已在 novelWriter 之外被修改，是否覆盖掉磁盘上的版本？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="483" />
+      <location filename="../novelwriter/gui/doceditor.py" line="490" />
       <source>Could not save document.</source>
       <translation>无法保存文档。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="508" />
+      <location filename="../novelwriter/gui/doceditor.py" line="515" />
       <source>Saved Document: {0}</source>
       <translation>已保存文档: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="677" />
+      <location filename="../novelwriter/gui/doceditor.py" line="684" />
       <source>Spell checking requires the package PyEnchant. It does not appear to be installed.</source>
       <translation>拼写检查需要软件包 PyEnchant。它似乎未安装。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="703" />
+      <location filename="../novelwriter/gui/doceditor.py" line="710" />
       <source>Spell check complete</source>
       <translation>完成拼写检查</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="823" />
+      <location filename="../novelwriter/gui/doceditor.py" line="830" />
       <source>Document Details</source>
       <translation>文档详情</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="825" />
+      <location filename="../novelwriter/gui/doceditor.py" line="832" />
       <source>Created: {0}</source>
       <translation>已创建{0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="826" />
+      <location filename="../novelwriter/gui/doceditor.py" line="833" />
       <source>Updated: {0}</source>
       <translation>已更新: {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="828" />
+      <location filename="../novelwriter/gui/doceditor.py" line="835" />
       <source>File Location: {0}</source>
       <translation>文件位置</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1149" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1156" />
       <source>Set as Document Name</source>
       <translation>设置为文档名称</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1155" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
       <source>Open URL</source>
       <translation>打开 URL</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1162" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1169" />
       <source>Follow Tag</source>
       <translation>跟随标签</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1166" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1173" />
       <source>Create Note for Tag</source>
       <translation>为标签创建笔记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1172" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1179" />
       <source>Cut</source>
       <translation>剪贴</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1174" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1181" />
       <source>Copy</source>
       <translation>复制</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1177" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
       <source>Paste</source>
       <translation>粘贴</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1182" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1189" />
       <source>Select All</source>
       <translation>全选</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1184" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1191" />
       <source>Select Word</source>
       <translation>选定单词</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1188" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1195" />
       <source>Select Paragraph</source>
       <translation>选定段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1204" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1211" />
       <source>Spelling Suggestion(s)</source>
       <translation>拼写建议</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1209" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1216" />
       <source>No Suggestions</source>
       <translation>无建议</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1213" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1220" />
       <source>Ignore Word</source>
       <translation>忽略单词</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1215" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1222" />
       <source>Add Word to Dictionary</source>
       <translation>向字典中添加单词</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1619" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1626" />
       <source>Please select some text before calling replace quotes.</source>
       <translation>在替换引号之前请选择文本。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="1974" />
+      <location filename="../novelwriter/gui/doceditor.py" line="1992" />
       <source>Do you want to create a new project note for the tag '{0}'?</source>
       <translation>您想要为标记为'{0}'创建一个新的项目说明吗？</translation>
     </message>
@@ -1220,52 +1320,52 @@
   <context>
     <name>GuiDocToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2346" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2362" />
       <source>Markdown Bold</source>
       <translation>Markdown加粗</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2352" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2368" />
       <source>Markdown Italic</source>
       <translation>Markdown斜体</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2358" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2374" />
       <source>Markdown Strikethrough</source>
       <translation>Markdown 删除线</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2364" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2380" />
       <source>Shortcode Bold</source>
       <translation>Shortcode 加粗</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2370" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2386" />
       <source>Shortcode Italic</source>
       <translation>Shortcode斜体</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2376" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2392" />
       <source>Shortcode Strikethrough</source>
       <translation>Shortcode删除线</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2382" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2398" />
       <source>Shortcode Underline</source>
       <translation>Shortcode下划线</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2388" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2404" />
       <source>Shortcode Highlight</source>
       <translation>短代码高亮</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2394" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2410" />
       <source>Shortcode Superscript</source>
       <translation>Shortcode上标</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/doceditor.py" line="2400" />
+      <location filename="../novelwriter/gui/doceditor.py" line="2416" />
       <source>Shortcode Subscript</source>
       <translation>Shortcode下标</translation>
     </message>
@@ -2196,38 +2296,38 @@
   <context>
     <name>GuiMainStatus</name>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="213" />
-      <location filename="../novelwriter/gui/statusbar.py" line="64" />
+      <location filename="../novelwriter/gui/statusbar.py" line="212" />
+      <location filename="../novelwriter/gui/statusbar.py" line="63" />
       <source>None</source>
       <translation>无</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="72" />
+      <location filename="../novelwriter/gui/statusbar.py" line="71" />
       <source>Editor</source>
       <translation>编辑器</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="80" />
+      <location filename="../novelwriter/gui/statusbar.py" line="79" />
       <source>Project</source>
       <translation>项目</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="100" />
+      <location filename="../novelwriter/gui/statusbar.py" line="99" />
       <source>Session Time</source>
       <translation>会话时间</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="179" />
+      <location filename="../novelwriter/gui/statusbar.py" line="178" />
       <source>Words: {0} ({1})</source>
       <translation>单词: {0} ({1})</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="181" />
+      <location filename="../novelwriter/gui/statusbar.py" line="180" />
       <source>Project word count (session change)</source>
       <translation>项目单词个数 （session chang）</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/statusbar.py" line="183" />
+      <location filename="../novelwriter/gui/statusbar.py" line="182" />
       <source>Novel word count (session change)</source>
       <translation>单词计数 (会话更改)</translation>
     </message>
@@ -3204,47 +3304,47 @@
   <context>
     <name>GuiProjectToolBar</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="252" />
+      <location filename="../novelwriter/gui/projtree.py" line="253" />
       <source>Project Content</source>
       <translation>项目内容</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="261" />
+      <location filename="../novelwriter/gui/projtree.py" line="262" />
       <source>Quick Links</source>
       <translation>快捷链接</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="267" />
+      <location filename="../novelwriter/gui/projtree.py" line="268" />
       <source>Move Up</source>
       <translation>上移</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="271" />
+      <location filename="../novelwriter/gui/projtree.py" line="272" />
       <source>Move Down</source>
       <translation>下移</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="311" />
+      <location filename="../novelwriter/gui/projtree.py" line="312" />
       <source>Add Item</source>
       <translation>添加条目</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="318" />
+      <location filename="../novelwriter/gui/projtree.py" line="319" />
       <source>Expand All</source>
       <translation>全部展开</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="321" />
+      <location filename="../novelwriter/gui/projtree.py" line="322" />
       <source>Collapse All</source>
       <translation>全部折叠</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="324" />
+      <location filename="../novelwriter/gui/projtree.py" line="325" />
       <source>Empty Trash</source>
       <translation>清空回收站</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="328" />
+      <location filename="../novelwriter/gui/projtree.py" line="329" />
       <source>More Options</source>
       <translation>更多选项</translation>
     </message>
@@ -3252,93 +3352,93 @@
   <context>
     <name>GuiProjectTree</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="625" />
+      <location filename="../novelwriter/gui/projtree.py" line="626" />
       <source>Did not find anywhere to add the file or folder!</source>
       <translation>没有找到任何地方添加文件或文件夹！</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="629" />
+      <location filename="../novelwriter/gui/projtree.py" line="630" />
       <source>Cannot add new files or folders to the Trash folder.</source>
       <translation>无法将新文件或文件夹添加到废纸篓文件夹。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="643" />
+      <location filename="../novelwriter/gui/projtree.py" line="644" />
       <source>New Note</source>
       <translation>新笔记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="646" />
+      <location filename="../novelwriter/gui/projtree.py" line="647" />
       <source>New Chapter</source>
       <translation>新章节</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="649" />
+      <location filename="../novelwriter/gui/projtree.py" line="650" />
       <source>New Scene</source>
       <translation>新场景</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="652" />
+      <location filename="../novelwriter/gui/projtree.py" line="653" />
       <source>New Document</source>
       <translation>新文档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="655" />
+      <location filename="../novelwriter/gui/projtree.py" line="656" />
       <source>New Folder</source>
       <translation>新文件夹</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="705" />
+      <location filename="../novelwriter/gui/projtree.py" line="706" />
       <source>No documents selected for merging.</source>
       <translation>未选择要合并的文档。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="713" />
+      <location filename="../novelwriter/gui/projtree.py" line="714" />
       <source>Merged</source>
       <translation>已合并</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="771" />
-      <location filename="../novelwriter/gui/projtree.py" line="727" />
+      <location filename="../novelwriter/gui/projtree.py" line="772" />
+      <location filename="../novelwriter/gui/projtree.py" line="728" />
       <source>Could not write document content.</source>
       <translation>无法写入文档内容。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="786" />
+      <location filename="../novelwriter/gui/projtree.py" line="787" />
       <source>Do you want to duplicate this document?</source>
       <translation>您想要复制此文档吗？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="788" />
+      <location filename="../novelwriter/gui/projtree.py" line="789" />
       <source>Do you want to duplicate this item and all child items?</source>
       <translation>您想要复制此项目和所有子项目吗？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="793" />
+      <location filename="../novelwriter/gui/projtree.py" line="794" />
       <source>Could not duplicate all items.</source>
       <translation>无法复制所有项目。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="909" />
+      <location filename="../novelwriter/gui/projtree.py" line="910" />
       <source>Root folders can only be deleted when they are empty.</source>
       <translation>只有当根文件夹为空时才能删除。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="913" />
+      <location filename="../novelwriter/gui/projtree.py" line="914" />
       <source>Permanently delete selected item(s)?</source>
       <translation>永久删除所选项目？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="923" />
+      <location filename="../novelwriter/gui/projtree.py" line="924" />
       <source>Move selected item(s) to Trash?</source>
       <translation>将所选项目移动到回收站？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="938" />
+      <location filename="../novelwriter/gui/projtree.py" line="939" />
       <source>The Trash folder is already empty.</source>
       <translation>回收站文件夹已清空。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="941" />
+      <location filename="../novelwriter/gui/projtree.py" line="942" />
       <source>Permanently delete {0} file(s) from Trash?</source>
       <translation>从回收站中永久删除 {0} 文件？</translation>
     </message>
@@ -3637,7 +3737,7 @@
       <translation>不是已知的项目文件格式。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="475" />
+      <location filename="../novelwriter/core/project.py" line="471" />
       <location filename="../novelwriter/core/project.py" line="288" />
       <location filename="../novelwriter/core/project.py" line="283" />
       <location filename="../novelwriter/core/project.py" line="278" />
@@ -3685,98 +3785,98 @@
       <translation>此项目由较新版本的 novelWriter 版本 {0} 保存。 这是版本 {1}。 如果继续打开项目，可能有些属性和设置不会保留，但整体项目应该没问题。 继续打开项目？</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="362" />
+      <location filename="../novelwriter/core/project.py" line="360" />
       <source>Recovered</source>
       <translation>已复原</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="364" />
+      <location filename="../novelwriter/core/project.py" line="362" />
       <source>Found {0} orphaned file(s) in the project. {1} file(s) were recovered.</source>
       <translation>在项目中找到了 {0} 个无主文件(s) 。 {1} 文件已被恢复。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="380" />
+      <location filename="../novelwriter/core/project.py" line="378" />
       <source>Opened Project: {0}</source>
       <translation>已打开的项目：{0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="391" />
+      <location filename="../novelwriter/core/project.py" line="389" />
       <source>There is no project open.</source>
       <translation>没有打开的项目。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="414" />
+      <location filename="../novelwriter/core/project.py" line="412" />
       <source>Failed to save project.</source>
       <translation>保存项目失败。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="428" />
+      <location filename="../novelwriter/core/project.py" line="424" />
       <source>Saved Project: {0}</source>
       <translation>已保存项目： {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="450" />
+      <location filename="../novelwriter/core/project.py" line="446" />
       <source>Backing up project ...</source>
       <translation>项目备份中……</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="453" />
+      <location filename="../novelwriter/core/project.py" line="449" />
       <source>Cannot backup project because no project name is set. Please set a Project Name in Project Settings.</source>
       <translation>由于未设置项目名，无法备份项目。 请在项目设置中指定项目名。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="465" />
+      <location filename="../novelwriter/core/project.py" line="461" />
       <source>Could not create backup folder.</source>
       <translation>无法创建备份文件夹。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="474" />
+      <location filename="../novelwriter/core/project.py" line="470" />
       <source>Created a backup of your project of size {0}B.</source>
       <translation>创建了大小为 {0}B 的项目备份。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="478" />
+      <location filename="../novelwriter/core/project.py" line="474" />
       <source>Could not write backup archive.</source>
       <translation>无法写入备份存档。</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="481" />
+      <location filename="../novelwriter/core/project.py" line="477" />
       <source>Project backed up to '{0}'</source>
       <translation>项目备份到{0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="495" />
       <location filename="../novelwriter/core/project.py" line="491" />
+      <location filename="../novelwriter/core/project.py" line="487" />
       <source>New</source>
       <translation>新建</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="492" />
+      <location filename="../novelwriter/core/project.py" line="488" />
       <source>Note</source>
       <translation>笔记</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="493" />
+      <location filename="../novelwriter/core/project.py" line="489" />
       <source>Draft</source>
       <translation>草稿</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="494" />
+      <location filename="../novelwriter/core/project.py" line="490" />
       <source>Finished</source>
       <translation>已完成</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="496" />
+      <location filename="../novelwriter/core/project.py" line="492" />
       <source>Minor</source>
       <translation>次要</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="497" />
+      <location filename="../novelwriter/core/project.py" line="493" />
       <source>Major</source>
       <translation>主要</translation>
     </message>
     <message>
-      <location filename="../novelwriter/core/project.py" line="498" />
+      <location filename="../novelwriter/core/project.py" line="494" />
       <source>Main</source>
       <translation>主要的</translation>
     </message>
@@ -4019,109 +4119,6 @@
     </message>
   </context>
   <context>
-    <name>Shape</name>
-    <message>
-      <location filename="../novelwriter/constants.py" line="369" />
-      <source>Square</source>
-      <translation>正方形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="370" />
-      <source>Triangle</source>
-      <translation>三角形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="371" />
-      <source>Nabla</source>
-      <translation>倒三角形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="372" />
-      <source>Diamond</source>
-      <translation>菱形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="373" />
-      <source>Pentagon</source>
-      <translation>五边形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="374" />
-      <source>Hexagon</source>
-      <translation>六边形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="375" />
-      <source>Star</source>
-      <translation>星形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="376" />
-      <source>Pacman</source>
-      <translation>吃豆人形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="379" />
-      <source>1/4 Circle</source>
-      <translation>1/4 圆</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="380" />
-      <source>Half Circle</source>
-      <translation>半圆</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="381" />
-      <source>3/4 Circle</source>
-      <translation>3/4 圈</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="382" />
-      <source>Full Circle</source>
-      <translation>圆形</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="385" />
-      <source>1 Bar</source>
-      <translation>1 条</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="386" />
-      <source>2 Bars</source>
-      <translation>2 条</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="387" />
-      <source>3 Bars</source>
-      <translation>3 条</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="388" />
-      <source>4 Bars</source>
-      <translation>4 条</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="391" />
-      <source>1 Block</source>
-      <translation>1 块</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="392" />
-      <source>2 Blocks</source>
-      <translation>2 块</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="393" />
-      <source>3 Blocks</source>
-      <translation>3 块</translation>
-    </message>
-    <message>
-      <location filename="../novelwriter/constants.py" line="394" />
-      <source>4 Blocks</source>
-      <translation>4 块</translation>
-    </message>
-  </context>
-  <context>
     <name>SharedData</name>
     <message>
       <location filename="../novelwriter/shared.py" line="278" />
@@ -4147,57 +4144,57 @@
   <context>
     <name>Stats</name>
     <message>
-      <location filename="../novelwriter/constants.py" line="332" />
+      <location filename="../novelwriter/constants.py" line="338" />
       <source>Characters</source>
       <translation>字符数</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="333" />
+      <location filename="../novelwriter/constants.py" line="339" />
       <source>Characters in Text</source>
       <translation>文本中的字符</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="334" />
+      <location filename="../novelwriter/constants.py" line="340" />
       <source>Characters in Headings</source>
       <translation>标题中的字符</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="335" />
+      <location filename="../novelwriter/constants.py" line="341" />
       <source>Paragraphs</source>
       <translation>段落</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="336" />
+      <location filename="../novelwriter/constants.py" line="342" />
       <source>Headings</source>
       <translation>标题</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="337" />
+      <location filename="../novelwriter/constants.py" line="343" />
       <source>Characters, No Spaces</source>
       <translation>字符，无空格</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="338" />
+      <location filename="../novelwriter/constants.py" line="344" />
       <source>Characters in Text, No Spaces</source>
       <translation>文本中的字符，无空格</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="339" />
+      <location filename="../novelwriter/constants.py" line="345" />
       <source>Characters in Headings, No Spaces</source>
       <translation>标题中的字符，无空格</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="340" />
+      <location filename="../novelwriter/constants.py" line="346" />
       <source>Words</source>
       <translation>单词</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="341" />
+      <location filename="../novelwriter/constants.py" line="347" />
       <source>Words in Text</source>
       <translation>文本中的单词</translation>
     </message>
     <message>
-      <location filename="../novelwriter/constants.py" line="342" />
+      <location filename="../novelwriter/constants.py" line="348" />
       <source>Words in Headings</source>
       <translation>标题中的单词</translation>
     </message>
@@ -4941,121 +4938,121 @@
   <context>
     <name>_TreeContextMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1133" />
+      <location filename="../novelwriter/gui/projtree.py" line="1134" />
       <source>Empty Trash</source>
       <translation>清空回收站</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1154" />
+      <location filename="../novelwriter/gui/projtree.py" line="1155" />
       <source>Rename</source>
       <translation>重命名</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1169" />
+      <location filename="../novelwriter/gui/projtree.py" line="1170" />
       <source>Duplicate</source>
       <translation>重复</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1189" />
+      <location filename="../novelwriter/gui/projtree.py" line="1190" />
       <source>Open Document</source>
       <translation>打开文档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1194" />
+      <location filename="../novelwriter/gui/projtree.py" line="1195" />
       <source>View Document</source>
       <translation>查看文档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1203" />
+      <location filename="../novelwriter/gui/projtree.py" line="1204" />
       <source>Create New ...</source>
       <translation>创建新的...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1215" />
+      <location filename="../novelwriter/gui/projtree.py" line="1216" />
       <source>Rename to Heading</source>
       <translation>重命名为标题</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1224" />
+      <location filename="../novelwriter/gui/projtree.py" line="1225" />
       <source>Set Active to ...</source>
       <translation>设置活跃性为...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1230" />
+      <location filename="../novelwriter/gui/projtree.py" line="1231" />
       <source>Toggle Active</source>
       <translation>切换活动状态</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1237" />
+      <location filename="../novelwriter/gui/projtree.py" line="1238" />
       <source>Set Status to ...</source>
       <translation>设置状态为...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1267" />
-      <location filename="../novelwriter/gui/projtree.py" line="1249" />
+      <location filename="../novelwriter/gui/projtree.py" line="1268" />
+      <location filename="../novelwriter/gui/projtree.py" line="1250" />
       <source>Manage Labels ...</source>
       <translation>管理标签...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1255" />
+      <location filename="../novelwriter/gui/projtree.py" line="1256" />
       <source>Set Importance to ...</source>
       <translation>设置重要性为...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1276" />
+      <location filename="../novelwriter/gui/projtree.py" line="1277" />
       <source>Transform ...</source>
       <translation>转换 ...</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1298" />
-      <location filename="../novelwriter/gui/projtree.py" line="1294" />
-      <location filename="../novelwriter/gui/projtree.py" line="1290" />
-      <location filename="../novelwriter/gui/projtree.py" line="1286" />
+      <location filename="../novelwriter/gui/projtree.py" line="1299" />
+      <location filename="../novelwriter/gui/projtree.py" line="1295" />
+      <location filename="../novelwriter/gui/projtree.py" line="1291" />
+      <location filename="../novelwriter/gui/projtree.py" line="1287" />
       <source>Convert to {0}</source>
       <translation>转换为 {0}</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1302" />
+      <location filename="../novelwriter/gui/projtree.py" line="1303" />
       <source>Merge Child Items into Self</source>
       <translation>将子项合并到该项</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1304" />
+      <location filename="../novelwriter/gui/projtree.py" line="1305" />
       <source>Merge Child Items into New</source>
       <translation>将子项合并为新项</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1308" />
+      <location filename="../novelwriter/gui/projtree.py" line="1309" />
       <source>Merge Documents in Folder</source>
       <translation>合并文件夹中的文档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1312" />
+      <location filename="../novelwriter/gui/projtree.py" line="1313" />
       <source>Split Document by Headings</source>
       <translation>按标题拆分文档</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1319" />
+      <location filename="../novelwriter/gui/projtree.py" line="1320" />
       <source>Expand All</source>
       <translation>全部展开</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1321" />
+      <location filename="../novelwriter/gui/projtree.py" line="1322" />
       <source>Collapse All</source>
       <translation>全部折叠</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1331" />
+      <location filename="../novelwriter/gui/projtree.py" line="1332" />
       <source>Delete Permanently</source>
       <translation>永久删除</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1333" />
+      <location filename="../novelwriter/gui/projtree.py" line="1334" />
       <source>Move to Trash</source>
       <translation>移动到回收站</translation>
     </message>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1409" />
+      <location filename="../novelwriter/gui/projtree.py" line="1410" />
       <source>Do you want to convert the folder to a {0}? This action cannot be reversed.</source>
       <translation>您想要将文件夹转换为 {0} 吗？此操作不能被撤销。</translation>
     </message>
@@ -5063,7 +5060,7 @@
   <context>
     <name>_UpdatableMenu</name>
     <message>
-      <location filename="../novelwriter/gui/projtree.py" line="1047" />
+      <location filename="../novelwriter/gui/projtree.py" line="1048" />
       <source>From Template</source>
       <translation>从模板</translation>
     </message>

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -32,7 +32,7 @@ from novelwriter.enum import (
 )
 
 
-def trConst(text: str, context: Literal["Constant", "Stats", "Shape"] = "Constant") -> str:
+def trConst(text: str, context: Literal["Constant", "Stats"] = "Constant") -> str:
     """Wrapper function for locally translating constants."""
     return QCoreApplication.translate(context, text)
 
@@ -372,32 +372,32 @@ class nwLabels:
         nwBuildFmt.J_NWD:  ".json",
     }
     SHAPES_PLAIN = {
-        nwStatusShape.SQUARE:   QT_TRANSLATE_NOOP("Shape", "Square"),
-        nwStatusShape.TRIANGLE: QT_TRANSLATE_NOOP("Shape", "Triangle"),
-        nwStatusShape.NABLA:    QT_TRANSLATE_NOOP("Shape", "Nabla"),
-        nwStatusShape.DIAMOND:  QT_TRANSLATE_NOOP("Shape", "Diamond"),
-        nwStatusShape.PENTAGON: QT_TRANSLATE_NOOP("Shape", "Pentagon"),
-        nwStatusShape.HEXAGON:  QT_TRANSLATE_NOOP("Shape", "Hexagon"),
-        nwStatusShape.STAR:     QT_TRANSLATE_NOOP("Shape", "Star"),
-        nwStatusShape.PACMAN:   QT_TRANSLATE_NOOP("Shape", "Pacman"),
+        nwStatusShape.SQUARE:   QT_TRANSLATE_NOOP("Constant", "Square"),
+        nwStatusShape.TRIANGLE: QT_TRANSLATE_NOOP("Constant", "Triangle"),
+        nwStatusShape.NABLA:    QT_TRANSLATE_NOOP("Constant", "Nabla"),
+        nwStatusShape.DIAMOND:  QT_TRANSLATE_NOOP("Constant", "Diamond"),
+        nwStatusShape.PENTAGON: QT_TRANSLATE_NOOP("Constant", "Pentagon"),
+        nwStatusShape.HEXAGON:  QT_TRANSLATE_NOOP("Constant", "Hexagon"),
+        nwStatusShape.STAR:     QT_TRANSLATE_NOOP("Constant", "Star"),
+        nwStatusShape.PACMAN:   QT_TRANSLATE_NOOP("Constant", "Pacman"),
     }
     SHAPES_CIRCLE = {
-        nwStatusShape.CIRCLE_Q: QT_TRANSLATE_NOOP("Shape", "1/4 Circle"),
-        nwStatusShape.CIRCLE_H: QT_TRANSLATE_NOOP("Shape", "Half Circle"),
-        nwStatusShape.CIRCLE_T: QT_TRANSLATE_NOOP("Shape", "3/4 Circle"),
-        nwStatusShape.CIRCLE:   QT_TRANSLATE_NOOP("Shape", "Full Circle"),
+        nwStatusShape.CIRCLE_Q: QT_TRANSLATE_NOOP("Constant", "1/4 Circle"),
+        nwStatusShape.CIRCLE_H: QT_TRANSLATE_NOOP("Constant", "Half Circle"),
+        nwStatusShape.CIRCLE_T: QT_TRANSLATE_NOOP("Constant", "3/4 Circle"),
+        nwStatusShape.CIRCLE:   QT_TRANSLATE_NOOP("Constant", "Full Circle"),
     }
     SHAPES_BARS = {
-        nwStatusShape.BARS_1: QT_TRANSLATE_NOOP("Shape", "1 Bar"),
-        nwStatusShape.BARS_2: QT_TRANSLATE_NOOP("Shape", "2 Bars"),
-        nwStatusShape.BARS_3: QT_TRANSLATE_NOOP("Shape", "3 Bars"),
-        nwStatusShape.BARS_4: QT_TRANSLATE_NOOP("Shape", "4 Bars"),
+        nwStatusShape.BARS_1: QT_TRANSLATE_NOOP("Constant", "1 Bar"),
+        nwStatusShape.BARS_2: QT_TRANSLATE_NOOP("Constant", "2 Bars"),
+        nwStatusShape.BARS_3: QT_TRANSLATE_NOOP("Constant", "3 Bars"),
+        nwStatusShape.BARS_4: QT_TRANSLATE_NOOP("Constant", "4 Bars"),
     }
     SHAPES_BLOCKS = {
-        nwStatusShape.BLOCK_1: QT_TRANSLATE_NOOP("Shape", "1 Block"),
-        nwStatusShape.BLOCK_2: QT_TRANSLATE_NOOP("Shape", "2 Blocks"),
-        nwStatusShape.BLOCK_3: QT_TRANSLATE_NOOP("Shape", "3 Blocks"),
-        nwStatusShape.BLOCK_4: QT_TRANSLATE_NOOP("Shape", "4 Blocks"),
+        nwStatusShape.BLOCK_1: QT_TRANSLATE_NOOP("Constant", "1 Block"),
+        nwStatusShape.BLOCK_2: QT_TRANSLATE_NOOP("Constant", "2 Blocks"),
+        nwStatusShape.BLOCK_3: QT_TRANSLATE_NOOP("Constant", "3 Blocks"),
+        nwStatusShape.BLOCK_4: QT_TRANSLATE_NOOP("Constant", "4 Blocks"),
     }
     FILE_FILTERS = {
         "*.txt": QT_TRANSLATE_NOOP("Constant", "Text files"),

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -23,8 +23,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
-from typing import Literal
-
 from PyQt5.QtCore import QT_TRANSLATE_NOOP, QCoreApplication
 
 from novelwriter.enum import (
@@ -32,9 +30,14 @@ from novelwriter.enum import (
 )
 
 
-def trConst(text: str, context: Literal["Constant", "Stats"] = "Constant") -> str:
+def trConst(text: str) -> str:
     """Wrapper function for locally translating constants."""
-    return QCoreApplication.translate(context, text)
+    return QCoreApplication.translate("Constant", text)
+
+
+def trStats(text: str) -> str:
+    """Wrapper function for locally translating stats constants."""
+    return QCoreApplication.translate("Stats", text)
 
 
 class nwConst:

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -409,7 +409,7 @@ class _StatusPage(NFixedPage):
         def buildMenu(menu: QMenu, items: dict[nwStatusShape, str]) -> None:
             for shape, label in items.items():
                 icon = NWStatus.createIcon(self._iPx, iColor, shape)
-                action = menu.addAction(icon, trConst(label, "Shape"))
+                action = menu.addAction(icon, trConst(label))
                 action.triggered.connect(qtLambda(self._selectShape, shape))
                 self._icons[shape] = icon
 

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -32,7 +32,7 @@ from PyQt5.QtWidgets import QGridLayout, QLabel, QWidget
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import elide
-from novelwriter.constants import nwLabels, nwStats, trConst
+from novelwriter.constants import nwLabels, nwStats, trConst, trStats
 from novelwriter.enum import nwChange
 from novelwriter.types import (
     QtAlignLeft, QtAlignLeftBase, QtAlignRight, QtAlignRightBase,
@@ -65,9 +65,9 @@ class GuiItemDetails(QWidget):
         fntValue = self.font()
         fntValue.setPointSizeF(0.9*fPt)
 
-        trStats1 = trConst(nwLabels.STATS_NAME[nwStats.CHARS], "Stats")
-        trStats2 = trConst(nwLabels.STATS_NAME[nwStats.WORDS], "Stats")
-        trStats3 = trConst(nwLabels.STATS_NAME[nwStats.PARAGRAPHS], "Stats")
+        trStats1 = trStats(nwLabels.STATS_NAME[nwStats.CHARS])
+        trStats2 = trStats(nwLabels.STATS_NAME[nwStats.WORDS])
+        trStats3 = trStats(nwLabels.STATS_NAME[nwStats.PARAGRAPHS])
 
         # Label
         self.labelName = QLabel(self.tr("Label"), self)

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -35,7 +35,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import openExternalPath, qtLambda
 from novelwriter.constants import (
     nwConst, nwKeyWords, nwLabels, nwShortcode, nwStats, nwStyles, nwUnicode,
-    trConst
+    trConst, trStats
 )
 from novelwriter.enum import nwDocAction, nwDocInsert, nwFocus, nwView
 from novelwriter.extensions.eventfilters import StatusTipFilter
@@ -601,7 +601,7 @@ class GuiMainMenu(QMenuBar):
         self.mInsField = self.insMenu.addMenu(self.tr("Word/Character Count"))
         for field in nwStats.ALL_FIELDS:
             value = nwShortcode.FIELD_VALUE.format(field)
-            action = self.mInsField.addAction(trConst(nwLabels.STATS_NAME[field], "Stats"))
+            action = self.mInsField.addAction(trStats(nwLabels.STATS_NAME[field]))
             action.triggered.connect(qtLambda(self.requestDocInsertText.emit, value))
 
         # Insert > Breaks and Vertical Space

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -42,7 +42,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import checkInt, formatFileFilter
-from novelwriter.constants import nwKeyWords, nwLabels, nwStats, nwStyles, trConst
+from novelwriter.constants import nwKeyWords, nwLabels, nwStats, nwStyles, trConst, trStats
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass, nwItemLayout, nwItemType, nwOutline
 from novelwriter.error import logException
 from novelwriter.extensions.configlayout import NColourLabel
@@ -815,9 +815,9 @@ class GuiOutlineDetails(QScrollArea):
 
         bFont = SHARED.theme.guiFontB
 
-        trStats1 = trConst(nwLabels.STATS_NAME[nwStats.CHARS], "Stats")
-        trStats2 = trConst(nwLabels.STATS_NAME[nwStats.WORDS], "Stats")
-        trStats3 = trConst(nwLabels.STATS_NAME[nwStats.PARAGRAPHS], "Stats")
+        trStats1 = trStats(nwLabels.STATS_NAME[nwStats.CHARS])
+        trStats2 = trStats(nwLabels.STATS_NAME[nwStats.WORDS])
+        trStats3 = trStats(nwLabels.STATS_NAME[nwStats.PARAGRAPHS])
 
         # Details Area
         self.titleLabel = QLabel(self.tr("Title"), self)

--- a/novelwriter/tools/manuscript.py
+++ b/novelwriter/tools/manuscript.py
@@ -43,7 +43,7 @@ from PyQt5.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import fuzzyTime
-from novelwriter.constants import nwLabels, nwStats, trConst
+from novelwriter.constants import nwLabels, nwStats, trStats
 from novelwriter.core.buildsettings import BuildCollection, BuildSettings
 from novelwriter.core.docbuild import NWBuildDocument
 from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton, NToolDialog
@@ -1037,17 +1037,17 @@ class _StatsWidget(QWidget):
         hPx = CONFIG.pxInt(12)
         vPx = CONFIG.pxInt(4)
 
-        trAllChars = trConst(nwLabels.STATS_NAME[nwStats.CHARS], "Stats")
-        trTextChars = trConst(nwLabels.STATS_NAME[nwStats.CHARS_TEXT], "Stats")
-        trTitleChars = trConst(nwLabels.STATS_NAME[nwStats.CHARS_TITLE], "Stats")
-        trParagraphCount = trConst(nwLabels.STATS_NAME[nwStats.PARAGRAPHS], "Stats")
-        trTitleCount = trConst(nwLabels.STATS_NAME[nwStats.TITLES], "Stats")
-        trAllWordChars = trConst(nwLabels.STATS_NAME[nwStats.WCHARS_ALL], "Stats")
-        trTextWordChars = trConst(nwLabels.STATS_NAME[nwStats.WCHARS_TEXT], "Stats")
-        trTitleWordChars = trConst(nwLabels.STATS_NAME[nwStats.WCHARS_TITLE], "Stats")
-        trAllWords = trConst(nwLabels.STATS_NAME[nwStats.WORDS], "Stats")
-        trTextWords = trConst(nwLabels.STATS_NAME[nwStats.WORDS_TEXT], "Stats")
-        trTitleWords = trConst(nwLabels.STATS_NAME[nwStats.WORDS_TITLE], "Stats")
+        trAllChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS])
+        trTextChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_TEXT])
+        trTitleChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_TITLE])
+        trParagraphCount = trStats(nwLabels.STATS_NAME[nwStats.PARAGRAPHS])
+        trTitleCount = trStats(nwLabels.STATS_NAME[nwStats.TITLES])
+        trAllWordChars = trStats(nwLabels.STATS_NAME[nwStats.WCHARS_ALL])
+        trTextWordChars = trStats(nwLabels.STATS_NAME[nwStats.WCHARS_TEXT])
+        trTitleWordChars = trStats(nwLabels.STATS_NAME[nwStats.WCHARS_TITLE])
+        trAllWords = trStats(nwLabels.STATS_NAME[nwStats.WORDS])
+        trTextWords = trStats(nwLabels.STATS_NAME[nwStats.WORDS_TEXT])
+        trTitleWords = trStats(nwLabels.STATS_NAME[nwStats.WORDS_TITLE])
 
         # Minimal Form
         self.minWordCount = QLabel(self)


### PR DESCRIPTION
**Summary:**

This PR changes the context name for status label icon shapes from Shapes back to Constants and restores the old translations.

**Related Issue(s):**

Related #2246

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
