### PR TITLE
Fix dialogue highlighting inconsistency

### DIFF
--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -393,7 +393,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         else:  # Text Paragraph
             self.setCurrentBlockState(BLOCK_TEXT)
             hRules = self._txtRules if self._isNovel else self._minRules
-            if self._dialogParser.enabled:
+            if self._isNovel and self._dialogParser.enabled:
                 for pos, end in self._dialogParser(text):
                     length = end - pos
                     self.setFormat(pos, length, self._hStyles["dialog"])


### PR DESCRIPTION
**Summary:**

This PR fixes an inconsistency where dialogue highlighting is enabled in the editor for project notes, but turned off everywhere else.

**Related Issue(s):**

Closes #2297

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
