### PR TITLE
Overload editor mimedata insert

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -40,8 +40,8 @@ from enum import Enum, IntFlag
 from time import time
 
 from PyQt6.QtCore import (
-    QObject, QPoint, QRect, QRegularExpression, QRunnable, Qt, QTimer,
-    QVariant, pyqtSignal, pyqtSlot
+    QMimeData, QObject, QPoint, QRect, QRegularExpression, QRunnable, Qt,
+    QTimer, QVariant, pyqtSignal, pyqtSlot
 )
 from PyQt6.QtGui import (
     QAction, QCursor, QDragEnterEvent, QDragMoveEvent, QDropEvent,
@@ -1071,6 +1071,13 @@ class GuiDocEditor(QPlainTextEdit):
             rect.translate(vM.left(), vM.top())
             return rect
         return super().inputMethodQuery(query)
+
+    def insertFromMimeData(self, source: QMimeData | None) -> None:
+        """Overload mime data insertion in the document."""
+        if source and source.hasText():
+            # Block empty inserts (Issue #2598)
+            logger.debug("Inserted text in document")
+            super().insertFromMimeData(source)
 
     ##
     #  Public Slots

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1076,7 +1076,7 @@ class GuiDocEditor(QPlainTextEdit):
         """Overload mime data insertion in the document."""
         if source and source.hasText():
             # Block empty inserts (Issue #2598)
-            logger.debug("Inserted text in document")
+            logger.debug("Inserted text into document")
             super().insertFromMimeData(source)
 
     ##


### PR DESCRIPTION
**Summary:**

This PR solves an issue where with some Qt/PyQt versions, the application crashes when pasting from an empty clipboard. The solution is to overload the `insertFromMimeData` method and block it when there is no text to insert.

**Related Issue(s):**

Closes #2598

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
