### PR TITLE
Fix font matching style bug

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -445,6 +445,7 @@ def fontMatcher(font: QFont) -> QFont:
     default Qt font matching algorithm doesn't handle well changing
     application fonts at runtime.
     """
+    font.setStyleName(None)  # Make sure no font style name is set from config, see #2502
     info = QFontInfo(font)
     if (famRequest := font.family()) != (famActual := info.family()):
         logger.warning("Font mismatch: Requested '%s', but got '%s'", famRequest, famActual)

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -537,6 +537,11 @@ def testBaseCommon_fontMatcher(monkeypatch):
     nonsense = QFont("nonesense", 10)
     assert fontMatcher(nonsense) is nonsense
 
+    # Style is reset
+    nonsense.setStyleName("blabla")
+    assert nonsense.styleName() == "blabla"
+    assert fontMatcher(nonsense).styleName() == ""
+
     # General font
     if len(QFontDatabase.families()) > 1:
         fontOne = QFont(QFontDatabase.families()[0])


### PR DESCRIPTION
**Summary:**

This PR fixes an issue where the Qt font matching algorithm gets limited by a style name being set when the font settings value is parsed from the font dialog. Basically, selecting a style in the font dialog populates the style name value and passes it to the `styleName` property of the `QFont` object. This actually goes against the recommendation in the Qt docs on mixing style name with explicit weight/emphasis settings. This PR explicitly sets the `styleName` property to None in the custom `fontMatcher` helper function.

**Related Issue(s):**

Closes #2502
Related #2110

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
