### PR TITLE
feat(gui/doceditor): improve IME support and prevent input area from being obscured #2362

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -580,9 +580,9 @@ class GuiDocEditor(QPlainTextEdit):
         self.setDocumentChanged(False)
         self.docTextChanged.emit(self._docHandle, self._lastEdit)
 
-        oldCount = SHARED.project.index.getHandleHeaderCount(tHandle)
+        oldCount = SHARED.project.index.getCounts(tHandle)
         SHARED.project.index.scanText(tHandle, text)
-        newCount = SHARED.project.index.getHandleHeaderCount(tHandle)
+        newCount = SHARED.project.index.getCounts(tHandle)
 
         if self._nwItem.itemClass == nwItemClass.NOVEL:
             if oldCount == newCount:


### PR DESCRIPTION

**Summary:**
This PR addresses issue #2267, which concerns the text input area being obscured when using a Chinese Input Method Editor (IME). It builds upon the solution proposed by **@Jack-name**, but modifies the implementation to avoid application crashes.

- @Jack-name suggested changes across `gui/doceditor.py` to improve handling of this situation.However, the proposed solution caused crashes due to unstable calls to `getHandleHeaderCount()` in `GuiDocEditor.saveText()`.
- Replaces calls to `getHandleHeaderCount()` with `getCounts()` in  `gui/doceditor.py`(line 583 & 585).

**Related Issue(s):**
Closes #2267

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All linting checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
