### PR TITLE
Fix dimmed novel selector

### DIFF
--- a/novelwriter/extensions/novelselector.py
+++ b/novelwriter/extensions/novelselector.py
@@ -34,6 +34,7 @@ from PyQt6.QtWidgets import QComboBox
 from novelwriter import SHARED
 from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass
+from novelwriter.types import QtColDisabled
 
 if TYPE_CHECKING:
     from PyQt6.QtWidgets import QWidget
@@ -93,7 +94,9 @@ class NovelSelector(QComboBox):
     def updateTheme(self) -> None:
         """Update theme colours."""
         palette = self.palette()
-        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, palette.text())
+        palette.setBrush(QtColDisabled, QPalette.ColorRole.Text, palette.text())
+        palette.setBrush(QtColDisabled, QPalette.ColorRole.WindowText, palette.windowText())
+        palette.setBrush(QtColDisabled, QPalette.ColorRole.ButtonText, palette.buttonText())
         self.setPalette(palette)
         self.refreshNovelList()
 

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -45,7 +45,10 @@ from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwStandardButton, nwTheme
 from novelwriter.error import logException
 from novelwriter.extensions.modified import NPushButton
-from novelwriter.types import QtBlack, QtHexArgb, QtPaintAntiAlias, QtTransparent
+from novelwriter.types import (
+    QtBlack, QtColActive, QtColDisabled, QtColInactive, QtHexArgb,
+    QtPaintAntiAlias, QtTransparent
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -438,10 +441,6 @@ class GuiTheme:
         text = self._guiPalette.text().color()
         window = self._guiPalette.window().color()
         highlight = self._guiPalette.highlight().color()
-
-        QtColActive = QPalette.ColorGroup.Active
-        QtColInactive = QPalette.ColorGroup.Inactive
-        QtColDisabled = QPalette.ColorGroup.Disabled
 
         if window.lightnessF() < 0.15:
             # If window is too dark, we need a lighter ref colour for shades

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -24,10 +24,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QColor, QFont, QPainter, QTextCharFormat, QTextCursor, QTextFormat
+from PyQt6.QtGui import (
+    QColor, QFont, QPainter, QPalette, QTextCharFormat, QTextCursor,
+    QTextFormat
+)
 from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QHeaderView, QSizePolicy, QStyle
 
-# Qt Alignment Flags
+# Alignment Flags
 
 QtAlignAbsolute = Qt.AlignmentFlag.AlignAbsolute
 QtAlignCenter = Qt.AlignmentFlag.AlignCenter
@@ -48,7 +51,7 @@ QtVAlignNormal = QTextCharFormat.VerticalAlignment.AlignNormal
 QtVAlignSub = QTextCharFormat.VerticalAlignment.AlignSubScript
 QtVAlignSuper = QTextCharFormat.VerticalAlignment.AlignSuperScript
 
-# Qt Text Formats
+# Text Formats
 
 QtPageBreakBefore = QTextFormat.PageBreakFlag.PageBreak_AlwaysBefore
 QtPageBreakAfter = QTextFormat.PageBreakFlag.PageBreak_AlwaysAfter
@@ -58,7 +61,7 @@ QtTextUserProperty = QTextFormat.Property.UserProperty
 
 QtPropLineHeight = 1  # QTextBlockFormat.LineHeightTypes.ProportionalHeight
 
-# Qt Painter Types
+# Painter Types
 
 QtTransparent = QColor(0, 0, 0, 0)
 QtBlack = QColor(0, 0, 0)
@@ -70,10 +73,14 @@ QtPaintAntiAlias = QPainter.RenderHint.Antialiasing
 QtMouseOver = QStyle.StateFlag.State_MouseOver
 QtSelected = QStyle.StateFlag.State_Selected
 
-# Qt Colour Types
+# Colour Types
 
 QtHexRgb = QColor.NameFormat.HexRgb
 QtHexArgb = QColor.NameFormat.HexArgb
+
+QtColActive = QPalette.ColorGroup.Active
+QtColInactive = QPalette.ColorGroup.Inactive
+QtColDisabled = QPalette.ColorGroup.Disabled
 
 # Qt Tree and Table Types
 


### PR DESCRIPTION
**Summary:**

This PR changes the disabled brushes for the novel selector to ensure the text is not dimmed when there's only one selection option.

**Related Issue(s):**

Closes #2482

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
