### PR TITLE
Improve Welcome dialog

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -262,7 +262,16 @@ def formatTime(t: int) -> str:
 
 def formatVersion(value: str) -> str:
     """Format a version number into a more human readable form."""
-    return value.lower().replace("a", " Alpha ").replace("b", " Beta ").replace("rc", " RC ")
+    major, _, version = value.partition(".")
+    if "." in version:
+        version = version.replace(".", " Patch ")
+    elif "a" in version:
+        version = version.replace("a", " Alpha ")
+    elif "b" in version:
+        version = version.replace("b", " Beta ")
+    elif "rc" in version:
+        version = version.replace("rc", " RC ")
+    return f"{major}.{version}" if major and version else ""
 
 
 def formatFileFilter(extensions: list[str | tuple[str, str]]) -> str:

--- a/novelwriter/extensions/versioninfo.py
+++ b/novelwriter/extensions/versioninfo.py
@@ -104,7 +104,7 @@ class VersionInfoWidget(QWidget):
     @pyqtSlot(str, str)
     def _updateReleaseInfo(self, tag: str, reason: str) -> None:
         """Update the widget release info."""
-        if version := tag.lstrip("v"):
+        if version := formatVersion(tag.lstrip("v")):
             download = f"<a href='#website'>{__domain__}</a>"
             self._lblRelease.setText(self._trLatest.format(
                 f"{version} \u2013 {self._trDownload.format(download)}"

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -336,9 +336,11 @@ def testBaseCommon_formatTime():
 def testBaseCommon_formatVersion():
     """Test the formatVersion function."""
     assert formatVersion("1.2") == "1.2"
+    assert formatVersion("1.2.1") == "1.2 Patch 1"
     assert formatVersion("1.2a1") == "1.2 Alpha 1"
     assert formatVersion("1.2b2") == "1.2 Beta 2"
     assert formatVersion("1.2rc3") == "1.2 RC 3"
+    assert formatVersion("12345") == ""
 
 
 @pytest.mark.base

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-from PyQt6.QtCore import QPoint
+from PyQt6.QtCore import QPoint, Qt
 from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import QFileDialog, QMenu
 
@@ -136,7 +136,23 @@ def testToolWelcome_Open(qtbot, monkeypatch, nwGUI, fncPath):
         "Project One", "/stuff/project_one", f"Last Opened: {dateTwo}, Word Count: 12.3\u2009k"
     )
 
+    # Change selection with arrow keys
+    assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
+    qtbot.keyClick(tabOpen, Qt.Key.Key_Left)  # Does nothing
+    assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
+    qtbot.keyClick(tabOpen, Qt.Key.Key_Right)  # Does nothing
+    assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
+    qtbot.keyClick(tabOpen, Qt.Key.Key_Down)  # Selects lower
+    assert tabOpen.selectedPath.text() == "Path: /stuff/project_one"
+    qtbot.keyClick(tabOpen, Qt.Key.Key_Down)  # Does nothing (already on last)
+    assert tabOpen.selectedPath.text() == "Path: /stuff/project_one"
+    qtbot.keyClick(tabOpen, Qt.Key.Key_Up)  # Selects upper
+    assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
+    qtbot.keyClick(tabOpen, Qt.Key.Key_Up)  # Does nothing (already on first)
+    assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
+
     # Single click item
+    qtbot.mouseClick(vPort, QtMouseLeft, pos=posOne, delay=10)
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
     qtbot.mouseClick(vPort, QtMouseLeft, pos=posTwo, delay=10)
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_one"


### PR DESCRIPTION
**Summary:**

This PR:
* Improves the human readable representation of the version number on the Welcome and About dialogs.
* Allows the user to open the selected project from the project list with the Enter key.
* Maps the Up and Down arrow keys directly to the project list without the need to manually change focus. It is a capture all keypresses implementation that just forwards the arrow keys to the list view.
* Updates tests.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
