### PR TITLE
Fix colour reset bug for status labels

### DIFF
--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -441,9 +441,9 @@ class ProjectXMLReader:
         for xEntry in xItem:
             if xEntry.tag == "entry":
                 key   = xEntry.attrib.get("key", None)
-                red   = checkInt(xEntry.attrib.get("red", 0), 0)    # Deprecated in 1.5 R6
-                green = checkInt(xEntry.attrib.get("green", 0), 0)  # Deprecated in 1.5 R6
-                blue  = checkInt(xEntry.attrib.get("blue", 0), 0)   # Deprecated in 1.5 R6
+                red   = checkInt(xEntry.attrib.get("red", 0), 0)    # Removed in 1.5 R6
+                green = checkInt(xEntry.attrib.get("green", 0), 0)  # Removed in 1.5 R6
+                blue  = checkInt(xEntry.attrib.get("blue", 0), 0)   # Removed in 1.5 R6
                 color = xEntry.attrib.get("color")  # Added in 1.5 R6
                 count = checkInt(xEntry.attrib.get("count", 0), 0)
                 shape = xEntry.attrib.get("shape", "")

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -192,7 +192,8 @@ class NWStatus:
     def refreshIcons(self) -> None:
         """Refresh all icons."""
         for entry in self._store.values():
-            entry.color = SHARED.theme.parseColor(entry.theme)
+            if entry.theme != CUSTOM_COL:
+                entry.color = SHARED.theme.parseColor(entry.theme)
             entry.icon = NWStatus.createIcon(self._height, entry.color, entry.shape)
         return
 

--- a/tests/test_core/test_core_status.py
+++ b/tests/test_core/test_core_status.py
@@ -324,22 +324,54 @@ def testCoreStatus_Entries(mockGUI, mockRnd):
 
 
 @pytest.mark.core
-def testCoreStatus_RefreshIcons(mockGUIwithTheme, mockRnd):
-    """Test refreshing the icons of the NWStatus class."""
+def testCoreStatus_RefreshIcons_Theme(mockGUIwithTheme, mockRnd):
+    """Test refreshing the icons with theme colours."""
     nStatus = NWStatus(NWStatus.STATUS)
     nStatus.add(None, "New",      "default", "SQUARE", 0)
     nStatus.add(None, "Note",     "red",     "CIRCLE", 0)
     nStatus.add(None, "Draft",    "yellow",  "SQUARE", 0)
     nStatus.add(None, "Finished", "green",   "SQUARE", 0)
 
-    beforeIcons = [nStatus[statusKeys[i]].icon for i in range(4)]
+    iconsA = [nStatus[statusKeys[i]].icon for i in range(4)]
+    themeA = [nStatus[statusKeys[i]].theme for i in range(4)]
 
     # Refreshing the icons should generate new ones
     nStatus.refreshIcons()
-    afterIcons = [nStatus[statusKeys[i]].icon for i in range(4)]
+    iconsB = [nStatus[statusKeys[i]].icon for i in range(4)]
+    themeB = [nStatus[statusKeys[i]].theme for i in range(4)]
 
-    for before, after in zip(beforeIcons, afterIcons, strict=False):
+    for before, after in zip(iconsA, iconsB, strict=False):
         assert before is not after
+
+    assert themeA == themeB
+
+
+@pytest.mark.core
+def testCoreStatus_RefreshIcons_Custom(mockGUIwithTheme, mockRnd):
+    """Test refreshing the icons with custom colours."""
+    nStatus = NWStatus(NWStatus.STATUS)
+    nStatus.add(None, "New",      "#707070", "SQUARE", 0)
+    nStatus.add(None, "Note",     "#ff0000", "CIRCLE", 0)
+    nStatus.add(None, "Draft",    "#ffff00", "SQUARE", 0)
+    nStatus.add(None, "Finished", "#00ff00", "SQUARE", 0)
+
+    iconsA = [nStatus[statusKeys[i]].icon for i in range(4)]
+    themeA = [nStatus[statusKeys[i]].theme for i in range(4)]
+    colorA = [nStatus[statusKeys[i]].color.getRgb() for i in range(4)]
+
+    # Refreshing the icons should generate new ones
+    nStatus.refreshIcons()
+    iconsB = [nStatus[statusKeys[i]].icon for i in range(4)]
+    themeB = [nStatus[statusKeys[i]].theme for i in range(4)]
+    colorB = [nStatus[statusKeys[i]].color.getRgb() for i in range(4)]
+
+    for before, after in zip(iconsA, iconsB, strict=False):
+        assert before is not after
+
+    # But they should have the same colour value (#2452)
+    assert themeA == [CUSTOM_COL, CUSTOM_COL, CUSTOM_COL, CUSTOM_COL]
+    assert themeB == [CUSTOM_COL, CUSTOM_COL, CUSTOM_COL, CUSTOM_COL]
+    assert colorA == colorB
 
 
 @pytest.mark.core


### PR DESCRIPTION
**Summary:**

This PR fixes a bug where the colour was reset to black when switching theme for status and importance labels using a custom colour.

**Related Issue(s):**

Closes #2452

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
