### PR TITLE
Adjust windows for IME conversion suggestions to not cover text

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -39,8 +39,8 @@ from enum import Enum, IntFlag
 from time import time
 
 from PyQt6.QtCore import (
-    QObject, QPoint, QRegularExpression, QRunnable, Qt, QTimer, pyqtSignal,
-    pyqtSlot
+    QObject, QPoint, QRect, QRegularExpression, QRunnable, Qt, QTimer,
+    QVariant, pyqtSignal, pyqtSlot
 )
 from PyQt6.QtGui import (
     QAction, QCursor, QDragEnterEvent, QDragMoveEvent, QDropEvent,
@@ -75,8 +75,9 @@ from novelwriter.text.counting import standardCounter
 from novelwriter.tools.lipsum import GuiLipsum
 from novelwriter.types import (
     QtAlignCenterTop, QtAlignJustify, QtAlignLeft, QtAlignLeftTop,
-    QtAlignRight, QtKeepAnchor, QtModCtrl, QtModNone, QtModShift, QtMouseLeft,
-    QtMoveAnchor, QtMoveLeft, QtMoveRight, QtScrollAlwaysOff, QtScrollAsNeeded
+    QtAlignRight, QtImCursorRectangle, QtKeepAnchor, QtModCtrl, QtModNone,
+    QtModShift, QtMouseLeft, QtMoveAnchor, QtMoveLeft, QtMoveRight,
+    QtScrollAlwaysOff, QtScrollAsNeeded
 )
 
 logger = logging.getLogger(__name__)
@@ -1028,17 +1029,15 @@ class GuiDocEditor(QPlainTextEdit):
                 pos = self.mapToGlobal(rect.bottomLeft())
                 self._completer.move(pos)
 
-    def inputMethodQuery(self, query: Qt.InputMethodQuery) -> object:
+    def inputMethodQuery(self, query: Qt.InputMethodQuery) -> QRect | QVariant:
         """Adjust completion windows for CJK input methods to consider
         the viewport margins.
         """
-        if query == Qt.InputMethodQuery.ImCursorRectangle:
+        if query == QtImCursorRectangle:
             rect = self.cursorRect()
             vM = self.viewportMargins()
             rect.translate(vM.left(), vM.top())
-
             return rect
-
         return super().inputMethodQuery(query)
 
     ##

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -39,8 +39,8 @@ from enum import Enum, IntFlag
 from time import time
 
 from PyQt6.QtCore import (
-    QObject, QPoint, QRegularExpression, QRunnable, Qt, QTimer, pyqtSignal,
-    pyqtSlot
+    QObject, QPoint, QRegularExpression, QRunnable, Qt, QTimer, QVariant,
+    pyqtSignal, pyqtSlot
 )
 from PyQt6.QtGui import (
     QAction, QCursor, QDragEnterEvent, QDragMoveEvent, QDropEvent, QKeyEvent,
@@ -1018,7 +1018,7 @@ class GuiDocEditor(QPlainTextEdit):
         return
 
     def inputMethodEvent(self, event: QInputMethodEvent) -> None:
-        """Handle text being input from CJK input methods"""
+        """Handle text being input from CJK input methods."""
         super().inputMethodEvent(event)
         if event.commitString():
             self.ensureCursorVisible()
@@ -1027,7 +1027,7 @@ class GuiDocEditor(QPlainTextEdit):
                 pos = self.mapToGlobal(rect.bottomLeft())
                 self._completer.move(pos)
 
-    def inputMethodQuery(self, query: Qt.InputMethodQuery):
+    def inputMethodQuery(self, query: Qt.InputMethodQuery) -> QVariant:
         """Adjust completion windows for CJK input methods to consider
         the viewport margins.
         """

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -39,13 +39,14 @@ from enum import Enum, IntFlag
 from time import time
 
 from PyQt6.QtCore import (
-    QObject, QPoint, QRegularExpression, QRunnable, Qt, QTimer, QVariant,
-    pyqtSignal, pyqtSlot
+    QObject, QPoint, QRegularExpression, QRunnable, Qt, QTimer, pyqtSignal,
+    pyqtSlot
 )
 from PyQt6.QtGui import (
-    QAction, QCursor, QDragEnterEvent, QDragMoveEvent, QDropEvent, QKeyEvent,
-    QKeySequence, QInputMethodEvent, QMouseEvent, QPalette, QPixmap, QResizeEvent,
-    QShortcut, QTextBlock, QTextCursor, QTextDocument, QTextOption,
+    QAction, QCursor, QDragEnterEvent, QDragMoveEvent, QDropEvent,
+    QInputMethodEvent, QKeyEvent, QKeySequence, QMouseEvent, QPalette, QPixmap,
+    QResizeEvent, QShortcut, QTextBlock, QTextCursor, QTextDocument,
+    QTextOption
 )
 from PyQt6.QtWidgets import (
     QApplication, QFrame, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QMenu,
@@ -1027,7 +1028,7 @@ class GuiDocEditor(QPlainTextEdit):
                 pos = self.mapToGlobal(rect.bottomLeft())
                 self._completer.move(pos)
 
-    def inputMethodQuery(self, query: Qt.InputMethodQuery) -> QVariant:
+    def inputMethodQuery(self, query: Qt.InputMethodQuery) -> object:
         """Adjust completion windows for CJK input methods to consider
         the viewport margins.
         """

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -44,8 +44,8 @@ from PyQt6.QtCore import (
 )
 from PyQt6.QtGui import (
     QAction, QCursor, QDragEnterEvent, QDragMoveEvent, QDropEvent, QKeyEvent,
-    QKeySequence, QMouseEvent, QPalette, QPixmap, QResizeEvent, QShortcut,
-    QTextBlock, QTextCursor, QTextDocument, QTextOption
+    QKeySequence, QInputMethodEvent, QMouseEvent, QPalette, QPixmap, QResizeEvent,
+    QShortcut, QTextBlock, QTextCursor, QTextDocument, QTextOption,
 )
 from PyQt6.QtWidgets import (
     QApplication, QFrame, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QMenu,
@@ -1016,6 +1016,29 @@ class GuiDocEditor(QPlainTextEdit):
         self.updateDocMargins()
         super().resizeEvent(event)
         return
+
+    def inputMethodEvent(self, event: QInputMethodEvent) -> None:
+        """Handle text being input from CJK input methods"""
+        super().inputMethodEvent(event)
+        if event.commitString():
+            self.ensureCursorVisible()
+            if self._completer.isVisible():
+                rect = self.cursorRect()
+                pos = self.mapToGlobal(rect.bottomLeft())
+                self._completer.move(pos)
+
+    def inputMethodQuery(self, query: Qt.InputMethodQuery):
+        """Adjust completion windows for CJK input methods to consider
+        the viewport margins.
+        """
+        if query == Qt.InputMethodQuery.ImCursorRectangle:
+            rect = self.cursorRect()
+            vM = self.viewportMargins()
+            rect.translate(vM.left(), vM.top())
+
+            return rect
+
+        return super().inputMethodQuery(query)
 
     ##
     #  Public Slots

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -110,6 +110,8 @@ QtMoveAnchor = QTextCursor.MoveMode.MoveAnchor
 QtMoveLeft = QTextCursor.MoveOperation.Left
 QtMoveRight = QTextCursor.MoveOperation.Right
 
+QtImCursorRectangle = Qt.InputMethodQuery.ImCursorRectangle
+
 # Size Policy
 
 QtSizeExpanding = QSizePolicy.Policy.Expanding

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -1942,18 +1942,18 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
         "%Note.Consistency: \n"
     )
 
-    # CJK completer reposition (#2267)
+    # CJK completer reposition (#2267 and #2517)
     qtbot.keyClick(docEditor, "%", delay=KEY_DELAY)
     assert completer.isVisible() is True
     completer.move(0, 0)
-    assert completer.pos().x() == 0
-    assert completer.pos().y() == 0
+    assert completer.pos().x() == 0  # Completer menu at 0
+    assert completer.pos().y() == 0  # Completer menu at 0
 
     event = QInputMethodEvent()
-    event.setCommitString("Ping")
+    event.setCommitString("Text")
     docEditor.inputMethodEvent(event)
-    assert completer.pos().x() > 0  # Should have moved
-    assert completer.pos().y() > 0  # Should have moved
+    assert completer.pos().x() > 0  # Completer should have moved
+    assert completer.pos().y() > 0  # Completer should have moved
 
     # qtbot.stop()
 

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -27,7 +27,8 @@ import pytest
 from PyQt6.QtCore import QEvent, QMimeData, QPointF, Qt, QThreadPool, QUrl
 from PyQt6.QtGui import (
     QAction, QClipboard, QDesktopServices, QDragEnterEvent, QDragMoveEvent,
-    QDropEvent, QFont, QMouseEvent, QTextBlock, QTextCursor, QTextOption
+    QDropEvent, QFont, QInputMethodEvent, QMouseEvent, QTextBlock, QTextCursor,
+    QTextOption
 )
 from PyQt6.QtWidgets import QApplication, QMenu, QPlainTextEdit
 
@@ -1940,6 +1941,19 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
         "%Story.Resolution: \n"
         "%Note.Consistency: \n"
     )
+
+    # CJK completer reposition (#2267)
+    qtbot.keyClick(docEditor, "%", delay=KEY_DELAY)
+    assert completer.isVisible() is True
+    completer.move(0, 0)
+    assert completer.pos().x() == 0
+    assert completer.pos().y() == 0
+
+    event = QInputMethodEvent()
+    event.setCommitString("Ping")
+    docEditor.inputMethodEvent(event)
+    assert completer.pos().x() > 0  # Should have moved
+    assert completer.pos().y() > 0  # Should have moved
 
     # qtbot.stop()
 


### PR DESCRIPTION
**Summary:**

Repositions the IME suggestion windows so they don't block the text. Works for Japanese and Chinese at least:
<img width="285" height="111" alt="image" src="https://github.com/user-attachments/assets/e633984f-d083-47af-8cdc-cdc51e888569" />
<img width="291" height="96" alt="image" src="https://github.com/user-attachments/assets/45f7f48a-a33e-40fb-9701-df959ef343ee" />

**Related Issue(s):**

Closes #2267

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
