### PR TITLE
Use label for template title

### DIFF
--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -224,7 +224,7 @@ class NWProject:
 
         return True
 
-    def copyFileContent(self, tHandle: str, sHandle: str) -> bool:
+    def copyFileContent(self, tHandle: str, sHandle: str, newTitle: str | None = None) -> bool:
         """Copy content to a new document after it is created. This
         will not run if the file exists and is not empty.
         """
@@ -239,6 +239,14 @@ class NWProject:
 
         logger.debug("Populating '%s' with text from '%s'", tHandle, sHandle)
         text = self._storage.getDocumentText(sHandle)
+        if (
+            newTitle and (lines := text.split("\n")) and lines
+            and lines[0].startswith(("# ", "## ", "### ", "#### ", "#! ", "##! ", "###! "))
+        ):
+            prefix, _, _ = lines[0].partition(" ")
+            lines[0] = f"{prefix} {newTitle}"
+            text = "\n".join(lines)
+
         self._storage.getDocument(tHandle).writeDocument(text)
         sItem.setLayout(tItem.itemLayout)
         self._index.reIndexHandle(tHandle)

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -667,7 +667,7 @@ class GuiProjectTree(QTreeView):
                     if itemType == nwItemType.FILE:
                         if tHandle := SHARED.project.newFile(newLabel, sHandle, sPos):
                             if copyDoc:
-                                SHARED.project.copyFileContent(tHandle, copyDoc)
+                                SHARED.project.copyFileContent(tHandle, copyDoc, newLabel)
                             elif hLevel > 0:
                                 SHARED.project.writeNewFile(tHandle, hLevel, not nNote)
                             SHARED.project.index.reIndexHandle(tHandle)

--- a/sample/content/5aec885635c85.nwd
+++ b/sample/content/5aec885635c85.nwd
@@ -1,7 +1,7 @@
 %%~name: Scene
-%%~path: 09f22ae8369f7/5aec885635c85
+%%~path: f4ed1ae756a1f/5aec885635c85
 %%~kind: TEMPLATE/DOCUMENT
-%%~hash: 05c9750b00020f8cf9a7bc7362bf19681022cc03
+%%~hash: 537fb0132a80101060b40b42ad8875ebbcb40a5b
 %%~date: 2024-02-02 10:58:47/2024-02-02 10:59:32
 ### Scene
 

--- a/tests/reference/coreProject_NewFileFolder_nwProject.nwx
+++ b/tests/reference/coreProject_NewFileFolder_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="2.8a0" hexVersion="0x020800a0" fileVersion="1.5" fileRevision="6" timeStamp="2025-06-12 18:02:57">
+<novelWriterXML appVersion="2.8a2" hexVersion="0x020800a2" fileVersion="1.5" fileRevision="6" timeStamp="2025-07-17 15:27:23">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -22,13 +22,13 @@
       <entry key="s000003" count="0" color="green" shape="STAR">Finished</entry>
     </status>
     <importance>
-      <entry key="i000004" count="5" color="purple" shape="SQUARE">New</entry>
+      <entry key="i000004" count="6" color="purple" shape="SQUARE">New</entry>
       <entry key="i000005" count="0" color="purple" shape="BLOCK_2">Minor</entry>
       <entry key="i000006" count="0" color="purple" shape="BLOCK_3">Major</entry>
       <entry key="i000007" count="0" color="purple" shape="BLOCK_4">Main</entry>
     </importance>
   </settings>
-  <content items="12" novelWords="10" notesWords="6" novelChars="45" notesChars="22">
+  <content items="13" novelWords="10" notesWords="9" novelChars="45" notesChars="33">
     <item handle="0000000000008" parent="None" root="0000000000008" order="0" type="ROOT" class="NOVEL">
       <meta expanded="no" />
       <name status="s000000" import="i000004">Novel</name>
@@ -72,6 +72,10 @@
     <item handle="0000000000013" parent="000000000000a" root="000000000000a" order="1" type="FILE" class="CHARACTER" layout="NOTE">
       <meta expanded="no" heading="H1" charCount="11" wordCount="3" paraCount="1" cursorPos="0" />
       <name status="s000000" import="i000004" active="yes">John</name>
+    </item>
+    <item handle="0000000000014" parent="000000000000a" root="000000000000a" order="2" type="FILE" class="CHARACTER" layout="NOTE">
+      <meta expanded="no" heading="H1" charCount="11" wordCount="3" paraCount="1" cursorPos="0" />
+      <name status="s000000" import="i000004" active="yes">Mike</name>
     </item>
     <item handle="000000000000b" parent="None" root="000000000000b" order="3" type="ROOT" class="WORLD">
       <meta expanded="no" />

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -100,6 +100,7 @@ def testCoreProject_NewFileFolder(monkeypatch, fncPath, tstPaths, mockGUI, mockR
     bHandle = "0000000000011"
     cHandle = "0000000000012"
     dHandle = "0000000000013"
+    eHandle = "0000000000014"
     xHandle = "1234567890abc"
 
     # Invalid call
@@ -111,11 +112,13 @@ def testCoreProject_NewFileFolder(monkeypatch, fncPath, tstPaths, mockGUI, mockR
     assert project.newFile("Hello", aHandle) == bHandle
     assert project.newFile("Jane", C.hCharRoot) == cHandle
     assert project.newFile("John", C.hCharRoot) == dHandle
+    assert project.newFile("Mike", C.hCharRoot) == eHandle
 
     assert aHandle in project.tree
     assert bHandle in project.tree
     assert cHandle in project.tree
     assert dHandle in project.tree
+    assert eHandle in project.tree
 
     # Write to file, failed
     assert project.writeNewFile("blabla", 1, True) is False         # Not a handle
@@ -150,6 +153,10 @@ def testCoreProject_NewFileFolder(monkeypatch, fncPath, tstPaths, mockGUI, mockR
     dText = project.storage.getDocument(dHandle).readDocument()
 
     assert dText == cText
+
+    # Copy file content, and update title
+    assert project.copyFileContent(eHandle, cHandle, "Lars") is True
+    assert project.storage.getDocument(eHandle).readDocument() == "# Lars\n\nHi Jane\n\n"
 
     # Save, close and check
     assert project.projChanged is True

--- a/tests/test_gui/test_gui_projtree.py
+++ b/tests/test_gui/test_gui_projtree.py
@@ -1454,7 +1454,7 @@ def testGuiProjTree_Templates(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     nwNewCharacter = project.tree[hNewCharacter]
     assert nwNewCharacter is not None
     assert nwNewCharacter.itemName == "Note"
-    assert project.storage.getDocument(hNewCharacter).readDocument() == "# Jane\n\n@tag: Jane\n\n"
+    assert project.storage.getDocument(hNewCharacter).readDocument() == "# Note\n\n@tag: Jane\n\n"
 
     # Clearing the menu and rebuilding it should work
     projBar.mTemplates.clearMenu()


### PR DESCRIPTION
**Summary:**

When creating a document from a template, update the title in the copied text content with the label added to the new file. This only works if the first line of the template file is a valid title.

**Related Issue(s):**

Closes #2238

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All linting checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
