### PR TITLE
Fixes for Release 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Release Notes
 
-The 2.7 release updates the 2.7 RC 1 release and makes an improvement to the build settings tool.
-It also updates most translations and updates the French version of the documentation.
+The 2.8 release is based on the features added in 2.8 beta 1 and 2.8 RC 1.
 
 See the website for complete [Release Notes](https://novelwriter.io/releases/release_2_8.html).
 

--- a/setup/macos/build.sh
+++ b/setup/macos/build.sh
@@ -55,6 +55,8 @@ else
     echo "Missing: setup/macos/Info.plist"
     exit 1
 fi
+echo "Generating requirements.txt"
+python3 pkgutils.py gen-req
 
 # Check that other assets are present
 echo "Checking assets"
@@ -108,7 +110,6 @@ conda install -c conda-forge enchant hunspell-en --yes
 
 # Install dependencies
 echo "Installing Python dependencies ..."
-python3 pkgutils.py gen-req
 pip install -r "$SRC_DIR/requirements.txt"
 
 # Leave conda env


### PR DESCRIPTION
**Summary:**

This PR:
* Removes text from the release notes that was for another release.
* Fixes the MacOS build script.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
