### PR TITLE
Increase spacing on push buttons

### DIFF
--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -224,6 +224,10 @@ class NPushButton(QPushButton):
         if self._icon and self._color:
             self.setIcon(SHARED.theme.getIcon(self._icon, self._color))
 
+    def setText(self, text: str) -> None:
+        """Overload the text setter to add padding."""
+        return super().setText(f" {text}")
+
 
 class NIconToolButton(QToolButton):
     """Custom: Modified QToolButton.


### PR DESCRIPTION
**Summary:**

A simple change to add a little more space between icon and text on buttons. There is no way to do this with settings or style sheets. The only two options are to add a literal space in the label, or re-implement the painter.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
