### PR TITLE
Fix datetime truncation bug

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -34,8 +34,8 @@ from time import time
 from typing import TYPE_CHECKING, Final
 
 from PyQt6.QtCore import (
-    PYQT_VERSION, PYQT_VERSION_STR, QT_VERSION, QT_VERSION_STR, QLibraryInfo,
-    QLocale, QStandardPaths, QSysInfo, QTranslator
+    PYQT_VERSION, PYQT_VERSION_STR, QT_VERSION, QT_VERSION_STR, QDate,
+    QDateTime, QLibraryInfo, QLocale, QStandardPaths, QSysInfo, QTranslator
 )
 from PyQt6.QtGui import QFont, QFontDatabase, QFontMetrics
 from PyQt6.QtWidgets import QApplication
@@ -467,11 +467,16 @@ class Config:
 
     def localDate(self, value: datetime) -> str:
         """Return a localised date format."""
-        return self._dLocale.toString(value, self._dShortDate)
+        # Explicitly convert the date first, see bug #2325
+        return self._dLocale.toString(QDate(value.year, value.month, value.day), self._dShortDate)
 
     def localDateTime(self, value: datetime) -> str:
         """Return a localised datetime format."""
-        return self._dLocale.toString(value, self._dShortDateTime)
+        # Explicitly convert the datetime first, see bug #2325
+        return self._dLocale.toString(
+            QDateTime(value.year, value.month, value.day, value.hour, value.minute, value.second),
+            self._dShortDateTime,
+        )
 
     def listLanguages(self, lngSet: int) -> list[tuple[str, str]]:
         """List localisation files in the i18n folder. The default GUI

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -192,9 +192,11 @@ def testBaseConfig_Localisation(fncPath, tstPaths):
 
     # Date Formats
     # Checks for bug #2325
-    assert CONFIG._dLocale.bcp47Name() == "en-GB"
-    assert CONFIG.localDate(datetime.datetime.fromtimestamp(1746370775)) == "04/05/2025"
-    assert CONFIG.localDateTime(datetime.datetime.fromtimestamp(1746370775)) == "04/05/2025 16:59"
+    ts = datetime.datetime.fromtimestamp(1746370775)
+    CONFIG._dShortDate = "dd/MM/yyyy"
+    CONFIG._dShortDateTime = "dd/MM/yyyy HH:mm"
+    assert CONFIG.localDate(ts) == ts.strftime("%d/%m/%Y")
+    assert CONFIG.localDateTime(ts) == ts.strftime("%d/%m/%Y %H:%M")
 
 
 @pytest.mark.base

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
+import datetime
 import json
 import sys
 
@@ -188,6 +189,12 @@ def testBaseConfig_Localisation(fncPath, tstPaths):
 
     languages = tstConf.listLanguages(tstConf.LANG_NW)
     assert languages == [("en_GB", "British English"), ("fr", "Français")]
+
+    # Date Formats
+    # Checks for bug #2325
+    assert CONFIG._dLocale.bcp47Name() == "en-GB"
+    assert CONFIG.localDate(datetime.datetime.fromtimestamp(1746370775)) == "04/05/2025"
+    assert CONFIG.localDateTime(datetime.datetime.fromtimestamp(1746370775)) == "04/05/2025 16:59"
 
 
 @pytest.mark.base


### PR DESCRIPTION
**Summary:**

There appears to be a datetime truncation issue in PyQt6 where datetime using QLocale are truncated to a QDate somewhere, causing the time part to not be printed. This PR finxes it by explicitly converting the Python datetime to QDate and QDateTime first instead of relying on PyQt6.

**Related Issue(s):**

Closes #2325

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
