### PR TITLE
Increase PDF page limit

### DIFF
--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -285,10 +285,11 @@ class ToQTextDocument(Tokenizer):
         printer.setPageMargins(self._pageMargins, QPageLayout.Unit.Millimeter)
         printer.setOutputFileName(str(path))
 
-        if layout := self._document.documentLayout():
-            layout.setPaintDevice(printer)
-
-        self._document.setPageSize(printer.pageRect(QPrinter.Unit.DevicePixel).size())
+        ptPage = self._pageSize.size(QPageSize.Unit.Millimeter)
+        self._document.setPageSize(QSizeF(
+            (ptPage.width() - self._pageMargins.left() - self._pageMargins.right()) / 25.4*96,
+            (ptPage.height() - self._pageMargins.top() - self._pageMargins.bottom()) / 25.4*96,
+        ))
         self._document.print(printer)
 
     def closeDocument(self) -> None:

--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -132,7 +132,7 @@ class ToQTextDocument(Tokenizer):
         if pdf:
             family = self._textFont.family()
             style = self._textFont.styleName()
-            self._dpi = 1200 if QFontDatabase.isScalable(family, style) else 72
+            self._dpi = 300 if QFontDatabase.isScalable(family, style) else 72
 
         self._document.setUndoRedoEnabled(False)
         self._document.blockSignals(True)
@@ -285,11 +285,10 @@ class ToQTextDocument(Tokenizer):
         printer.setPageMargins(self._pageMargins, QPageLayout.Unit.Millimeter)
         printer.setOutputFileName(str(path))
 
-        ptPage = self._pageSize.size(QPageSize.Unit.Millimeter)
-        self._document.setPageSize(QSizeF(
-            (ptPage.width() - self._pageMargins.left() - self._pageMargins.right()) / 25.4*96,
-            (ptPage.height() - self._pageMargins.top() - self._pageMargins.bottom()) / 25.4*96,
-        ))
+        if layout := self._document.documentLayout():
+            layout.setPaintDevice(printer)
+
+        self._document.setPageSize(printer.pageRect(QPrinter.Unit.DevicePixel).size())
         self._document.print(printer)
 
     def closeDocument(self) -> None:


### PR DESCRIPTION
**Summary:**

This PR solves an issue with the PDF build. There seems to be a limit to how large the paint device used to render the PDF document can be, which runs out of space after about 700 pages on 1200 DPI. This PR reduces the DPI to 300, which should allow for a couple thousand pages. It doesn't solve the underlying problem, which seems to be in the Qt library, but makes it less of an issue for novelWriter.

**Related Issue(s):**

Closes #2637

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
