### PR TITLE
Fix theme docs and add docs version pinning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,23 +14,25 @@ import time
 project = "novelWriter"
 copyright = f"{datetime.date.today().year}"  # noqa: A001
 
-tmp_authors = ["Veronica Berglyd Olsen"]
-if additional := os.environ.get("SPHINX_I18N_AUTHORS"):
-    tmp_authors.extend(a.strip() for a in additional.split(","))
+if override_authors := os.environ.get("SPHINX_I18N_AUTHORS"):
+    author = override_authors
+else:
+    author = "Veronica Berglyd Olsen"
 
-author = ", ".join(tmp_authors)
-
-initFile = os.path.join(
-    os.path.dirname(__file__), os.pardir, os.pardir,
-    "novelwriter", "__init__.py"
-)
-with open(initFile, encoding="utf-8") as inFile:
-    for aLine in inFile:
-        if aLine.startswith("__version__"):
-            release = aLine.split('"')[1].strip()
-            break
-    else:
-        release = "unknown"
+if override_version := os.environ.get("SPHINX_I18N_VERSION"):
+    release = override_version
+else:
+    initFile = os.path.join(
+        os.path.dirname(__file__), os.pardir, os.pardir,
+        "novelwriter", "__init__.py"
+    )
+    with open(initFile, encoding="utf-8") as inFile:
+        for aLine in inFile:
+            if aLine.startswith("__version__"):
+                release = aLine.split('"')[1].strip()
+                break
+        else:
+            release = "unknown"
 
 version = release.partition("-")[0]
 
@@ -42,7 +44,7 @@ time.tzset()
 needs_sphinx = "5.0"
 extensions = ["sphinx_design", "sphinx_copybutton"]
 templates_path = ["_templates"]
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 master_doc = "index"
 today_fmt = "%A, %d %B %Y at %H:%M"
 language = "en"
@@ -67,8 +69,8 @@ html_theme_options = {
     "navigation_with_keys": True,
     "use_repository_button": True,
     "use_issues_button": True,
-    "pygment_light_style": "tango",
-    "pygment_dark_style": "dracula",
+    "pygments_light_style": "tango",
+    "pygments_dark_style": "dracula",
 }
 html_sidebars = {
     "**": ["navbar-logo", "sidebar-title", "sbt-sidebar-nav"],

--- a/docs/source/locales/authors_fr.conf
+++ b/docs/source/locales/authors_fr.conf
@@ -1,2 +1,0 @@
-# French translation authors, one name per line
-Jean-Michel Heras

--- a/docs/source/locales/config.toml
+++ b/docs/source/locales/config.toml
@@ -1,0 +1,3 @@
+[fr]
+version = "2.7"
+authors = ["Jean-Michel Heras", "Veronica Berglyd Olsen"]

--- a/docs/source/user_interface/main_window.rst
+++ b/docs/source/user_interface/main_window.rst
@@ -186,17 +186,11 @@ See :ref:`docs_features_shortcuts` for more details.
 Colour Themes
 =============
 
-By default, novelWriter uses a light colour theme. You can also choose between a standard dark
-theme that have neutral colours, or a series of other included themes, from **Preferences**. 
+By default, novelWriter should pick a dark or light theme based on the colour mode of your
+operating system. You can select which colour mode to use from the application sidebar.
+
+The default light and dark theme can be changed from **Preferences**. There are a number of themes
+to choose from. There are also some high contrast themes available.
 
 If you wish, you *can* create your own colour themes, and even have them added to the application.
 See :ref:`docs_more_custom_theme` for more details.
-
-Switching the GUI colour theme does not affect the colours of the editor and viewer. They have
-separate themes selectable from the "Document colour theme" setting in **Preferences**. They are
-separated because there are a lot more options to choose from for the editor and viewer.
-
-.. note::
-
-   If you switch between light and dark mode on the GUI, you should also switch editor theme to
-   match, otherwise icons may be hard to see in the editor and viewer.


### PR DESCRIPTION
**Summary:**

This PR:
* Removes some outdated info about colour themes from the docs.
* Adds a `config.toml` file to docs localisation so the docs version can be pinned to the version it was translated from.

**Related Issue(s):**

Closes #2619

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
