### PR TITLE
Rename assets build workflow

### DIFF
--- a/.github/workflows/part_assets.yml
+++ b/.github/workflows/part_assets.yml
@@ -1,4 +1,4 @@
-name: BuildAssets
+name: Part-Assets
 
 on: workflow_call
 


### PR DESCRIPTION
**Summary:**

Forgot to rename the assets build job.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
