### PR TITLE
Dynamically update spell check dictionaries in the menu

### DIFF
--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -91,6 +91,18 @@ class GuiMainMenu(QMenuBar):
         """Forward spell check check state to its action."""
         self.aSpellCheck.setChecked(state)
 
+    @pyqtSlot()
+    def updateSpellCheckLanguages(self) -> None:
+        """Update the list of available spell check languages."""
+        self.mSelectLanguage.clear()
+        languages = SHARED.spelling.listDictionaries()
+        languages.insert(0, ("None", self.tr("Default")))
+        for tag, language in languages:
+            aSpell = QAction(self.mSelectLanguage)
+            aSpell.setText(language)
+            aSpell.triggered.connect(qtLambda(self._changeSpelling, tag))
+            self.mSelectLanguage.addAction(aSpell)
+
     ##
     #  Private Slots
     ##
@@ -992,18 +1004,6 @@ class GuiMainMenu(QMenuBar):
         self.aPreferences.setMenuRole(QAction.MenuRole.PreferencesRole)
         self.aPreferences.triggered.connect(self.mainGui.showPreferencesDialog)
         self.mainGui.addAction(self.aPreferences)
-
-    @pyqtSlot()
-    def updateSpellCheckLanguages(self) -> None:
-        """Update the list of available spell check languages."""
-        self.mSelectLanguage.clear()
-        languages = SHARED.spelling.listDictionaries()
-        languages.insert(0, ("None", self.tr("Default")))
-        for tag, language in languages:
-            aSpell = QAction(self.mSelectLanguage)
-            aSpell.setText(language)
-            aSpell.triggered.connect(qtLambda(self._changeSpelling, tag))
-            self.mSelectLanguage.addAction(aSpell)
 
     def _buildHelpMenu(self) -> None:
         """Assemble the Help menu."""

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -824,14 +824,16 @@ class GuiMain(QMainWindow):
 
     @pyqtSlot()
     def showDictionariesDialog(self) -> None:
-        """Show the download dictionaries dialog and update language list when closed."""
+        """Show the download dictionaries dialog and update language
+        list when closed.
+        """
         dialog = GuiDictionaries(self)
         dialog.activateDialog()
         if not dialog.initDialog():
             dialog.close()
             SHARED.error(self.tr("Could not initialise the dialog."))
             return
-            
+
         dialog.finished.connect(self.mainMenu.updateSpellCheckLanguages)
 
     ##


### PR DESCRIPTION
**Summary:**

1. **Refactored Spell Check Language Menu**
   - Moved language menu creation to a dedicated **updateSpellCheckLanguages()** method in **GuiMainMenu**
   - Method now clears and repopulates the language menu with available dictionaries

2. **Dynamic Menu Updates**
   - Menu is populated during application startup
   - Added event handler to update menu when dictionaries dialog is closed
   - New dictionaries appear immediately in the language menu

These changes ensure the spell check language menu stays up-to-date with newly installed dictionaries without requiring an application restart.

**Related Issue(s):**

Closes #2558

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
