### PR TITLE
Add a tests run script and more requirement files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 77.0.3"]
+requires = ["setuptools >= 77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+-r requirements-dev.txt
+-r docs/requirements.txt
+-r setup/requirements.txt
+-r tests/requirements.txt

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Run novelWriter Tests."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+if __name__ == "__main__":
+    """Parse command line options and run the commands."""
+    parser = argparse.ArgumentParser(usage="run_tests.py [--flags]")
+    parser.add_argument("-o", action="store_true", help="Run off screen")
+    parser.add_argument("-r", action="store_true", help="Generate reports")
+    parser.add_argument("-t", action="store_true", help="Generate terminal report")
+    parser.add_argument("-m", help="Test modules")
+    parser.add_argument("-k", help="Test filters")
+
+    args = parser.parse_args()
+
+    env = os.environ.copy()
+    cmd = [sys.executable, "-m", "pytest", "-vv"]
+
+    if args.o:
+        env["QT_QPA_PLATFORM"] = "offscreen"
+    if args.r or args.t:
+        cmd += ["--cov=novelwriter"]
+    if args.r:
+        cmd += ["--cov-report=xml", "--cov-report=html"]
+    if args.t:
+        cmd += ["--cov-report=term"]
+    if args.m:
+        cmd += ["-m", args.m]
+    if args.k:
+        cmd += ["-k", args.k]
+
+    subprocess.call(cmd, env=env)

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+twine

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,2 +1,2 @@
-setuptools
+setuptools>=77.0
 twine


### PR DESCRIPTION
**Summary:**

* Adds a small command line Python script to assist running tests. It takes the longer format arguments and compacts them to simple switches.
* Adds a `requirements-all.txt` to make it quicker to create virtual envs.
* Adds a `setup/requirements.txt` file for package building.

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All linting checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
