### PR TITLE
Allow theme colours for status and importance labels

### DIFF
--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -447,7 +447,6 @@ class nwLabels:
         "Custom": (-1.0, -1.0),
     }
     THEME_COLORS: Final[dict[str, str]] = {
-        "theme":   QT_TRANSLATE_NOOP("Constant", "Theme Colours"),
         "default": QT_TRANSLATE_NOOP("Constant", "Foreground Colour"),
         "base":    QT_TRANSLATE_NOOP("Constant", "Background Colour"),
         "faded":   QT_TRANSLATE_NOOP("Constant", "Faded Colour"),

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -483,14 +483,14 @@ class NWProject:
 
     def setDefaultStatusImport(self) -> None:
         """Set the default status and importance values."""
-        self._data.itemStatus.add(None, self.tr("New"),      (120, 120, 120), "STAR", 0)
-        self._data.itemStatus.add(None, self.tr("Note"),     (205, 171, 143), "TRIANGLE", 0)
-        self._data.itemStatus.add(None, self.tr("Draft"),    (143, 240, 164), "CIRCLE_T", 0)
-        self._data.itemStatus.add(None, self.tr("Finished"), (249, 240, 107), "STAR", 0)
-        self._data.itemImport.add(None, self.tr("New"),      (120, 120, 120), "SQUARE", 0)
-        self._data.itemImport.add(None, self.tr("Minor"),    (220, 138, 221), "BLOCK_2", 0)
-        self._data.itemImport.add(None, self.tr("Major"),    (220, 138, 221), "BLOCK_3", 0)
-        self._data.itemImport.add(None, self.tr("Main"),     (220, 138, 221), "BLOCK_4", 0)
+        self._data.itemStatus.add(None, self.tr("New"), "faded", "STAR", 0)
+        self._data.itemStatus.add(None, self.tr("Note"), "red", "TRIANGLE", 0)
+        self._data.itemStatus.add(None, self.tr("Draft"), "yellow", "CIRCLE_T", 0)
+        self._data.itemStatus.add(None, self.tr("Finished"), "green", "STAR", 0)
+        self._data.itemImport.add(None, self.tr("New"), "purple", "SQUARE", 0)
+        self._data.itemImport.add(None, self.tr("Minor"), "purple", "BLOCK_2", 0)
+        self._data.itemImport.add(None, self.tr("Major"), "purple", "BLOCK_3", 0)
+        self._data.itemImport.add(None, self.tr("Main"), "purple", "BLOCK_4", 0)
         return
 
     def setProjectLang(self, language: str | None) -> None:
@@ -545,6 +545,12 @@ class NWProject:
             self._data.itemImport.update(update)
             SHARED.emitStatusLabelsChanged(self, kind)
             self._tree.refreshAllItems()
+        return
+
+    def updateTheme(self) -> None:
+        """Update theme elements."""
+        self._data.itemStatus.refreshIcons()
+        self._data.itemImport.refreshIcons()
         return
 
     def localLookup(self, word: str | int) -> str:

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 FILE_VERSION = "1.5"  # The current project file format version
-FILE_REVISION = "5"   # The current project file format revision
+FILE_REVISION = "6"   # The current project file format revision
 HEX_VERSION = 0x0105
 
 NUM_VERSION = {
@@ -111,6 +111,8 @@ class ProjectXMLReader:
                nodes. 2.5.
         Rev 5: Added novelChars and notesChars attributes to content
                node. 2.7 RC 1.
+        Rev 6: Replaced red, green and blue attributes with a single
+               color attribute. 2.8 Beta 1.
     """
 
     def __init__(self, path: str | Path) -> None:
@@ -439,12 +441,15 @@ class ProjectXMLReader:
         for xEntry in xItem:
             if xEntry.tag == "entry":
                 key   = xEntry.attrib.get("key", None)
-                red   = checkInt(xEntry.attrib.get("red", 0), 0)
-                green = checkInt(xEntry.attrib.get("green", 0), 0)
-                blue  = checkInt(xEntry.attrib.get("blue", 0), 0)
+                red   = checkInt(xEntry.attrib.get("red", 0), 0)    # Deprecated in 1.5 Rev 6
+                green = checkInt(xEntry.attrib.get("green", 0), 0)  # Deprecated in 1.5 Rev 6
+                blue  = checkInt(xEntry.attrib.get("blue", 0), 0)   # Deprecated in 1.5 Rev 6
+                color = xEntry.attrib.get("color")  # Added in 1.5 Rev 6
                 count = checkInt(xEntry.attrib.get("count", 0), 0)
                 shape = xEntry.attrib.get("shape", "")
-                sObject.add(key, xEntry.text or "", (red, green, blue), shape, count)
+                if color is None:
+                    color = f"{red}, {green}, {blue}"
+                sObject.add(key, xEntry.text or "", color, shape, count)
         return
 
     def _parseDictKeyText(self, xItem: ET.Element) -> dict:

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -441,10 +441,10 @@ class ProjectXMLReader:
         for xEntry in xItem:
             if xEntry.tag == "entry":
                 key   = xEntry.attrib.get("key", None)
-                red   = checkInt(xEntry.attrib.get("red", 0), 0)    # Deprecated in 1.5 Rev 6
-                green = checkInt(xEntry.attrib.get("green", 0), 0)  # Deprecated in 1.5 Rev 6
-                blue  = checkInt(xEntry.attrib.get("blue", 0), 0)   # Deprecated in 1.5 Rev 6
-                color = xEntry.attrib.get("color")  # Added in 1.5 Rev 6
+                red   = checkInt(xEntry.attrib.get("red", 0), 0)    # Deprecated in 1.5 R6
+                green = checkInt(xEntry.attrib.get("green", 0), 0)  # Deprecated in 1.5 R6
+                blue  = checkInt(xEntry.attrib.get("blue", 0), 0)   # Deprecated in 1.5 R6
+                color = xEntry.attrib.get("color")  # Added in 1.5 R6
                 count = checkInt(xEntry.attrib.get("count", 0), 0)
                 shape = xEntry.attrib.get("shape", "")
                 if color is None:

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -189,6 +189,16 @@ class NWStatus:
             logger.error("Could not parse entry %s", str(data))
         return None
 
+    def refreshIcons(self) -> None:
+        """Refresh all icons."""
+        for entry in self._store.values():
+            if entry.theme != CUSTOM_COL:
+                print("<", entry.color.name(QColor.NameFormat.HexRgb))
+                entry.color = SHARED.theme.parseColor(entry.theme)
+                print(">", entry.color.name(QColor.NameFormat.HexRgb))
+            entry.icon = NWStatus.createIcon(self._height, entry.color, entry.shape)
+        return
+
     @staticmethod
     def createIcon(height: int, color: QColor, shape: nwStatusShape) -> QIcon:
         """Generate an icon for a status label."""

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -192,10 +192,7 @@ class NWStatus:
     def refreshIcons(self) -> None:
         """Refresh all icons."""
         for entry in self._store.values():
-            if entry.theme != CUSTOM_COL:
-                print("<", entry.color.name(QColor.NameFormat.HexRgb))
-                entry.color = SHARED.theme.parseColor(entry.theme)
-                print(">", entry.color.name(QColor.NameFormat.HexRgb))
+            entry.color = SHARED.theme.parseColor(entry.theme)
             entry.icon = NWStatus.createIcon(self._height, entry.color, entry.shape)
         return
 

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -35,6 +35,7 @@ from PyQt6.QtGui import QColor, QIcon, QPainter, QPainterPath, QPixmap, QPolygon
 
 from novelwriter import SHARED
 from novelwriter.common import simplified
+from novelwriter.constants import nwLabels
 from novelwriter.enum import nwStatusShape
 from novelwriter.types import QtPaintAntiAlias, QtTransparent
 
@@ -43,12 +44,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+CUSTOM_COL = "custom"
+
 
 @dataclasses.dataclass
 class StatusEntry:
 
     name: str
     color: QColor
+    theme: str
     shape: nwStatusShape
     icon: QIcon
     count: int = 0
@@ -62,7 +66,7 @@ class StatusEntry:
         return status
 
 
-NO_ENTRY = StatusEntry("", QColor(0, 0, 0), nwStatusShape.SQUARE, QIcon(), 0)
+NO_ENTRY = StatusEntry("", QColor(0, 0, 0), CUSTOM_COL, nwStatusShape.SQUARE, QIcon(), 0)
 
 T_UpdateEntry = list[tuple[str | None, StatusEntry]]
 T_StatusKind = Literal["s", "i"]
@@ -97,15 +101,12 @@ class NWStatus:
     #  Methods
     ##
 
-    def add(self, key: str | None, name: str, color: tuple[int, int, int],
-            shape: str, count: int) -> str:
+    def add(self, key: str | None, name: str, color: str, shape: str, count: int) -> str:
         """Add or update a status entry. If the key is invalid, a new
         key is generated.
         """
-        if isinstance(color, tuple) and len(color) == 3:
-            qColor = QColor(*color)
-        else:
-            qColor = QColor(100, 100, 100)
+        qColor = SHARED.theme.parseColor(color)
+        theme = color if color in nwLabels.THEME_COLORS else CUSTOM_COL
 
         try:
             iShape = nwStatusShape[shape]
@@ -115,7 +116,7 @@ class NWStatus:
         key = self._checkKey(key)
         name = simplified(name)
         icon = self.createIcon(self._height, qColor, iShape)
-        self._store[key] = StatusEntry(name, qColor, iShape, icon, count)
+        self._store[key] = StatusEntry(name, qColor, theme, iShape, icon, count)
 
         if self._default is None:
             self._default = key
@@ -157,12 +158,14 @@ class NWStatus:
     def pack(self) -> Iterable[tuple[str, dict]]:
         """Pack the status entries into a dictionary."""
         for key, entry in self._store.items():
+            if entry.theme == CUSTOM_COL:
+                color = entry.color.name(QColor.NameFormat.HexRgb)
+            else:
+                color = entry.theme
             yield (entry.name, {
                 "key":   key,
                 "count": str(entry.count),
-                "red":   str(entry.color.red()),
-                "green": str(entry.color.green()),
-                "blue":  str(entry.color.blue()),
+                "color": color,
                 "shape": entry.shape.name,
             })
         return
@@ -179,8 +182,9 @@ class NWStatus:
         try:
             shape = nwStatusShape[str(data[0])]
             color = QColor(str(data[1]))
+            theme = CUSTOM_COL if data[1].startswith("#") else data[1]
             icon = NWStatus.createIcon(self._height, color, shape)
-            return StatusEntry(simplified(data[2]), color, shape, icon)
+            return StatusEntry(simplified(data[2]), color, theme, shape, icon)
         except Exception:
             logger.error("Could not parse entry %s", str(data))
         return None

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -294,6 +294,7 @@ class GuiPreferences(NDialog):
         # Tree Icon Colours
         self.iconColTree = NComboBox(self)
         self.iconColTree.setMinimumWidth(200)
+        self.iconColTree.addItem(self.tr("Theme Colours"), DEF_TREECOL)
         for key, label in nwLabels.THEME_COLORS.items():
             self.iconColTree.addItem(trConst(label), key)
         self.iconColTree.setCurrentData(CONFIG.iconColTree, DEF_TREECOL)

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -40,7 +40,7 @@ from PyQt6.QtWidgets import QApplication
 
 from novelwriter import CONFIG
 from novelwriter.common import checkInt, minmax
-from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS
+from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS, DEF_TREECOL
 from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwTheme
 from novelwriter.error import logException
@@ -438,7 +438,7 @@ class GuiTheme:
             self._guiPalette.setBrush(QtColDisabled, QPalette.ColorRole.Accent, grey)
 
         # Set project override colours
-        if (override := CONFIG.iconColTree) != "theme":
+        if (override := CONFIG.iconColTree) != DEF_TREECOL:
             color = self._qColors.get(override, QtBlack)
             self._setBaseColor("root", color)
             self._setBaseColor("folder", color)
@@ -465,11 +465,7 @@ class GuiTheme:
         """Load a standard style sheet."""
         return self._styleSheets.get(name, "")
 
-    ##
-    #  Internal Functions
-    ##
-
-    def _parseColor(self, value: str, default: QColor = QtBlack) -> QColor:
+    def parseColor(self, value: str, default: QColor = QtBlack) -> QColor:
         """Parse a string as a colour value."""
         if value in self._qColors:
             # Named colour
@@ -499,6 +495,10 @@ class GuiTheme:
                 result[i] = checkInt(data[i].strip(), result[i])
             return QColor(*result)
         return default
+
+    ##
+    #  Internal Functions
+    ##
 
     def _setBaseColor(self, key: str, color: QColor) -> None:
         """Set the colour for a named colour."""
@@ -560,7 +560,7 @@ class GuiTheme:
 
     def _readColor(self, parser: ConfigParser, section: str, name: str) -> QColor:
         """Parse a colour value from a config string."""
-        return self._parseColor(parser.get(section, name, fallback="default"))
+        return self.parseColor(parser.get(section, name, fallback="default"))
 
     def _setPalette(
         self, parser: ConfigParser, section: str, name: str, value: QPalette.ColorRole

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -913,6 +913,7 @@ class GuiMain(QMainWindow):
     def refreshThemeColors(self, syntax: bool = False, force: bool = False) -> None:
         """Refresh the GUI theme."""
         SHARED.theme.loadTheme(force=force)
+        SHARED.project.updateTheme()
         self.setPalette(QApplication.palette())
         self.docEditor.updateTheme()
         self.docViewer.updateTheme()

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7.1" hexVersion="0x020701f0" fileVersion="1.5" fileRevision="5" timeStamp="2025-06-09 22:54:50">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2194" autoCount="286" editTime="96892">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 13:04:43">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2221" autoCount="289" editTime="97582">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -20,20 +20,20 @@
       <entry key="C">D</entry>
     </autoReplace>
     <status>
-      <entry key="sf12341" count="8" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="sf24ce6" count="2" red="200" green="50" blue="0" shape="SQUARE">Notes</entry>
-      <entry key="sc24b8f" count="3" red="182" green="60" blue="0" shape="BARS_1">Started</entry>
-      <entry key="s90e6c9" count="5" red="193" green="129" blue="0" shape="BARS_2">1st Draft</entry>
-      <entry key="sd51c5b" count="1" red="193" green="129" blue="0" shape="BARS_3">2nd Draft</entry>
-      <entry key="s8ae72a" count="1" red="193" green="129" blue="0" shape="BARS_4">3rd Draft</entry>
-      <entry key="s78ea90" count="1" red="58" green="180" blue="58" shape="STAR">Finished</entry>
+      <entry key="sf12341" count="8" color="faded" shape="STAR">New</entry>
+      <entry key="sf24ce6" count="2" color="red" shape="STAR">Notes</entry>
+      <entry key="sc24b8f" count="3" color="yellow" shape="BARS_1">Started</entry>
+      <entry key="s90e6c9" count="5" color="yellow" shape="BARS_2">1st Draft</entry>
+      <entry key="sd51c5b" count="1" color="yellow" shape="BARS_3">2nd Draft</entry>
+      <entry key="s8ae72a" count="1" color="yellow" shape="BARS_4">3rd Draft</entry>
+      <entry key="s78ea90" count="1" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="ia857f0" count="5" red="100" green="100" blue="100" shape="SQUARE">None</entry>
-      <entry key="i4a1d39" count="1" red="220" green="138" blue="221" shape="BLOCK_1">Background</entry>
-      <entry key="icfb3a5" count="1" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i2d7a54" count="2" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i56be10" count="1" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="ia857f0" count="5" color="faded" shape="STAR">None</entry>
+      <entry key="i4a1d39" count="1" color="purple" shape="BLOCK_1">Background</entry>
+      <entry key="icfb3a5" count="1" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i2d7a54" count="2" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i56be10" count="1" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="31" novelWords="1016" notesWords="416" novelChars="5602" notesChars="2285">
@@ -58,7 +58,7 @@
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2999" wordCount="530" paraCount="16" cursorPos="718" />
+      <meta expanded="no" heading="H3" charCount="2999" wordCount="530" paraCount="16" cursorPos="1225" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,8 @@ from PyQt6.QtWidgets import QMessageBox
 sys.path.insert(1, str(Path(__file__).parent.parent.absolute()))
 
 from novelwriter import CONFIG, SHARED
+from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT
+from novelwriter.enum import nwTheme
 
 from tests.mocked import MockGuiMain
 from tests.tools import cleanProject
@@ -60,6 +62,10 @@ def resetConfigVars():
     CONFIG._dLocale = QLocale("en_GB")
     CONFIG._manuals = {"manual": _TMP_ROOT / "manual.pdf"}
     CONFIG.guiLocale = "en_GB"
+    CONFIG.darkTheme = DEF_GUI_DARK
+    CONFIG.lightTheme = DEF_GUI_LIGHT
+    CONFIG.themeMode = nwTheme.LIGHT
+    CONFIG.emphLabels = True  # Ensures better coverage, off by default
     return
 
 
@@ -157,11 +163,19 @@ def mockGUI(qtbot, monkeypatch):
     monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.Yes)
     gui = MockGuiMain()
     theme = GuiTheme()
-    theme.loadTheme()
     monkeypatch.setattr(SHARED, "_gui", gui)
     monkeypatch.setattr(SHARED, "_theme", theme)
 
     return gui
+
+
+@pytest.fixture(scope="function")
+def mockGUIwithTheme(mockGUI):
+    """Create a mock instance of novelWriter's main GUI class with the
+    theme instance initialised.
+    """
+    SHARED.theme.initThemes()
+    return mockGUI
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ sys.path.insert(1, str(Path(__file__).parent.parent.absolute()))
 
 from novelwriter import CONFIG, SHARED
 
-from tests.mocked import MockGuiMain, MockTheme
+from tests.mocked import MockGuiMain
 from tests.tools import cleanProject
 
 _TST_ROOT = Path(__file__).parent
@@ -151,12 +151,16 @@ def projPath(fncPath):
 @pytest.fixture(scope="function")
 def mockGUI(qtbot, monkeypatch):
     """Create a mock instance of novelWriter's main GUI class."""
+    from novelwriter.gui.theme import GuiTheme
+
     monkeypatch.setattr(QMessageBox, "exec", lambda *a: None)
     monkeypatch.setattr(QMessageBox, "result", lambda *a: QMessageBox.StandardButton.Yes)
     gui = MockGuiMain()
-    theme = MockTheme()
+    theme = GuiTheme()
+    theme.loadTheme()
     monkeypatch.setattr(SHARED, "_gui", gui)
     monkeypatch.setattr(SHARED, "_theme", theme)
+
     return gui
 
 

--- a/tests/files/nwProject-1.5.nwx
+++ b/tests/files/nwProject-1.5.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:07:59">
+<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="6" timeStamp="2025-04-29 22:07:59">
   <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2179" autoCount="285" editTime="1000">
     <name>Sample Project</name>
     <author>Jane Smith</author>
@@ -20,20 +20,20 @@
       <entry key="C">D</entry>
     </autoReplace>
     <status>
-      <entry key="sf12341" count="8" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="sf24ce6" count="2" red="200" green="50" blue="0" shape="SQUARE">Notes</entry>
-      <entry key="sc24b8f" count="3" red="182" green="60" blue="0" shape="BARS_1">Started</entry>
-      <entry key="s90e6c9" count="5" red="193" green="129" blue="0" shape="BARS_2">1st Draft</entry>
-      <entry key="sd51c5b" count="1" red="193" green="129" blue="0" shape="BARS_3">2nd Draft</entry>
-      <entry key="s8ae72a" count="1" red="193" green="129" blue="0" shape="BARS_4">3rd Draft</entry>
-      <entry key="s78ea90" count="1" red="58" green="180" blue="58" shape="STAR">Finished</entry>
+      <entry key="sf12341" count="8" color="#646464" shape="SQUARE">New</entry>
+      <entry key="sf24ce6" count="2" color="#c83200" shape="SQUARE">Notes</entry>
+      <entry key="sc24b8f" count="3" color="#b63c00" shape="BARS_1">Started</entry>
+      <entry key="s90e6c9" count="5" color="#c18100" shape="BARS_2">1st Draft</entry>
+      <entry key="sd51c5b" count="1" color="#c18100" shape="BARS_3">2nd Draft</entry>
+      <entry key="s8ae72a" count="1" color="#c18100" shape="BARS_4">3rd Draft</entry>
+      <entry key="s78ea90" count="1" color="#3ab43a" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="ia857f0" count="5" red="100" green="100" blue="100" shape="SQUARE">None</entry>
-      <entry key="i4a1d39" count="1" red="220" green="138" blue="221" shape="BLOCK_1">Background</entry>
-      <entry key="icfb3a5" count="1" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i2d7a54" count="2" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i56be10" count="1" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="ia857f0" count="5" color="#646464" shape="SQUARE">None</entry>
+      <entry key="i4a1d39" count="1" color="#dc8add" shape="BLOCK_1">Background</entry>
+      <entry key="icfb3a5" count="1" color="#dc8add" shape="BLOCK_2">Minor</entry>
+      <entry key="i2d7a54" count="2" color="#dc8add" shape="BLOCK_3">Major</entry>
+      <entry key="i56be10" count="1" color="#dc8add" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="31" novelWords="1016" notesWords="416" novelChars="5602" notesChars="2285">

--- a/tests/lipsum/nwProject.nwx
+++ b/tests/lipsum/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:45:09">
-  <project id="5ac0df12-8b8b-476b-9905-21d33685687c" saveCount="52" autoCount="29" editTime="2465">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 19:19:46">
+  <project id="5ac0df12-8b8b-476b-9905-21d33685687c" saveCount="54" autoCount="29" editTime="2469">
     <name>Lorem Ipsum</name>
     <author>lipsum.com</author>
   </project>
@@ -19,16 +19,16 @@
       <entry key="Rep2">Replace Text 2</entry>
     </autoReplace>
     <status>
-      <entry key="sbaa94f" count="3" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="s27bf7c" count="0" red="200" green="50" blue="0" shape="SQUARE">Note</entry>
-      <entry key="s92a87b" count="5" red="200" green="150" blue="0" shape="SQUARE">Draft</entry>
-      <entry key="sedd043" count="7" red="50" green="200" blue="0" shape="SQUARE">Finished</entry>
+      <entry key="sbaa94f" count="3" color="#646464" shape="SQUARE">New</entry>
+      <entry key="s27bf7c" count="0" color="#c83200" shape="SQUARE">Note</entry>
+      <entry key="s92a87b" count="5" color="#c89600" shape="SQUARE">Draft</entry>
+      <entry key="sedd043" count="7" color="#32c800" shape="SQUARE">Finished</entry>
     </status>
     <importance>
-      <entry key="i613591" count="7" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="i560cbf" count="0" red="200" green="50" blue="0" shape="SQUARE">Minor</entry>
-      <entry key="i37861c" count="0" red="200" green="150" blue="0" shape="SQUARE">Major</entry>
-      <entry key="id6b1d0" count="0" red="50" green="200" blue="0" shape="SQUARE">Main</entry>
+      <entry key="i613591" count="7" color="#646464" shape="SQUARE">New</entry>
+      <entry key="i560cbf" count="0" color="#c83200" shape="SQUARE">Minor</entry>
+      <entry key="i37861c" count="0" color="#c89600" shape="SQUARE">Major</entry>
+      <entry key="id6b1d0" count="0" color="#32c800" shape="SQUARE">Main</entry>
     </importance>
   </settings>
   <content items="22" novelWords="3115" notesWords="738" novelChars="20774" notesChars="5003">

--- a/tests/reference/coreProject_NewFileFolder_nwProject.nwx
+++ b/tests/reference/coreProject_NewFileFolder_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:42:54">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:02:57">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -16,16 +16,16 @@
     </lastHandle>
     <autoReplace />
     <status>
-      <entry key="s000000" count="7" red="120" green="120" blue="120" shape="STAR">New</entry>
-      <entry key="s000001" count="0" red="205" green="171" blue="143" shape="TRIANGLE">Note</entry>
-      <entry key="s000002" count="0" red="143" green="240" blue="164" shape="CIRCLE_T">Draft</entry>
-      <entry key="s000003" count="0" red="249" green="240" blue="107" shape="STAR">Finished</entry>
+      <entry key="s000000" count="7" color="faded" shape="STAR">New</entry>
+      <entry key="s000001" count="0" color="red" shape="TRIANGLE">Note</entry>
+      <entry key="s000002" count="0" color="yellow" shape="CIRCLE_T">Draft</entry>
+      <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="5" red="120" green="120" blue="120" shape="SQUARE">New</entry>
-      <entry key="i000005" count="0" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i000006" count="0" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i000007" count="0" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="i000004" count="5" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="12" novelWords="10" notesWords="6" novelChars="45" notesChars="22">

--- a/tests/reference/coreProject_NewRoot_nwProject.nwx
+++ b/tests/reference/coreProject_NewRoot_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:42:54">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:02:57">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -16,16 +16,16 @@
     </lastHandle>
     <autoReplace />
     <status>
-      <entry key="s000000" count="6" red="120" green="120" blue="120" shape="STAR">New</entry>
-      <entry key="s000001" count="0" red="205" green="171" blue="143" shape="TRIANGLE">Note</entry>
-      <entry key="s000002" count="0" red="143" green="240" blue="164" shape="CIRCLE_T">Draft</entry>
-      <entry key="s000003" count="0" red="249" green="240" blue="107" shape="STAR">Finished</entry>
+      <entry key="s000000" count="6" color="faded" shape="STAR">New</entry>
+      <entry key="s000001" count="0" color="red" shape="TRIANGLE">Note</entry>
+      <entry key="s000002" count="0" color="yellow" shape="CIRCLE_T">Draft</entry>
+      <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="10" red="120" green="120" blue="120" shape="SQUARE">New</entry>
-      <entry key="i000005" count="0" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i000006" count="0" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i000007" count="0" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="i000004" count="10" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="16" novelWords="9" notesWords="0" novelChars="40" notesChars="0">

--- a/tests/reference/coreTools_DocDuplicator_nwProject.nwx
+++ b/tests/reference/coreTools_DocDuplicator_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:42:52">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:02:55">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -16,16 +16,16 @@
     </lastHandle>
     <autoReplace />
     <status>
-      <entry key="s000000" count="16" red="120" green="120" blue="120" shape="STAR">New</entry>
-      <entry key="s000001" count="0" red="205" green="171" blue="143" shape="TRIANGLE">Note</entry>
-      <entry key="s000002" count="0" red="143" green="240" blue="164" shape="CIRCLE_T">Draft</entry>
-      <entry key="s000003" count="0" red="249" green="240" blue="107" shape="STAR">Finished</entry>
+      <entry key="s000000" count="16" color="faded" shape="STAR">New</entry>
+      <entry key="s000001" count="0" color="red" shape="TRIANGLE">Note</entry>
+      <entry key="s000002" count="0" color="yellow" shape="CIRCLE_T">Draft</entry>
+      <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="3" red="120" green="120" blue="120" shape="SQUARE">New</entry>
-      <entry key="i000005" count="0" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i000006" count="0" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i000007" count="0" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="i000004" count="3" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="19" novelWords="28" notesWords="0" novelChars="129" notesChars="0">

--- a/tests/reference/coreTools_ProjectBuilderA_nwProject.nwx
+++ b/tests/reference/coreTools_ProjectBuilderA_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:42:52">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:02:55">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Project A</name>
     <author>Jane Doe</author>
@@ -16,16 +16,16 @@
     </lastHandle>
     <autoReplace />
     <status>
-      <entry key="s000000" count="15" red="120" green="120" blue="120" shape="STAR">New</entry>
-      <entry key="s000001" count="0" red="205" green="171" blue="143" shape="TRIANGLE">Note</entry>
-      <entry key="s000002" count="0" red="143" green="240" blue="164" shape="CIRCLE_T">Draft</entry>
-      <entry key="s000003" count="0" red="249" green="240" blue="107" shape="STAR">Finished</entry>
+      <entry key="s000000" count="15" color="faded" shape="STAR">New</entry>
+      <entry key="s000001" count="0" color="red" shape="TRIANGLE">Note</entry>
+      <entry key="s000002" count="0" color="yellow" shape="CIRCLE_T">Draft</entry>
+      <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="7" red="120" green="120" blue="120" shape="SQUARE">New</entry>
-      <entry key="i000005" count="0" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i000006" count="0" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i000007" count="0" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="i000004" count="7" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="22" novelWords="0" notesWords="0" novelChars="0" notesChars="0">

--- a/tests/reference/coreTools_ProjectBuilderB_nwProject.nwx
+++ b/tests/reference/coreTools_ProjectBuilderB_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:42:52">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:02:55">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Project B</name>
     <author>Jane Doe</author>
@@ -16,16 +16,16 @@
     </lastHandle>
     <autoReplace />
     <status>
-      <entry key="s000000" count="9" red="120" green="120" blue="120" shape="STAR">New</entry>
-      <entry key="s000001" count="0" red="205" green="171" blue="143" shape="TRIANGLE">Note</entry>
-      <entry key="s000002" count="0" red="143" green="240" blue="164" shape="CIRCLE_T">Draft</entry>
-      <entry key="s000003" count="0" red="249" green="240" blue="107" shape="STAR">Finished</entry>
+      <entry key="s000000" count="9" color="faded" shape="STAR">New</entry>
+      <entry key="s000001" count="0" color="red" shape="TRIANGLE">Note</entry>
+      <entry key="s000002" count="0" color="yellow" shape="CIRCLE_T">Draft</entry>
+      <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="7" red="120" green="120" blue="120" shape="SQUARE">New</entry>
-      <entry key="i000005" count="0" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i000006" count="0" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i000007" count="0" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="i000004" count="7" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="16" novelWords="0" notesWords="0" novelChars="0" notesChars="0">

--- a/tests/reference/fmtToDocX_SaveDocument_core.xml
+++ b/tests/reference/fmtToDocX_SaveDocument_core.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
 <cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <dcterms:created xsi:type="dcterms:W3CDTF">2025-04-29T22:46:36</dcterms:created>
-  <dcterms:modified xsi:type="dcterms:W3CDTF">2025-04-29T22:46:36</dcterms:modified>
+  <dcterms:created xsi:type="dcterms:W3CDTF">2025-06-12T19:20:06</dcterms:created>
+  <dcterms:modified xsi:type="dcterms:W3CDTF">2025-06-12T19:20:06</dcterms:modified>
   <dc:creator>lipsum.com</dc:creator>
   <dc:title>Lorem Ipsum</dc:title>
   <dc:language>en_GB</dc:language>
-  <cp:revision>52</cp:revision>
+  <cp:revision>54</cp:revision>
   <cp:lastModifiedBy>lipsum.com</cp:lastModifiedBy>
 </cp:coreProperties>

--- a/tests/reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:08:41">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:34:07">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="4">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -16,16 +16,16 @@
     </lastHandle>
     <autoReplace />
     <status>
-      <entry key="s000000" count="5" red="120" green="120" blue="120" shape="STAR">New</entry>
-      <entry key="s000001" count="0" red="205" green="171" blue="143" shape="TRIANGLE">Note</entry>
-      <entry key="s000002" count="0" red="143" green="240" blue="164" shape="CIRCLE_T">Draft</entry>
-      <entry key="s000003" count="0" red="249" green="240" blue="107" shape="STAR">Finished</entry>
+      <entry key="s000000" count="5" color="faded" shape="STAR">New</entry>
+      <entry key="s000001" count="0" color="red" shape="TRIANGLE">Note</entry>
+      <entry key="s000002" count="0" color="yellow" shape="CIRCLE_T">Draft</entry>
+      <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="7" red="120" green="120" blue="120" shape="SQUARE">New</entry>
-      <entry key="i000005" count="0" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i000006" count="0" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i000007" count="0" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="i000004" count="7" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="12" novelWords="173" notesWords="27" novelChars="1007" notesChars="133">

--- a/tests/reference/guiEditor_Main_Initial_nwProject.nwx
+++ b/tests/reference/guiEditor_Main_Initial_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2025-04-29 22:01:24">
+<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:03:05">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="2" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -16,16 +16,16 @@
     </lastHandle>
     <autoReplace />
     <status>
-      <entry key="s000000" count="5" red="120" green="120" blue="120" shape="STAR">New</entry>
-      <entry key="s000001" count="0" red="205" green="171" blue="143" shape="TRIANGLE">Note</entry>
-      <entry key="s000002" count="0" red="143" green="240" blue="164" shape="CIRCLE_T">Draft</entry>
-      <entry key="s000003" count="0" red="249" green="240" blue="107" shape="STAR">Finished</entry>
+      <entry key="s000000" count="5" color="faded" shape="STAR">New</entry>
+      <entry key="s000001" count="0" color="red" shape="TRIANGLE">Note</entry>
+      <entry key="s000002" count="0" color="yellow" shape="CIRCLE_T">Draft</entry>
+      <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="3" red="120" green="120" blue="120" shape="SQUARE">New</entry>
-      <entry key="i000005" count="0" red="220" green="138" blue="221" shape="BLOCK_2">Minor</entry>
-      <entry key="i000006" count="0" red="220" green="138" blue="221" shape="BLOCK_3">Major</entry>
-      <entry key="i000007" count="0" red="220" green="138" blue="221" shape="BLOCK_4">Main</entry>
+      <entry key="i000004" count="3" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
+      <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
+      <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
   <content items="8" novelWords="9" notesWords="0" novelChars="40" notesChars="0">

--- a/tests/reference/projectXML_ReadLegacy10.nwx
+++ b/tests/reference/projectXML_ReadLegacy10.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2020-05-28 09:59:15">
+<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="6" timeStamp="2020-05-28 09:59:15">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="0" autoCount="0" editTime="1000">
     <name>Sample Project</name>
     <author>Jay Doh</author>
@@ -20,19 +20,19 @@
       <entry key="C">D</entry>
     </autoReplace>
     <status>
-      <entry key="s000000" count="0" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="s000001" count="0" red="200" green="50" blue="0" shape="SQUARE">Notes</entry>
-      <entry key="s000002" count="0" red="182" green="60" blue="0" shape="SQUARE">Started</entry>
-      <entry key="s000003" count="0" red="193" green="129" blue="0" shape="SQUARE">1st Draft</entry>
-      <entry key="s000004" count="0" red="193" green="129" blue="0" shape="SQUARE">2nd Draft</entry>
-      <entry key="s000005" count="0" red="193" green="129" blue="0" shape="SQUARE">3rd Draft</entry>
-      <entry key="s000006" count="0" red="58" green="180" blue="58" shape="SQUARE">Finished</entry>
+      <entry key="s000000" count="0" color="#646464" shape="SQUARE">New</entry>
+      <entry key="s000001" count="0" color="#c83200" shape="SQUARE">Notes</entry>
+      <entry key="s000002" count="0" color="#b63c00" shape="SQUARE">Started</entry>
+      <entry key="s000003" count="0" color="#c18100" shape="SQUARE">1st Draft</entry>
+      <entry key="s000004" count="0" color="#c18100" shape="SQUARE">2nd Draft</entry>
+      <entry key="s000005" count="0" color="#c18100" shape="SQUARE">3rd Draft</entry>
+      <entry key="s000006" count="0" color="#3ab43a" shape="SQUARE">Finished</entry>
     </status>
     <importance>
-      <entry key="i000007" count="0" red="100" green="100" blue="100" shape="SQUARE">None</entry>
-      <entry key="i000008" count="0" red="0" green="122" blue="188" shape="SQUARE">Minor</entry>
-      <entry key="i000009" count="0" red="21" green="0" blue="180" shape="SQUARE">Major</entry>
-      <entry key="i00000a" count="0" red="117" green="0" blue="175" shape="SQUARE">Main</entry>
+      <entry key="i000007" count="0" color="#646464" shape="SQUARE">None</entry>
+      <entry key="i000008" count="0" color="#007abc" shape="SQUARE">Minor</entry>
+      <entry key="i000009" count="0" color="#1500b4" shape="SQUARE">Major</entry>
+      <entry key="i00000a" count="0" color="#7500af" shape="SQUARE">Main</entry>
     </importance>
   </settings>
   <content items="22" novelWords="0" notesWords="0" novelChars="0" notesChars="0">

--- a/tests/reference/projectXML_ReadLegacy11.nwx
+++ b/tests/reference/projectXML_ReadLegacy11.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2020-06-26 21:20:24">
+<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="6" timeStamp="2020-06-26 21:20:24">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
     <name>Sample Project</name>
     <author>Jay Doh</author>
@@ -20,19 +20,19 @@
       <entry key="C">D</entry>
     </autoReplace>
     <status>
-      <entry key="s000000" count="0" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="s000001" count="0" red="200" green="50" blue="0" shape="SQUARE">Notes</entry>
-      <entry key="s000002" count="0" red="182" green="60" blue="0" shape="SQUARE">Started</entry>
-      <entry key="s000003" count="0" red="193" green="129" blue="0" shape="SQUARE">1st Draft</entry>
-      <entry key="s000004" count="0" red="193" green="129" blue="0" shape="SQUARE">2nd Draft</entry>
-      <entry key="s000005" count="0" red="193" green="129" blue="0" shape="SQUARE">3rd Draft</entry>
-      <entry key="s000006" count="0" red="58" green="180" blue="58" shape="SQUARE">Finished</entry>
+      <entry key="s000000" count="0" color="#646464" shape="SQUARE">New</entry>
+      <entry key="s000001" count="0" color="#c83200" shape="SQUARE">Notes</entry>
+      <entry key="s000002" count="0" color="#b63c00" shape="SQUARE">Started</entry>
+      <entry key="s000003" count="0" color="#c18100" shape="SQUARE">1st Draft</entry>
+      <entry key="s000004" count="0" color="#c18100" shape="SQUARE">2nd Draft</entry>
+      <entry key="s000005" count="0" color="#c18100" shape="SQUARE">3rd Draft</entry>
+      <entry key="s000006" count="0" color="#3ab43a" shape="SQUARE">Finished</entry>
     </status>
     <importance>
-      <entry key="i000007" count="0" red="100" green="100" blue="100" shape="SQUARE">None</entry>
-      <entry key="i000008" count="0" red="0" green="122" blue="188" shape="SQUARE">Minor</entry>
-      <entry key="i000009" count="0" red="21" green="0" blue="180" shape="SQUARE">Major</entry>
-      <entry key="i00000a" count="0" red="117" green="0" blue="175" shape="SQUARE">Main</entry>
+      <entry key="i000007" count="0" color="#646464" shape="SQUARE">None</entry>
+      <entry key="i000008" count="0" color="#007abc" shape="SQUARE">Minor</entry>
+      <entry key="i000009" count="0" color="#1500b4" shape="SQUARE">Major</entry>
+      <entry key="i00000a" count="0" color="#7500af" shape="SQUARE">Main</entry>
     </importance>
   </settings>
   <content items="22" novelWords="0" notesWords="0" novelChars="0" notesChars="0">

--- a/tests/reference/projectXML_ReadLegacy12.nwx
+++ b/tests/reference/projectXML_ReadLegacy12.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2021-08-30 23:33:44">
+<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="6" timeStamp="2021-08-30 23:33:44">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
     <name>Sample Project</name>
     <author>Jay Doh</author>
@@ -20,19 +20,19 @@
       <entry key="C">D</entry>
     </autoReplace>
     <status>
-      <entry key="s000000" count="0" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="s000001" count="0" red="200" green="50" blue="0" shape="SQUARE">Notes</entry>
-      <entry key="s000002" count="0" red="182" green="60" blue="0" shape="SQUARE">Started</entry>
-      <entry key="s000003" count="0" red="193" green="129" blue="0" shape="SQUARE">1st Draft</entry>
-      <entry key="s000004" count="0" red="193" green="129" blue="0" shape="SQUARE">2nd Draft</entry>
-      <entry key="s000005" count="0" red="193" green="129" blue="0" shape="SQUARE">3rd Draft</entry>
-      <entry key="s000006" count="0" red="58" green="180" blue="58" shape="SQUARE">Finished</entry>
+      <entry key="s000000" count="0" color="#646464" shape="SQUARE">New</entry>
+      <entry key="s000001" count="0" color="#c83200" shape="SQUARE">Notes</entry>
+      <entry key="s000002" count="0" color="#b63c00" shape="SQUARE">Started</entry>
+      <entry key="s000003" count="0" color="#c18100" shape="SQUARE">1st Draft</entry>
+      <entry key="s000004" count="0" color="#c18100" shape="SQUARE">2nd Draft</entry>
+      <entry key="s000005" count="0" color="#c18100" shape="SQUARE">3rd Draft</entry>
+      <entry key="s000006" count="0" color="#3ab43a" shape="SQUARE">Finished</entry>
     </status>
     <importance>
-      <entry key="i000007" count="0" red="100" green="100" blue="100" shape="SQUARE">None</entry>
-      <entry key="i000008" count="0" red="0" green="122" blue="188" shape="SQUARE">Minor</entry>
-      <entry key="i000009" count="0" red="21" green="0" blue="180" shape="SQUARE">Major</entry>
-      <entry key="i00000a" count="0" red="117" green="0" blue="175" shape="SQUARE">Main</entry>
+      <entry key="i000007" count="0" color="#646464" shape="SQUARE">None</entry>
+      <entry key="i000008" count="0" color="#007abc" shape="SQUARE">Minor</entry>
+      <entry key="i000009" count="0" color="#1500b4" shape="SQUARE">Major</entry>
+      <entry key="i00000a" count="0" color="#7500af" shape="SQUARE">Main</entry>
     </importance>
   </settings>
   <content items="25" novelWords="840" notesWords="376" novelChars="0" notesChars="0">

--- a/tests/reference/projectXML_ReadLegacy13.nwx
+++ b/tests/reference/projectXML_ReadLegacy13.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2022-10-25 18:26:15">
+<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="6" timeStamp="2022-10-25 18:26:15">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
     <name>Sample Project</name>
     <author>Jay Doh</author>
@@ -20,19 +20,19 @@
       <entry key="C">D</entry>
     </autoReplace>
     <status>
-      <entry key="s000000" count="0" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="s000001" count="0" red="200" green="50" blue="0" shape="SQUARE">Notes</entry>
-      <entry key="s000002" count="0" red="182" green="60" blue="0" shape="SQUARE">Started</entry>
-      <entry key="s000003" count="0" red="193" green="129" blue="0" shape="SQUARE">1st Draft</entry>
-      <entry key="s000004" count="0" red="193" green="129" blue="0" shape="SQUARE">2nd Draft</entry>
-      <entry key="s000005" count="0" red="193" green="129" blue="0" shape="SQUARE">3rd Draft</entry>
-      <entry key="s000006" count="0" red="58" green="180" blue="58" shape="SQUARE">Finished</entry>
+      <entry key="s000000" count="0" color="#646464" shape="SQUARE">New</entry>
+      <entry key="s000001" count="0" color="#c83200" shape="SQUARE">Notes</entry>
+      <entry key="s000002" count="0" color="#b63c00" shape="SQUARE">Started</entry>
+      <entry key="s000003" count="0" color="#c18100" shape="SQUARE">1st Draft</entry>
+      <entry key="s000004" count="0" color="#c18100" shape="SQUARE">2nd Draft</entry>
+      <entry key="s000005" count="0" color="#c18100" shape="SQUARE">3rd Draft</entry>
+      <entry key="s000006" count="0" color="#3ab43a" shape="SQUARE">Finished</entry>
     </status>
     <importance>
-      <entry key="i000007" count="0" red="100" green="100" blue="100" shape="SQUARE">None</entry>
-      <entry key="i000008" count="0" red="0" green="122" blue="188" shape="SQUARE">Minor</entry>
-      <entry key="i000009" count="0" red="21" green="0" blue="180" shape="SQUARE">Major</entry>
-      <entry key="i00000a" count="0" red="117" green="0" blue="175" shape="SQUARE">Main</entry>
+      <entry key="i000007" count="0" color="#646464" shape="SQUARE">None</entry>
+      <entry key="i000008" count="0" color="#007abc" shape="SQUARE">Minor</entry>
+      <entry key="i000009" count="0" color="#1500b4" shape="SQUARE">Major</entry>
+      <entry key="i00000a" count="0" color="#7500af" shape="SQUARE">Main</entry>
     </importance>
   </settings>
   <content items="25" novelWords="830" notesWords="376" novelChars="0" notesChars="0">

--- a/tests/reference/projectXML_ReadLegacy14.nwx
+++ b/tests/reference/projectXML_ReadLegacy14.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="5" timeStamp="2022-10-15 12:12:59">
+<novelWriterXML appVersion="2.7b1" hexVersion="0x020700b1" fileVersion="1.5" fileRevision="6" timeStamp="2022-10-15 12:12:59">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
     <name>Sample Project</name>
     <author>Jay Doh</author>
@@ -20,19 +20,19 @@
       <entry key="C">D</entry>
     </autoReplace>
     <status>
-      <entry key="sf12341" count="4" red="100" green="100" blue="100" shape="SQUARE">New</entry>
-      <entry key="sf24ce6" count="2" red="200" green="50" blue="0" shape="SQUARE">Notes</entry>
-      <entry key="sc24b8f" count="3" red="182" green="60" blue="0" shape="SQUARE">Started</entry>
-      <entry key="s90e6c9" count="7" red="193" green="129" blue="0" shape="SQUARE">1st Draft</entry>
-      <entry key="sd51c5b" count="0" red="193" green="129" blue="0" shape="SQUARE">2nd Draft</entry>
-      <entry key="s8ae72a" count="0" red="193" green="129" blue="0" shape="SQUARE">3rd Draft</entry>
-      <entry key="s78ea90" count="1" red="58" green="180" blue="58" shape="SQUARE">Finished</entry>
+      <entry key="sf12341" count="4" color="#646464" shape="SQUARE">New</entry>
+      <entry key="sf24ce6" count="2" color="#c83200" shape="SQUARE">Notes</entry>
+      <entry key="sc24b8f" count="3" color="#b63c00" shape="SQUARE">Started</entry>
+      <entry key="s90e6c9" count="7" color="#c18100" shape="SQUARE">1st Draft</entry>
+      <entry key="sd51c5b" count="0" color="#c18100" shape="SQUARE">2nd Draft</entry>
+      <entry key="s8ae72a" count="0" color="#c18100" shape="SQUARE">3rd Draft</entry>
+      <entry key="s78ea90" count="1" color="#3ab43a" shape="SQUARE">Finished</entry>
     </status>
     <importance>
-      <entry key="ia857f0" count="5" red="100" green="100" blue="100" shape="SQUARE">None</entry>
-      <entry key="icfb3a5" count="2" red="0" green="122" blue="188" shape="SQUARE">Minor</entry>
-      <entry key="i2d7a54" count="2" red="21" green="0" blue="180" shape="SQUARE">Major</entry>
-      <entry key="i56be10" count="1" red="117" green="0" blue="175" shape="SQUARE">Main</entry>
+      <entry key="ia857f0" count="5" color="#646464" shape="SQUARE">None</entry>
+      <entry key="icfb3a5" count="2" color="#007abc" shape="SQUARE">Minor</entry>
+      <entry key="i2d7a54" count="2" color="#1500b4" shape="SQUARE">Major</entry>
+      <entry key="i56be10" count="1" color="#7500af" shape="SQUARE">Main</entry>
     </importance>
   </settings>
   <content items="27" novelWords="954" notesWords="409" novelChars="0" notesChars="0">

--- a/tests/test_core/test_core_item.py
+++ b/tests/test_core/test_core_item.py
@@ -547,8 +547,8 @@ def testCoreItem_ClassDefaults(mockGUI):
 def testCoreItem_PackUnpack(mockGUI, caplog, mockRnd):
     """Test packing and unpacking entries for the NWItem class."""
     project = NWProject()
-    project.data.itemStatus.add(None, "New", (100, 100, 100), "SQUARE", 0)
-    project.data.itemImport.add(None, "New", (100, 100, 100), "SQUARE", 0)
+    project.data.itemStatus.add(None, "New", "#646464", "SQUARE", 0)
+    project.data.itemImport.add(None, "New", "#646464", "SQUARE", 0)
 
     # Invalid
     item = NWItem(project, "0000000000000")

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -27,12 +27,11 @@ from shutil import copyfile
 
 import pytest
 
-from PyQt6.QtGui import QColor
-
 from novelwriter.constants import nwFiles
 from novelwriter.core.item import NWItem
 from novelwriter.core.projectdata import NWProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
+from novelwriter.core.status import CUSTOM_COL
 from novelwriter.enum import nwStatusShape
 
 from tests.mocked import causeOSError
@@ -137,7 +136,7 @@ def testCoreProjectXML_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
     assert xmlReader.state == XMLReadState.PARSED_OK
     assert xmlReader.xmlRoot == "novelWriterXML"
     assert xmlReader.xmlVersion == 0x0105
-    assert xmlReader.xmlRevision == 5
+    assert xmlReader.xmlRevision == 6
     assert xmlReader.appVersion == "2.7b1"
     assert xmlReader.hexVersion == 0x020700b1
 
@@ -173,19 +172,31 @@ def testCoreProjectXML_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
     assert data.itemImport["i2d7a54"].name == "Major"
     assert data.itemImport["i56be10"].name == "Main"
 
-    assert data.itemStatus["sf12341"].color == QColor(100, 100, 100)
-    assert data.itemStatus["sf24ce6"].color == QColor(200, 50, 0)
-    assert data.itemStatus["sc24b8f"].color == QColor(182, 60, 0)
-    assert data.itemStatus["s90e6c9"].color == QColor(193, 129, 0)
-    assert data.itemStatus["sd51c5b"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s8ae72a"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s78ea90"].color == QColor(58, 180, 58)
+    assert data.itemStatus["sf12341"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemStatus["sf24ce6"].color.getRgb() == (200, 50, 0, 255)
+    assert data.itemStatus["sc24b8f"].color.getRgb() == (182, 60, 0, 255)
+    assert data.itemStatus["s90e6c9"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["sd51c5b"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s8ae72a"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s78ea90"].color.getRgb() == (58, 180, 58, 255)
 
-    assert data.itemImport["ia857f0"].color == QColor(100, 100, 100)
-    assert data.itemImport["i4a1d39"].color == QColor(220, 138, 221)
-    assert data.itemImport["icfb3a5"].color == QColor(220, 138, 221)
-    assert data.itemImport["i2d7a54"].color == QColor(220, 138, 221)
-    assert data.itemImport["i56be10"].color == QColor(220, 138, 221)
+    assert data.itemImport["ia857f0"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemImport["icfb3a5"].color.getRgb() == (220, 138, 221, 255)
+    assert data.itemImport["i2d7a54"].color.getRgb() == (220, 138, 221, 255)
+    assert data.itemImport["i56be10"].color.getRgb() == (220, 138, 221, 255)
+
+    assert data.itemStatus["sf12341"].theme == CUSTOM_COL
+    assert data.itemStatus["sf24ce6"].theme == CUSTOM_COL
+    assert data.itemStatus["sc24b8f"].theme == CUSTOM_COL
+    assert data.itemStatus["s90e6c9"].theme == CUSTOM_COL
+    assert data.itemStatus["sd51c5b"].theme == CUSTOM_COL
+    assert data.itemStatus["s8ae72a"].theme == CUSTOM_COL
+    assert data.itemStatus["s78ea90"].theme == CUSTOM_COL
+
+    assert data.itemImport["ia857f0"].theme == CUSTOM_COL
+    assert data.itemImport["icfb3a5"].theme == CUSTOM_COL
+    assert data.itemImport["i2d7a54"].theme == CUSTOM_COL
+    assert data.itemImport["i56be10"].theme == CUSTOM_COL
 
     assert data.itemStatus["sf12341"].shape == nwStatusShape.SQUARE
     assert data.itemStatus["sf24ce6"].shape == nwStatusShape.SQUARE
@@ -305,18 +316,31 @@ def testCoreProjectXML_ReadLegacy10(tstPaths, fncPath, mockGUI, mockRnd):
     assert data.itemImport["i000009"].name == "Major"
     assert data.itemImport["i00000a"].name == "Main"
 
-    assert data.itemStatus["s000000"].color == QColor(100, 100, 100)
-    assert data.itemStatus["s000001"].color == QColor(200, 50, 0)
-    assert data.itemStatus["s000002"].color == QColor(182, 60, 0)
-    assert data.itemStatus["s000003"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000004"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000005"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000006"].color == QColor(58, 180, 58)
+    assert data.itemStatus["s000000"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemStatus["s000001"].color.getRgb() == (200, 50, 0, 255)
+    assert data.itemStatus["s000002"].color.getRgb() == (182, 60, 0, 255)
+    assert data.itemStatus["s000003"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000004"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000005"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000006"].color.getRgb() == (58, 180, 58, 255)
 
-    assert data.itemImport["i000007"].color == QColor(100, 100, 100)
-    assert data.itemImport["i000008"].color == QColor(0, 122, 188)
-    assert data.itemImport["i000009"].color == QColor(21, 0, 180)
-    assert data.itemImport["i00000a"].color == QColor(117, 0, 175)
+    assert data.itemImport["i000007"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemImport["i000008"].color.getRgb() == (0, 122, 188, 255)
+    assert data.itemImport["i000009"].color.getRgb() == (21, 0, 180, 255)
+    assert data.itemImport["i00000a"].color.getRgb() == (117, 0, 175, 255)
+
+    assert data.itemStatus["s000000"].theme == CUSTOM_COL
+    assert data.itemStatus["s000001"].theme == CUSTOM_COL
+    assert data.itemStatus["s000002"].theme == CUSTOM_COL
+    assert data.itemStatus["s000003"].theme == CUSTOM_COL
+    assert data.itemStatus["s000004"].theme == CUSTOM_COL
+    assert data.itemStatus["s000005"].theme == CUSTOM_COL
+    assert data.itemStatus["s000006"].theme == CUSTOM_COL
+
+    assert data.itemImport["i000007"].theme == CUSTOM_COL
+    assert data.itemImport["i000008"].theme == CUSTOM_COL
+    assert data.itemImport["i000009"].theme == CUSTOM_COL
+    assert data.itemImport["i00000a"].theme == CUSTOM_COL
 
     assert data.itemStatus["s000000"].shape == nwStatusShape.SQUARE
     assert data.itemStatus["s000001"].shape == nwStatusShape.SQUARE
@@ -450,18 +474,31 @@ def testCoreProjectXML_ReadLegacy11(tstPaths, fncPath, mockGUI, mockRnd):
     assert data.itemImport["i000009"].name == "Major"
     assert data.itemImport["i00000a"].name == "Main"
 
-    assert data.itemStatus["s000000"].color == QColor(100, 100, 100)
-    assert data.itemStatus["s000001"].color == QColor(200, 50, 0)
-    assert data.itemStatus["s000002"].color == QColor(182, 60, 0)
-    assert data.itemStatus["s000003"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000004"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000005"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000006"].color == QColor(58, 180, 58)
+    assert data.itemStatus["s000000"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemStatus["s000001"].color.getRgb() == (200, 50, 0, 255)
+    assert data.itemStatus["s000002"].color.getRgb() == (182, 60, 0, 255)
+    assert data.itemStatus["s000003"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000004"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000005"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000006"].color.getRgb() == (58, 180, 58, 255)
 
-    assert data.itemImport["i000007"].color == QColor(100, 100, 100)
-    assert data.itemImport["i000008"].color == QColor(0, 122, 188)
-    assert data.itemImport["i000009"].color == QColor(21, 0, 180)
-    assert data.itemImport["i00000a"].color == QColor(117, 0, 175)
+    assert data.itemImport["i000007"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemImport["i000008"].color.getRgb() == (0, 122, 188, 255)
+    assert data.itemImport["i000009"].color.getRgb() == (21, 0, 180, 255)
+    assert data.itemImport["i00000a"].color.getRgb() == (117, 0, 175, 255)
+
+    assert data.itemStatus["s000000"].theme == CUSTOM_COL
+    assert data.itemStatus["s000001"].theme == CUSTOM_COL
+    assert data.itemStatus["s000002"].theme == CUSTOM_COL
+    assert data.itemStatus["s000003"].theme == CUSTOM_COL
+    assert data.itemStatus["s000004"].theme == CUSTOM_COL
+    assert data.itemStatus["s000005"].theme == CUSTOM_COL
+    assert data.itemStatus["s000006"].theme == CUSTOM_COL
+
+    assert data.itemImport["i000007"].theme == CUSTOM_COL
+    assert data.itemImport["i000008"].theme == CUSTOM_COL
+    assert data.itemImport["i000009"].theme == CUSTOM_COL
+    assert data.itemImport["i00000a"].theme == CUSTOM_COL
 
     assert data.itemStatus["s000000"].shape == nwStatusShape.SQUARE
     assert data.itemStatus["s000001"].shape == nwStatusShape.SQUARE
@@ -595,18 +632,31 @@ def testCoreProjectXML_ReadLegacy12(tstPaths, fncPath, mockGUI, mockRnd):
     assert data.itemImport["i000009"].name == "Major"
     assert data.itemImport["i00000a"].name == "Main"
 
-    assert data.itemStatus["s000000"].color == QColor(100, 100, 100)
-    assert data.itemStatus["s000001"].color == QColor(200, 50, 0)
-    assert data.itemStatus["s000002"].color == QColor(182, 60, 0)
-    assert data.itemStatus["s000003"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000004"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000005"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000006"].color == QColor(58, 180, 58)
+    assert data.itemStatus["s000000"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemStatus["s000001"].color.getRgb() == (200, 50, 0, 255)
+    assert data.itemStatus["s000002"].color.getRgb() == (182, 60, 0, 255)
+    assert data.itemStatus["s000003"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000004"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000005"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000006"].color.getRgb() == (58, 180, 58, 255)
 
-    assert data.itemImport["i000007"].color == QColor(100, 100, 100)
-    assert data.itemImport["i000008"].color == QColor(0, 122, 188)
-    assert data.itemImport["i000009"].color == QColor(21, 0, 180)
-    assert data.itemImport["i00000a"].color == QColor(117, 0, 175)
+    assert data.itemImport["i000007"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemImport["i000008"].color.getRgb() == (0, 122, 188, 255)
+    assert data.itemImport["i000009"].color.getRgb() == (21, 0, 180, 255)
+    assert data.itemImport["i00000a"].color.getRgb() == (117, 0, 175, 255)
+
+    assert data.itemStatus["s000000"].theme == CUSTOM_COL
+    assert data.itemStatus["s000001"].theme == CUSTOM_COL
+    assert data.itemStatus["s000002"].theme == CUSTOM_COL
+    assert data.itemStatus["s000003"].theme == CUSTOM_COL
+    assert data.itemStatus["s000004"].theme == CUSTOM_COL
+    assert data.itemStatus["s000005"].theme == CUSTOM_COL
+    assert data.itemStatus["s000006"].theme == CUSTOM_COL
+
+    assert data.itemImport["i000007"].theme == CUSTOM_COL
+    assert data.itemImport["i000008"].theme == CUSTOM_COL
+    assert data.itemImport["i000009"].theme == CUSTOM_COL
+    assert data.itemImport["i00000a"].theme == CUSTOM_COL
 
     assert data.itemStatus["s000000"].shape == nwStatusShape.SQUARE
     assert data.itemStatus["s000001"].shape == nwStatusShape.SQUARE
@@ -743,18 +793,31 @@ def testCoreProjectXML_ReadLegacy13(tstPaths, fncPath, mockGUI, mockRnd):
     assert data.itemImport["i000009"].name == "Major"
     assert data.itemImport["i00000a"].name == "Main"
 
-    assert data.itemStatus["s000000"].color == QColor(100, 100, 100)
-    assert data.itemStatus["s000001"].color == QColor(200, 50, 0)
-    assert data.itemStatus["s000002"].color == QColor(182, 60, 0)
-    assert data.itemStatus["s000003"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000004"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000005"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s000006"].color == QColor(58, 180, 58)
+    assert data.itemStatus["s000000"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemStatus["s000001"].color.getRgb() == (200, 50, 0, 255)
+    assert data.itemStatus["s000002"].color.getRgb() == (182, 60, 0, 255)
+    assert data.itemStatus["s000003"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000004"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000005"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s000006"].color.getRgb() == (58, 180, 58, 255)
 
-    assert data.itemImport["i000007"].color == QColor(100, 100, 100)
-    assert data.itemImport["i000008"].color == QColor(0, 122, 188)
-    assert data.itemImport["i000009"].color == QColor(21, 0, 180)
-    assert data.itemImport["i00000a"].color == QColor(117, 0, 175)
+    assert data.itemImport["i000007"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemImport["i000008"].color.getRgb() == (0, 122, 188, 255)
+    assert data.itemImport["i000009"].color.getRgb() == (21, 0, 180, 255)
+    assert data.itemImport["i00000a"].color.getRgb() == (117, 0, 175, 255)
+
+    assert data.itemStatus["s000000"].theme == CUSTOM_COL
+    assert data.itemStatus["s000001"].theme == CUSTOM_COL
+    assert data.itemStatus["s000002"].theme == CUSTOM_COL
+    assert data.itemStatus["s000003"].theme == CUSTOM_COL
+    assert data.itemStatus["s000004"].theme == CUSTOM_COL
+    assert data.itemStatus["s000005"].theme == CUSTOM_COL
+    assert data.itemStatus["s000006"].theme == CUSTOM_COL
+
+    assert data.itemImport["i000007"].theme == CUSTOM_COL
+    assert data.itemImport["i000008"].theme == CUSTOM_COL
+    assert data.itemImport["i000009"].theme == CUSTOM_COL
+    assert data.itemImport["i00000a"].theme == CUSTOM_COL
 
     assert data.itemStatus["s000000"].shape == nwStatusShape.SQUARE
     assert data.itemStatus["s000001"].shape == nwStatusShape.SQUARE
@@ -891,18 +954,31 @@ def testCoreProjectXML_ReadLegacy14(tstPaths, fncPath, mockGUI, mockRnd):
     assert data.itemImport["i2d7a54"].name == "Major"
     assert data.itemImport["i56be10"].name == "Main"
 
-    assert data.itemStatus["sf12341"].color == QColor(100, 100, 100)
-    assert data.itemStatus["sf24ce6"].color == QColor(200, 50, 0)
-    assert data.itemStatus["sc24b8f"].color == QColor(182, 60, 0)
-    assert data.itemStatus["s90e6c9"].color == QColor(193, 129, 0)
-    assert data.itemStatus["sd51c5b"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s8ae72a"].color == QColor(193, 129, 0)
-    assert data.itemStatus["s78ea90"].color == QColor(58, 180, 58)
+    assert data.itemStatus["sf12341"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemStatus["sf24ce6"].color.getRgb() == (200, 50, 0, 255)
+    assert data.itemStatus["sc24b8f"].color.getRgb() == (182, 60, 0, 255)
+    assert data.itemStatus["s90e6c9"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["sd51c5b"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s8ae72a"].color.getRgb() == (193, 129, 0, 255)
+    assert data.itemStatus["s78ea90"].color.getRgb() == (58, 180, 58, 255)
 
-    assert data.itemImport["ia857f0"].color == QColor(100, 100, 100)
-    assert data.itemImport["icfb3a5"].color == QColor(0, 122, 188)
-    assert data.itemImport["i2d7a54"].color == QColor(21, 0, 180)
-    assert data.itemImport["i56be10"].color == QColor(117, 0, 175)
+    assert data.itemImport["ia857f0"].color.getRgb() == (100, 100, 100, 255)
+    assert data.itemImport["icfb3a5"].color.getRgb() == (0, 122, 188, 255)
+    assert data.itemImport["i2d7a54"].color.getRgb() == (21, 0, 180, 255)
+    assert data.itemImport["i56be10"].color.getRgb() == (117, 0, 175, 255)
+
+    assert data.itemStatus["sf12341"].theme == CUSTOM_COL
+    assert data.itemStatus["sf24ce6"].theme == CUSTOM_COL
+    assert data.itemStatus["sc24b8f"].theme == CUSTOM_COL
+    assert data.itemStatus["s90e6c9"].theme == CUSTOM_COL
+    assert data.itemStatus["sd51c5b"].theme == CUSTOM_COL
+    assert data.itemStatus["s8ae72a"].theme == CUSTOM_COL
+    assert data.itemStatus["s78ea90"].theme == CUSTOM_COL
+
+    assert data.itemImport["ia857f0"].theme == CUSTOM_COL
+    assert data.itemImport["icfb3a5"].theme == CUSTOM_COL
+    assert data.itemImport["i2d7a54"].theme == CUSTOM_COL
+    assert data.itemImport["i56be10"].theme == CUSTOM_COL
 
     assert data.itemStatus["sf12341"].shape == nwStatusShape.SQUARE
     assert data.itemStatus["sf24ce6"].shape == nwStatusShape.SQUARE

--- a/tests/test_core/test_core_status.py
+++ b/tests/test_core/test_core_status.py
@@ -24,7 +24,7 @@ import pytest
 
 from PyQt6.QtGui import QColor, QIcon
 
-from novelwriter.core.status import NWStatus, StatusEntry, _ShapeCache
+from novelwriter.core.status import CUSTOM_COL, NWStatus, StatusEntry, _ShapeCache
 from novelwriter.enum import nwStatusShape
 
 from tests.tools import C
@@ -38,11 +38,12 @@ def testCoreStatus_StatusEntry():
     """Test the StatusEntry class."""
     color = QColor(255, 0, 0)
     icon = NWStatus.createIcon(24, color, nwStatusShape.CIRCLE)
-    entry = StatusEntry("Test", color, nwStatusShape.CIRCLE, icon, 42)
+    entry = StatusEntry("Test", color, CUSTOM_COL, nwStatusShape.CIRCLE, icon, 42)
 
     # Check values
     assert entry.name == "Test"
     assert entry.color is color
+    assert entry.theme == CUSTOM_COL
     assert entry.shape == nwStatusShape.CIRCLE
     assert entry.icon is icon
     assert entry.count == 42
@@ -55,6 +56,7 @@ def testCoreStatus_StatusEntry():
     assert other.name == "Test"
     assert other.color is not color  # Not the same object
     assert other.color == color      # But same colours
+    assert entry.theme == CUSTOM_COL
     assert other.shape == nwStatusShape.CIRCLE
     assert other.icon is not icon    # Not the same icon, but a copy
     assert other.count == 42
@@ -73,14 +75,14 @@ def testCoreStatus_Internal(mockGUI, mockRnd):
     assert nStatus._newKey() == statusKeys[1]
 
     # Key collision, should move to key 3
-    nStatus.add(statusKeys[2], "Crash", (0, 0, 0), "SQUARE", 0)
+    nStatus.add(statusKeys[2], "Crash", "#000000", "SQUARE", 0)
     assert nStatus._newKey() == statusKeys[3]
 
     assert nImport._newKey() == importKeys[0]
     assert nImport._newKey() == importKeys[1]
 
     # Key collision, should move to key 3
-    nImport.add(importKeys[2], "Crash", (0, 0, 0), "SQUARE", 0)
+    nImport.add(importKeys[2], "Crash", "#000000", "SQUARE", 0)
     assert nImport._newKey() == importKeys[3]
 
     # Check Key
@@ -119,14 +121,14 @@ def testCoreStatus_Internal(mockGUI, mockRnd):
 def testCoreStatus_Iterator(mockGUI, mockRnd):
     """Test the iterator functions of the NWStatus class."""
     nStatus = NWStatus(NWStatus.STATUS)
-    nStatus.add(None, "New",      (100, 100, 100), "SQUARE", 0)
-    nStatus.add(None, "Note",     (200, 50,  0),   "CIRCLE", 1)
-    nStatus.add(None, "Draft",    (200, 150, 0),   "SQUARE", 2)
-    nStatus.add(None, "Finished", (50,  200, 0),   "CIRCLE", 3)
+    nStatus.add(None, "New",      "#646464", "SQUARE", 0)
+    nStatus.add(None, "Note",     "#ff3f00", "CIRCLE", 1)
+    nStatus.add(None, "Draft",    "#ffaf00", "SQUARE", 2)
+    nStatus.add(None, "Finished", "#3fff00", "CIRCLE", 3)
 
     # Direct access
     entry = nStatus[statusKeys[0]]
-    assert entry.color == QColor(100, 100, 100)
+    assert entry.color.getRgb() == (100, 100, 100, 255)
     assert entry.name == "New"
     assert entry.count == 0
     assert isinstance(entry.icon, QIcon)
@@ -146,8 +148,8 @@ def testCoreStatus_Iterator(mockGUI, mockRnd):
     ]
 
     # Content : Colours
-    assert [e.color for _, e in nStatus.iterItems()] == [
-        QColor(100, 100, 100), QColor(200, 50,  0), QColor(200, 150, 0), QColor(50,  200, 0)
+    assert [e.color.getRgb() for _, e in nStatus.iterItems()] == [
+        (100, 100, 100, 255), (255, 63,  0, 255), (255, 175, 0, 255), (63,  255, 0, 255)
     ]
 
     # Content : Shape
@@ -168,27 +170,31 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
     # ===
 
     # Has a key
-    nStatus.add(statusKeys[0], "Entry 1", (200, 100, 50), "SQUARE", 0)
+    nStatus.add(statusKeys[0], "Entry 1", "200, 100, 50", "SQUARE", 0)
     assert nStatus[statusKeys[0]].name == "Entry 1"
-    assert nStatus[statusKeys[0]].color == QColor(200, 100, 50)
+    assert nStatus[statusKeys[0]].color.getRgb() == (200, 100, 50, 255)
+    assert nStatus[statusKeys[0]].theme == CUSTOM_COL
     assert nStatus[statusKeys[0]].shape == nwStatusShape.SQUARE
 
     # Doesn't have a key
-    nStatus.add(None, "Entry 2", (210, 110, 60), "SQUARE", 0)
+    nStatus.add(None, "Entry 2", "210, 110, 60", "SQUARE", 0)
     assert nStatus[statusKeys[1]].name == "Entry 2"
-    assert nStatus[statusKeys[1]].color == QColor(210, 110, 60)
+    assert nStatus[statusKeys[1]].color.getRgb() == (210, 110, 60, 255)
+    assert nStatus[statusKeys[1]].theme == CUSTOM_COL
     assert nStatus[statusKeys[1]].shape == nwStatusShape.SQUARE
 
     # Wrong colour spec, unknown shape
-    nStatus.add(None, "Entry 3", "what?", "", 0)  # type: ignore
+    nStatus.add(None, "Entry 3", "what?", "", 0)
     assert nStatus[statusKeys[2]].name == "Entry 3"
-    assert nStatus[statusKeys[2]].color == QColor(100, 100, 100)
+    assert nStatus[statusKeys[2]].color.getRgb() == (0, 0, 0, 255)
+    assert nStatus[statusKeys[2]].theme == CUSTOM_COL
     assert nStatus[statusKeys[2]].shape == nwStatusShape.SQUARE
 
-    # Wrong colour count
-    nStatus.add(None, "Entry 4", (10, 20), "CIRCLE", 0)  # type: ignore
+    # Wrong colour definition
+    nStatus.add(None, "Entry 4", "#stuff#", "CIRCLE", 0)
     assert nStatus[statusKeys[3]].name == "Entry 4"
-    assert nStatus[statusKeys[3]].color == QColor(100, 100, 100)
+    assert nStatus[statusKeys[3]].color.getRgb() == (0, 0, 0, 255)
+    assert nStatus[statusKeys[3]].theme == CUSTOM_COL
     assert nStatus[statusKeys[3]].shape == nwStatusShape.CIRCLE
 
     # Check
@@ -202,8 +208,6 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
     assert nStatus.check("s987654") == statusKeys[0]
 
     # Name Access
-    # ===========
-
     assert nStatus[statusKeys[0]].name == "Entry 1"
     assert nStatus[statusKeys[1]].name == "Entry 2"
     assert nStatus[statusKeys[2]].name == "Entry 3"
@@ -211,17 +215,20 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
     assert nStatus["blablabla"].name == "Entry 1"
 
     # Colour Access
-    # =============
+    assert nStatus[statusKeys[0]].color.getRgb() == (200, 100, 50, 255)
+    assert nStatus[statusKeys[1]].color.getRgb() == (210, 110, 60, 255)
+    assert nStatus[statusKeys[2]].color.getRgb() == (0, 0, 0, 255)
+    assert nStatus[statusKeys[3]].color.getRgb() == (0, 0, 0, 255)
+    assert nStatus["blablabla"].color.getRgb() == (200, 100, 50, 255)
 
-    assert nStatus[statusKeys[0]].color == QColor(200, 100, 50)
-    assert nStatus[statusKeys[1]].color == QColor(210, 110, 60)
-    assert nStatus[statusKeys[2]].color == QColor(100, 100, 100)
-    assert nStatus[statusKeys[3]].color == QColor(100, 100, 100)
-    assert nStatus["blablabla"].color == QColor(200, 100, 50)
+    # Theme Access
+    assert nStatus[statusKeys[0]].theme == CUSTOM_COL
+    assert nStatus[statusKeys[1]].theme == CUSTOM_COL
+    assert nStatus[statusKeys[2]].theme == CUSTOM_COL
+    assert nStatus[statusKeys[3]].theme == CUSTOM_COL
+    assert nStatus["blablabla"].theme == CUSTOM_COL
 
     # Icon Access
-    # ===========
-
     assert isinstance(nStatus[statusKeys[0]].icon, QIcon)
     assert isinstance(nStatus[statusKeys[1]].icon, QIcon)
     assert isinstance(nStatus[statusKeys[2]].icon, QIcon)
@@ -229,8 +236,6 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
     assert isinstance(nStatus["blablabla"].icon, QIcon)
 
     # Shape Access
-    # ============
-
     assert nStatus[statusKeys[0]].shape == nwStatusShape.SQUARE
     assert nStatus[statusKeys[1]].shape == nwStatusShape.SQUARE
     assert nStatus[statusKeys[2]].shape == nwStatusShape.SQUARE
@@ -322,10 +327,10 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
 def testCoreStatus_Pack(mockGUI, mockRnd):
     """Test data packing of the NWStatus class."""
     nStatus = NWStatus(NWStatus.STATUS)
-    nStatus.add(None, "New",      (100, 100, 100), "SQUARE", 0)
-    nStatus.add(None, "Note",     (200, 50,  0),   "CIRCLE", 0)
-    nStatus.add(None, "Draft",    (200, 150, 0),   "SQUARE", 0)
-    nStatus.add(None, "Finished", (50,  200, 0),   "SQUARE", 0)
+    nStatus.add(None, "New",      "#646464", "SQUARE", 0)
+    nStatus.add(None, "Note",     "#c83200", "CIRCLE", 0)
+    nStatus.add(None, "Draft",    "#c89600", "SQUARE", 0)
+    nStatus.add(None, "Finished", "#32c800", "SQUARE", 0)
 
     countTo = [3, 5, 7, 9]
     for i, n in enumerate(countTo):
@@ -337,33 +342,25 @@ def testCoreStatus_Pack(mockGUI, mockRnd):
         ("New", {
             "key": statusKeys[0],
             "count": "3",
-            "red": "100",
-            "green": "100",
-            "blue": "100",
+            "color": "#646464",
             "shape": "SQUARE",
         }),
         ("Note", {
             "key": statusKeys[1],
             "count": "5",
-            "red": "200",
-            "green": "50",
-            "blue": "0",
+            "color": "#c83200",
             "shape": "CIRCLE",
         }),
         ("Draft", {
             "key": statusKeys[2],
             "count": "7",
-            "red": "200",
-            "green": "150",
-            "blue": "0",
+            "color": "#c89600",
             "shape": "SQUARE",
         }),
         ("Finished", {
             "key": statusKeys[3],
             "count": "9",
-            "red": "50",
-            "green": "200",
-            "blue": "0",
+            "color": "#32c800",
             "shape": "SQUARE",
         }),
     ]

--- a/tests/test_core/test_core_status.py
+++ b/tests/test_core/test_core_status.py
@@ -324,13 +324,32 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
 
 
 @pytest.mark.core
-def testCoreStatus_Pack(mockGUI, mockRnd):
+def testCoreStatus_RefreshIcons(mockGUIwithTheme, mockRnd):
+    """Test refreshing the icons of the NWStatus class."""
+    nStatus = NWStatus(NWStatus.STATUS)
+    nStatus.add(None, "New",      "default", "SQUARE", 0)
+    nStatus.add(None, "Note",     "red",     "CIRCLE", 0)
+    nStatus.add(None, "Draft",    "yellow",  "SQUARE", 0)
+    nStatus.add(None, "Finished", "green",   "SQUARE", 0)
+
+    beforeIcons = [nStatus[statusKeys[i]].icon for i in range(4)]
+
+    # Refreshing the icons should generate new ones
+    nStatus.refreshIcons()
+    afterIcons = [nStatus[statusKeys[i]].icon for i in range(4)]
+
+    for before, after in zip(beforeIcons, afterIcons, strict=False):
+        assert before is not after
+
+
+@pytest.mark.core
+def testCoreStatus_Pack(mockGUIwithTheme, mockRnd):
     """Test data packing of the NWStatus class."""
     nStatus = NWStatus(NWStatus.STATUS)
     nStatus.add(None, "New",      "#646464", "SQUARE", 0)
     nStatus.add(None, "Note",     "#c83200", "CIRCLE", 0)
     nStatus.add(None, "Draft",    "#c89600", "SQUARE", 0)
-    nStatus.add(None, "Finished", "#32c800", "SQUARE", 0)
+    nStatus.add(None, "Finished", "default", "SQUARE", 0)
 
     countTo = [3, 5, 7, 9]
     for i, n in enumerate(countTo):
@@ -360,7 +379,7 @@ def testCoreStatus_Pack(mockGUI, mockRnd):
         ("Finished", {
             "key": statusKeys[3],
             "count": "9",
-            "color": "#32c800",
+            "color": "default",
             "shape": "SQUARE",
         }),
     ]

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -27,7 +27,7 @@ from PyQt6.QtGui import QAction, QFont, QFontDatabase, QKeyEvent
 from PyQt6.QtWidgets import QFileDialog, QFontDialog
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT
+from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_TREECOL
 from novelwriter.constants import nwUnicode
 from novelwriter.dialogs.preferences import GuiPreferences
 from novelwriter.dialogs.quotes import GuiQuoteSelect
@@ -198,7 +198,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     prefs.iconColDocs.setChecked(True)
     prefs.emphLabels.setChecked(True)
 
-    assert CONFIG.iconColTree == "theme"
+    assert CONFIG.iconColTree == DEF_TREECOL
     assert CONFIG.iconColDocs is False
     assert CONFIG.emphLabels is False
 

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -196,11 +196,11 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     # Project View
     prefs.iconColTree.setCurrentData("faded", "default")
     prefs.iconColDocs.setChecked(True)
-    prefs.emphLabels.setChecked(True)
+    prefs.emphLabels.setChecked(False)
 
     assert CONFIG.iconColTree == DEF_TREECOL
     assert CONFIG.iconColDocs is False
-    assert CONFIG.emphLabels is False
+    assert CONFIG.emphLabels is True
 
     # Behaviour
     prefs.autoSaveDoc.stepUp()
@@ -362,7 +362,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     # Project View
     assert CONFIG.iconColTree == "faded"
     assert CONFIG.iconColDocs is True
-    assert CONFIG.emphLabels is True
+    assert CONFIG.emphLabels is False
 
     # Behaviour
     assert CONFIG.autoSaveDoc == 31

--- a/tests/test_dialogs/test_dlg_projectsettings.py
+++ b/tests/test_dialogs/test_dlg_projectsettings.py
@@ -214,22 +214,22 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, mockRn
 
     assert update[0][0] == C.sNew
     assert update[0][1].name == "New"
-    assert update[0][1].color == QColor(120, 120, 120)
+    assert update[0][1].color.getRgb() == (108, 108, 108, 255)
     assert update[0][1].shape == nwStatusShape.STAR
 
     assert update[1][0] == C.sDraft
     assert update[1][1].name == "Draft"
-    assert update[1][1].color == QColor(143, 240, 164)
+    assert update[1][1].color.getRgb() == (163, 156, 52, 255)
     assert update[1][1].shape == nwStatusShape.CIRCLE_T
 
     assert update[2][0] == C.sFinished
     assert update[2][1].name == "Finished"
-    assert update[2][1].color == QColor(249, 240, 107)
+    assert update[2][1].color.getRgb() == (41, 102, 41, 255)
     assert update[2][1].shape == nwStatusShape.STAR
 
     assert update[3][0] is None
     assert update[3][1].name == "Final"
-    assert update[3][1].color == QColor(20, 30, 40)
+    assert update[3][1].color.getRgb() == (20, 30, 40, 255)
     assert update[3][1].shape == nwStatusShape.CIRCLE
 
     # Move items, none selected -> no change
@@ -289,22 +289,22 @@ def testDlgProjSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, mockRn
 
     assert update[0][0] == C.iNew
     assert update[0][1].name == "New"
-    assert update[0][1].color == QColor(120, 120, 120)
+    assert update[0][1].color.getRgb() == (179, 90, 179, 255)
     assert update[0][1].shape == nwStatusShape.SQUARE
 
     assert update[1][0] == C.iMajor
     assert update[1][1].name == "Major"
-    assert update[1][1].color == QColor(220, 138, 221)
+    assert update[1][1].color.getRgb() == (179, 90, 179, 255)
     assert update[1][1].shape == nwStatusShape.BLOCK_3
 
     assert update[2][0] == C.iMain
     assert update[2][1].name == "Main"
-    assert update[2][1].color == QColor(220, 138, 221)
+    assert update[2][1].color.getRgb() == (179, 90, 179, 255)
     assert update[2][1].shape == nwStatusShape.BLOCK_4
 
     assert update[3][0] is None
     assert update[3][1].name == "Final"
-    assert update[3][1].color == QColor(20, 30, 40)
+    assert update[3][1].color.getRgb() == (20, 30, 40, 255)
     assert update[3][1].shape == nwStatusShape.TRIANGLE
 
     # Check Project
@@ -354,10 +354,10 @@ def testDlgProjSettings_StatusImportExport(qtbot, monkeypatch, nwGUI, projPath, 
 
     assert expFile.is_file() is True
     assert expFile.read_text().split() == [
-        "STAR,#787878,New",
-        "TRIANGLE,#cdab8f,Note",
-        "CIRCLE_T,#8ff0a4,Draft",
-        "STAR,#f9f06b,Finished",
+        "STAR,#6c6c6c,New",
+        "TRIANGLE,#a62a2d,Note",
+        "CIRCLE_T,#a39c34,Draft",
+        "STAR,#296629,Finished",
     ]
 
     # Import Error

--- a/tests/test_gui/test_gui_docviewerpanel.py
+++ b/tests/test_gui/test_gui_docviewerpanel.py
@@ -224,7 +224,7 @@ def testGuiViewerPanel_Tags(qtbot, monkeypatch, caplog, nwGUI, projPath, mockRnd
 
     # Update Labels
     assert charTab.topLevelItem(0).text(charTab.C_IMPORT) == "New"
-    SHARED.project.data.itemImport.add(C.iNew, "Stuff", (100, 100, 100), "SQUARE", 0)
+    SHARED.project.data.itemImport.add(C.iNew, "Stuff", "#646464", "SQUARE", 0)
     viewPanel.updateStatusLabels("i")
     assert charTab.topLevelItem(0).text(charTab.C_IMPORT) == "Stuff"
 

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -267,8 +267,7 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     # Change some settings
     CONFIG.hideHScroll = True
     CONFIG.hideVScroll = True
-    CONFIG.autoScrollPos = 80
-    CONFIG.autoScroll = True
+    CONFIG.autoScroll = False
 
     # Add a Character File
     nwGUI._changeView(nwView.PROJECT)

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -55,37 +55,37 @@ def testGuiTheme_ParseColor():
     theme._qColors["grey"] = QColor(127, 127, 127)
 
     # By Name
-    assert theme._parseColor("red").getRgb() == (255, 0, 0, 255)
-    assert theme._parseColor("green").getRgb() == (0, 255, 0, 255)
-    assert theme._parseColor("blue").getRgb() == (0, 0, 255, 255)
-    assert theme._parseColor("bob").getRgb() == (0, 0, 0, 255)
+    assert theme.parseColor("red").getRgb() == (255, 0, 0, 255)
+    assert theme.parseColor("green").getRgb() == (0, 255, 0, 255)
+    assert theme.parseColor("blue").getRgb() == (0, 0, 255, 255)
+    assert theme.parseColor("bob").getRgb() == (0, 0, 0, 255)
 
     # CSS Format
-    assert theme._parseColor("#ff0000").getRgb() == (255, 0, 0, 255)
-    assert theme._parseColor("#ff00007f").getRgb() == (255, 0, 0, 127)
-    assert theme._parseColor("#ff00").getRgb() == (0, 0, 0, 255)  # Too short -> ignored
-    assert theme._parseColor("#ff00007f15").getRgb() == (0, 0, 0, 255)  # Too long -> ignored
+    assert theme.parseColor("#ff0000").getRgb() == (255, 0, 0, 255)
+    assert theme.parseColor("#ff00007f").getRgb() == (255, 0, 0, 127)
+    assert theme.parseColor("#ff00").getRgb() == (0, 0, 0, 255)  # Too short -> ignored
+    assert theme.parseColor("#ff00007f15").getRgb() == (0, 0, 0, 255)  # Too long -> ignored
 
     # Name + Alpha
-    assert theme._parseColor("red:255").getRgb() == (255, 0, 0, 255)
-    assert theme._parseColor("red:127").getRgb() == (255, 0, 0, 127)
-    assert theme._parseColor("red:512").getRgb() == (255, 0, 0, 255)  # Value truncated
+    assert theme.parseColor("red:255").getRgb() == (255, 0, 0, 255)
+    assert theme.parseColor("red:127").getRgb() == (255, 0, 0, 127)
+    assert theme.parseColor("red:512").getRgb() == (255, 0, 0, 255)  # Value truncated
 
     # Name + Lighter
-    assert theme._parseColor("grey:L100").getRgb() == (127, 127, 127, 255)
-    assert theme._parseColor("grey:L150").getRgb() == (190, 190, 190, 255)
-    assert theme._parseColor("grey:L50").getRgb() == (63, 63, 63, 255)
+    assert theme.parseColor("grey:L100").getRgb() == (127, 127, 127, 255)
+    assert theme.parseColor("grey:L150").getRgb() == (190, 190, 190, 255)
+    assert theme.parseColor("grey:L50").getRgb() == (63, 63, 63, 255)
 
     # Name + Darker
-    assert theme._parseColor("grey:D100").getRgb() == (127, 127, 127, 255)
-    assert theme._parseColor("grey:D150").getRgb() == (85, 85, 85, 255)
-    assert theme._parseColor("grey:D50").getRgb() == (254, 254, 254, 255)
+    assert theme.parseColor("grey:D100").getRgb() == (127, 127, 127, 255)
+    assert theme.parseColor("grey:D150").getRgb() == (85, 85, 85, 255)
+    assert theme.parseColor("grey:D50").getRgb() == (254, 254, 254, 255)
 
     # Values
-    assert theme._parseColor("255, 0, 0").getRgb() == (255, 0, 0, 255)
-    assert theme._parseColor("255, 0, 0, 255").getRgb() == (255, 0, 0, 255)
-    assert theme._parseColor("255, 0, 0, 127").getRgb() == (255, 0, 0, 127)
-    assert theme._parseColor("255, 0, 0, 127, 42").getRgb() == (255, 0, 0, 127)  # Truncated
+    assert theme.parseColor("255, 0, 0").getRgb() == (255, 0, 0, 255)
+    assert theme.parseColor("255, 0, 0, 255").getRgb() == (255, 0, 0, 255)
+    assert theme.parseColor("255, 0, 0, 127").getRgb() == (255, 0, 0, 127)
+    assert theme.parseColor("255, 0, 0, 127, 42").getRgb() == (255, 0, 0, 127)  # Truncated
 
 
 @pytest.mark.gui


### PR DESCRIPTION
**Summary:**

This PR updates the Project Settings for Status and Importance labels to allow using theme colours as icon colours. Existing projects default to the "Custom" colour setting where a colour picker lets the user set the colour like before.

The project format changes from 1.5 Revision 5 to Revision 6, and the `red`, `green` and `blue` attributes are replaced with a single `color` attribute that can be any string the theme class can parse, but defaults to hex colour for custom values and the base theme colour names for theme colours.

**Related Issue(s):**

Closes #2366
Closes #2357

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
