### PR TITLE
Fix Windows launch script for manual usage

### DIFF
--- a/utils/build_windows.py
+++ b/utils/build_windows.py
@@ -214,7 +214,6 @@ def main(args: argparse.Namespace) -> None:
 
     print("Updating starting script ...")
     writeFile(outDir / "novelWriter.pyw", (
-        "#!/usr/bin/env python3\n"
         "import os\n"
         "import sys\n"
         "\n"


### PR DESCRIPTION
**Summary:**

This PR removes the shebang from the launch script generated for Windows install.

**Related Issue(s):**

Closes #1284

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
