### PR TITLE
Add Qt6 SVG plugins as a direct dependency for Debian

### DIFF
--- a/setup/debian/control
+++ b/setup/debian/control
@@ -13,7 +13,8 @@ Build-Depends:
   python3-pyqt6 (>= 6.4),
   python3-pyqt6.qtsvg (>= 6.4),
   python3-enchant (>= 2.0),
-  qt6-image-formats-plugins (>= 6.4)
+  qt6-image-formats-plugins (>= 6.4),
+  qt6-svg-plugins (>= 6.4)
 Standards-Version: 4.5.1
 Homepage: https://novelwriter.io
 X-Python3-Version: >= 3.11
@@ -27,5 +28,6 @@ Depends:
   python3-pyqt6 (>= 6.4),
   python3-pyqt6.qtsvg (>= 6.4),
   python3-enchant (>= 2.0),
-  qt6-image-formats-plugins (>= 6.4)
+  qt6-image-formats-plugins (>= 6.4),
+  qt6-svg-plugins (>= 6.4)
 Description: A plain text editor for planning and writing novels


### PR DESCRIPTION
**Summary:**

On some Debian-derived distos, the `qt6-svg-plugins` package is not installed. This PR adds it to the control file for packaging.

**Related Issue(s):**

Closes #2604

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
