### PR TITLE
Block main GUI from getting larger than screen

### DIFF
--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -38,7 +38,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED, __hexversion__, __version__
-from novelwriter.common import formatFileFilter, formatVersion, hexToInt
+from novelwriter.common import formatFileFilter, formatVersion, hexToInt, minmax
 from novelwriter.constants import nwConst
 from novelwriter.dialogs.about import GuiAbout
 from novelwriter.dialogs.preferences import GuiPreferences
@@ -103,7 +103,7 @@ class GuiMain(QMainWindow):
         SHARED.initSharedData(self)
 
         # Prepare Main Window
-        self.resize(*CONFIG.mainWinSize)
+        self._setWindowSize(CONFIG.mainWinSize)
         self._updateWindowTitle()
 
         nwIcon = CONFIG.assetPath("icons") / "novelwriter.svg"
@@ -1325,6 +1325,15 @@ class GuiMain(QMainWindow):
     ##
     #  Internal Functions
     ##
+
+    def _setWindowSize(self, size: list[int]) -> None:
+        """Set the main window size."""
+        if len(size) == 2 and (screen := SHARED.mainScreen):
+            availSize = screen.availableSize()
+            width = minmax(size[0], 900, availSize.width())
+            height = minmax(size[1], 500, availSize.height())
+            self.resize(width, height)
+        return
 
     def _updateWindowTitle(self, projName: str | None = None) -> None:
         """Set the window title and add the project's name."""

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -32,8 +32,8 @@ from time import time
 from typing import TYPE_CHECKING, TypeVar
 
 from PyQt6.QtCore import QObject, QRunnable, QThreadPool, QTimer, QUrl, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QDesktopServices, QFont
-from PyQt6.QtWidgets import QFileDialog, QFontDialog, QMessageBox, QWidget
+from PyQt6.QtGui import QDesktopServices, QFont, QScreen
+from PyQt6.QtWidgets import QApplication, QFileDialog, QFontDialog, QMessageBox, QWidget
 
 from novelwriter.common import formatFileFilter
 from novelwriter.constants import nwFiles
@@ -149,6 +149,11 @@ class SharedData(QObject):
     def lastAlert(self) -> str:
         """Return the last alert message."""
         return self._lastAlert
+
+    @property
+    def mainScreen(self) -> QScreen | None:
+        """Return the screen of the main window."""
+        return QApplication.screenAt(self.mainGui.rect().center())
 
     ##
     #  Setters


### PR DESCRIPTION
**Summary:**

This PR adds a check when resizing the main window to ensure that the size cannot exceed the size of the screen the app is loading on.

**Related Issue(s):**

Closes #2354

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
