### PR TITLE
Fix missing tag display in outline

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -708,17 +708,19 @@ class Index:
         return 0, 0, 0
 
     def getReferences(self, tHandle: str, sTitle: str | None = None) -> dict[str, list[str]]:
-        """Extract all references made in a file, and optionally title
-        section.
+        """Extract all tags and references made in a file, and
+        optionally title section.
         """
-        tRefs = {x: [] for x in nwKeyWords.VALID_KEYS}
+        refs = {x: [] for x in nwKeyWords.VALID_KEYS}
         for rTitle, hItem in self._itemIndex.iterItemHeaders(tHandle):
             if sTitle is None or sTitle == rTitle:
                 for aTag, refTypes in hItem.references.items():
                     for refType in refTypes:
-                        if refType in tRefs:
-                            tRefs[refType].append(self._tagsIndex.tagName(aTag))
-        return tRefs
+                        if refType in refs:
+                            refs[refType].append(self._tagsIndex.tagName(aTag))
+                if tag := hItem.tag:
+                    refs[nwKeyWords.TAG_KEY] = [self._tagsIndex.tagName(tag)]
+        return refs
 
     def getReferenceForHeader(self, tHandle: str, nHead: int, keyClass: str) -> list[str]:
         """Get the display names for a tags class for insertion into a

--- a/novelwriter/core/indexdata.py
+++ b/novelwriter/core/indexdata.py
@@ -348,16 +348,20 @@ class IndexHeading:
             for keyword in types:
                 if keyword in refs and (name := self._cache.tags.tagName(tag)):
                     refs[keyword].append(name)
-            if tag := self._tag:
-                refs[nwKeyWords.TAG_KEY] = [self._cache.tags.tagName(tag)]
+            if name := self._cache.tags.tagName(self._tag):
+                refs[nwKeyWords.TAG_KEY] = [name]
         return refs
 
     def getReferencesByKeyword(self, keyword: str) -> list[str]:
         """Extract all references for this heading."""
         refs = []
-        for tag, types in self._refs.items():
-            if keyword in types and (name := self._cache.tags.tagName(tag)):
+        if keyword == nwKeyWords.TAG_KEY:
+            if name := self._cache.tags.tagName(self._tag):
                 refs.append(name)
+        else:
+            for tag, types in self._refs.items():
+                if keyword in types and (name := self._cache.tags.tagName(tag)):
+                    refs.append(name)
         return refs
 
     ##

--- a/novelwriter/core/indexdata.py
+++ b/novelwriter/core/indexdata.py
@@ -342,12 +342,14 @@ class IndexHeading:
     ##
 
     def getReferences(self) -> dict[str, list[str]]:
-        """Extract all references for this heading."""
+        """Extract all tags and references for this heading."""
         refs = {x: [] for x in nwKeyWords.VALID_KEYS}
         for tag, types in self._refs.items():
             for keyword in types:
                 if keyword in refs and (name := self._cache.tags.tagName(tag)):
                     refs[keyword].append(name)
+            if tag := self._tag:
+                refs[nwKeyWords.TAG_KEY] = [self._cache.tags.tagName(tag)]
         return refs
 
     def getReferencesByKeyword(self, keyword: str) -> list[str]:

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -593,6 +593,7 @@ class GuiNovelTree(NTreeView):
             lines = []
             if head := SHARED.project.index.getItemHeading(tHandle, sTitle):
                 tags = head.getReferences()
+                appendTags(tags, nwKeyWords.TAG_KEY, lines)
                 appendTags(tags, nwKeyWords.POV_KEY, lines)
                 appendTags(tags, nwKeyWords.FOCUS_KEY, lines)
                 appendTags(tags, nwKeyWords.CHAR_KEY, lines)

--- a/sample/content/636b6aa9b697b.nwd
+++ b/sample/content/636b6aa9b697b.nwd
@@ -1,10 +1,11 @@
 %%~name: Making a Scene
 %%~path: 6a2d6d5f4f401/636b6aa9b697b
 %%~kind: NOVEL/DOCUMENT
-%%~hash: 1f3d98a6a27b4f9a7f2239fcd78f9e2263cd3b97
-%%~date: Unknown/2025-05-18 22:36:59
+%%~hash: b39201b02e3db63493d61d09e5fec5765a937255
+%%~date: Unknown/2025-06-24 09:09:56
 ### Making a Scene
 
+@tag: Scene
 @pov: Jane
 @char: John, Jane
 @location: Earth

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.7.1" hexVersion="0x020701f0" fileVersion="1.5" fileRevision="5" timeStamp="2025-06-09 22:54:50">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2194" autoCount="286" editTime="96892">
+<novelWriterXML appVersion="2.7.1" hexVersion="0x020701f0" fileVersion="1.5" fileRevision="5" timeStamp="2025-06-24 16:14:48">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2208" autoCount="287" editTime="97150">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -58,7 +58,7 @@
       <name status="sf24ce6" import="ia857f0" active="yes">Chapter One</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="2999" wordCount="530" paraCount="16" cursorPos="718" />
+      <meta expanded="no" heading="H3" charCount="2999" wordCount="530" paraCount="16" cursorPos="93" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">

--- a/tests/test_core/test_core_index.py
+++ b/tests/test_core/test_core_index.py
@@ -695,6 +695,7 @@ def testCoreIndex_ExtractData(nwGUI, fncPath, mockRnd):
     ))
     assert index.scanText(nHandle, (
         "# Hello World!\n"
+        "@tag: Scene\n"
         "@pov: Jane\n"
         "@char: Jane, John\n\n"
         "% this is a comment\n\n"
@@ -749,11 +750,13 @@ def testCoreIndex_ExtractData(nwGUI, fncPath, mockRnd):
 
     # Look up an invalid handle
     refs = index.getReferences("Not a handle")
+    assert refs["@tag"] == []
     assert refs["@pov"] == []
     assert refs["@char"] == []
 
     # The novel file should now refer to Jane as @pov and @char
     refs = index.getReferences(nHandle)
+    assert refs["@tag"] == ["Scene"]
     assert refs["@pov"] == ["Jane"]
     assert refs["@char"] == ["Jane", "John"]
 
@@ -791,7 +794,7 @@ def testCoreIndex_ExtractData(nwGUI, fncPath, mockRnd):
 
     # getKeyWordTags
     # ==============
-    assert index.getKeyWordTags("@mention") == ["Jane", "John"]
+    assert index.getKeyWordTags("@mention") == ["Jane", "John", "Scene"]
     assert index.getKeyWordTags("@char") == ["Jane", "John"]
     assert index.getKeyWordTags("@plot") == []
     assert index.getKeyWordTags("@tag") == []

--- a/tests/test_core/test_core_indexdata.py
+++ b/tests/test_core/test_core_indexdata.py
@@ -267,6 +267,7 @@ def testCoreIndexData_IndexHeadingReferences():
     head = IndexHeading(cache, "T0001")
 
     # Add some references
+    head.setTag("Scene")
     head.addReference("Jane", "@pov")
     head.addReference("Jane", "@char")
     head.addReference("John", "@char")
@@ -290,6 +291,7 @@ def testCoreIndexData_IndexHeadingReferences():
     }
 
     # Set names
+    cache.tags.add("Scene", "Scene", "0000000000000", "T00001", "NOVEL")
     cache.tags.add("Jane", "Jane", "0000000000000", "T00001", "CHARACTER")
     cache.tags.add("John", "John", "0000000000000", "T00001", "CHARACTER")
     cache.tags.add("Main", "Main", "0000000000000", "T00001", "PLOT")
@@ -301,7 +303,7 @@ def testCoreIndexData_IndexHeadingReferences():
         "@plot": ["Main"],
         "@object": ["Gun"],
         "@story": [],
-        "@tag": [],
+        "@tag": ["Scene"],
         "@focus": [],
         "@custom": [],
         "@time": [],
@@ -316,7 +318,7 @@ def testCoreIndexData_IndexHeadingReferences():
     assert head.getReferencesByKeyword("@plot") == ["Main"]
     assert head.getReferencesByKeyword("@object") == ["Gun"]
     assert head.getReferencesByKeyword("@story") == []
-    assert head.getReferencesByKeyword("@tag") == []
+    assert head.getReferencesByKeyword("@tag") == ["Scene"]
     assert head.getReferencesByKeyword("@focus") == []
     assert head.getReferencesByKeyword("@custom") == []
     assert head.getReferencesByKeyword("@time") == []


### PR DESCRIPTION
**Summary:**

This PR adds the tag to reference data extracted from the index. This was apparently missing in the implementation when the `@story` tag was added in #2072.

**Related Issue(s):**

Closes #2428

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
