### PR TITLE
Add to docs tips & tricks

### DIFF
--- a/docs/source/usage/howto.rst
+++ b/docs/source/usage/howto.rst
@@ -43,6 +43,18 @@ Managing the Project
    project.
 
 
+Application Usage
+=================
+
+.. dropdown:: How can I increase the line height?
+   :animate: fade-in-slide-down
+
+   Unfortunately, in this case, novelWriter uses the plain text editor component of the underlying
+   framework (called Qt) which doesn't support changing the line height. However, you can choose an
+   editor font with larger leading (the spacing between the lines). A good font for this case is
+   `Noto <https://fonts.google.com/noto>`__, which comes in both Sans-Serif and Serif.
+
+
 Layout Tricks
 =============
 


### PR DESCRIPTION
**Summary:**

This PR adds a tip in Tips & Tricks in the docs on how to achieve more line height by picking a font with larger leading.

**Related Issue(s):**

Closes #2559

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
