### PR TITLE
Fix ConfigParser interpolation

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -680,11 +680,12 @@ class NWConfigParser(ConfigParser):
     """Common: Adapted Config Parser
 
     This is a subclass of the standard config parser that adds type safe
-    helper functions, and support for lists.
+    helper functions, and support for lists. It also turns off
+    interpolation, which would require % symbols to be escaped (#2455).
     """
 
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(interpolation=None)
         return
 
     def rdStr(self, section: str, option: str, default: str) -> str:

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -271,8 +271,8 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     prefs.dialogLine.setText("–")
     prefs.narratorBreak.setCurrentData("–", "")
     prefs.narratorDialog.setCurrentData("–", "")
-    prefs.altDialogOpen.setText("<")
-    prefs.altDialogClose.setText(">")
+    prefs.altDialogOpen.setText("%")  # Symbol also tests for #2455
+    prefs.altDialogClose.setText("%")  # Symbol also tests for #2455
     prefs.highlightEmph.setChecked(False)
     prefs.showMultiSpaces.setChecked(False)
 
@@ -401,8 +401,8 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.dialogLine == "–"
     assert CONFIG.narratorBreak == "–"
     assert CONFIG.narratorDialog == "–"
-    assert CONFIG.altDialogOpen == "<"
-    assert CONFIG.altDialogClose == ">"
+    assert CONFIG.altDialogOpen == "%"
+    assert CONFIG.altDialogClose == "%"
     assert CONFIG.highlightEmph is False
     assert CONFIG.showMultiSpaces is False
 


### PR DESCRIPTION
**Summary:**

This PR fixes an issue where `%` symbols could not be used in string settings field since this symbol by default is used for copying values from other fields in the ConfigParser used by the Config class. This has been broken since day 1, but no one has reported it yet. It actually crashes novelWriter.

This feature is now turned off.

**Related Issue(s):**

Closes #2455

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
