### PR TITLE
Alert when the loading of a spellcheck dictionary fails

### DIFF
--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -54,6 +54,7 @@ class NWSpellEnchant:
         self._enchant = FakeEnchant()
         self._userDict = UserDictionary(project)
         self._language = None
+        self._requested = None
         self._broker = None
         logger.debug("Ready: NWSpellEnchant")
 
@@ -66,7 +67,13 @@ class NWSpellEnchant:
 
     @property
     def spellLanguage(self) -> str | None:
+        """Return the current spell check language."""
         return self._language
+
+    @property
+    def requestedLanguage(self) -> str | None:
+        """Return the requested spell check language."""
+        return self._requested
 
     ##
     #  Setters
@@ -81,6 +88,7 @@ class NWSpellEnchant:
         self._enchant = FakeEnchant()
         self._broker = None
         self._language = None
+        self._requested = language or None
 
         try:
             import enchant

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -500,6 +500,7 @@ class GuiMain(QMainWindow):
         QApplication.processEvents()
         self.docEditor.setDocumentChanged(False)
         SHARED.project.setProjectChanged(False)
+        SHARED.reportSpellCheckStatus()
 
         logger.debug("Project loaded in %.3f ms", (time() - tStart)*1000)
 

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -256,6 +256,14 @@ class SharedData(QObject):
             _, provider = self.spelling.describeDict()
             self.spellLanguageChanged.emit(language, provider)
 
+    def reportSpellCheckStatus(self) -> None:
+        """Report the state of the spell checker."""
+        spell = self.spelling
+        if (req := spell.requestedLanguage) is not None and req != spell.spellLanguage:
+            self.warn(self.tr(
+                "Could not load spell checking for language code '{0}'."
+            ).format(req))
+
     def updateIdleTime(self, currTime: float, userIdle: bool) -> None:
         """Update the idle time record. If the userIdle flag is True,
         the user idle counter is updated with the time difference since


### PR DESCRIPTION
**Summary:**

This PR adds a check that will pop an alert if a spell check dictionary was requested, but it could not be loaded. The check is only run at project load.

**Related Issue(s):**

Closes #2631

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
