### PR TITLE
Add heading size setting for editor

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -87,14 +87,14 @@ class Config:
         "iconColDocs", "iconColTree", "iconTheme", "incNotesWCount", "isDebug", "kernelVer",
         "lastNotes", "lightTheme", "lineHighlight", "mainPanePos", "mainWinSize", "memInfo",
         "moveMainWin", "narratorBreak", "narratorDialog", "nativeFont", "osDarwin", "osLinux",
-        "osType", "osUnknown", "osWindows", "outlinePanePos", "prefsWinSize", "scrollPastEnd",
-        "searchCase", "searchLoop", "searchMatchCap", "searchNextFile", "searchProjCase",
-        "searchProjRegEx", "searchProjWord", "searchRegEx", "searchWord", "showEditToolBar",
-        "showFullPath", "showLineEndings", "showMultiSpaces", "showSessionTime", "showTabsNSpaces",
-        "showViewerPanel", "spellLanguage", "stopWhenIdle", "tabWidth", "textFont", "textMargin",
-        "textWidth", "themeMode", "useCharCount", "userIdleTime", "verPyQtString", "verPyQtValue",
-        "verPyString", "verQtString", "verQtValue", "viewComments", "viewNotes", "viewPanePos",
-        "viewSynopsis", "vimMode", "welcomeWinSize",
+        "osType", "osUnknown", "osWindows", "outlinePanePos", "prefsWinSize", "scaleHeadings",
+        "scrollPastEnd", "searchCase", "searchLoop", "searchMatchCap", "searchNextFile",
+        "searchProjCase", "searchProjRegEx", "searchProjWord", "searchRegEx", "searchWord",
+        "showEditToolBar", "showFullPath", "showLineEndings", "showMultiSpaces", "showSessionTime",
+        "showTabsNSpaces", "showViewerPanel", "spellLanguage", "stopWhenIdle", "tabWidth",
+        "textFont", "textMargin", "textWidth", "themeMode", "useCharCount", "userIdleTime",
+        "verPyQtString", "verPyQtValue", "verPyString", "verQtString", "verQtValue",
+        "viewComments", "viewNotes", "viewPanePos", "viewSynopsis", "vimMode", "welcomeWinSize"
     )
 
     LANG_NW   = 1
@@ -213,6 +213,7 @@ class Config:
         self.showTabsNSpaces = False    # Show tabs and spaces in editor
         self.showLineEndings = False    # Show line endings in editor
         self.showMultiSpaces = False    # Highlight multiple spaces in the text
+        self.scaleHeadings   = True     # Use a larger size for headings
 
         self.doReplace       = True     # Enable auto-replace as you type
         self.doReplaceSQuote = True     # Smart single quotes
@@ -698,6 +699,7 @@ class Config:
         self.showTabsNSpaces = conf.rdBool(sec, "showtabsnspaces", self.showTabsNSpaces)
         self.showLineEndings = conf.rdBool(sec, "showlineendings", self.showLineEndings)
         self.showMultiSpaces = conf.rdBool(sec, "showmultispaces", self.showMultiSpaces)
+        self.scaleHeadings   = conf.rdBool(sec, "scaleheadings", self.scaleHeadings)
         self.incNotesWCount  = conf.rdBool(sec, "incnoteswcount", self.incNotesWCount)
         self.showFullPath    = conf.rdBool(sec, "showfullpath", self.showFullPath)
         self.dialogStyle     = conf.rdInt(sec, "dialogstyle", self.dialogStyle)
@@ -829,6 +831,7 @@ class Config:
             "showtabsnspaces": str(self.showTabsNSpaces),
             "showlineendings": str(self.showLineEndings),
             "showmultispaces": str(self.showMultiSpaces),
+            "scaleheadings":   str(self.scaleHeadings),
             "incnoteswcount":  str(self.incNotesWCount),
             "showfullpath":    str(self.showFullPath),
             "dialogstyle":     str(self.dialogStyle),

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -559,6 +559,13 @@ class GuiPreferences(NDialog):
             unit=self.tr("px")
         )
 
+        # Scale Headings
+        self.scaleHeadings = NSwitch(self)
+        self.scaleHeadings.setChecked(CONFIG.scaleHeadings)
+        self.mainForm.addRow(
+            self.tr("Use a larger font size for headings"), self.scaleHeadings
+        )
+
         # Highlight Current Line
         self.lineHighlight = NSwitch(self)
         self.lineHighlight.setChecked(CONFIG.lineHighlight)
@@ -1082,12 +1089,15 @@ class GuiPreferences(NDialog):
 
         # Text Editing
         lineHighlight = self.lineHighlight.isChecked()
+        scaleHeadings = self.scaleHeadings.isChecked()
 
         updateSyntax |= CONFIG.lineHighlight != lineHighlight
+        updateSyntax |= CONFIG.scaleHeadings != scaleHeadings
 
         CONFIG.spellLanguage   = self.spellLanguage.currentData()
         CONFIG.autoSelect      = self.autoSelect.isChecked()
         CONFIG.cursorWidth     = self.cursorWidth.value()
+        CONFIG.scaleHeadings   = scaleHeadings
         CONFIG.lineHighlight   = lineHighlight
         CONFIG.showTabsNSpaces = self.showTabsNSpaces.isChecked()
         CONFIG.showLineEndings = self.showLineEndings.isChecked()

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -95,16 +95,21 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         colEmph = syntax.emph if CONFIG.highlightEmph else None
 
+        h1Size = nwStyles.H_SIZES[1] if CONFIG.scaleHeadings else None
+        h2Size = nwStyles.H_SIZES[2] if CONFIG.scaleHeadings else None
+        h3Size = nwStyles.H_SIZES[3] if CONFIG.scaleHeadings else None
+        h4Size = nwStyles.H_SIZES[4] if CONFIG.scaleHeadings else None
+
         # Create Character Formats
         self._addCharFormat("text",      syntax.text)
-        self._addCharFormat("header1",   syntax.head, "b", nwStyles.H_SIZES[1])
-        self._addCharFormat("header2",   syntax.head, "b", nwStyles.H_SIZES[2])
-        self._addCharFormat("header3",   syntax.head, "b", nwStyles.H_SIZES[3])
-        self._addCharFormat("header4",   syntax.head, "b", nwStyles.H_SIZES[4])
-        self._addCharFormat("head1h",    syntax.headH, "b", nwStyles.H_SIZES[1])
-        self._addCharFormat("head2h",    syntax.headH, "b", nwStyles.H_SIZES[2])
-        self._addCharFormat("head3h",    syntax.headH, "b", nwStyles.H_SIZES[3])
-        self._addCharFormat("head4h",    syntax.headH, "b", nwStyles.H_SIZES[4])
+        self._addCharFormat("header1",   syntax.head, "b", h1Size)
+        self._addCharFormat("header2",   syntax.head, "b", h2Size)
+        self._addCharFormat("header3",   syntax.head, "b", h3Size)
+        self._addCharFormat("header4",   syntax.head, "b", h4Size)
+        self._addCharFormat("head1h",    syntax.headH, "b", h1Size)
+        self._addCharFormat("head2h",    syntax.headH, "b", h2Size)
+        self._addCharFormat("head3h",    syntax.headH, "b", h3Size)
+        self._addCharFormat("head4h",    syntax.headH, "b", h4Size)
         self._addCharFormat("bold",      colEmph, "b")
         self._addCharFormat("italic",    colEmph, "i")
         self._addCharFormat("strike",    syntax.hidden, "s")

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2025-11-08 16:24:26
+timestamp = 2026-02-18 09:57:24
 
 [Main]
 font = 
@@ -67,6 +67,7 @@ spellcheck = en
 showtabsnspaces = False
 showlineendings = False
 showmultispaces = False
+scaleheadings = True
 incnoteswcount = True
 showfullpath = True
 dialogstyle = 2
@@ -96,3 +97,4 @@ searchmatchcap = False
 searchprojcase = False
 searchprojword = False
 searchprojregex = False
+

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -249,6 +249,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     prefs.spellLanguage.setCurrentIndex(prefs.spellLanguage.findData("de"))
     prefs.autoSelect.setChecked(False)
     prefs.cursorWidth.setValue(5)
+    prefs.scaleHeadings.setChecked(False)
     prefs.lineHighlight.setChecked(False)
     prefs.showTabsNSpaces.setChecked(True)
     prefs.showLineEndings.setChecked(True)
@@ -256,6 +257,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.spellLanguage != "de"
     assert CONFIG.autoSelect is True
     assert CONFIG.cursorWidth == 1
+    assert CONFIG.scaleHeadings is True
     assert CONFIG.lineHighlight is True
     assert CONFIG.showTabsNSpaces is False
     assert CONFIG.showLineEndings is False
@@ -398,6 +400,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.spellLanguage == "de"
     assert CONFIG.autoSelect is False
     assert CONFIG.cursorWidth == 5
+    assert CONFIG.scaleHeadings is False
     assert CONFIG.lineHighlight is False
     assert CONFIG.showTabsNSpaces is True
     assert CONFIG.showLineEndings is True


### PR DESCRIPTION
**Summary:**

This PR adds a setting in Preferences to turn off the scaling of headings in the editor. I.e. makes it a true plain text editor with all text the same size.

**Related Issue(s):**

Closes #2636

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
