### PR TITLE
Fix input method query

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -39,6 +39,7 @@ import logging
 from enum import Enum, IntFlag
 from time import time
 
+from PyQt6 import sip
 from PyQt6.QtCore import (
     QMimeData, QObject, QPoint, QRect, QRegularExpression, QRunnable, Qt,
     QTimer, QVariant, pyqtSignal, pyqtSlot
@@ -76,12 +77,13 @@ from novelwriter.text.counting import standardCounter
 from novelwriter.tools.lipsum import GuiLipsum
 from novelwriter.types import (
     QtAlignCenterTop, QtAlignJustify, QtAlignLeft, QtAlignLeftTop,
-    QtAlignRight, QtBlack, QtImCursorRectangle, QtKeepAnchor, QtModCtrl,
-    QtModNone, QtModShift, QtMouseLeft, QtMoveAnchor, QtMoveDown, QtMoveEnd,
-    QtMoveEndOfLine, QtMoveEndOfWord, QtMoveLeft, QtMoveNextChar,
-    QtMoveNextWord, QtMovePreviousWord, QtMoveRight, QtMoveStart,
-    QtMoveStartOfLine, QtMoveUp, QtScrollAlwaysOff, QtScrollAsNeeded,
-    QtSelectBlock, QtSelectDocument, QtSelectLine, QtSelectWord, QtTransparent
+    QtAlignRight, QtBlack, QtImCurrentSelection, QtImCursorRectangle,
+    QtKeepAnchor, QtModCtrl, QtModNone, QtModShift, QtMouseLeft, QtMoveAnchor,
+    QtMoveDown, QtMoveEnd, QtMoveEndOfLine, QtMoveEndOfWord, QtMoveLeft,
+    QtMoveNextChar, QtMoveNextWord, QtMovePreviousWord, QtMoveRight,
+    QtMoveStart, QtMoveStartOfLine, QtMoveUp, QtScrollAlwaysOff,
+    QtScrollAsNeeded, QtSelectBlock, QtSelectDocument, QtSelectLine,
+    QtSelectWord, QtTransparent
 )
 
 logger = logging.getLogger(__name__)
@@ -1070,6 +1072,12 @@ class GuiDocEditor(QPlainTextEdit):
             rect = self.cursorRect()
             rect.translate(vM.left(), vM.top())
             return rect
+        elif query == QtImCurrentSelection:
+            # See issue #2622
+            ac = sip.enableautoconversion(QVariant, False)  # type: ignore
+            variant = super().inputMethodQuery(query)
+            sip.enableautoconversion(QVariant, ac)  # type: ignore
+            return variant
         return super().inputMethodQuery(query)
 
     def insertFromMimeData(self, source: QMimeData | None) -> None:

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -131,6 +131,7 @@ QtSelectBlock = QTextCursor.SelectionType.BlockUnderCursor
 QtSelectDocument = QTextCursor.SelectionType.Document
 
 QtImCursorRectangle = Qt.InputMethodQuery.ImCursorRectangle
+QtImCurrentSelection = Qt.InputMethodQuery.ImCurrentSelection
 
 # Size Policy
 


### PR DESCRIPTION
**Summary:**

This PR fixes a type conversion issue in PyQt6 for a specific enum value for an inputMethodQuery in the editor. The issue seems to be isolated to Qt 6.10 which returns a struct wrapped in a QVariant. The solution turns off the QVariant conversion.

See PyQt mailing list: https://www.riverbankcomputing.com/pipermail/pyqt/2025-December/046413.html

**Related Issue(s):**

Closes #2622

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
