### PR TITLE
Add header promotion info to docs and update handling for HTML

### DIFF
--- a/docs/source/usage/chapters_and_scenes.rst
+++ b/docs/source/usage/chapters_and_scenes.rst
@@ -94,3 +94,8 @@ Page breaks can be automatically added before titles, partition, chapter and sce
 the **Manuscript Build** tool when you build your project to a format that supports page breaks.
 If you want page breaks in other places, you have to specify them manually.
 See :ref:`docs_usage_formatting_breaks` for more details.
+
+.. note::
+
+   When you build a manuscript from your project, the level of the headings in your document will
+   change. See :ref:`docs_ui_manuscript_head_promote` for more details.

--- a/docs/source/user_interface/manuscript.rst
+++ b/docs/source/user_interface/manuscript.rst
@@ -198,6 +198,21 @@ See :ref:`docs_usage_headings_levels` for more info on how to format alternative
 your text.
 
 
+.. _docs_ui_manuscript_head_promote:
+
+Heading Level Promotion
+^^^^^^^^^^^^^^^^^^^^^^^
+
+When you build the manuscript, novel headings are promoted one level relative to the level
+specified in the source documents as typed in the editor. The promotion follows these rules:
+
+#. The main novel title and partition titles are converted to regular text paragraphs with a larger
+   font size.
+#. Chapter titles are promoted to the top-most heading of the document, that is level 1.
+#. Scenes and Section titles, if used, are promoted to level 2 and 3, respectively.
+#. Headings in note documents are left as-is.
+
+
 Output Settings
 ---------------
 

--- a/novelwriter/formats/tohtml.py
+++ b/novelwriter/formats/tohtml.py
@@ -200,7 +200,7 @@ class ToHtml(Tokenizer):
 
             elif tType in (BlockTyp.TITLE, BlockTyp.PART):
                 tHead = tText.replace("\n", "<br>")
-                lines.append(f"<h1 class='title'{hStyle}>{aNm}{tHead}</h1>\n")
+                lines.append(f"<p class='title'{hStyle}>{aNm}{tHead}</p>\n")
 
             elif tType == BlockTyp.HEAD1:
                 tHead = tText.replace("\n", "<br>")
@@ -342,6 +342,7 @@ class ToHtml(Tokenizer):
         fFam = font.family()
         fSz = font.pointSize()
         fW = FONT_WEIGHTS.get(font.weight(), 400)
+        hW = FONT_WEIGHTS.get(700 if self._boldHeads else 400, 400)
         fS = FONT_STYLE.get(font.style(), "normal")
 
         lHeight = round(100 * self._lineHeight)
@@ -359,23 +360,23 @@ class ToHtml(Tokenizer):
         styles.append(f"mark {{background: {mColor};}}")
         styles.append(f"h1, h2, h3, h4 {{color: {hColor}; page-break-after: avoid;}}")
         styles.append(
-            f"h1 {{font-size: {fSz1:.2f}em; "
+            f"h1 {{font-size: {fSz1:.2f}em; font-weight: {hW}; "
             f"margin-top: {mtH1:.2f}em; margin-bottom: {mbH1:.2f}em;}}"
         )
         styles.append(
-            f"h2 {{font-size: {fSz2:.2f}em; "
+            f"h2 {{font-size: {fSz2:.2f}em; font-weight: {hW}; "
             f"margin-top: {mtH2:.2f}em; margin-bottom: {mbH2:.2f}em;}}"
         )
         styles.append(
-            f"h3 {{font-size: {fSz3:.2f}em; "
+            f"h3 {{font-size: {fSz3:.2f}em; font-weight: {hW}; "
             f"margin-top: {mtH3:.2f}em; margin-bottom: {mbH3:.2f}em;}}"
         )
         styles.append(
-            f"h4 {{font-size: {fSz4:.2f}em; "
+            f"h4 {{font-size: {fSz4:.2f}em; font-weight: {hW}; "
             f"margin-top: {mtH4:.2f}em; margin-bottom: {mbH4:.2f}em;}}"
         )
         styles.append(
-            f".title {{font-size: {fSz0:.2f}em; "
+            f".title {{font-size: {fSz0:.2f}em; font-weight: {hW}; "
             f"margin-top: {mtH0:.2f}em; margin-bottom: {mbH0:.2f}em;}}"
         )
         styles.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ markers = [
     "base: Base classes tests",
     "core: Core classes tests",
     "gui: GUI classes tests",
+    "opt_assets: Include optional asset tests",
 ]
 
 [tool.coverage.run]

--- a/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.htm
+++ b/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.htm
@@ -10,16 +10,16 @@ p {text-align: left; line-height: 150%; margin-top: 0.00em; margin-bottom: 0.60e
 a {color: #4271ae;}
 mark {background: #ffffa6;}
 h1, h2, h3, h4 {color: #4271ae; page-break-after: avoid;}
-h1 {font-size: 2.00em; margin-top: 1.50em; margin-bottom: 0.60em;}
-h2 {font-size: 1.75em; margin-top: 1.50em; margin-bottom: 0.60em;}
-h3 {font-size: 1.50em; margin-top: 1.20em; margin-bottom: 0.60em;}
-h4 {font-size: 1.25em; margin-top: 1.20em; margin-bottom: 0.60em;}
-.title {font-size: 2.50em; margin-top: 1.50em; margin-bottom: 0.60em;}
+h1 {font-size: 2.00em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}
+h2 {font-size: 1.75em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}
+h3 {font-size: 1.50em; font-weight: 700; margin-top: 1.20em; margin-bottom: 0.60em;}
+h4 {font-size: 1.25em; font-weight: 700; margin-top: 1.20em; margin-bottom: 0.60em;}
+.title {font-size: 2.50em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}
 .sep {text-align: center; margin-top: 1.20em; margin-bottom: 1.20em;}
 </style>
 </head>
 <body>
-<h1 class='title' style='text-align: center;'>Lorem Ipsum</h1>
+<p class='title' style='text-align: center;'>Lorem Ipsum</p>
 <p style='text-align: center;'><strong>By lipsum.com</strong></p>
 <p style='text-align: center;'>Word Count: 4,184</p>
 <p style='text-align: center;'>Character Count: 27,998</p>
@@ -32,7 +32,7 @@ h4 {font-size: 1.25em; margin-top: 1.20em; margin-bottom: 0.60em;}
 <p class='comment' style='text-align: justify;'><strong><span style='color: #813709'>Synopsis:</span></strong> <span style='color: #813709'>Explanation from the lipsum.com website.</span></p>
 <p style='text-align: justify;'><em>Lorem Ipsum</em> is simply dummy text<sup><a href='#footnote_1'>1</a></sup> of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 <p style='text-align: justify; text-indent: 1.40em;'>See <a href='http://lipsum.com'>http://lipsum.com</a></p>
-<h1 class='title' style='text-align: center; page-break-before: always;'>Part: Act One</h1>
+<p class='title' style='text-align: center; page-break-before: always;'>Part: Act One</p>
 <p style='text-align: center;'>“Fusce maximus felis libero”</p>
 <h1 style='page-break-before: always;'>Chapter: Chapter One</h1>
 <p class='meta meta-pov' style='margin-bottom: 0;'><strong><span style='color: #f5871f'>Point of View:</span></strong> <span style='color: #4271ae'><a href='#tag_bod'>Bod</a></span></p>
@@ -103,7 +103,7 @@ h4 {font-size: 1.25em; margin-top: 1.20em; margin-bottom: 0.60em;}
 <p style='text-align: justify; text-indent: 1.40em;'>Donec luctus lectus efficitur, blandit nisi vitae, dignissim tellus. Pellentesque euismod pharetra augue gravida hendrerit. Quisque nisi mi, mattis ac nisi non, maximus malesuada ante. Nulla lobortis, diam eu ornare ornare, tellus enim feugiat arcu, non vestibulum tortor nunc eu justo. Integer blandit felis justo, eu semper est scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam ultricies, nisi vel elementum commodo, nisl dolor tincidunt magna, sed varius est nunc at lectus. Aliquam dolor tortor, sodales placerat ultricies quis, sodales quis sapien. Duis ullamcorper sollicitudin risus at mattis. Integer consequat et nunc at condimentum. Pellentesque cursus congue augue, non suscipit lectus sodales ut. Nam a mi bibendum, blandit nisl eu, accumsan nunc. Aliquam a ex mauris. Sed nec sem quis arcu dignissim tempus eget et turpis. Ut sed ex nec ipsum ultrices lobortis.</p>
 <p style='text-align: justify; text-indent: 1.40em;'>Pellentesque rhoncus pharetra eros, non mollis nisi pretium non. Mauris accumsan quis odio quis euismod. Maecenas ultrices, augue et aliquam tincidunt, erat tellus ornare ligula, quis ultrices turpis nibh vel justo. Fusce gravida odio tellus. In a congue diam. Mauris consequat ex id leo lacinia dictum. Fusce id sem sodales, ultrices sapien ac, convallis orci. Donec gravida nunc sit amet nisi hendrerit, sed porta enim aliquam. In hac habitasse platea dictumst. Cras a orci felis. Curabitur non felis nec urna maximus auctor ut ut nisi. Curabitur at turpis eleifend, blandit eros at, molestie odio. Phasellus euismod neque augue.</p>
 <p style='text-align: justify; text-indent: 1.40em;'>Integer egestas maximus leo eu facilisis. Nunc rhoncus dignissim lectus eu lacinia. Praesent lacinia urna porttitor aliquam condimentum. Nulla eu eros dictum, dictum nunc vitae, sagittis nibh. Integer ante neque, consequat nec sollicitudin id, consectetur vitae dolor. Nullam volutpat sem orci, quis viverra magna auctor a. Suspendisse potenti. Maecenas commodo sed neque pellentesque vehicula. Sed luctus nisl risus, elementum semper purus interdum vel. Ut pulvinar, massa sit amet venenatis placerat, nunc lacus hendrerit odio, non aliquet nunc risus eu lectus. Maecenas feugiat semper ligula, id lobortis sem porta eu. Integer posuere elit magna, at mollis eros bibendum et. Ut imperdiet purus vel nulla aliquam maximus. Morbi sodales purus tellus, a rhoncus sem rutrum sit amet. Quisque risus sem, laoreet nec convallis nec, rutrum vitae justo.</p>
-<h1 class='title' style='text-align: center; page-break-before: always;'>Notes: Characters</h1>
+<p class='title' style='text-align: center; page-break-before: always;'>Notes: Characters</p>
 <h1>Nobody Owens</h1>
 <p class='meta meta-tag' style='margin-bottom: 0;'><strong><span style='color: #f5871f'>Tag:</span></strong> <span style='color: #4271ae'><a name='tag_bod'>Bod</a></span> | <span style='color: #4271ae'>Nobody Owens</span></p>
 <p class='meta meta-plot' style='margin-top: 0;'><strong><span style='color: #f5871f'>Plot:</span></strong> <span style='color: #4271ae'><a href='#tag_main'>Main</a></span></p>
@@ -111,13 +111,13 @@ h4 {font-size: 1.25em; margin-top: 1.20em; margin-bottom: 0.60em;}
 <p style='text-align: justify;'>Pellentesque nec erat ut nulla posuere commodo. Curabitur nisi augue, imperdiet et porta imperdiet, efficitur id leo. Cras finibus arcu at nibh commodo congue. Proin suscipit placerat condimentum. Aenean ante enim, cursus id lorem a, blandit venenatis nibh. Maecenas suscipit porta elit, sit amet porta felis porttitor eu. Sed a dui nibh. Phasellus sed faucibus dui. Pellentesque felis nulla, ultrices non efficitur quis, rutrum id mi. Mauris tempus auctor nisl, in bibendum enim pellentesque sit amet. Proin nunc lacus, imperdiet nec posuere ac, interdum non lectus.</p>
 <p style='text-align: justify; text-indent: 1.40em;'>Suspendisse faucibus est auctor orci mollis luctus. Praesent quis sodales neque. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec sodales rutrum mattis. In in sem ornare, consequat nulla ac, convallis arcu. Duis ac metus id felis commodo commodo sit amet eget diam. Curabitur rhoncus lacinia leo at sodales. Etiam finibus porta diam a viverra. Praesent nisi urna, volutpat sit amet odio at, vehicula vehicula leo. In non enim eget nisl luctus commodo. Pellentesque pellentesque at lectus at luctus. Quisque nec felis bibendum, lacinia libero ut, lacinia eros. Integer finibus ultricies nibh sit amet placerat.</p>
 <p style='text-align: justify; text-indent: 1.40em;'>Nullam scelerisque velit et tortor congue vestibulum a at nisi. Vivamus sodales ut turpis a convallis. In dignissim nibh at luctus sodales. Etiam sit amet rhoncus massa. Phasellus ligula magna, sollicitudin non imperdiet sit amet, volutpat vel magna. Nunc vestibulum tempor lectus, sit amet porta nunc hendrerit in. Curabitur non odio sit amet massa tincidunt facilisis. Integer et luctus nunc, eget euismod leo. Praesent faucibus metus sed purus convallis scelerisque. Fusce viverra lorem et placerat malesuada. In at elit malesuada, ullamcorper risus vitae, sodales dolor. Donec quis elementum lectus. Quisque eu eros at dui imperdiet euismod ut id neque.</p>
-<h1 class='title' style='text-align: center; page-break-before: always;'>Notes: Plot</h1>
+<p class='title' style='text-align: center; page-break-before: always;'>Notes: Plot</p>
 <h1>Main Plot</h1>
 <p class='meta meta-tag'><strong><span style='color: #f5871f'>Tag:</span></strong> <span style='color: #4271ae'><a name='tag_main'>Main</a></span></p>
 <p class='comment' style='text-align: justify;'><strong><span style='color: #813709'>Short Description:</span></strong> <span style='color: #813709'>Where it all happens</span></p>
 <p style='text-align: justify;'>Suspendisse vulputate malesuada pellentesque. Aenean sollicitudin cursus mi, vitae ultricies felis ullamcorper eu. Duis luctus risus mi, in accumsan velit cursus ut. Vestibulum eleifend leo in magna eleifend fermentum. Proin nec ornare elit. Phasellus nec interdum risus. In a volutpat augue, quis egestas justo. Morbi porta mauris mattis bibendum imperdiet.</p>
 <p style='text-align: justify; text-indent: 1.40em;'>Mauris ut erat eu lorem malesuada egestas vel vel urna. Maecenas ac semper quam. Maecenas aliquet metus non interdum mattis. Proin consectetur molestie ligula. Aliquam sollicitudin pulvinar urna a pellentesque. Suspendisse ultrices, est mattis scelerisque porta, nisi nisi laoreet nisl, non condimentum quam ante a velit. Proin scelerisque justo augue, nec laoreet ligula egestas at. Etiam enim quam, ultrices non accumsan hendrerit, elementum vel ligula. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nam efficitur odio libero, in vestibulum arcu aliquam at. Cras non vehicula augue. Integer lobortis, est vitae aliquam facilisis, metus ligula aliquet eros, at porttitor sem tortor eget massa. Aliquam varius scelerisque neque sed gravida. Aenean eleifend lorem id ante elementum sollicitudin. Proin commodo massa a quam volutpat, mollis fermentum turpis efficitur.</p>
-<h1 class='title' style='text-align: center; page-break-before: always;'>Notes: World</h1>
+<p class='title' style='text-align: center; page-break-before: always;'>Notes: World</p>
 <h1>Ancient Europe</h1>
 <p class='meta meta-tag'><strong><span style='color: #f5871f'>Tag:</span></strong> <span style='color: #4271ae'><a name='tag_europe'>Europe</a></span> | <span style='color: #4271ae'>Ancient Europe</span></p>
 <p class='comment' style='text-align: justify;'><strong><span style='color: #813709'>Short Description:</span></strong> <span style='color: #813709'>A strange place</span></p>

--- a/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.json
+++ b/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.json
@@ -2,8 +2,8 @@
   "meta": {
     "projectName": "Lorem Ipsum",
     "novelAuthor": "lipsum.com",
-    "buildTime": 1750360261,
-    "buildTimeStr": "2025-06-19 21:11:01"
+    "buildTime": 1769342696,
+    "buildTimeStr": "2026-01-25 13:04:56"
   },
   "text": {
     "css": [
@@ -12,16 +12,16 @@
       "a {color: #4271ae;}",
       "mark {background: #ffffa6;}",
       "h1, h2, h3, h4 {color: #4271ae; page-break-after: avoid;}",
-      "h1 {font-size: 2.00em; margin-top: 1.50em; margin-bottom: 0.60em;}",
-      "h2 {font-size: 1.75em; margin-top: 1.50em; margin-bottom: 0.60em;}",
-      "h3 {font-size: 1.50em; margin-top: 1.20em; margin-bottom: 0.60em;}",
-      "h4 {font-size: 1.25em; margin-top: 1.20em; margin-bottom: 0.60em;}",
-      ".title {font-size: 2.50em; margin-top: 1.50em; margin-bottom: 0.60em;}",
+      "h1 {font-size: 2.00em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}",
+      "h2 {font-size: 1.75em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}",
+      "h3 {font-size: 1.50em; font-weight: 700; margin-top: 1.20em; margin-bottom: 0.60em;}",
+      "h4 {font-size: 1.25em; font-weight: 700; margin-top: 1.20em; margin-bottom: 0.60em;}",
+      ".title {font-size: 2.50em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}",
       ".sep {text-align: center; margin-top: 1.20em; margin-bottom: 1.20em;}"
     ],
     "html": [
       [
-        "<h1 class='title' style='text-align: center;'>Lorem Ipsum</h1>",
+        "<p class='title' style='text-align: center;'>Lorem Ipsum</p>",
         "<p style='text-align: center;'><strong>By lipsum.com</strong></p>",
         "<p style='text-align: center;'>Word Count: 4,184</p>",
         "<p style='text-align: center;'>Character Count: 27,998</p>",
@@ -40,7 +40,7 @@
         "<p style='text-align: justify; text-indent: 1.40em;'>See <a href='http://lipsum.com'>http://lipsum.com</a></p>"
       ],
       [
-        "<h1 class='title' style='text-align: center; page-break-before: always;'>Part: Act One</h1>",
+        "<p class='title' style='text-align: center; page-break-before: always;'>Part: Act One</p>",
         "<p style='text-align: center;'>\u201cFusce maximus felis libero\u201d</p>"
       ],
       [
@@ -129,7 +129,7 @@
         "<p style='text-align: justify; text-indent: 1.40em;'>Integer egestas maximus leo eu facilisis. Nunc rhoncus dignissim lectus eu lacinia. Praesent lacinia urna porttitor aliquam condimentum. Nulla eu eros dictum, dictum nunc vitae, sagittis nibh. Integer ante neque, consequat nec sollicitudin id, consectetur vitae dolor. Nullam volutpat sem orci, quis viverra magna auctor a. Suspendisse potenti. Maecenas commodo sed neque pellentesque vehicula. Sed luctus nisl risus, elementum semper purus interdum vel. Ut pulvinar, massa sit amet venenatis placerat, nunc lacus hendrerit odio, non aliquet nunc risus eu lectus. Maecenas feugiat semper ligula, id lobortis sem porta eu. Integer posuere elit magna, at mollis eros bibendum et. Ut imperdiet purus vel nulla aliquam maximus. Morbi sodales purus tellus, a rhoncus sem rutrum sit amet. Quisque risus sem, laoreet nec convallis nec, rutrum vitae justo.</p>"
       ],
       [
-        "<h1 class='title' style='text-align: center; page-break-before: always;'>Notes: Characters</h1>"
+        "<p class='title' style='text-align: center; page-break-before: always;'>Notes: Characters</p>"
       ],
       [
         "<h1>Nobody Owens</h1>",
@@ -141,7 +141,7 @@
         "<p style='text-align: justify; text-indent: 1.40em;'>Nullam scelerisque velit et tortor congue vestibulum a at nisi. Vivamus sodales ut turpis a convallis. In dignissim nibh at luctus sodales. Etiam sit amet rhoncus massa. Phasellus ligula magna, sollicitudin non imperdiet sit amet, volutpat vel magna. Nunc vestibulum tempor lectus, sit amet porta nunc hendrerit in. Curabitur non odio sit amet massa tincidunt facilisis. Integer et luctus nunc, eget euismod leo. Praesent faucibus metus sed purus convallis scelerisque. Fusce viverra lorem et placerat malesuada. In at elit malesuada, ullamcorper risus vitae, sodales dolor. Donec quis elementum lectus. Quisque eu eros at dui imperdiet euismod ut id neque.</p>"
       ],
       [
-        "<h1 class='title' style='text-align: center; page-break-before: always;'>Notes: Plot</h1>"
+        "<p class='title' style='text-align: center; page-break-before: always;'>Notes: Plot</p>"
       ],
       [
         "<h1>Main Plot</h1>",
@@ -151,7 +151,7 @@
         "<p style='text-align: justify; text-indent: 1.40em;'>Mauris ut erat eu lorem malesuada egestas vel vel urna. Maecenas ac semper quam. Maecenas aliquet metus non interdum mattis. Proin consectetur molestie ligula. Aliquam sollicitudin pulvinar urna a pellentesque. Suspendisse ultrices, est mattis scelerisque porta, nisi nisi laoreet nisl, non condimentum quam ante a velit. Proin scelerisque justo augue, nec laoreet ligula egestas at. Etiam enim quam, ultrices non accumsan hendrerit, elementum vel ligula. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nam efficitur odio libero, in vestibulum arcu aliquam at. Cras non vehicula augue. Integer lobortis, est vitae aliquam facilisis, metus ligula aliquet eros, at porttitor sem tortor eget massa. Aliquam varius scelerisque neque sed gravida. Aenean eleifend lorem id ante elementum sollicitudin. Proin commodo massa a quam volutpat, mollis fermentum turpis efficitur.</p>"
       ],
       [
-        "<h1 class='title' style='text-align: center; page-break-before: always;'>Notes: World</h1>"
+        "<p class='title' style='text-align: center; page-break-before: always;'>Notes: World</p>"
       ],
       [
         "<h1>Ancient Europe</h1>",

--- a/tests/test_formats/test_fmt_tohtml.py
+++ b/tests/test_formats/test_fmt_tohtml.py
@@ -51,7 +51,7 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: center;'>Part<br>Title</h1>\n"
+        "<p class='title' style='text-align: center;'>Part<br>Title</p>\n"
     )
 
     # Header 2
@@ -81,7 +81,7 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: center; page-break-before: always;'>Title</h1>\n"
+        "<p class='title' style='text-align: center; page-break-before: always;'>Title</p>\n"
     )
 
     # Unnumbered
@@ -127,8 +127,8 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: center; page-break-before: always;'>"
-        "<a name='0000000000000:T0001'></a>Heading One</h1>\n"
+        "<p class='title' style='text-align: center; page-break-before: always;'>"
+        "<a name='0000000000000:T0001'></a>Heading One</p>\n"
     )
 
     # Unnumbered
@@ -498,8 +498,8 @@ def testFmtToHtml_ConvertDirect(mockGUI):
     ]
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: center; page-break-before: always;'>"
-        "<a name='0000000000000:T0001'></a>A Title</h1>\n"
+        "<p class='title' style='text-align: center; page-break-before: always;'>"
+        "<a name='0000000000000:T0001'></a>A Title</p>\n"
     )
 
     # Unnumbered
@@ -541,7 +541,7 @@ def testFmtToHtml_ConvertDirect(mockGUI):
     ]
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: left;'>A Title</h1>\n"
+        "<p class='title' style='text-align: left;'>A Title</p>\n"
     )
 
     # Align Right
@@ -550,7 +550,7 @@ def testFmtToHtml_ConvertDirect(mockGUI):
     ]
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: right;'>A Title</h1>\n"
+        "<p class='title' style='text-align: right;'>A Title</p>\n"
     )
 
     # Align Centre
@@ -559,7 +559,7 @@ def testFmtToHtml_ConvertDirect(mockGUI):
     ]
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: center;'>A Title</h1>\n"
+        "<p class='title' style='text-align: center;'>A Title</p>\n"
     )
 
     # Align Justify
@@ -568,7 +568,7 @@ def testFmtToHtml_ConvertDirect(mockGUI):
     ]
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' style='text-align: justify;'>A Title</h1>\n"
+        "<p class='title' style='text-align: justify;'>A Title</p>\n"
     )
 
     # Page Break
@@ -580,8 +580,8 @@ def testFmtToHtml_ConvertDirect(mockGUI):
     ]
     html.doConvert()
     assert html._pages[-1] == (
-        "<h1 class='title' "
-        "style='page-break-before: always; page-break-after: always;'>A Title</h1>\n"
+        "<p class='title' "
+        "style='page-break-before: always; page-break-after: always;'>A Title</p>\n"
     )
 
     # Indent
@@ -711,7 +711,7 @@ def testFmtToHtml_Save(mockGUI, fncPath):
         "#### A Section\n\n\tMore text in scene two.\n",
     ]
     resText = [(
-        "<h1 class='title' style='text-align: center;'>My Novel</h1>\n"
+        "<p class='title' style='text-align: center;'>My Novel</p>\n"
         "<p><strong>By Jane Doh</strong></p>\n"
     ), (
         "<h1 style='page-break-before: always;'>Chapter 1</h1>\n"

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -662,12 +662,16 @@ def testGuiTheme_CheckTheme(theme):
     assert deprecated == [], "Deprecated options in theme file"
 
 
-ICONS = []
-_listContent(ICONS, CONFIG.assetPath("icons"), ".icons")
-
-
-@pytest.mark.gui
-@pytest.mark.parametrize("icons", [a.stem for a in ICONS])
+@pytest.mark.parametrize("icons", [
+    pytest.param(
+        a.stem,
+        marks=(
+            (pytest.mark.gui,)
+            if a.stem.startswith("material")
+            else (pytest.mark.gui, pytest.mark.opt_assets)
+        ),
+    ) for a in CONFIG.assetPath("icons").iterdir() if a.is_dir and a.suffix == ".icons"
+])
 def testGuiTheme_CheckIcons(icons, tstPaths):
     """Test loading all icons."""
     keysFile: Path = tstPaths.filesDir / "all_icons.json"


### PR DESCRIPTION
**Summary:**

This PR:
* Changes the way novel title and partition titles are exported to HTML where they are now exported as `<p>` tags instead of `<h1>`.
* Updates the documentation to cover promotion of headings in the manuscript.
* Adds a way to exclude optional assets from tests (unrelated, but annoying when switching between branches)

**Related Issue(s):**

Closes #2641

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
