### PR TITLE
Improve dialogue highlighting settings

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -301,7 +301,7 @@ def uniqueCompact(text: str) -> str:
 def processDialogSymbols(symbols: str) -> str:
     """Process dialogue line symbols."""
     result = ""
-    for c in uniqueCompact("".join(symbols.split())):
+    for c in uniqueCompact(symbols):
         if c in nwQuotes.ALLOWED:
             result += c
     return result

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -301,7 +301,7 @@ def uniqueCompact(text: str) -> str:
 def processDialogSymbols(symbols: str) -> str:
     """Process dialogue line symbols."""
     result = ""
-    for c in uniqueCompact(symbols):
+    for c in uniqueCompact("".join(symbols.split())):
         if c in nwQuotes.ALLOWED:
             result += c
     return result

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -29,7 +29,7 @@ import logging
 from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QAction, QCloseEvent, QKeyEvent, QKeySequence
 from PyQt6.QtWidgets import (
-    QCompleter, QDialogButtonBox, QFileDialog, QHBoxLayout, QLineEdit,
+    QCompleter, QDialogButtonBox, QFileDialog, QHBoxLayout, QLineEdit, QMenu,
     QPushButton, QVBoxLayout, QWidget
 )
 
@@ -639,14 +639,26 @@ class GuiPreferences(NDialog):
         )
 
         # Dialogue Line
+        self.mnLineSymbols = QMenu(self)
+        for symbol in nwQuotes.ALLOWED:
+            label = trConst(nwQuotes.SYMBOLS.get(symbol, nwQuotes.DASHES.get(symbol, "None")))
+            self.mnLineSymbols.addAction(
+                f"[ {symbol } ] {label}",
+                lambda symbol=symbol: self._insertDialogLineSymbol(symbol)
+            )
+
         self.dialogLine = QLineEdit(self)
-        self.dialogLine.setMaxLength(4)
-        self.dialogLine.setFixedWidth(boxFixed)
+        self.dialogLine.setMinimumWidth(100)
         self.dialogLine.setAlignment(QtAlignCenter)
-        self.dialogLine.setText(CONFIG.dialogLine)
+        self.dialogLine.setText(" ".join(CONFIG.dialogLine))
+
+        self.dialogLineButton = NIconToolButton(self, iSz, "add", "green")
+        self.dialogLineButton.setMenu(self.mnLineSymbols)
+
         self.mainForm.addRow(
             self.tr("Dialogue line symbols"), self.dialogLine,
-            self.tr("Lines starting with any of these symbols are dialogue.")
+            self.tr("Lines starting with any of these symbols are dialogue."),
+            button=self.dialogLineButton
         )
 
         # Narrator Break
@@ -911,6 +923,14 @@ class GuiPreferences(NDialog):
     def _toggledBackupOnClose(self, state: bool) -> None:
         """Toggle switch that depends on the backup on close switch."""
         self.askBeforeBackup.setEnabled(state)
+        return
+
+    @pyqtSlot(str)
+    def _insertDialogLineSymbol(self, symbol: str) -> None:
+        """Insert a symbol in the dialogue line box."""
+        current = self.dialogLine.text()
+        values = processDialogSymbols(f"{current} {symbol}")
+        self.dialogLine.setText(" ".join(values))
         return
 
     @pyqtSlot(bool)

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -600,6 +600,7 @@ class GuiPreferences(NDialog):
         self.sidebar.addButton(title, section)
         self.mainForm.addGroupLabel(title, section)
 
+        # Dialogue Quotes
         self.dialogStyle = NComboBox(self)
         self.dialogStyle.addItem(self.tr("None"), 0)
         self.dialogStyle.addItem(self.tr("Single Quotes"), 1)
@@ -611,6 +612,15 @@ class GuiPreferences(NDialog):
             self.tr("Applies to the selected quote styles.")
         )
 
+        # Open-Ended Dialogue
+        self.allowOpenDial = NSwitch(self)
+        self.allowOpenDial.setChecked(CONFIG.allowOpenDial)
+        self.mainForm.addRow(
+            self.tr("Allow open-ended dialogue"), self.allowOpenDial,
+            self.tr("Highlight dialogue line with no closing quote.")
+        )
+
+        # Alternative Dialogue
         self.altDialogOpen = QLineEdit(self)
         self.altDialogOpen.setMaxLength(4)
         self.altDialogOpen.setFixedWidth(boxFixed)
@@ -628,13 +638,7 @@ class GuiPreferences(NDialog):
             self.tr("Custom highlighting of dialogue text.")
         )
 
-        self.allowOpenDial = NSwitch(self)
-        self.allowOpenDial.setChecked(CONFIG.allowOpenDial)
-        self.mainForm.addRow(
-            self.tr("Allow open-ended dialogue"), self.allowOpenDial,
-            self.tr("Highlight dialogue line with no closing quote.")
-        )
-
+        # Dialogue Line
         self.dialogLine = QLineEdit(self)
         self.dialogLine.setMaxLength(4)
         self.dialogLine.setFixedWidth(boxFixed)
@@ -645,6 +649,7 @@ class GuiPreferences(NDialog):
             self.tr("Lines starting with any of these symbols are dialogue.")
         )
 
+        # Narrator Break
         self.narratorBreak = NComboBox(self)
         self.narratorDialog = NComboBox(self)
         for key, value in nwQuotes.DASHES.items():
@@ -664,6 +669,7 @@ class GuiPreferences(NDialog):
             self.tr("Alternates dialogue highlighting within any paragraph.")
         )
 
+        # Emphasis
         self.highlightEmph = NSwitch(self)
         self.highlightEmph.setChecked(CONFIG.highlightEmph)
         self.mainForm.addRow(
@@ -671,6 +677,7 @@ class GuiPreferences(NDialog):
             self.tr("Applies to the document editor only.")
         )
 
+        # Additional Spaces
         self.showMultiSpaces = NSwitch(self)
         self.showMultiSpaces.setChecked(CONFIG.showMultiSpaces)
         self.mainForm.addRow(

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -268,13 +268,16 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     # Text Highlighting
     prefs.dialogStyle.setCurrentData(3, 0)
     prefs.allowOpenDial.setChecked(False)
-    prefs.dialogLine.setText("–")
-    prefs.narratorBreak.setCurrentData("–", "")
-    prefs.narratorDialog.setCurrentData("–", "")
+    prefs.dialogLine.setText(nwUnicode.U_EMDASH)
+    prefs.narratorBreak.setCurrentData(nwUnicode.U_EMDASH, "")
+    prefs.narratorDialog.setCurrentData(nwUnicode.U_EMDASH, "")
     prefs.altDialogOpen.setText("%")  # Symbol also tests for #2455
     prefs.altDialogClose.setText("%")  # Symbol also tests for #2455
     prefs.highlightEmph.setChecked(False)
     prefs.showMultiSpaces.setChecked(False)
+
+    prefs._insertDialogLineSymbol(nwUnicode.U_ENDASH)
+    assert prefs.dialogLine.text() == f"{nwUnicode.U_ENDASH} {nwUnicode.U_EMDASH}"
 
     assert CONFIG.dialogStyle == 2
     assert CONFIG.allowOpenDial is True
@@ -398,9 +401,9 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     # Text Highlighting
     assert CONFIG.dialogStyle == 3
     assert CONFIG.allowOpenDial is False
-    assert CONFIG.dialogLine == "–"
-    assert CONFIG.narratorBreak == "–"
-    assert CONFIG.narratorDialog == "–"
+    assert CONFIG.dialogLine == f"{nwUnicode.U_ENDASH}{nwUnicode.U_EMDASH}"
+    assert CONFIG.narratorBreak == nwUnicode.U_EMDASH
+    assert CONFIG.narratorDialog == nwUnicode.U_EMDASH
     assert CONFIG.altDialogOpen == "%"
     assert CONFIG.altDialogClose == "%"
     assert CONFIG.highlightEmph is False


### PR DESCRIPTION
**Summary:**

This PR:
* Moves the open ended dialogue switch above the alternate dialogue box so not to confuse them as the setting only applies to quoted dialogue.
* Add a button and menu to add symbols to the dialogue line symbols box as it isn't clear what symbols are allowed in it. It is also difficult to type these symbols on many keyboards.

**Related Issue(s):**

Closes #2453
Closes #2454

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
