### PR TITLE
Allow using empty lines as margins in manuscript

### DIFF
--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -112,6 +112,7 @@ SETTINGS_TEMPLATE: dict[str, tuple[type, T_BuildValue]] = {
     "format.textMarginB":      (float, nwStyles.T_MARGIN["TT"][1]),
     "format.sepMarginT":       (float, nwStyles.T_MARGIN["SP"][0]),
     "format.sepMarginB":       (float, nwStyles.T_MARGIN["SP"][1]),
+    "format.lineForMargin":    (bool, False),
     "format.pageUnit":         (str, "cm"),
     "format.pageSize":         (str, "A4"),
     "format.pageWidth":        (float, 21.0),
@@ -183,6 +184,7 @@ SETTINGS_LABELS = {
     "format.h4Margin":         QT_TRANSLATE_NOOP("Builds", "Heading 4"),
     "format.textMargin":       QT_TRANSLATE_NOOP("Builds", "Text Paragraph"),
     "format.sepMargin":        QT_TRANSLATE_NOOP("Builds", "Scene Separator"),
+    "format.lineForMargin":    QT_TRANSLATE_NOOP("Builds", "Use Empty Lines As Margins"),
 
     "format.grpPage":          QT_TRANSLATE_NOOP("Builds", "Page Layout"),
     "format.pageUnit":         QT_TRANSLATE_NOOP("Builds", "Unit"),

--- a/novelwriter/core/docbuild.py
+++ b/novelwriter/core/docbuild.py
@@ -338,6 +338,7 @@ class NWBuildDocument:
                 scale*self._build.getFloat("format.leftMargin"),
                 scale*self._build.getFloat("format.rightMargin"),
             )
+            bldObj.setLineForMargin(self._build.getBool("format.lineForMargin"))
 
         return self._build.buildItemFilter(
             self._project, withRoots=self._build.getBool("text.addNoteHeadings")

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -915,6 +915,16 @@ class Tokenizer(ABC):
                     pLines = []
                     self._noIndent = False
 
+            elif addEmptyLine and cBlock[0] in HEADING_BLOCKS:
+                if cBlock[4] & BlockFmt.PBB:
+                    sBlocks.append((BlockTyp.SKIP, "", "", [], BlockFmt.PBB))
+                    sBlocks.append((
+                        cBlock[0], cBlock[1], cBlock[2], cBlock[3], cBlock[4] & ~BlockFmt.PBB
+                    ))
+                else:
+                    sBlocks.append((BlockTyp.SKIP, "", "", [], BlockFmt.NONE))
+                    sBlocks.append(cBlock)
+
             else:
                 sBlocks.append(cBlock)
 

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1258,6 +1258,12 @@ class _FormattingTab(NScrollableForm):
             unit="em",
         )
 
+        # Empty Lines
+        self.lineForMargin = NSwitch(self, height=iPx)
+        self.lineForMargin.clicked.connect(self._updateTextMarginState)
+
+        self.addRow(self._build.getLabel("format.lineForMargin"), self.lineForMargin)
+
         # Page Layout
         # ===========
 
@@ -1478,6 +1484,9 @@ class _FormattingTab(NScrollableForm):
         self.textMarginB.setValue(self._build.getFloat("format.textMarginB"))
         self.sepMarginT.setValue(self._build.getFloat("format.sepMarginT"))
         self.sepMarginB.setValue(self._build.getFloat("format.sepMarginB"))
+        self.lineForMargin.setChecked(self._build.getBool("format.lineForMargin"))
+
+        self._updateTextMarginState()
 
         # Page Layout
         # ===========
@@ -1568,6 +1577,7 @@ class _FormattingTab(NScrollableForm):
         self._build.setValue("format.textMarginB", self.textMarginB.value())
         self._build.setValue("format.sepMarginT", self.sepMarginT.value())
         self._build.setValue("format.sepMarginB", self.sepMarginB.value())
+        self._build.setValue("format.lineForMargin", self.lineForMargin.isChecked())
 
         # Page Layout
         self._build.setValue("format.pageUnit", str(self.pageUnit.currentData()))
@@ -1694,6 +1704,25 @@ class _FormattingTab(NScrollableForm):
         """Update the meta language helper info."""
         code = self.metaLanguage.text().strip()
         self.lblMetaLanguage.setText(languageName(code))
+
+    @pyqtSlot()
+    def _updateTextMarginState(self) -> None:
+        """Update the enabled state of text margin settings."""
+        enabled = not self.lineForMargin.isChecked()
+        self.titleMarginT.setEnabled(enabled)
+        self.titleMarginB.setEnabled(enabled)
+        self.h1MarginT.setEnabled(enabled)
+        self.h1MarginB.setEnabled(enabled)
+        self.h2MarginT.setEnabled(enabled)
+        self.h2MarginB.setEnabled(enabled)
+        self.h3MarginT.setEnabled(enabled)
+        self.h3MarginB.setEnabled(enabled)
+        self.h4MarginT.setEnabled(enabled)
+        self.h4MarginB.setEnabled(enabled)
+        self.textMarginT.setEnabled(enabled)
+        self.textMarginB.setEnabled(enabled)
+        self.sepMarginT.setEnabled(enabled)
+        self.sepMarginB.setEnabled(enabled)
 
     ##
     #  Internal Functions

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -1324,6 +1324,67 @@ def testFmtToken_LineBreak(mockGUI):
 
 
 @pytest.mark.core
+def testFmtToken_LineForMargin(mockGUI):
+    """Test using empty lines between blocks in the Tokenizer class."""
+    project = NWProject()
+    tokens = BareTokenizer(project)
+    tokens._handle = TMH
+    tokens._isNovel = True
+    tokens.setLineForMargin(True)
+    tokens.setChapterStyle(False, True)
+
+    # Between paragraphs
+    tokens._text = "Line one\n\nLine two"
+    tokens._isFirst = True
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.TEXT, "", "Line one", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+        (BlockTyp.TEXT, "", "Line two", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+    ]
+
+    # Not between hard line breaks
+    tokens._text = "Line one\nLine two"
+    tokens._isFirst = True
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.TEXT, "", "Line one\nLine two", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+    ]
+
+    # Between heading and text
+    tokens._text = "### Scene\n\nLine one"
+    tokens._isFirst = True
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+        (BlockTyp.HEAD2, f"{TMH}:T0001", "Scene", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+        (BlockTyp.TEXT, "", "Line one", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+    ]
+
+    # Between two chapters
+    tokens._text = "## Chapter One\n\nText\n\n## Chapter Two\n\nText"
+    tokens._isFirst = True
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+        (BlockTyp.HEAD1, f"{TMH}:T0001", "Chapter One", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+        (BlockTyp.TEXT, "", "Text", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.PBB),
+        (BlockTyp.HEAD1, f"{TMH}:T0002", "Chapter Two", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+        (BlockTyp.TEXT, "", "Text", [], BlockFmt.NONE),
+        (BlockTyp.SKIP, "", "", [], BlockFmt.NONE),
+    ]
+
+
+
+@pytest.mark.core
 def testFmtToken_ShortcodeValue(mockGUI):
     """Test processing of shortcodes with values."""
     project = NWProject()
@@ -1347,7 +1408,6 @@ def testFmtToken_ShortcodeValue(mockGUI):
             (13, TextFmt.FIELD, f"{TMH}:abcd"),
         ], BlockFmt.NONE
     )]
-
 
 @pytest.mark.core
 def testFmtToken_Dialogue(mockGUI):


### PR DESCRIPTION
**Summary:**

This PR adds an option to use empty lines as margins for headers and paragraphs. It respects the compact meta blocks (adds no blank lines), adds a line before and after headings, just like the default margin settings, and adds a blank line after all paragraphs and comments.

Everything is handled in the second pass of the Tokenizer, so there is very little code change.

**Related Issue(s):**

Closes #2648
Discussion #2646

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
