### PR TITLE
Drop highlighting trailing spaces

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -202,7 +202,7 @@ class Config:
         self.doJustify       = False    # Justify text
         self.showTabsNSpaces = False    # Show tabs and spaces in editor
         self.showLineEndings = False    # Show line endings in editor
-        self.showMultiSpaces = True     # Highlight multiple spaces in the text
+        self.showMultiSpaces = False    # Highlight multiple spaces in the text
 
         self.doReplace       = True     # Enable auto-replace as you type
         self.doReplaceSQuote = True     # Smart single quotes

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -701,7 +701,7 @@ class GuiPreferences(NDialog):
         self.showMultiSpaces = NSwitch(self)
         self.showMultiSpaces.setChecked(CONFIG.showMultiSpaces)
         self.mainForm.addRow(
-            self.tr("Highlight multiple or trailing spaces"), self.showMultiSpaces,
+            self.tr("Highlight multiple spaces between words"), self.showMultiSpaces,
             self.tr("Applies to the document editor only.")
         )
 

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -141,7 +141,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         # Multiple or Trailing Spaces
         if CONFIG.showMultiSpaces:
-            rxRule = re.compile(r"[ ]{2,}|[ ]*$", re.UNICODE)
+            rxRule = re.compile(r"\s{2,}")
             hlRule = {
                 0: self._hStyles["mspaces"],
             }
@@ -150,7 +150,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             self._cmnRules.append((rxRule, hlRule))
 
         # Non-Breaking Spaces
-        rxRule = re.compile(f"[{nwUnicode.U_NBSP}{nwUnicode.U_THNBSP}]+", re.UNICODE)
+        rxRule = re.compile(f"[{nwUnicode.U_NBSP}{nwUnicode.U_THNBSP}]+")
         hlRule = {
             0: self._hStyles["nobreak"],
         }
@@ -239,7 +239,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._cmnRules.append((rxRule, hlRule))
 
         # Alignment Tags
-        rxRule = re.compile(r"(^>{1,2}|<{1,2}$)", re.UNICODE)
+        rxRule = re.compile(r"(^>{1,2}|<{1,2}$)")
         hlRule = {
             1: self._hStyles["markup"],
         }
@@ -247,7 +247,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._txtRules.append((rxRule, hlRule))
 
         # Auto-Replace Tags
-        rxRule = re.compile(r"<(\S+?)>", re.UNICODE)
+        rxRule = re.compile(r"<(\S+?)>")
         hlRule = {
             0: self._hStyles["replace"],
         }

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2025-06-14 17:03:01
+timestamp = 2025-08-24 15:30:16
 
 [Main]
 font = 
@@ -63,7 +63,7 @@ fmtpadthin = False
 spellcheck = en
 showtabsnspaces = False
 showlineendings = False
-showmultispaces = True
+showmultispaces = False
 incnoteswcount = True
 showfullpath = True
 dialogstyle = 2

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -279,7 +279,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     prefs.altDialogOpen.setText("%")  # Symbol also tests for #2455
     prefs.altDialogClose.setText("%")  # Symbol also tests for #2455
     prefs.highlightEmph.setChecked(False)
-    prefs.showMultiSpaces.setChecked(False)
+    prefs.showMultiSpaces.setChecked(True)
 
     prefs._insertDialogLineSymbol(nwUnicode.U_ENDASH)
     assert prefs.dialogLine.text() == f"{nwUnicode.U_ENDASH} {nwUnicode.U_EMDASH}"
@@ -292,7 +292,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.altDialogOpen == ""
     assert CONFIG.altDialogClose == ""
     assert CONFIG.highlightEmph is True
-    assert CONFIG.showMultiSpaces is True
+    assert CONFIG.showMultiSpaces is False
 
     # Text Automation
     prefs.doReplaceSQuote.setChecked(False)
@@ -413,7 +413,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.altDialogOpen == "%"
     assert CONFIG.altDialogClose == "%"
     assert CONFIG.highlightEmph is False
-    assert CONFIG.showMultiSpaces is False
+    assert CONFIG.showMultiSpaces is True
 
     # Text Automation
     assert CONFIG.doReplace is False


### PR DESCRIPTION
**Summary:**

This PR changes the highlight multiple spaces feature in the editor to not highlight trailing spaces, which will always blink at the end of the current sentence when the user is writing.

**Related Issue(s):**

Closes #2501

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
