### PR TITLE
Re-implement Novel View as an item model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1173,7 +1173,7 @@ _These Release Notes also include the changes from the 2.2 Beta 1 and 2.2 RC 1 r
 **Usability**
 
 * Use `Ctrl+K, H` for inserting short description comments (alias to synopsis), drop the space
-  after the `%` symbol when inserting special comments, add a browse icon to the open open project
+  after the `%` symbol when inserting special comments, add a browse icon to the open project
   dialog, and remove the popup warning for Alpha releases. PR #1626.
 * Menu entries no longer clear the status bar message when they are hovered. This was caused by a
   status tip feature in Qt, which prints a blank message to the status bar. PR #1630.

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -68,23 +68,23 @@ class Config:
         "_backupPath",
 
         "appName", "appHandle", "guiLocale", "guiTheme", "guiSyntax", "guiFont", "hideVScroll",
-        "hideHScroll", "lastNotes", "nativeFont", "iconTheme", "iconColTree", "iconColDocs",
-        "mainWinSize", "welcomeWinSize", "prefsWinSize", "mainPanePos", "viewPanePos",
-        "outlinePanePos", "autoSaveProj", "autoSaveDoc", "emphLabels", "backupOnClose",
-        "askBeforeBackup", "askBeforeExit", "textFont", "textWidth", "textMargin", "tabWidth",
-        "cursorWidth", "focusWidth", "hideFocusFooter", "showFullPath", "autoSelect", "doJustify",
-        "showTabsNSpaces", "showLineEndings", "showMultiSpaces", "doReplace", "doReplaceSQuote",
-        "doReplaceDQuote", "doReplaceDash", "doReplaceDots", "autoScroll", "autoScrollPos",
-        "scrollPastEnd", "dialogStyle", "allowOpenDial", "dialogLine", "narratorBreak",
-        "narratorDialog", "altDialogOpen", "altDialogClose", "highlightEmph", "stopWhenIdle",
-        "userIdleTime", "incNotesWCount", "fmtApostrophe", "fmtSQuoteOpen", "fmtSQuoteClose",
-        "fmtDQuoteOpen", "fmtDQuoteClose", "fmtPadBefore", "fmtPadAfter", "fmtPadThin",
-        "spellLanguage", "showViewerPanel", "showEditToolBar", "showSessionTime", "viewComments",
-        "viewSynopsis", "searchCase", "searchWord", "searchRegEx", "searchLoop", "searchNextFile",
-        "searchMatchCap", "searchProjCase", "searchProjWord", "searchProjRegEx", "verQtString",
-        "verQtValue", "verPyQtString", "verPyQtValue", "verPyString", "osType", "osLinux",
-        "osWindows", "osDarwin", "osUnknown", "hostName", "kernelVer", "isDebug", "memInfo",
-        "hasEnchant",
+        "hideHScroll", "lastNotes", "nativeFont", "useCharCount", "iconTheme", "iconColTree",
+        "iconColDocs", "mainWinSize", "welcomeWinSize", "prefsWinSize", "mainPanePos",
+        "viewPanePos", "outlinePanePos", "autoSaveProj", "autoSaveDoc", "emphLabels",
+        "backupOnClose", "askBeforeBackup", "askBeforeExit", "textFont", "textWidth", "textMargin",
+        "tabWidth", "cursorWidth", "focusWidth", "hideFocusFooter", "showFullPath", "autoSelect",
+        "doJustify", "showTabsNSpaces", "showLineEndings", "showMultiSpaces", "doReplace",
+        "doReplaceSQuote", "doReplaceDQuote", "doReplaceDash", "doReplaceDots", "autoScroll",
+        "autoScrollPos", "scrollPastEnd", "dialogStyle", "allowOpenDial", "dialogLine",
+        "narratorBreak", "narratorDialog", "altDialogOpen", "altDialogClose", "highlightEmph",
+        "stopWhenIdle", "userIdleTime", "incNotesWCount", "fmtApostrophe", "fmtSQuoteOpen",
+        "fmtSQuoteClose", "fmtDQuoteOpen", "fmtDQuoteClose", "fmtPadBefore", "fmtPadAfter",
+        "fmtPadThin", "spellLanguage", "showViewerPanel", "showEditToolBar", "showSessionTime",
+        "viewComments", "viewSynopsis", "searchCase", "searchWord", "searchRegEx", "searchLoop",
+        "searchNextFile", "searchMatchCap", "searchProjCase", "searchProjWord", "searchProjRegEx",
+        "verQtString", "verQtValue", "verPyQtString", "verPyQtValue", "verPyString", "osType",
+        "osLinux", "osWindows", "osDarwin", "osUnknown", "hostName", "kernelVer", "isDebug",
+        "memInfo", "hasEnchant",
     )
 
     LANG_NW   = 1
@@ -157,6 +157,7 @@ class Config:
         self.hideHScroll  = False       # Hide horizontal scroll bars on main widgets
         self.lastNotes    = "0x0"       # The latest release notes that have been shown
         self.nativeFont   = True        # Use native font dialog
+        self.useCharCount = False       # Use character count as primary count
 
         # Icons
         self.iconTheme   = DEF_ICONS    # Icons theme
@@ -591,16 +592,17 @@ class Config:
         # Main
         sec = "Main"
         self.setGuiFont(conf.rdStr(sec, "font", ""))
-        self.guiTheme    = conf.rdStr(sec, "theme", self.guiTheme)
-        self.guiSyntax   = conf.rdStr(sec, "syntax", self.guiSyntax)
-        self.iconTheme   = conf.rdStr(sec, "icons", self.iconTheme)
-        self.iconColTree = conf.rdStr(sec, "iconcoltree", self.iconColTree)
-        self.iconColDocs = conf.rdBool(sec, "iconcoldocs", self.iconColDocs)
-        self.guiLocale   = conf.rdStr(sec, "localisation", self.guiLocale)
-        self.hideVScroll = conf.rdBool(sec, "hidevscroll", self.hideVScroll)
-        self.hideHScroll = conf.rdBool(sec, "hidehscroll", self.hideHScroll)
-        self.lastNotes   = conf.rdStr(sec, "lastnotes", self.lastNotes)
-        self.nativeFont  = conf.rdBool(sec, "nativefont", self.nativeFont)
+        self.guiTheme     = conf.rdStr(sec, "theme", self.guiTheme)
+        self.guiSyntax    = conf.rdStr(sec, "syntax", self.guiSyntax)
+        self.iconTheme    = conf.rdStr(sec, "icons", self.iconTheme)
+        self.iconColTree  = conf.rdStr(sec, "iconcoltree", self.iconColTree)
+        self.iconColDocs  = conf.rdBool(sec, "iconcoldocs", self.iconColDocs)
+        self.guiLocale    = conf.rdStr(sec, "localisation", self.guiLocale)
+        self.hideVScroll  = conf.rdBool(sec, "hidevscroll", self.hideVScroll)
+        self.hideHScroll  = conf.rdBool(sec, "hidehscroll", self.hideHScroll)
+        self.lastNotes    = conf.rdStr(sec, "lastnotes", self.lastNotes)
+        self.nativeFont   = conf.rdBool(sec, "nativefont", self.nativeFont)
+        self.useCharCount = conf.rdBool(sec, "usecharcount", self.useCharCount)
 
         # Sizes
         sec = "Sizes"
@@ -717,6 +719,7 @@ class Config:
             "hidehscroll":  str(self.hideHScroll),
             "lastnotes":    str(self.lastNotes),
             "nativefont":   str(self.nativeFont),
+            "usecharcount": str(self.useCharCount),
         }
 
         conf["Sizes"] = {

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -818,13 +818,13 @@ class TagsIndex:
         }
         return
 
-    def tagName(self, tagKey: str) -> str:
+    def tagName(self, tagKey: str, default: str = "") -> str:
         """Get the name of a given tag."""
-        return self._tags.get(tagKey.lower(), {}).get("name", "")
+        return self._tags.get(tagKey.lower(), {}).get("name", default)
 
-    def tagDisplay(self, tagKey: str) -> str:
+    def tagDisplay(self, tagKey: str, default: str = "") -> str:
         """Get the display name of a given tag."""
-        return self._tags.get(tagKey.lower(), {}).get("display", "")
+        return self._tags.get(tagKey.lower(), {}).get("display", default)
 
     def tagHandle(self, tagKey: str) -> str | None:
         """Get the handle of a given tag."""

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -125,7 +125,11 @@ class Index:
         if (item := SHARED.project.tree[tHandle]) and item.isRootType() and item.isNovelLike():
             model = NovelModel()
             for handle in SHARED.project.tree.subTree(tHandle):
-                if node := self._itemIndex[handle]:
+                if (
+                    (node := self._itemIndex[handle])
+                    and node.item.isDocumentLayout()
+                    and node.item.isActive
+                ):
                     model.append(node)
             self._novelModels[tHandle] = model
         return

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -87,7 +87,7 @@ class Index:
 
         # Storage and State
         self._tagsIndex = TagsIndex()
-        self._itemIndex = ItemIndex(project)
+        self._itemIndex = ItemIndex(project, self._tagsIndex)
         self._indexBroken = False
 
         # Models
@@ -906,10 +906,11 @@ class ItemIndex:
     IndexHeading object for each heading of the text.
     """
 
-    __slots__ = ("_project", "_items")
+    __slots__ = ("_project", "_tags", "_items")
 
-    def __init__(self, project: NWProject) -> None:
+    def __init__(self, project: NWProject, tagsIndex: TagsIndex) -> None:
         self._project = project
+        self._tags = tagsIndex
         self._items: dict[str, IndexNode] = {}
         return
 
@@ -936,7 +937,7 @@ class ItemIndex:
         """Add a new item to the index. This will overwrite the item if
         it already exists.
         """
-        self._items[tHandle] = IndexNode(tHandle, nwItem)
+        self._items[tHandle] = IndexNode(self._tags, tHandle, nwItem)
         return
 
     def allItemTags(self, tHandle: str) -> list[str]:
@@ -994,7 +995,7 @@ class ItemIndex:
         if tHandle in self._items:
             tItem = self._items[tHandle]
             sTitle = tItem.nextHeading()
-            tItem.addHeading(IndexHeading(sTitle, lineNo, level, text))
+            tItem.addHeading(IndexHeading(self._tags, sTitle, lineNo, level, text))
             return sTitle
         return TT_NONE
 
@@ -1065,7 +1066,7 @@ class ItemIndex:
 
             nwItem = self._project.tree[tHandle]
             if nwItem is not None:
-                tItem = IndexNode(tHandle, nwItem)
+                tItem = IndexNode(self._tags, tHandle, nwItem)
                 tItem.unpackData(tData)
                 self._items[tHandle] = tItem
 

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -123,7 +123,7 @@ class Index:
     def _generateNovelModel(self, tHandle: str) -> None:
         """Generate a novel model for a specific handle."""
         if (item := SHARED.project.tree[tHandle]) and item.isRootType() and item.isNovelLike():
-            model = NovelModel(item)
+            model = NovelModel()
             for handle in SHARED.project.tree.subTree(tHandle):
                 if node := self._itemIndex[handle]:
                     model.append(node)

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -479,7 +479,7 @@ class Index:
 
     def _generateNovelModel(self, tHandle: str) -> None:
         """Generate a novel model for a specific handle."""
-        if (item := SHARED.project.tree[tHandle]) and item.isRootType() and item.isNovelLike():
+        if (item := self._project.tree[tHandle]) and item.isRootType() and item.isNovelLike():
             model = NovelModel()
             model.setExtraColumn(self._novelExtra)
             self._appendSubTreeToModel(tHandle, model)
@@ -488,7 +488,7 @@ class Index:
 
     def _appendSubTreeToModel(self, tHandle: str, model: NovelModel) -> None:
         """Append all active novel documents to a novel model."""
-        for handle in SHARED.project.tree.subTree(tHandle):
+        for handle in self._project.tree.subTree(tHandle):
             if (
                 (node := self._itemIndex[handle])
                 and node.item.isDocumentLayout()

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -39,7 +39,7 @@ from novelwriter.common import isHandle, isItemClass, isTitleTag, jsonEncode
 from novelwriter.constants import nwFiles, nwKeyWords, nwStyles
 from novelwriter.core.indexdata import NOTE_TYPES, TT_NONE, IndexHeading, IndexNode, T_NoteTypes
 from novelwriter.core.novelmodel import NovelModel
-from novelwriter.enum import nwComment, nwItemClass, nwItemLayout, nwItemType
+from novelwriter.enum import nwComment, nwItemClass, nwItemLayout, nwItemType, nwNovelExtra
 from novelwriter.error import logException
 from novelwriter.text.comments import processComment
 from novelwriter.text.counting import standardCounter
@@ -92,6 +92,7 @@ class Index:
 
         # Models
         self._novelModels: dict[str, NovelModel] = {}
+        self._novelExtra = nwNovelExtra.HIDDEN
 
         # TimeStamps
         self._indexChange = 0.0
@@ -119,6 +120,15 @@ class Index:
         if tHandle not in self._novelModels:
             self._generateNovelModel(tHandle)
         return self._novelModels.get(tHandle)
+
+    ##
+    #  Setters
+    ##
+
+    def setNovelModelExtraColumn(self, extra: nwNovelExtra) -> None:
+        """Set the data content type of the novel model extra column."""
+        self._novelExtra = extra
+        return
 
     ##
     #  Public Methods
@@ -184,6 +194,7 @@ class Index:
             logger.info("Refreshing novel model '%s'", tHandle)
             model.beginResetModel()
             model.clear()
+            model.setExtraColumn(self._novelExtra)
             self._appendSubTreeToModel(tHandle, model)
             model.endResetModel()
         return
@@ -439,8 +450,9 @@ class Index:
         self._itemIndex.setHeadingCounts(tHandle, sTitle, cC, wC, pC)
         return
 
-    def _indexKeyword(self, tHandle: str, line: str, sTitle: str,
-                      itemClass: nwItemClass, tags: dict[str, bool]) -> None:
+    def _indexKeyword(
+        self, tHandle: str, line: str, sTitle: str, itemClass: nwItemClass, tags: dict[str, bool]
+    ) -> None:
         """Validate and save the information about a reference to a tag
         in another file, or the setting of a tag in the file. A record
         of active tags is updated so that no longer used tags can be
@@ -469,6 +481,7 @@ class Index:
         """Generate a novel model for a specific handle."""
         if (item := SHARED.project.tree[tHandle]) and item.isRootType() and item.isNovelLike():
             model = NovelModel()
+            model.setExtraColumn(self._novelExtra)
             self._appendSubTreeToModel(tHandle, model)
             self._novelModels[tHandle] = model
         return

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -120,18 +120,32 @@ class Index:
             self._generateNovelModel(tHandle)
         return self._novelModels.get(tHandle)
 
+    def refreshNovelModel(self, tHandle: str) -> None:
+        """Refresh a novel model."""
+        if model := self.getNovelModel(tHandle):
+            model.beginResetModel()
+            model.clear()
+            self._appendSubTreeToModel(tHandle, model)
+            model.endResetModel()
+        return
+
     def _generateNovelModel(self, tHandle: str) -> None:
         """Generate a novel model for a specific handle."""
         if (item := SHARED.project.tree[tHandle]) and item.isRootType() and item.isNovelLike():
             model = NovelModel()
-            for handle in SHARED.project.tree.subTree(tHandle):
-                if (
-                    (node := self._itemIndex[handle])
-                    and node.item.isDocumentLayout()
-                    and node.item.isActive
-                ):
-                    model.append(node)
+            self._appendSubTreeToModel(tHandle, model)
             self._novelModels[tHandle] = model
+        return
+
+    def _appendSubTreeToModel(self, tHandle: str, model: NovelModel) -> None:
+        """Append all active novel documents to a novel model."""
+        for handle in SHARED.project.tree.subTree(tHandle):
+            if (
+                (node := self._itemIndex[handle])
+                and node.item.isDocumentLayout()
+                and node.item.isActive
+            ):
+                model.append(node)
         return
 
     ##

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -123,6 +123,7 @@ class Index:
     def refreshNovelModel(self, tHandle: str) -> None:
         """Refresh a novel model."""
         if model := self.getNovelModel(tHandle):
+            logger.debug("Refreshing novel model '%s'", tHandle)
             model.beginResetModel()
             model.clear()
             self._appendSubTreeToModel(tHandle, model)
@@ -170,6 +171,8 @@ class Index:
                 self.scanText(nwItem.itemHandle, text, blockSignal=True)
         self._indexBroken = False
         SHARED.emitIndexAvailable(self._project)
+        for tHandle in self._novelModels:
+            self.refreshNovelModel(tHandle)
         return
 
     def deleteHandle(self, tHandle: str) -> None:

--- a/novelwriter/core/indexdata.py
+++ b/novelwriter/core/indexdata.py
@@ -332,16 +332,16 @@ class IndexHeading:
         refs = {x: [] for x in nwKeyWords.VALID_KEYS}
         for tag, types in self._refs.items():
             for keyword in types:
-                if keyword in refs:
-                    refs[keyword].append(self._tags.tagName(tag))
+                if keyword in refs and (name := self._tags.tagName(tag)):
+                    refs[keyword].append(name)
         return refs
 
     def getReferencesByKeyword(self, keyword: str) -> list[str]:
         """Extract all references for this heading."""
         refs = []
         for tag, types in self._refs.items():
-            if keyword in types:
-                refs.append(self._tags.tagName(tag))
+            if keyword in types and (name := self._tags.tagName(tag)):
+                refs.append(name)
         return refs
 
     ##

--- a/novelwriter/core/indexdata.py
+++ b/novelwriter/core/indexdata.py
@@ -31,6 +31,7 @@ import logging
 from collections.abc import ItemsView, Sequence
 from typing import TYPE_CHECKING, Literal
 
+from novelwriter import CONFIG
 from novelwriter.common import checkInt, isListInstance, isTitleTag
 from novelwriter.constants import nwKeyWords, nwStyles
 
@@ -236,6 +237,10 @@ class IndexHeading:
     @property
     def title(self) -> str:
         return self._title
+
+    @property
+    def mainCount(self) -> int:
+        return self._counts[0 if CONFIG.useCharCount else 1]
 
     @property
     def charCount(self) -> int:

--- a/novelwriter/core/indexdata.py
+++ b/novelwriter/core/indexdata.py
@@ -36,6 +36,7 @@ from novelwriter.common import checkInt, isListInstance, isTitleTag
 from novelwriter.constants import nwKeyWords, nwStyles
 
 if TYPE_CHECKING:  # pragma: no cover
+    from novelwriter.core.index import TagsIndex
     from novelwriter.core.item import NWItem
 
 logger = logging.getLogger(__name__)
@@ -56,12 +57,13 @@ class IndexNode:
     must be reset each time the item is re-indexed.
     """
 
-    __slots__ = ("_handle", "_item", "_headings", "_count", "_notes")
+    __slots__ = ("_tags", "_handle", "_item", "_headings", "_notes", "_count")
 
-    def __init__(self, tHandle: str, nwItem: NWItem) -> None:
+    def __init__(self, tagsIndex: TagsIndex, tHandle: str, nwItem: NWItem) -> None:
+        self._tags = tagsIndex
         self._handle = tHandle
         self._item = nwItem
-        self._headings: dict[str, IndexHeading] = {TT_NONE: IndexHeading(TT_NONE)}
+        self._headings: dict[str, IndexHeading] = {TT_NONE: IndexHeading(self._tags, TT_NONE)}
         self._notes: dict[str, set[str]] = {}
         self._count = 0
         return
@@ -179,7 +181,7 @@ class IndexNode:
         """Unpack an item entry from the data."""
         for key, entry in data.items():
             if isTitleTag(key):
-                heading = IndexHeading(key)
+                heading = IndexHeading(self._tags, key)
                 heading.unpackData(entry)
                 self.addHeading(heading)
             elif key == "document":
@@ -202,9 +204,16 @@ class IndexHeading:
     of all references made under the heading.
     """
 
-    __slots__ = ("_key", "_line", "_level", "_title", "_counts", "_tag", "_refs", "_comments")
+    __slots__ = (
+        "_tags", "_key", "_line", "_level", "_title",
+        "_counts", "_tag", "_refs", "_comments",
+    )
 
-    def __init__(self, key: str, line: int = 0, level: str = "H0", title: str = "") -> None:
+    def __init__(
+        self, tagsIndex: TagsIndex, key: str, line: int = 0,
+        level: str = "H0", title: str = "",
+    ) -> None:
+        self._tags = tagsIndex
         self._key = key
         self._line = line
         self._level = level
@@ -313,6 +322,27 @@ class IndexHeading:
                 self._refs[tag] = set()
             self._refs[tag].add(keyword)
         return
+
+    ##
+    #  Getters
+    ##
+
+    def getReferences(self) -> dict[str, list[str]]:
+        """Extract all references for this heading."""
+        refs = {x: [] for x in nwKeyWords.VALID_KEYS}
+        for tag, types in self._refs.items():
+            for keyword in types:
+                if keyword in refs:
+                    refs[keyword].append(self._tags.tagName(tag))
+        return refs
+
+    def getReferencesByKeyword(self, keyword: str) -> list[str]:
+        """Extract all references for this heading."""
+        refs = []
+        for tag, types in self._refs.items():
+            if keyword in types:
+                refs.append(self._tags.tagName(tag))
+        return refs
 
     ##
     #  Data Methods

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -293,6 +293,12 @@ class NWItem:
         self._project.tree.refreshItems([self._handle])
         return
 
+    def notifyNovelStructureChange(self) -> None:
+        """Notify that the structure of a novel has changed."""
+        if self._root and self._class == nwItemClass.NOVEL:
+            self._project.tree.novelStructureChanged(self._root)
+        return
+
     ##
     #  Lookup Methods
     ##

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -331,7 +331,7 @@ class ProjectModel(QAbstractItemModel):
         return QModelIndex()
 
     def index(self, row: int, column: int, parent: QModelIndex = QModelIndex()) -> QModelIndex:
-        """get the index of a child item of a parent."""
+        """Get the index of a child item of a parent."""
         if self.hasIndex(row, column, parent):
             node: ProjectNode = parent.internalPointer() if parent.isValid() else self._root
             if child := node.child(row):

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -193,7 +193,7 @@ class ProjectNode:
         return self._parent
 
     def child(self, row: int) -> ProjectNode | None:
-        """Return a child ofg the node."""
+        """Return a child of the node."""
         if 0 <= row < len(self._children):
             return self._children[row]
         return None
@@ -218,6 +218,7 @@ class ProjectNode:
             child._row = len(self._children)
             self._children.append(child)
         self._refreshChildrenPos()
+        self._item.notifyNovelStructureChange()
         return
 
     def takeChild(self, pos: int) -> ProjectNode | None:
@@ -226,6 +227,7 @@ class ProjectNode:
             node = self._children.pop(pos)
             self._refreshChildrenPos()
             self.updateCount()
+            self._item.notifyNovelStructureChange()
             return node
         return None
 
@@ -236,6 +238,7 @@ class ProjectNode:
             node = self._children.pop(source)
             self._children.insert(target, node)
             self._refreshChildrenPos()
+            self._item.notifyNovelStructureChange()
         return
 
     def setExpanded(self, state: bool) -> None:

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -77,11 +77,11 @@ class NovelModel(QAbstractTableModel):
     ##
 
     def rowCount(self, index: QModelIndex) -> int:
-        """Return the number of rows for an entry."""
+        """Return the number of rows."""
         return len(self._rows)
 
     def columnCount(self, index: QModelIndex) -> int:
-        """Return the number of columns for an entry."""
+        """Return the number of columns."""
         return self._columns
 
     def data(self, index: QModelIndex, role: Qt.ItemDataRole) -> T_NodeData:
@@ -89,7 +89,7 @@ class NovelModel(QAbstractTableModel):
         try:
             return self._rows[index.row()].get(C_FACTOR*index.column() | role)
         except Exception:
-            print("NovelModel Debug: Oops!")
+            logger.error("Novel model index is inconsistent")
         return None
 
     def handle(self, index: QModelIndex) -> str | None:
@@ -97,7 +97,7 @@ class NovelModel(QAbstractTableModel):
         try:
             return self._rows[index.row()].get(R_HANDLE)  # type: ignore
         except Exception:
-            print("NovelModel Debug: Oops!")
+            logger.error("Novel model index is inconsistent")
         return None
 
     def key(self, index: QModelIndex) -> str | None:
@@ -105,7 +105,7 @@ class NovelModel(QAbstractTableModel):
         try:
             return self._rows[index.row()].get(R_KEY)  # type: ignore
         except Exception:
-            print("NovelModel Debug: Oops!")
+            logger.error("Novel model index is inconsistent")
         return None
 
     ##
@@ -134,12 +134,17 @@ class NovelModel(QAbstractTableModel):
                 current.append(i)
 
         if current == []:
+            logger.warning("No novel model entries for '%s'", handle)
             return False
 
         cols = self._columns - 1
-
         first = current[0]
         last = current[-1]
+
+        if len(current) != last - first + 1:
+            logger.warning("Novel model entries for '%s' are not continuous", handle)
+            return False
+
         remains = []
         try:
             for key, head in node.items():
@@ -165,6 +170,7 @@ class NovelModel(QAbstractTableModel):
         except Exception:
             # This is faster than to check for index boundaries.
             # We definitely don't want to cause a crash.
+            logger.error("Novel model refresh error for '%s'", handle)
             logException()
             return False
 

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -30,7 +30,7 @@ from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt
 from PyQt6.QtGui import QIcon, QPixmap
 
 from novelwriter import SHARED
-from novelwriter.constants import nwKeyWords, nwStyles
+from novelwriter.constants import nwKeyWords, nwLabels, nwStyles, trConst
 from novelwriter.core.indexdata import IndexHeading, IndexNode
 from novelwriter.enum import nwNovelExtra
 from novelwriter.error import logException
@@ -52,7 +52,7 @@ T_NodeData = str | tuple[str, str] | QIcon | QPixmap | Qt.AlignmentFlag | None
 
 class NovelModel(QAbstractTableModel):
 
-    __slots__ = ("_rows", "_header", "_more", "_columns", "_extra")
+    __slots__ = ("_rows", "_header", "_more", "_columns", "_extraKey", "_extraLabel")
 
     def __init__(self) -> None:
         super().__init__()
@@ -60,7 +60,8 @@ class NovelModel(QAbstractTableModel):
         self._header: list[QSize] = []
         self._more = SHARED.theme.getIcon("more_arrow")
         self._columns = 3
-        self._extra = ""
+        self._extraKey = ""
+        self._extraLabel = ""
         return
 
     def __del__(self) -> None:  # pragma: no cover
@@ -85,16 +86,20 @@ class NovelModel(QAbstractTableModel):
         match extra:
             case nwNovelExtra.HIDDEN:
                 self._columns = 3
-                self._extra = ""
+                self._extraKey = ""
+                self._extraLabel = ""
             case nwNovelExtra.POV:
                 self._columns = 4
-                self._extra = nwKeyWords.POV_KEY
+                self._extraKey = nwKeyWords.POV_KEY
+                self._extraLabel = trConst(nwLabels.KEY_NAME[nwKeyWords.POV_KEY])
             case nwNovelExtra.FOCUS:
                 self._columns = 4
-                self._extra = nwKeyWords.FOCUS_KEY
+                self._extraKey = nwKeyWords.FOCUS_KEY
+                self._extraLabel = trConst(nwLabels.KEY_NAME[nwKeyWords.FOCUS_KEY])
             case nwNovelExtra.PLOT:
                 self._columns = 4
-                self._extra = nwKeyWords.PLOT_KEY
+                self._extraKey = nwKeyWords.PLOT_KEY
+                self._extraLabel = trConst(nwLabels.KEY_NAME[nwKeyWords.PLOT_KEY])
         return
 
     ##
@@ -209,6 +214,7 @@ class NovelModel(QAbstractTableModel):
         """Generate a cache entry."""
         iLevel = nwStyles.H_LEVEL.get(heading.level, 0)
         data = {}
+        data[C_FACTOR*0 | R_TIP] = heading.title
         data[C_FACTOR*0 | R_TEXT] = heading.title
         data[C_FACTOR*0 | R_ICON] = SHARED.theme.getHeaderDecoration(iLevel)
         data[C_FACTOR*1 | R_TEXT] = f"{heading.mainCount:n}"
@@ -216,8 +222,10 @@ class NovelModel(QAbstractTableModel):
         if self._columns == 3:
             data[C_FACTOR*2 | R_ICON] = self._more
         else:
-            data[C_FACTOR*2 | R_TIP] = "Hello World"
-            data[C_FACTOR*2 | R_TEXT] = "Hello World"
+            if self._extraKey and (refs := heading.getReferencesByKeyword(self._extraKey)):
+                text = ", ".join(refs)
+                data[C_FACTOR*2 | R_TEXT] = text
+                data[C_FACTOR*2 | R_TIP] = f"<b>{self._extraLabel}:</b> {text}"
             data[C_FACTOR*3 | R_ICON] = self._more
         data[R_HANDLE] = handle
         data[R_KEY] = key

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import logging
 
-from PyQt5.QtCore import QSize
 from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt
 from PyQt6.QtGui import QIcon, QPixmap
 
@@ -52,12 +51,11 @@ T_NodeData = str | QIcon | QPixmap | Qt.AlignmentFlag | None
 
 class NovelModel(QAbstractTableModel):
 
-    __slots__ = ("_rows", "_header", "_more", "_columns", "_extraKey", "_extraLabel")
+    __slots__ = ("_rows", "_more", "_columns", "_extraKey", "_extraLabel")
 
     def __init__(self) -> None:
         super().__init__()
         self._rows: list[dict[int, T_NodeData]] = []
-        self._header: list[QSize] = []
         self._more = SHARED.theme.getIcon("more_arrow")
         self._columns = 3
         self._extraKey = ""

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -47,7 +47,7 @@ R_TIP    = Qt.ItemDataRole.ToolTipRole
 R_HANDLE = 0xff01
 R_KEY    = 0xff02
 
-T_NodeData = str | tuple[str, str] | QIcon | QPixmap | Qt.AlignmentFlag | None
+T_NodeData = str | QIcon | QPixmap | Qt.AlignmentFlag | None
 
 
 class NovelModel(QAbstractTableModel):
@@ -210,19 +210,19 @@ class NovelModel(QAbstractTableModel):
     #  Internal Functions
     ##
 
-    def _generateEntry(self, handle: str, key: str, heading: IndexHeading) -> dict:
+    def _generateEntry(self, handle: str, key: str, head: IndexHeading) -> dict[int, T_NodeData]:
         """Generate a cache entry."""
-        iLevel = nwStyles.H_LEVEL.get(heading.level, 0)
+        iLevel = nwStyles.H_LEVEL.get(head.level, 0)
         data = {}
-        data[C_FACTOR*0 | R_TIP] = heading.title
-        data[C_FACTOR*0 | R_TEXT] = heading.title
+        data[C_FACTOR*0 | R_TIP] = head.title
+        data[C_FACTOR*0 | R_TEXT] = head.title
         data[C_FACTOR*0 | R_ICON] = SHARED.theme.getHeaderDecoration(iLevel)
-        data[C_FACTOR*1 | R_TEXT] = f"{heading.mainCount:n}"
+        data[C_FACTOR*1 | R_TEXT] = f"{head.mainCount:n}"
         data[C_FACTOR*1 | R_ALIGN] = QtAlignRight
         if self._columns == 3:
             data[C_FACTOR*2 | R_ICON] = self._more
         else:
-            if self._extraKey and (refs := heading.getReferencesByKeyword(self._extraKey)):
+            if self._extraKey and (refs := head.getReferencesByKeyword(self._extraKey)):
                 text = ", ".join(refs)
                 data[C_FACTOR*2 | R_TEXT] = text
                 data[C_FACTOR*2 | R_TIP] = f"<b>{self._extraLabel}:</b> {text}"

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -1,0 +1,100 @@
+"""
+novelWriter – Novel Model
+=========================
+
+File History:
+Created: 2025-02-22 [2.7b1] NovelModel
+
+This file is a part of novelWriter
+Copyright (C) 2025 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+from __future__ import annotations
+
+import logging
+
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt
+from PyQt6.QtGui import QIcon, QPixmap
+
+from novelwriter import SHARED
+from novelwriter.constants import nwStyles
+from novelwriter.core.indexdata import IndexNode
+from novelwriter.core.item import NWItem
+from novelwriter.types import QtAlignRight
+
+logger = logging.getLogger(__name__)
+
+C_FACTOR = 0x0100
+
+C_TITLE_TEXT  = 0x0000 | Qt.ItemDataRole.DisplayRole
+C_TITLE_ICON  = 0x0000 | Qt.ItemDataRole.DecorationRole
+C_COUNT_TEXT  = 0x0100 | Qt.ItemDataRole.DisplayRole
+C_COUNT_ALIGN = 0x0100 | Qt.ItemDataRole.TextAlignmentRole
+C_EXTRA_TEXT  = 0x0200 | Qt.ItemDataRole.DisplayRole
+C_EXTRA_TIP   = 0x0200 | Qt.ItemDataRole.ToolTipRole
+C_MORE_ICON   = 0x0300 | Qt.ItemDataRole.DecorationRole
+
+T_NodeData = str | QIcon | QPixmap | Qt.AlignmentFlag | None
+
+
+class NovelModel(QAbstractTableModel):
+
+    def __init__(self, rootItem: NWItem) -> None:
+        super().__init__()
+        self._root = rootItem
+        self._rows: list[tuple[str, str, dict]] = []
+        self._more = SHARED.theme.getIcon("more_arrow")
+        return
+
+    def __del__(self) -> None:  # pragma: no cover
+        logger.debug("Delete: NovelModel")
+        return
+
+    ##
+    #  Model Interface
+    ##
+
+    def rowCount(self, index: QModelIndex) -> int:
+        """Return the number of rows for an entry."""
+        return len(self._rows)
+
+    def columnCount(self, index: QModelIndex) -> int:
+        """Return the number of columns for an entry."""
+        return 4
+
+    def data(self, index: QModelIndex, role: Qt.ItemDataRole) -> T_NodeData:
+        """Return display data for a node."""
+        if index.isValid() and (row := index.row()) < len(self._rows):
+            return self._rows[row][2].get(C_FACTOR*index.column() | role)
+        return None
+
+    ##
+    #  Data Methods
+    ##
+
+    def append(self, node: IndexNode) -> None:
+        """Append a node to the model."""
+        handle = node.handle
+        for key, head in node.items():
+            if key != "T0000":
+                iLevel = nwStyles.H_LEVEL.get(head.level, 0)
+                data = {}
+                data[C_TITLE_TEXT]  = head.title
+                data[C_TITLE_ICON]  = SHARED.theme.getHeaderDecoration(iLevel)
+                data[C_COUNT_TEXT]  = f"{head.mainCount:n}"
+                data[C_COUNT_ALIGN] = QtAlignRight
+                data[C_MORE_ICON]   = self._more
+                self._rows.append((handle, key, data))
+        return

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -84,8 +84,10 @@ class NovelModel(QAbstractTableModel):
 
     def data(self, index: QModelIndex, role: Qt.ItemDataRole) -> T_NodeData:
         """Return display data for a node."""
-        if index.isValid() and (row := index.row()) < len(self._rows):
-            return self._rows[row].get(C_FACTOR*index.column() | role)
+        try:
+            return self._rows[index.row()].get(C_FACTOR*index.column() | role)
+        except Exception:
+            print("NovelModel Debug: Oops!")
         return None
 
     def keys(self, index: QModelIndex) -> tuple[str | None, str | None]:

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -69,10 +69,10 @@ class NWProjectData:
         self._initCounts = [0, 0]
         self._currCounts = [0, 0]
         self._lastHandle: dict[str, str | None] = {
-            "editor":    None,
-            "viewer":    None,
-            "novelTree": None,
-            "outline":   None,
+            "editor":  None,
+            "viewer":  None,
+            "novel":   None,
+            "outline": None,
         }
         self._autoReplace: dict[str, str] = {}
         self._titleFormat: dict[str, str] = {

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -60,7 +60,7 @@ class NWTree:
     also used for file names.
     """
 
-    __slots__ = ("_project", "_model", "_items", "_nodes", "_trash")
+    __slots__ = ("_project", "_model", "_items", "_nodes", "_trash", "_ready")
 
     def __init__(self, project: NWProject) -> None:
         self._project = project
@@ -68,6 +68,7 @@ class NWTree:
         self._items: dict[str, NWItem] = {}
         self._nodes: dict[str, ProjectNode] = {}
         self._trash = None
+        self._ready = False
         logger.debug("Ready: NWTree")
         return
 
@@ -249,6 +250,7 @@ class NWTree:
             logger.error("Not all items could be added to project tree")
 
         self._trash = self._getTrashNode()
+        self._ready = True
         self._model.endInsertRows()
         self._model.layoutChanged.emit()
 
@@ -276,6 +278,12 @@ class NWTree:
         self._model.root.refresh()
         self._model.root.updateCount(propagate=False)
         self._model.layoutChanged.emit()
+        return
+
+    def novelStructureChanged(self, tHandle: str) -> None:
+        """Emit a novel structure change signal."""
+        if self._ready:
+            SHARED.novelStructureChanged.emit(tHandle)
         return
 
     def checkConsistency(self, prefix: str) -> tuple[int, int]:

--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -180,6 +180,14 @@ class nwOutline(Enum):
     SYNOP   = 19
 
 
+class nwNovelExtra(Enum):
+
+    HIDDEN = 0
+    POV    = 1
+    FOCUS  = 2
+    PLOT   = 3
+
+
 class nwBuildFmt(Enum):
 
     ODT    = 0

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -105,8 +105,11 @@ class NTreeView(QTreeView):
 
     def mousePressEvent(self, event: QMouseEvent | None) -> None:
         """Emit a signal on mouse middle click."""
-        if event and event.button() == QtMouseMiddle:
-            self.middleClicked.emit(self.indexAt(event.pos()))
+        if (
+            event and event.button() == QtMouseMiddle
+            and (index := self.indexAt(event.pos())).isValid()
+        ):
+            self.middleClicked.emit(index)
         return super().mousePressEvent(event)
 
 

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -30,15 +30,15 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from PyQt6.QtCore import QSize, Qt, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import QModelIndex, QSize, Qt, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QMouseEvent, QWheelEvent
 from PyQt6.QtWidgets import (
     QApplication, QComboBox, QDialog, QDoubleSpinBox, QLabel, QSpinBox,
-    QToolButton, QWidget
+    QToolButton, QTreeView, QWidget
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.types import QtMouseLeft
+from novelwriter.types import QtMouseLeft, QtMouseMiddle
 
 if TYPE_CHECKING:  # pragma: no cover
     from novelwriter.guimain import GuiMain
@@ -97,6 +97,17 @@ class NNonBlockingDialog(NDialog):
         self.raise_()
         QApplication.processEvents()
         return
+
+
+class NTreeView(QTreeView):
+
+    middleClicked = pyqtSignal(QModelIndex)
+
+    def mousePressEvent(self, event: QMouseEvent | None) -> None:
+        """Emit a signal on mouse middle click."""
+        if event and event.button() == QtMouseMiddle:
+            self.middleClicked.emit(self.indexAt(event.pos()))
+        return super().mousePressEvent(event)
 
 
 class NComboBox(QComboBox):

--- a/novelwriter/extensions/novelselector.py
+++ b/novelwriter/extensions/novelselector.py
@@ -53,8 +53,11 @@ class NovelSelector(QComboBox):
     ##
 
     @property
-    def handle(self) -> str:
-        return self.currentData()
+    def handle(self) -> str | None:
+        """Return the selected handle, if any."""
+        if tHandle := self.currentData():
+            return tHandle
+        return None
 
     @property
     def firstHandle(self) -> str | None:

--- a/novelwriter/extensions/novelselector.py
+++ b/novelwriter/extensions/novelselector.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 
 from PyQt6.QtCore import pyqtSignal, pyqtSlot
+from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import QComboBox, QWidget
 
 from novelwriter import SHARED
@@ -46,6 +47,7 @@ class NovelSelector(QComboBox):
         self._includeAll = False
         self._listFormat = None
         self.currentIndexChanged.connect(self._indexChanged)
+        self.updateTheme()
         return
 
     ##
@@ -84,6 +86,14 @@ class NovelSelector(QComboBox):
         """Set a format string for the list entries."""
         if value is None or "{0}" in value:
             self._listFormat = value
+        return
+
+    def updateTheme(self) -> None:
+        """Update theme colours."""
+        palette = self.palette()
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, palette.text())
+        self.setPalette(palette)
+        self.refreshNovelList()
         return
 
     ##

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -115,7 +115,6 @@ class GuiDocEditor(QPlainTextEdit):
     editedStatusChanged = pyqtSignal(bool)
     itemHandleChanged = pyqtSignal(str)
     loadDocumentTagRequest = pyqtSignal(str, Enum)
-    novelItemMetaChanged = pyqtSignal(str)
     novelStructureChanged = pyqtSignal()
     openDocumentRequest = pyqtSignal(str, Enum, str, bool)
     requestNewNoteCreation = pyqtSignal(str, nwItemClass)
@@ -498,18 +497,8 @@ class GuiDocEditor(QPlainTextEdit):
 
         self.setDocumentChanged(False)
         self.docTextChanged.emit(self._docHandle, self._lastEdit)
-
-        oldCount = SHARED.project.index.getHandleHeaderCount(tHandle)
         SHARED.project.index.scanText(tHandle, text)
-        newCount = SHARED.project.index.getHandleHeaderCount(tHandle)
 
-        if self._nwItem.itemClass == nwItemClass.NOVEL:
-            if oldCount == newCount:
-                self.novelItemMetaChanged.emit(tHandle)
-            else:
-                self.novelStructureChanged.emit()
-
-        # Update the status bar
         self.updateStatusMessage.emit(self.tr("Saved Document: {0}").format(self._nwItem.itemName))
 
         return True

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -115,7 +115,6 @@ class GuiDocEditor(QPlainTextEdit):
     editedStatusChanged = pyqtSignal(bool)
     itemHandleChanged = pyqtSignal(str)
     loadDocumentTagRequest = pyqtSignal(str, Enum)
-    novelStructureChanged = pyqtSignal()
     openDocumentRequest = pyqtSignal(str, Enum, str, bool)
     requestNewNoteCreation = pyqtSignal(str, nwItemClass)
     requestNextDocument = pyqtSignal(str, bool)

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -104,7 +104,7 @@ class GuiNovelView(QWidget):
 
     def openProjectTasks(self) -> None:
         """Run open project tasks."""
-        lastNovel = SHARED.project.data.getLastHandle("novelTree")
+        lastNovel = SHARED.project.data.getLastHandle("novel")
         if lastNovel and lastNovel not in SHARED.project.tree:
             lastNovel = SHARED.project.tree.findRoot(nwItemClass.NOVEL)
 
@@ -169,14 +169,6 @@ class GuiNovelView(QWidget):
     def updateRootItem(self, tHandle: str, change: nwChange) -> None:
         """If any root item changes, rebuild the novel root menu."""
         self.novelBar.buildNovelRootMenu()
-        return
-
-    @pyqtSlot(str)
-    def updateNovelItemMeta(self, tHandle: str) -> None:
-        """The meta data of a novel item has changed, and the tree item
-        needs to be refreshed.
-        """
-        # self.novelTree.refreshHandle(tHandle)
         return
 
 
@@ -299,8 +291,10 @@ class GuiNovelToolBar(QWidget):
 
     def setCurrentRoot(self, rootHandle: str | None) -> None:
         """Set the current active root handle."""
+        if rootHandle is None:
+            rootHandle = self.novelValue.firstHandle
         self.novelValue.setHandle(rootHandle)
-        SHARED.project.data.setLastHandle(rootHandle, "novelTree")
+        SHARED.project.data.setLastHandle(rootHandle, "novel")
         self.novelView.setCurrentNovel(rootHandle)
         return
 
@@ -318,7 +312,11 @@ class GuiNovelToolBar(QWidget):
         refresh when content structure changes.
         """
         self._active = state
-        if self._active and self._refresh.get(self.novelValue.handle, False):
+        if (
+            self._active
+            and (handle := self.novelValue.handle)
+            and self._refresh.get(handle, False)
+        ):
             self._refreshNovelTree(self.novelValue.handle)
         return
 

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -418,7 +418,8 @@ class GuiNovelTree(NTreeView):
         items are selected, return the first.
         """
         if model := self._getModel():
-            return model.keys(self.currentIndex())
+            index = self.currentIndex()
+            return model.handle(index), model.key(index)
         return None, None
 
     ##
@@ -452,7 +453,7 @@ class GuiNovelTree(NTreeView):
 
     def drawRow(self, painter: QPainter, opt: QStyleOptionViewItem, index: QModelIndex) -> None:
         """Draw a box on the active row."""
-        if (model := self._getModel()) and model.keys(index)[0] == self._actHandle:
+        if (model := self._getModel()) and model.handle(index) == self._actHandle:
             painter.fillRect(opt.rect, self.palette().alternateBase())
         super().drawRow(painter, opt, index)
         return
@@ -465,8 +466,7 @@ class GuiNovelTree(NTreeView):
     def _onSingleClick(self, index: QModelIndex) -> None:
         """The user single-clicked an index."""
         if index.isValid() and (model := self._getModel()):
-            keys = model.keys(index)
-            if (tHandle := keys[0]) and (sTitle := keys[1]):
+            if (tHandle := model.handle(index)) and (sTitle := model.key(index)):
                 self.novelView.selectedItemChanged.emit(tHandle)
                 if index.column() == model.columnCount(index) - 1:
                     pos = self.mapToGlobal(self.visualRect(index).topRight())
@@ -477,20 +477,22 @@ class GuiNovelTree(NTreeView):
     def _onDoubleClick(self, index: QModelIndex) -> None:
         """The user double-clicked an index."""
         if (
-            (model := self._getModel()) and (keys := model.keys(index))
-            and (tHandle := keys[0]) and (sTitle := keys[1])
+            (model := self._getModel())
+            and (tHandle := model.handle(index))
+            and (sTitle := model.key(index))
         ):
-            self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, sTitle or "", False)
+            self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, sTitle, False)
         return
 
     @pyqtSlot(QModelIndex)
     def _onMiddleClick(self, index: QModelIndex) -> None:
         """The user middle-clicked an index."""
         if (
-            (model := self._getModel()) and (keys := model.keys(index))
-            and (tHandle := keys[0]) and (sTitle := keys[1])
+            (model := self._getModel())
+            and (tHandle := model.handle(index))
+            and (sTitle := model.key(index))
         ):
-            self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, sTitle or "", False)
+            self.novelView.openDocumentRequest.emit(tHandle, nwDocMode.VIEW, sTitle, False)
         return
 
     ##

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -323,7 +323,9 @@ class GuiNovelToolBar(QWidget):
     @pyqtSlot()
     def _refreshNovelTree(self) -> None:
         """Rebuild the current tree."""
-        self.novelView.setCurrentNovel(SHARED.project.data.getLastHandle("novelTree"))
+        if rootHandle := self.novelValue.handle:
+            SHARED.project.index.refreshNovelModel(rootHandle)
+        # self.novelView.setCurrentNovel(SHARED.project.data.getLastHandle("novelTree"))
         return
 
     @pyqtSlot()

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -97,9 +97,9 @@ class GuiNovelView(QWidget):
 
     def clearNovelView(self) -> None:
         """Clear project-related GUI content."""
-        # self.novelTree.clearContent()
         self.novelBar.clearContent()
         self.novelBar.setEnabled(False)
+        self.novelTree.clearContent()
         return
 
     def openProjectTasks(self) -> None:
@@ -473,6 +473,11 @@ class GuiNovelTree(NTreeView):
     ##
     #  Class Methods
     ##
+
+    def clearContent(self) -> None:
+        """Clear the tree view."""
+        self.setModel(None)
+        return
 
     def resizeColumns(self) -> None:
         """Set the correct column sizes."""

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -45,8 +45,8 @@ from novelwriter.extensions.modified import NIconToolButton, NTreeView
 from novelwriter.extensions.novelselector import NovelSelector
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import (
-    QtHeaderFixed, QtHeaderStretch, QtHeaderToContents, QtScrollAlwaysOff,
-    QtScrollAsNeeded, QtSizeExpanding
+    QtHeaderStretch, QtHeaderToContents, QtScrollAlwaysOff, QtScrollAsNeeded,
+    QtSizeExpanding
 )
 
 logger = logging.getLogger(__name__)
@@ -481,12 +481,10 @@ class GuiNovelTree(NTreeView):
             header.setMinimumSectionSize(SHARED.theme.baseIconHeight + 6)
             header.setSectionResizeMode(0, QtHeaderStretch)
             header.setSectionResizeMode(1, QtHeaderToContents)
-            if model.columns == 3:
-                header.setSectionResizeMode(2, QtHeaderToContents)
-            elif model.columns == 4:
-                header.setSectionResizeMode(2, QtHeaderFixed)
+            header.setSectionResizeMode(2, QtHeaderToContents)
+            if model.columns == 4:
                 header.setSectionResizeMode(3, QtHeaderToContents)
-                header.resizeSection(2, int(self._lastColSize * vp.width()))
+                header.setMaximumSectionSize(int(self._lastColSize * vp.width()))
         return
 
     ##

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1399,6 +1399,7 @@ class _TreeContextMenu(QMenu):
         if itemLayout == nwItemLayout.DOCUMENT and self._item.documentAllowed():
             self._item.setLayout(nwItemLayout.DOCUMENT)
             self._item.notifyToRefresh()
+            self._item.notifyNovelStructureChange()
         elif itemLayout == nwItemLayout.NOTE:
             self._item.setLayout(nwItemLayout.NOTE)
             self._item.notifyToRefresh()
@@ -1415,6 +1416,7 @@ class _TreeContextMenu(QMenu):
                 self._item.setType(nwItemType.FILE)
                 self._item.setLayout(nwItemLayout.DOCUMENT)
                 self._item.notifyToRefresh()
+                self._item.notifyNovelStructureChange()
             elif msgYes and itemLayout == nwItemLayout.NOTE:
                 self._item.setType(nwItemType.FILE)
                 self._item.setLayout(nwItemLayout.NOTE)

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -517,7 +517,6 @@ class GuiProjectTree(QTreeView):
 
     def initSettings(self) -> None:
         """Set or update tree widget settings."""
-        # Scroll bars
         if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1022,7 +1022,7 @@ class GuiProjectTree(QTreeView):
         return [i for i in self.selectedIndexes() if i.column() == 0]
 
     def _getModel(self) -> ProjectModel | None:
-        """Return a project node corresponding to a model index."""
+        """Return the model, if it exists."""
         if isinstance(model := self.model(), ProjectModel):
             return model
         return None

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -694,7 +694,7 @@ class GuiIcons:
         else:
             icon = self._loadIcon(name, color, w, h)
             self._qIcons[key] = icon
-            logger.info("Icon: %s", key)
+            logger.debug("Icon: %s", key)
             return icon
 
     def getToggleIcon(self, name: str, size: tuple[int, int], color: str | None = None) -> QIcon:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -247,8 +247,6 @@ class GuiMain(QMainWindow):
         self.docEditor.itemHandleChanged.connect(self.novelView.setActiveHandle)
         self.docEditor.itemHandleChanged.connect(self.projView.setActiveHandle)
         self.docEditor.loadDocumentTagRequest.connect(self._followTag)
-        self.docEditor.novelItemMetaChanged.connect(self.novelView.updateNovelItemMeta)
-        self.docEditor.novelStructureChanged.connect(self.novelView.refreshTree)
         self.docEditor.openDocumentRequest.connect(self._openDocument)
         self.docEditor.requestNewNoteCreation.connect(SHARED.createNewNote)
         self.docEditor.requestNextDocument.connect(self.openNextDocument)
@@ -735,7 +733,6 @@ class GuiMain(QMainWindow):
 
             SHARED.project.index.rebuild()
             SHARED.project.tree.refreshAllItems()
-            self.novelView.refreshTree()
 
             tEnd = time()
             self.mainStatus.setStatusMessage(
@@ -1163,20 +1160,23 @@ class GuiMain(QMainWindow):
         elif view == nwView.PROJECT:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.projView)
-            self.novelView.setActive(False)
         elif view == nwView.NOVEL:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.novelView)
-            self.novelView.setActive(True)
         elif view == nwView.SEARCH:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.projSearch)
             self.projSearch.beginSearch(
                 self.docEditor.getSelectedText() if self.docEditor.anyFocus() else ""
             )
-            self.novelView.setActive(False)
         elif view == nwView.OUTLINE:
             self.mainStack.setCurrentWidget(self.outlineView)
+
+        # Set active status
+        isMain = self.mainStack.currentWidget() == self.splitMain
+        isNovel = self.projStack.currentWidget() == self.novelView
+        self.novelView.setActive(isMain and isNovel)
+
         return
 
     @pyqtSlot(nwDocAction)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1163,15 +1163,18 @@ class GuiMain(QMainWindow):
         elif view == nwView.PROJECT:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.projView)
+            self.novelView.setActive(False)
         elif view == nwView.NOVEL:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.novelView)
+            self.novelView.setActive(True)
         elif view == nwView.SEARCH:
             self.mainStack.setCurrentWidget(self.splitMain)
             self.projStack.setCurrentWidget(self.projSearch)
             self.projSearch.beginSearch(
                 self.docEditor.getSelectedText() if self.docEditor.anyFocus() else ""
             )
+            self.novelView.setActive(False)
         elif view == nwView.OUTLINE:
             self.mainStack.setCurrentWidget(self.outlineView)
         return

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -532,7 +532,7 @@ class GuiMain(QMainWindow):
     ) -> bool:
         """Open a specific document, optionally at a given line."""
         if not (SHARED.hasProject and tHandle):
-            logger.error("Nothing to open open")
+            logger.error("Nothing to open")
             return False
 
         if sTitle and tLine is None:

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -63,10 +63,11 @@ class SharedData(QObject):
     indexChangedTags = pyqtSignal(list, list)
     indexCleared = pyqtSignal()
     mainClockTick = pyqtSignal()
+    novelStructureChanged = pyqtSignal(str)
     projectItemChanged = pyqtSignal(str, Enum)
-    rootFolderChanged = pyqtSignal(str, Enum)
     projectStatusChanged = pyqtSignal(bool)
     projectStatusMessage = pyqtSignal(str)
+    rootFolderChanged = pyqtSignal(str, Enum)
     spellLanguageChanged = pyqtSignal(str, str)
     statusLabelsChanged = pyqtSignal(str)
 

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -137,9 +137,10 @@ class GuiNovelDetails(NNonBlockingDialog):
 
     def updateValues(self) -> None:
         """Load the dialogs initial values."""
-        self.overviewPage.updateProjectData()
-        self.overviewPage.novelValueChanged(self.novelSelector.handle)
-        self.contentsPage.novelValueChanged(self.novelSelector.handle)
+        if handle := self.novelSelector.handle:
+            self.overviewPage.updateProjectData()
+            self.overviewPage.novelValueChanged(handle)
+            self.contentsPage.novelValueChanged(handle)
         return
 
     ##

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7a3" hexVersion="0x020700a3" fileVersion="1.5" fileRevision="4" timeStamp="2025-02-16 21:53:19">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2160" autoCount="281" editTime="95932">
+<novelWriterXML appVersion="2.7a3" hexVersion="0x020700a3" fileVersion="1.5" fileRevision="4" timeStamp="2025-03-23 22:26:31">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2166" autoCount="282" editTime="96058">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">636b6aa9b697b</entry>
       <entry key="viewer">636b6aa9b697b</entry>
-      <entry key="novelTree">7031beac91f75</entry>
+      <entry key="novel">7031beac91f75</entry>
       <entry key="outline">7031beac91f75</entry>
     </lastHandle>
     <autoReplace>
@@ -66,7 +66,7 @@
       <name status="s90e6c9" import="ia857f0" active="yes">Another Scene</name>
     </item>
     <item handle="ba8a28a246524" parent="7031beac91f75" root="7031beac91f75" order="4" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H2" charCount="649" wordCount="101" paraCount="3" cursorPos="1182" />
+      <meta expanded="no" heading="H2" charCount="617" wordCount="101" paraCount="3" cursorPos="1182" />
       <name status="s78ea90" import="ia857f0" active="yes">Interlude</name>
     </item>
     <item handle="96b68994dfa3d" parent="7031beac91f75" root="7031beac91f75" order="5" type="FILE" class="NOVEL" layout="NOTE">

--- a/tests/files/nwProject-1.5.nwx
+++ b/tests/files/nwProject-1.5.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">636b6aa9b697b</entry>
       <entry key="viewer">636b6aa9b697b</entry>
-      <entry key="novelTree">7031beac91f75</entry>
+      <entry key="novel">7031beac91f75</entry>
       <entry key="outline">7031beac91f75</entry>
     </lastHandle>
     <autoReplace>

--- a/tests/lipsum/nwProject.nwx
+++ b/tests/lipsum/nwProject.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">7a992350f3eb6</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">b3643d0f92e32</entry>
+      <entry key="novel">b3643d0f92e32</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace>

--- a/tests/mocked.py
+++ b/tests/mocked.py
@@ -65,7 +65,10 @@ class MockTheme:
         self.guiFontBU = QFont()
         return
 
-    def getPixmap(self, *a):
+    def getPixmap(self, *a) -> QPixmap:
+        return QPixmap()
+
+    def getHeaderDecoration(self, *a) -> QPixmap:
         return QPixmap()
 
     def getIcon(self, *a) -> QIcon:

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2025-02-06 11:05:16
+timestamp = 2025-02-22 19:57:47
 
 [Main]
 font = 
@@ -13,6 +13,7 @@ hidevscroll = False
 hidehscroll = False
 lastnotes = 0x0
 nativefont = True
+usecharcount = False
 
 [Sizes]
 mainwindow = 1200, 650

--- a/tests/reference/coreProject_NewFileFolder_nwProject.nwx
+++ b/tests/reference/coreProject_NewFileFolder_nwProject.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace />

--- a/tests/reference/coreProject_NewRoot_nwProject.nwx
+++ b/tests/reference/coreProject_NewRoot_nwProject.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace />

--- a/tests/reference/coreTools_DocDuplicator_nwProject.nwx
+++ b/tests/reference/coreTools_DocDuplicator_nwProject.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace />

--- a/tests/reference/coreTools_ProjectBuilderA_nwProject.nwx
+++ b/tests/reference/coreTools_ProjectBuilderA_nwProject.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace />

--- a/tests/reference/coreTools_ProjectBuilderB_nwProject.nwx
+++ b/tests/reference/coreTools_ProjectBuilderB_nwProject.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace />

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">000000000000f</entry>
       <entry key="viewer">000000000000f</entry>
-      <entry key="novelTree">0000000000008</entry>
+      <entry key="novel">0000000000008</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace />

--- a/tests/reference/guiEditor_Main_Initial_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Initial_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.6b1" hexVersion="0x020600b1" fileVersion="1.5" fileRevision="4" timeStamp="2024-11-23 17:46:20">
+<novelWriterXML appVersion="2.7a3" hexVersion="0x020700a3" fileVersion="1.5" fileRevision="4" timeStamp="2025-03-23 22:33:54">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="2" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">0000000000008</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace />

--- a/tests/reference/projectXML_ReadLegacy10.nwx
+++ b/tests/reference/projectXML_ReadLegacy10.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace>

--- a/tests/reference/projectXML_ReadLegacy11.nwx
+++ b/tests/reference/projectXML_ReadLegacy11.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace>

--- a/tests/reference/projectXML_ReadLegacy12.nwx
+++ b/tests/reference/projectXML_ReadLegacy12.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace>

--- a/tests/reference/projectXML_ReadLegacy13.nwx
+++ b/tests/reference/projectXML_ReadLegacy13.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace>

--- a/tests/reference/projectXML_ReadLegacy14.nwx
+++ b/tests/reference/projectXML_ReadLegacy14.nwx
@@ -11,7 +11,7 @@
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>
-      <entry key="novelTree">None</entry>
+      <entry key="novel">None</entry>
       <entry key="outline">None</entry>
     </lastHandle>
     <autoReplace>

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -708,15 +708,6 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
     assert wC == 12  # Words in text and title only
     assert pC == 2   # Paragraphs in text only
 
-    # getItemData + getHandleHeaderCount
-    # ==================================
-
-    item = index.getItemData(nHandle)
-    assert isinstance(item, IndexNode)
-    assert item.headings() == ["T0001"]
-    assert index.getHandleHeaderCount(nHandle) == 1
-    assert index.getHandleHeaderCount("foo") == 0
-
     # getReferences
     # =============
 

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -28,7 +28,7 @@ import pytest
 
 from novelwriter import SHARED
 from novelwriter.constants import nwFiles
-from novelwriter.core.index import Index, IndexNode, TagsIndex
+from novelwriter.core.index import Index, TagsIndex
 from novelwriter.core.item import NWItem
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwComment, nwItemClass, nwItemLayout

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -30,15 +30,16 @@ from novelwriter import SHARED
 from novelwriter.constants import nwFiles
 from novelwriter.core.index import Index, TagsIndex
 from novelwriter.core.item import NWItem
+from novelwriter.core.novelmodel import NovelModel
 from novelwriter.core.project import NWProject
-from novelwriter.enum import nwComment, nwItemClass, nwItemLayout
+from novelwriter.enum import nwComment, nwItemClass, nwItemLayout, nwNovelExtra
 
 from tests.mocked import causeException
 from tests.tools import C, buildTestProject, cmpFiles
 
 
 @pytest.mark.core
-def testCoreIndex_LoadSave(qtbot, monkeypatch, prjLipsum, mockGUI, tstPaths):
+def testCoreIndex_LoadSave(qtbot, monkeypatch, prjLipsum, nwGUI, tstPaths):
     """Test core functionality of scanning, saving, loading and checking
     the index cache file.
     """
@@ -52,6 +53,18 @@ def testCoreIndex_LoadSave(qtbot, monkeypatch, prjLipsum, mockGUI, tstPaths):
     index = Index(project)
     assert repr(index) == "<Index project='Lorem Ipsum'>"
 
+    # Check Novel Model
+    model = index.getNovelModel("b3643d0f92e32")
+    assert isinstance(model, NovelModel)
+    assert model.columns == 3
+
+    index.setNovelModelExtraColumn(nwNovelExtra.POV)
+    index.refreshNovelModel("b3643d0f92e32")
+    model = index.getNovelModel("b3643d0f92e32")
+    assert isinstance(model, NovelModel)
+    assert model.columns == 4
+
+    # Re-index
     notIndexable = {
         "b3643d0f92e32": False,  # Novel ROOT
         "45e6b01ca35c1": False,  # Chapter One FOLDER
@@ -216,7 +229,7 @@ def testCoreIndex_ScanThis(mockGUI):
 
 
 @pytest.mark.core
-def testCoreIndex_CheckThese(mockGUI, fncPath, mockRnd):
+def testCoreIndex_CheckThese(nwGUI, fncPath, mockRnd):
     """Test the tag checker function checkThese."""
     project = NWProject()
     mockRnd.reset()
@@ -338,7 +351,7 @@ def testCoreIndex_CheckThese(mockGUI, fncPath, mockRnd):
 
 
 @pytest.mark.core
-def testCoreIndex_ScanText(monkeypatch, mockGUI, fncPath, mockRnd):
+def testCoreIndex_ScanText(monkeypatch, nwGUI, fncPath, mockRnd):
     """Check the index text scanner."""
     project = NWProject()
     mockRnd.reset()
@@ -586,7 +599,7 @@ def testCoreIndex_ScanText(monkeypatch, mockGUI, fncPath, mockRnd):
 
 
 @pytest.mark.core
-def testCoreIndex_CommentKeys(monkeypatch, mockGUI, fncPath, mockRnd):
+def testCoreIndex_CommentKeys(monkeypatch, nwGUI, fncPath, mockRnd):
     """Check the index comment key generator."""
     project = NWProject()
     mockRnd.reset()
@@ -623,7 +636,7 @@ def testCoreIndex_CommentKeys(monkeypatch, mockGUI, fncPath, mockRnd):
 
 
 @pytest.mark.core
-def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
+def testCoreIndex_ExtractData(nwGUI, fncPath, mockRnd):
     """Check the index data extraction functions."""
     project = NWProject()
     mockRnd.reset()
@@ -755,7 +768,9 @@ def testCoreIndex_ExtractData(mockGUI, fncPath, mockRnd):
 
     # getClassTags
     # ============
+    assert index.getClassTags(None) == ["Jane", "John"]
     assert index.getClassTags(nwItemClass.CHARACTER) == ["Jane", "John"]
+    assert index.getClassTags(nwItemClass.PLOT) == []
 
     # getTagsData
     # ===========
@@ -1142,7 +1157,7 @@ def testCoreIndex_TagsIndex():
 
 
 @pytest.mark.core
-def testCoreIndex_ItemIndex(mockGUI, fncPath, mockRnd):
+def testCoreIndex_ItemIndex(nwGUI, fncPath, mockRnd):
     """Check the ItemIndex class."""
     project = NWProject()
     mockRnd.reset()

--- a/tests/test_core/test_core_indexdata.py
+++ b/tests/test_core/test_core_indexdata.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import pytest
 
+from novelwriter.core.index import TagsIndex
 from novelwriter.core.indexdata import IndexHeading, IndexNode
 from novelwriter.core.item import NWItem
 from novelwriter.core.project import NWProject
@@ -33,9 +34,10 @@ def testCoreIndexData_IndexNode(mockGUI):
     handle = "0123456789abc"
     project = NWProject()
     item = NWItem(project, handle)
+    tags = TagsIndex()
 
     # Defaults
-    node = IndexNode(handle, item)
+    node = IndexNode(tags, handle, item)
     assert node.handle == handle
     assert node.item is item
     assert str(node) == f"<IndexNode handle='{handle}'>"
@@ -44,8 +46,8 @@ def testCoreIndexData_IndexNode(mockGUI):
     assert "T0000" in node  # Placeholder heading
 
     # Add a heading
-    head1 = IndexHeading(node.nextHeading(), line=1, level="H1", title="Heading 1")
-    head2 = IndexHeading(node.nextHeading(), line=10, level="H2", title="Heading 2")
+    head1 = IndexHeading(tags, node.nextHeading(), line=1, level="H1", title="Heading 1")
+    head2 = IndexHeading(tags, node.nextHeading(), line=10, level="H2", title="Heading 2")
     node.addHeading(head1)
     node.addHeading(head2)
     assert len(node) == 2
@@ -105,11 +107,12 @@ def testCoreIndexData_IndexNodePackUnpack(mockGUI):
     handle = "0123456789abc"
     project = NWProject()
     item = NWItem(project, handle)
-    node = IndexNode(handle, item)
+    tags = TagsIndex()
+    node = IndexNode(tags, handle, item)
 
     # Add some headings and notes
-    head1 = IndexHeading(node.nextHeading(), line=1, level="H1", title="Heading 1")
-    head2 = IndexHeading(node.nextHeading(), line=10, level="H2", title="Heading 2")
+    head1 = IndexHeading(tags, node.nextHeading(), line=1, level="H1", title="Heading 1")
+    head2 = IndexHeading(tags, node.nextHeading(), line=10, level="H2", title="Heading 2")
     node.addHeading(head1)
     node.addHeading(head2)
     node.setHeadingCounts("T0001", 42, 13, 3)
@@ -128,7 +131,7 @@ def testCoreIndexData_IndexNodePackUnpack(mockGUI):
     assert set(data["document"]["footnotes"]) == {"key1", "key2"}
 
     # Create a new node
-    new = IndexNode(handle, item)
+    new = IndexNode(tags, handle, item)
 
     # Unpack heading one
     data = {"T0001": {"meta": {
@@ -165,7 +168,8 @@ def testCoreIndexData_IndexNodePackUnpack(mockGUI):
 def testCoreIndexData_IndexHeading():
     """Test the IndexHeading class."""
     # Defaults
-    head = IndexHeading("T0001")
+    tags = TagsIndex()
+    head = IndexHeading(tags, "T0001")
     assert str(head) == "<IndexHeading key='T0001'>"
     assert repr(head) == "<IndexHeading key='T0001'>"
     assert head.key == "T0001"
@@ -234,11 +238,13 @@ def testCoreIndexData_IndexHeading():
 @pytest.mark.core
 def testCoreIndexData_IndexHeadingUnpackMeta():
     """Test IndexHeading class meta unpacking."""
+    tags = TagsIndex()
+
     # Valid
     data = {"meta": {
         "level": "H1", "title": "So it Begins", "line": 1, "tag": "begins", "counts": [95, 18, 1]
     }}
-    head = IndexHeading("T0001")
+    head = IndexHeading(tags, "T0001")
     head.unpackData(data)
     assert head.level == "H1"
     assert head.title == "So it Begins"
@@ -252,7 +258,7 @@ def testCoreIndexData_IndexHeadingUnpackMeta():
     data = {"meta": {
         "level": "H9", "title": None, "line": None, "tag": None, "counts": [42]
     }}
-    head = IndexHeading("T0001")
+    head = IndexHeading(tags, "T0001")
     head.unpackData(data)
     assert head.level == "H0"
     assert head.title == "None"
@@ -264,7 +270,7 @@ def testCoreIndexData_IndexHeadingUnpackMeta():
 
     # Empty
     data = {"meta": {}}
-    head = IndexHeading("T0001")
+    head = IndexHeading(tags, "T0001")
     head.unpackData(data)
     assert head.level == "H0"
     assert head.title == ""
@@ -278,11 +284,13 @@ def testCoreIndexData_IndexHeadingUnpackMeta():
 @pytest.mark.core
 def testCoreIndexData_IndexHeadingUnpackRefs():
     """Test IndexHeading class refs unpacking."""
+    tags = TagsIndex()
+
     # Valid
     data = {"refs": {
         "jane": "@char,@pov", "john": "@char", "earth": "@location", "space": "@mention,@location"
     }}
-    head = IndexHeading("T0001")
+    head = IndexHeading(tags, "T0001")
     head.unpackData(data)
     assert head.references["jane"] == {"@char", "@pov"}
     assert head.references["john"] == {"@char"}
@@ -291,18 +299,18 @@ def testCoreIndexData_IndexHeadingUnpackRefs():
 
     # Invalid key
     data = {"refs": {0: "@char,@pov"}}
-    head = IndexHeading("T0001")
+    head = IndexHeading(tags, "T0001")
     with pytest.raises(ValueError, match="Heading reference key must be a string"):
         head.unpackData(data)
 
     # Invalid value
     data = {"refs": {"jane": None}}
-    head = IndexHeading("T0001")
+    head = IndexHeading(tags, "T0001")
     with pytest.raises(ValueError, match="Heading reference value must be a string"):
         head.unpackData(data)
 
     # Invalid keyword
     data = {"refs": {"jane": "@char,@pov,@stuff"}}
-    head = IndexHeading("T0001")
+    head = IndexHeading(tags, "T0001")
     with pytest.raises(ValueError, match="Heading reference contains an invalid keyword"):
         head.unpackData(data)

--- a/tests/test_core/test_core_novelmodel.py
+++ b/tests/test_core/test_core_novelmodel.py
@@ -1,0 +1,178 @@
+"""
+novelWriter – Novel Model Tester
+================================
+
+This file is a part of novelWriter
+Copyright (C) 2025 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+from __future__ import annotations
+
+import pytest
+
+from PyQt6.QtCore import QModelIndex, Qt
+
+from novelwriter.core.indexdata import IndexHeading
+from novelwriter.core.novelmodel import NovelModel
+from novelwriter.core.project import NWProject
+from novelwriter.enum import nwNovelExtra
+
+from tests.tools import C, buildTestProject
+
+
+@pytest.mark.core
+def testCoreNovelModel_Interface(nwGUI, fncPath, mockRnd):
+    """Test the novel model interface."""
+    project = NWProject()
+    mockRnd.reset()
+    buildTestProject(project, fncPath)
+
+    model = project.index.getNovelModel(C.hNovelRoot)
+    assert isinstance(model, NovelModel)
+
+    root = QModelIndex()
+    assert root.row() == -1
+
+    # Initial structure
+    assert model.rowCount(root) == 3
+    assert model.columnCount(root) == 3
+    assert model.data(model.createIndex(0, 0), Qt.ItemDataRole.DisplayRole) == "New Novel"
+    assert model.handle(model.createIndex(0, 0)) == C.hTitlePage
+    assert model.key(model.createIndex(0, 0)) == "T0001"
+
+    # Clear the model and check error handling
+    model.clear()
+
+    assert model.data(root, Qt.ItemDataRole.DisplayRole) is None
+    assert model.handle(root) is None
+    assert model.key(root) is None
+
+
+@pytest.mark.core
+def testCoreNovelModel_Extra(nwGUI, fncPath, mockRnd):
+    """Test the novel model extra column."""
+    project = NWProject()
+    mockRnd.reset()
+    buildTestProject(project, fncPath)
+
+    root = QModelIndex()
+    model = project.index.getNovelModel(C.hNovelRoot)
+    assert isinstance(model, NovelModel)
+    assert model.rowCount(root) == 3
+
+    project.index._tagsIndex.add("Jane", "Jane", "0000000000000", "T0001", "CHARACTER")
+    project.index._tagsIndex.add("John", "John", "0000000000000", "T0001", "CHARACTER")
+    project.index._tagsIndex.add("Main", "Main", "0000000000000", "T0001", "PLOT")
+    project.index._tagsIndex.add("Side", "Side", "0000000000000", "T0001", "PLOT")
+
+    scene = project.index._itemIndex[C.hSceneDoc]
+    assert scene is not None
+    scene.addHeadingRef("T0001", ["Jane"], "@pov")
+    scene.addHeadingRef("T0001", ["John"], "@focus")
+    scene.addHeadingRef("T0001", ["Main"], "@plot")
+    scene.addHeadingRef("T0001", ["Side"], "@plot")
+
+    # No extra by default
+    assert model.columns == 3
+    assert model._extraKey == ""
+    assert model._extraLabel == ""
+
+    # Point of view
+    model.setExtraColumn(nwNovelExtra.POV)
+    model.refresh(scene)
+    assert model.columns == 4
+    assert model._extraKey == "@pov"
+    assert model._extraLabel == "Point of View"
+    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "Jane"
+
+    model.setExtraColumn(nwNovelExtra.HIDDEN)
+    assert model.columns == 3
+
+    # Focus
+    model.setExtraColumn(nwNovelExtra.FOCUS)
+    model.refresh(scene)
+    assert model.columns == 4
+    assert model._extraKey == "@focus"
+    assert model._extraLabel == "Focus"
+    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "John"
+
+    model.setExtraColumn(nwNovelExtra.HIDDEN)
+    assert model.columns == 3
+
+    # Plot
+    model.setExtraColumn(nwNovelExtra.PLOT)
+    model.refresh(scene)
+    assert model.columns == 4
+    assert model._extraKey == "@plot"
+    assert model._extraLabel == "Plot"
+    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "Main, Side"
+
+    model.setExtraColumn(nwNovelExtra.HIDDEN)
+    assert model.columns == 3
+
+
+@pytest.mark.core
+def testCoreNovelModel_Data(nwGUI, fncPath, mockRnd):
+    """Test the novel model data methods."""
+    project = NWProject()
+    mockRnd.reset()
+    buildTestProject(project, fncPath)
+
+    root = QModelIndex()
+    model = project.index.getNovelModel(C.hNovelRoot)
+    assert isinstance(model, NovelModel)
+    assert model.rowCount(root) == 3
+
+    title = project.index._itemIndex[C.hTitlePage]
+    chapter = project.index._itemIndex[C.hChapterDoc]
+    scene = project.index._itemIndex[C.hSceneDoc]
+
+    assert title is not None
+    assert chapter is not None
+    assert scene is not None
+
+    # Clear the model and try to refresh
+    model.clear()
+    assert model.rowCount(root) == 0
+
+    # Cannot refresh an empty model
+    assert model.refresh(title) is False
+
+    # Add all back
+    model.append(title)
+    model.append(chapter)
+    model.append(scene)
+
+    # Add headings to scene
+    scene.addHeading(IndexHeading(scene._tags, "T0002", 10, "H4", "A Section"))
+    scene.addHeading(IndexHeading(scene._tags, "T0003", 10, "H4", "Another Section"))
+    assert model.refresh(scene) is True
+    assert [
+        model.data(model.createIndex(i, 0), Qt.ItemDataRole.DisplayRole)
+        for i in range(model.rowCount(root))
+    ] == [
+        "New Novel", "New Chapter", "New Scene", "A Section", "Another Section",
+    ]
+
+    # Remove new headings
+    del scene._headings["T0002"]
+    del scene._headings["T0003"]
+    assert model.refresh(scene) is True
+    assert [
+        model.data(model.createIndex(i, 0), Qt.ItemDataRole.DisplayRole)
+        for i in range(model.rowCount(root))
+    ] == [
+        "New Novel", "New Chapter", "New Scene",
+    ]

--- a/tests/test_core/test_core_options.py
+++ b/tests/test_core/test_core_options.py
@@ -27,7 +27,7 @@ import pytest
 from novelwriter.constants import nwFiles
 from novelwriter.core.options import OptionState
 from novelwriter.core.project import NWProject
-from novelwriter.gui.noveltree import NovelTreeColumn
+from novelwriter.enum import nwNovelExtra
 
 from tests.mocked import causeOSError
 
@@ -110,7 +110,7 @@ def testCoreOptions_SetGet(mockGUI):
     project = NWProject()
     options = OptionState(project)
 
-    nwColHidden = NovelTreeColumn.HIDDEN
+    nwColHidden = nwNovelExtra.HIDDEN
 
     # Set invalid values
     assert options.setValue("MockGroup", "mockItem", None) is False
@@ -141,7 +141,7 @@ def testCoreOptions_SetGet(mockGUI):
     assert options.getFloat("GuiNovelDetails", "mockItem", None) is None  # type: ignore
     assert options.getBool("GuiNovelDetails", "clearDouble", None) is True  # type: ignore
     assert options.getBool("GuiNovelDetails", "mockItem", None) is None  # type: ignore
-    assert options.getEnum("GuiNovelView", "lastCol", NovelTreeColumn, nwColHidden) == nwColHidden
+    assert options.getEnum("GuiNovelView", "lastCol", nwNovelExtra, nwColHidden) == nwColHidden
 
     # Get from non-existent  groups
     assert options.getValue("SomeGroup", "mockItem", None) is None
@@ -149,4 +149,4 @@ def testCoreOptions_SetGet(mockGUI):
     assert options.getInt("SomeGroup", "mockItem", None) is None  # type: ignore
     assert options.getFloat("SomeGroup", "mockItem", None) is None  # type: ignore
     assert options.getBool("SomeGroup", "mockItem", None) is None  # type: ignore
-    assert options.getEnum("SomeGroup", "mockItem", NovelTreeColumn, None) is None  # type: ignore
+    assert options.getEnum("SomeGroup", "mockItem", nwNovelExtra, None) is None  # type: ignore

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -155,7 +155,7 @@ def testCoreProjectXML_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
 
     assert data.getLastHandle("editor") == "636b6aa9b697b"
     assert data.getLastHandle("viewer") == "636b6aa9b697b"
-    assert data.getLastHandle("novelTree") == "7031beac91f75"
+    assert data.getLastHandle("novel") == "7031beac91f75"
     assert data.getLastHandle("outline") == "7031beac91f75"
 
     assert data.itemStatus["sf12341"].name == "New"
@@ -284,7 +284,7 @@ def testCoreProjectXML_ReadLegacy10(tstPaths, fncPath, mockGUI, mockRnd):
 
     assert data.getLastHandle("editor") is None  # Dropped by conversion
     assert data.getLastHandle("viewer") is None  # Dropped by conversion
-    assert data.getLastHandle("novelTree") is None  # Doesn't exist in 1.0
+    assert data.getLastHandle("novel") is None  # Doesn't exist in 1.0
     assert data.getLastHandle("outline") is None  # Doesn't exist in 1.0
 
     assert data.itemStatus["s000000"].name == "New"
@@ -429,7 +429,7 @@ def testCoreProjectXML_ReadLegacy11(tstPaths, fncPath, mockGUI, mockRnd):
 
     assert data.getLastHandle("editor") is None  # Dropped by conversion
     assert data.getLastHandle("viewer") is None  # Dropped by conversion
-    assert data.getLastHandle("novelTree") is None  # Doesn't exist in 1.1
+    assert data.getLastHandle("novel") is None  # Doesn't exist in 1.1
     assert data.getLastHandle("outline") is None  # Doesn't exist in 1.1
 
     assert data.itemStatus["s000000"].name == "New"
@@ -574,7 +574,7 @@ def testCoreProjectXML_ReadLegacy12(tstPaths, fncPath, mockGUI, mockRnd):
 
     assert data.getLastHandle("editor") is None  # Dropped by conversion
     assert data.getLastHandle("viewer") is None  # Dropped by conversion
-    assert data.getLastHandle("novelTree") is None  # Doesn't exist in 1.2
+    assert data.getLastHandle("novel") is None  # Doesn't exist in 1.2
     assert data.getLastHandle("outline") is None  # Doesn't exist in 1.2
 
     assert data.itemStatus["s000000"].name == "New"
@@ -722,7 +722,7 @@ def testCoreProjectXML_ReadLegacy13(tstPaths, fncPath, mockGUI, mockRnd):
 
     assert data.getLastHandle("editor") is None  # Dropped by conversion
     assert data.getLastHandle("viewer") is None  # Dropped by conversion
-    assert data.getLastHandle("novelTree") is None  # Doesn't exist in 1.3
+    assert data.getLastHandle("novel") is None  # Doesn't exist in 1.3
     assert data.getLastHandle("outline") is None  # Doesn't exist in 1.3
 
     assert data.itemStatus["s000000"].name == "New"
@@ -870,7 +870,7 @@ def testCoreProjectXML_ReadLegacy14(tstPaths, fncPath, mockGUI, mockRnd):
 
     assert data.getLastHandle("editor") is None  # Dropped by conversion
     assert data.getLastHandle("viewer") is None  # Dropped by conversion
-    assert data.getLastHandle("novelTree") is None  # Doesn't exist in 1.3
+    assert data.getLastHandle("novel") is None  # Doesn't exist in 1.3
     assert data.getLastHandle("outline") is None  # Doesn't exist in 1.3
 
     assert data.itemStatus["sf12341"].name == "New"

--- a/tests/test_ext/test_ext_modified.py
+++ b/tests/test_ext/test_ext_modified.py
@@ -23,13 +23,13 @@ from __future__ import annotations
 import pytest
 
 from PyQt6.QtCore import QEvent, QPoint, QPointF, Qt
-from PyQt6.QtGui import QKeyEvent, QMouseEvent, QWheelEvent
+from PyQt6.QtGui import QKeyEvent, QMouseEvent, QStandardItem, QStandardItemModel, QWheelEvent
 from PyQt6.QtWidgets import QWidget
 
 from novelwriter.extensions.modified import (
-    NClickableLabel, NComboBox, NDialog, NDoubleSpinBox, NSpinBox
+    NClickableLabel, NComboBox, NDialog, NDoubleSpinBox, NSpinBox, NTreeView
 )
-from novelwriter.types import QtModNone, QtMouseLeft, QtRejected
+from novelwriter.types import QtModNone, QtMouseLeft, QtMouseMiddle, QtRejected
 
 from tests.tools import SimpleDialog
 
@@ -64,6 +64,32 @@ def testExtModified_NDialog(qtbot, monkeypatch):
     with qtbot.waitSignal(dialog.rejected, timeout=1000):
         dialog.keyPressEvent(QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Escape, QtModNone))
         assert dialog.result() == QtRejected
+
+
+@pytest.mark.gui
+def testExtModified_NTreeView(qtbot, monkeypatch):
+    """Test the NTreeView class."""
+    model = QStandardItemModel(1, 1)
+    model.insertRow(0, QStandardItem("Hello World"))
+
+    widget = NTreeView()
+    widget.setModel(model)
+    dialog = SimpleDialog(widget)
+    dialog.show()
+
+    vPort = widget.viewport()
+    item = model.item(0, 0)
+    assert vPort is not None
+    assert item is not None
+
+    position = QPointF(widget.visualRect(model.createIndex(0, 0)).center())
+    event = QMouseEvent(
+        QEvent.Type.MouseButtonPress, position, QtMouseMiddle, QtMouseMiddle, QtModNone
+    )
+    with qtbot.waitSignal(widget.middleClicked):
+        widget.mousePressEvent(event)
+
+    # qtbot.stop()
 
 
 @pytest.mark.gui

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -151,12 +151,12 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Novel Tree has focus
     nwGUI._changeView(nwView.NOVEL)
-    nwGUI.novelView.novelTree.refreshTree(rootHandle=None, overRide=True)
     with monkeypatch.context() as mp:
         mp.setattr(GuiNovelView, "treeHasFocus", lambda *a: True)
         assert nwGUI.docEditor.docHandle is None
-        selItem = nwGUI.novelView.novelTree.topLevelItem(2)
-        nwGUI.novelView.novelTree.setCurrentItem(selItem)
+        model = nwGUI.novelView.novelTree._getModel()
+        assert model is not None
+        nwGUI.novelView.novelTree.setCurrentIndex(model.createIndex(2, 0))
         nwGUI._keyPressReturn()
         assert nwGUI.docEditor.docHandle == sHandle
         nwGUI.closeDocument()

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -38,6 +38,7 @@ from tests.tools import C, buildTestProject
 
 
 @pytest.mark.gui
+@pytest.mark.skip
 def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test navigating the novel tree."""
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
@@ -207,7 +208,7 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Set Default Root
     # ================
-    SHARED.project.data.setLastHandle(C.hInvalid, "novelTree")
+    SHARED.project.data.setLastHandle(C.hInvalid, "novel")
     novelView.openProjectTasks()
     assert novelBar.novelValue.handle == C.hNovelRoot
 

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -24,22 +24,19 @@ from pathlib import Path
 
 import pytest
 
-from PyQt6.QtCore import QEvent, QPoint, Qt
-from PyQt6.QtGui import QFocusEvent
+from PyQt6.QtCore import QModelIndex, QPoint, Qt
 from PyQt6.QtWidgets import QInputDialog, QToolTip
 
 from novelwriter import CONFIG, SHARED
+from novelwriter.core.novelmodel import NovelModel
 from novelwriter.dialogs.editlabel import GuiEditLabel
-from novelwriter.enum import nwFocus, nwItemType, nwNovelExtra
-from novelwriter.gui.noveltree import GuiNovelTree
-from novelwriter.types import QtMouseLeft, QtMouseMiddle
+from novelwriter.enum import nwFocus, nwItemType, nwNovelExtra, nwView
 
 from tests.tools import C, buildTestProject
 
 
 @pytest.mark.gui
-@pytest.mark.skip
-def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
+def testGuiNovelView_Content(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test navigating the novel tree."""
     monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text: (text, True))
 
@@ -52,20 +49,22 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     contentPath = SHARED.project.storage.contentPath
     assert isinstance(contentPath, Path)
+    cHandle = "0000000000010"
 
-    (contentPath / "0000000000010.nwd").write_text(
+    (contentPath / f"{cHandle}.nwd").write_text(
         "# Jane Doe\n\n@tag: Jane\n\n", encoding="utf-8"
     )
-    (contentPath / "000000000000f.nwd").write_text((
+    (contentPath / f"{C.hSceneDoc}.nwd").write_text((
         "### Scene One\n\n"
         "@pov: Jane\n"
         "@focus: Jane\n\n"
-        "% Synopsis: This is a scene."
+        "% Synopsis: This is a scene.\n\n"
+        "This is some text in the edited scene."
     ), encoding="utf-8")
 
     novelView = nwGUI.novelView
-    novelTree = novelView.novelTree
-    novelBar  = novelView.novelBar
+    novelTree = nwGUI.novelView.novelTree
+    novelBar  = nwGUI.novelView.novelBar
 
     # Show/Hide Scrollbars
     # ====================
@@ -84,153 +83,101 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Populate Tree
     # =============
+    root = QModelIndex()
 
     novelView.setTreeFocus()
+    nwGUI._changeView(nwView.NOVEL)
 
-    nwGUI.projStack.setCurrentWidget(nwGUI.novelView)
-    nwGUI.rebuildIndex()
-    novelTree._populateTree(rootHandle=None)
-    assert novelTree.topLevelItemCount() == 3
+    # Clear tree
+    novelView.setCurrentNovel(None)
+    assert novelTree._getModel() is None
 
-    # Rebuild should preserve selection
-    topItem = novelTree.topLevelItem(0)
-    assert not topItem.isSelected()
-    topItem.setSelected(True)
-    assert novelTree.selectedItems()[0] == topItem
-    assert novelView.getSelectedHandle() == (C.hTitlePage, "T0001")
+    # Reload
+    novelBar._forceRefreshNovelTree()
+    model = novelTree._getModel()
+    assert isinstance(model, NovelModel)
 
-    # Refresh using the slot for the button
-    novelBar._refreshNovelTree()
-    assert novelTree.topLevelItem(0).isSelected()
+    # Check the items
+    assert model.rowCount(root) == 3
+    assert model.columnCount(root) == 3
+    assert model.data(model.createIndex(2, 1), Qt.ItemDataRole.DisplayRole) == "2"  # Word Count
+
+    nwGUI.rebuildIndex()  # This should update the word count to the edited scene
+    assert model.data(model.createIndex(2, 1), Qt.ItemDataRole.DisplayRole) == "10"  # Word Count
+
+    # Extra Column
+    # ============
+    novelBar.setLastColType(nwNovelExtra.POV)
+    assert model.rowCount(root) == 3
+    assert model.columnCount(root) == 4
+
+    # Scene column should contain the POV character
+    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "Jane"
+
+    # Resize the last column
+    assert novelTree.lastColSize == 25
+    with monkeypatch.context() as mp:
+        mp.setattr(QInputDialog, "getInt", lambda *a, **k: (40, True))
+        novelBar._selectLastColumnSize()
+    assert novelTree.lastColSize == 40
 
     # Open Items
     # ==========
 
     # Clear selection
     novelTree.clearSelection()
-    scItem = novelTree.topLevelItem(2)
-    scItem.setSelected(True)
-    assert scItem.isSelected()
+    assert novelView.getSelectedHandle() == (None, None)
 
-    # Clear selection with mouse
-    vPort = novelTree.viewport()
-    qtbot.mouseClick(vPort, QtMouseLeft, pos=vPort.rect().center(), delay=10)
-    assert not scItem.isSelected()
+    # Select scene
+    novelTree.setCurrentIndex(model.createIndex(2, 0))
+    assert novelView.getSelectedHandle() == (C.hSceneDoc, "T0001")
 
     # Double-click item
-    scItem.setSelected(True)
-    assert scItem.isSelected()
-    assert nwGUI.docEditor.docHandle is None
-    novelTree._treeDoubleClick(scItem, 0)
+    novelTree._onDoubleClick(model.createIndex(2, 0))
     assert nwGUI.docEditor.docHandle == C.hSceneDoc
 
-    # Open item with middle mouse button
-    scItem.setSelected(True)
-    assert scItem.isSelected()
-    assert nwGUI.docViewer.docHandle is None
-    qtbot.mouseClick(vPort, QtMouseMiddle, pos=vPort.rect().center(), delay=10)
-    assert nwGUI.docViewer.docHandle is None
-
-    scRect = novelTree.visualItemRect(scItem)
-    oldData = scItem.data(novelTree.C_TITLE, novelTree.D_HANDLE)
-    scItem.setData(novelTree.C_TITLE, novelTree.D_HANDLE, None)
-    qtbot.mouseClick(vPort, QtMouseMiddle, pos=scRect.center(), delay=10)
-    assert nwGUI.docViewer.docHandle is None
-
-    scItem.setData(novelTree.C_TITLE, novelTree.D_HANDLE, oldData)
-    qtbot.mouseClick(vPort, QtMouseMiddle, pos=scRect.center(), delay=10)
+    # Middle-click item
+    novelTree._onMiddleClick(model.createIndex(2, 0))
     assert nwGUI.docViewer.docHandle == C.hSceneDoc
-
-    # Last Column
-    # ===========
-
-    novelBar.setLastColType(nwNovelExtra.HIDDEN)
-    assert novelTree.isColumnHidden(novelTree.C_EXTRA) is True
-    assert novelTree.lastColType == nwNovelExtra.HIDDEN
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == ("", "")
-
-    novelBar.setLastColType(nwNovelExtra.PLOT)
-    assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == nwNovelExtra.PLOT
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
-        "", ""
-    )
-
-    novelBar.setLastColType(nwNovelExtra.FOCUS)
-    assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == nwNovelExtra.FOCUS
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
-        "Jane", "Focus: Jane"
-    )
-
-    novelBar.setLastColType(nwNovelExtra.POV)
-    assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == nwNovelExtra.POV
-    assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
-        "Jane", "Point of View: Jane"
-    )
-
-    novelTree._lastCol = None
-    assert novelTree._getLastColumnText("0000000000000", "T0000") == ("", "")
-
-    # This forces the resizeEvent function to process labels
-    spSize = nwGUI.splitMain.sizes()
-    nwGUI.splitMain.setSizes([spSize[0] + 10, spSize[1] - 10])
-
-    # Resize the last column
-    with monkeypatch.context() as mp:
-        mp.setattr(QInputDialog, "getInt", lambda *a, **k: (40, True))
-        novelBar._selectLastColumnSize()
 
     # Item Meta
     # =========
 
-    ttText = ""
+    toolTip = ""
 
     def showText(pos, text):
-        nonlocal ttText
-        ttText = text
+        nonlocal toolTip
+        toolTip = text
 
-    mIndex = novelTree.model().index(2, novelTree.C_MORE)
     with monkeypatch.context() as mp:
         mp.setattr(QToolTip, "showText", showText)
 
-        ttText = ""
-        novelTree._treeItemClicked(mIndex)
-        assert ttText == (
-            "<p><b>Point of View</b>: Jane<br><b>Focus</b>: Jane</p>"
-            "<p><b>Synopsis</b>: This is a scene.</p>"
+        toolTip = ""
+        novelTree._onSingleClick(model.createIndex(2, 3))
+        assert toolTip == (
+            "<p><b>Point of View:</b> Jane<br><b>Focus:</b> Jane</p>"
+            "<p><b>Synopsis:</b> This is a scene.</p>"
         )
 
-        ttText = ""
+        toolTip = ""
         novelTree._popMetaBox(QPoint(1, 1), C.hInvalid, "T0001")
-        assert ttText == ""
+        assert toolTip == ""
 
-    # Set Default Root
-    # ================
-    SHARED.project.data.setLastHandle(C.hInvalid, "novel")
-    novelView.openProjectTasks()
-    assert novelBar.novelValue.handle == C.hNovelRoot
+    # Active Status
+    # =============
+    assert novelBar._refresh == {C.hNovelRoot: False}
 
-    # Tree Focus
-    # ==========
-    with monkeypatch.context() as mp:
-        mp.setattr(GuiNovelTree, "hasFocus", lambda *a: False)
-        assert novelView.treeHasFocus() is False
-        mp.setattr(GuiNovelTree, "hasFocus", lambda *a: True)
-        assert novelView.treeHasFocus() is True
+    # Add a document while tree in focus
+    nwGUI._changeView(nwView.PROJECT)
+    assert novelBar._active is False
+    nwGUI.projView.projTree.setSelectedHandle(C.hChapterDir)
+    nwGUI.projView.projTree.newTreeItem(nwItemType.FILE, hLevel=3)
+    assert novelBar._refresh == {C.hNovelRoot: True}
 
-    # Other Checks
-    # ============
-
-    scItem = novelTree.topLevelItem(2)
-    scItem.setSelected(True)
-    assert scItem.isSelected()
-    novelTree.focusOutEvent(QFocusEvent(QEvent.Type.None_, Qt.FocusReason.MouseFocusReason))
-    assert not scItem.isSelected()
+    # Switch back and check that the refresh status is reset
+    nwGUI._changeView(nwView.NOVEL)
+    assert novelBar._refresh == {C.hNovelRoot: False}
 
     # Close
-    # =====
-
     # qtbot.stop()
     nwGUI.closeProject()

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -30,8 +30,8 @@ from PyQt6.QtWidgets import QInputDialog, QToolTip
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.dialogs.editlabel import GuiEditLabel
-from novelwriter.enum import nwFocus, nwItemType
-from novelwriter.gui.noveltree import GuiNovelTree, NovelTreeColumn
+from novelwriter.enum import nwFocus, nwItemType, nwNovelExtra
+from novelwriter.gui.noveltree import GuiNovelTree
 from novelwriter.types import QtMouseLeft, QtMouseMiddle
 
 from tests.tools import C, buildTestProject
@@ -143,28 +143,28 @@ def testGuiNovelTree_TreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     # Last Column
     # ===========
 
-    novelBar.setLastColType(NovelTreeColumn.HIDDEN)
+    novelBar.setLastColType(nwNovelExtra.HIDDEN)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is True
-    assert novelTree.lastColType == NovelTreeColumn.HIDDEN
+    assert novelTree.lastColType == nwNovelExtra.HIDDEN
     assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == ("", "")
 
-    novelBar.setLastColType(NovelTreeColumn.PLOT)
+    novelBar.setLastColType(nwNovelExtra.PLOT)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == NovelTreeColumn.PLOT
+    assert novelTree.lastColType == nwNovelExtra.PLOT
     assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
         "", ""
     )
 
-    novelBar.setLastColType(NovelTreeColumn.FOCUS)
+    novelBar.setLastColType(nwNovelExtra.FOCUS)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == NovelTreeColumn.FOCUS
+    assert novelTree.lastColType == nwNovelExtra.FOCUS
     assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
         "Jane", "Focus: Jane"
     )
 
-    novelBar.setLastColType(NovelTreeColumn.POV)
+    novelBar.setLastColType(nwNovelExtra.POV)
     assert novelTree.isColumnHidden(novelTree.C_EXTRA) is False
-    assert novelTree.lastColType == NovelTreeColumn.POV
+    assert novelTree.lastColType == nwNovelExtra.POV
     assert novelTree._getLastColumnText(C.hSceneDoc, "T0001") == (
         "Jane", "Point of View: Jane"
     )

--- a/tests/test_gui/test_gui_search.py
+++ b/tests/test_gui/test_gui_search.py
@@ -39,7 +39,6 @@ def testGuiDocSearch_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
     search = nwGUI.projSearch
 
     def totalCount():
-        nonlocal search
         res = search.searchResult
         return sum(
             int(res.topLevelItem(i).text(GuiProjectSearch.C_COUNT).strip("()"))

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -71,7 +71,7 @@ def testToolBuildSettings_Init(qtbot, nwGUI, projPath, mockRnd):
 
     @pyqtSlot(BuildSettings)
     def _testNewSettingsReady(new: BuildSettings):
-        nonlocal build, triggered
+        nonlocal triggered
         assert new is build
         triggered = True
 

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -131,7 +131,6 @@ def testToolWelcome_Open(qtbot, monkeypatch, nwGUI, fncPath):
 
     # Context Menu
     def getMenuForPos(pos: QPoint) -> QMenu | None:
-        nonlocal tabOpen
         tabOpen._openContextMenu(pos)
         for obj in tabOpen.children():
             if isinstance(obj, QMenu) and obj.objectName() == "ContextMenu":

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -219,6 +219,7 @@ def buildTestProject(obj: object, projPath: Path) -> None:
 
     if nwGUI is not None:
         nwGUI.projView.openProjectTasks()
+        nwGUI.novelView.openProjectTasks()
 
     return
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -216,6 +216,7 @@ def buildTestProject(obj: object, projPath: Path) -> None:
     project.setProjectChanged(True)
     project.saveProject(autoSave=True)
     project._valid = True
+    project._tree._ready = True
 
     if nwGUI is not None:
         nwGUI.projView.openProjectTasks()


### PR DESCRIPTION
**Summary:**

This PR re-implements the Novel View as an item model, in a similar way to the Project View in last release. Since the Novel View is read only, the model is relatively simple. Due to the complexity of mapping the novel structure to the project structure, this implementation still relies on re-building the model on project structure changes, like the old implementation did, but it handles data changes from document editing on the fly.

There should be no functionality change from this, although using an underlying model makes it easier to automatically push updates when the project changes, so there should be less of a need to use the manual refresh.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All flake8 checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
