### PR TITLE
Improve single quote dialogue highlighting

### DIFF
--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -505,7 +505,7 @@ class TextBlockData(QTextBlockUserData):
                     text = f"{text[:s]}{pad}{text[e:]}"
                     self._metaData.append((s, e, res.group(0), "url"))
 
-        self._text = text
+        self._text = text.replace("\u02bc", "'")
         self._offset = offset
 
         return

--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -93,7 +93,7 @@ class RegExPatterns:
             if CONFIG.dialogStyle in (1, 3):
                 qO = CONFIG.fmtSQuoteOpen.strip()[:1]
                 qC = CONFIG.fmtSQuoteClose.strip()[:1]
-                if qO == qC:
+                if qO == qC or qC in self.AMBIGUOUS:
                     rx.append(f"(?:\\B{qO}.+?{qC}\\B)")
                 else:
                     rx.append(f"(?:{qO}[^{qO}]+{qC})")
@@ -102,7 +102,7 @@ class RegExPatterns:
             if CONFIG.dialogStyle in (2, 3):
                 qO = CONFIG.fmtDQuoteOpen.strip()[:1]
                 qC = CONFIG.fmtDQuoteClose.strip()[:1]
-                if qO == qC:
+                if qO == qC or qC in self.AMBIGUOUS:
                     rx.append(f"(?:\\B{qO}.+?{qC}\\B)")
                 else:
                     rx.append(f"(?:{qO}[^{qO}]+{qC})")

--- a/tests/test_text/test_text_patterns.py
+++ b/tests/test_text/test_text_patterns.py
@@ -310,11 +310,11 @@ def testTextPatterns_DialogueStyle():
     assert allMatches(regEx, 'one "two" three') == []
 
     # Check with no whitespace, single quote
-    assert allMatches(regEx, "one\u2018two\u2019three") == [
-        [("\u2018two\u2019", 3, 8)]
-    ]
-    assert allMatches(regEx, "one\u2018two\u2019 three") == [
-        [("\u2018two\u2019", 3, 8)]
+    # The apostrophe ambiguity rule should kick in here
+    assert allMatches(regEx, "one\u2018two\u2019three") == []
+    assert allMatches(regEx, "one\u2018two\u2019 three") == []
+    assert allMatches(regEx, "one \u2018two\u02bc three\u2019 four") == [
+        [("\u2018two\u02bc three\u2019", 4, 16)],
     ]
 
     # Check with no whitespace, double quote


### PR DESCRIPTION
**Summary:**

This PR adds a word boundary condition to the dialogue highlighting rules if the closing quote is either a straight apostrophe or the Unicode right single quote symbol. This should help distinguishing between closing dialogue with a single quote and words with an internal apostrophe. It will not help with apostrophes used to indicate truncated words. In those cases the alternative apostrophe symbol is the only option.

This PR also replaces the alternative apostrophes when spell checking as most spell checkers don't understand this symbol.

**Related Issue(s):**

Closes #2271

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All linting checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
