### PR TITLE
Harden I/O handling to account for PermissionError from pathlib

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -478,6 +478,7 @@ def safeIterDir(path: Path, *, alert: bool = False) -> Generator[Path, None, Non
             from novelwriter import SHARED
             SHARED.newStatusMessage(exc, "warning")
 
+
 def safeExists(path: Path, *, alert: bool = False) -> bool:
     """Call Path.exists() with exception handling."""
     try:
@@ -488,6 +489,7 @@ def safeExists(path: Path, *, alert: bool = False) -> bool:
             from novelwriter import SHARED
             SHARED.newStatusMessage(exc, "warning")
         return False
+
 
 def safeIsFile(path: Path, *, alert: bool = False) -> bool:
     """Call Path.is_file() with exception handling."""

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -46,7 +46,7 @@ from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 from novelwriter.error import logException
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Generator
 
 logger = logging.getLogger(__name__)
 
@@ -462,6 +462,55 @@ def numberToRoman(value: int, toLower: bool = False) -> str:
             break
 
     return roman.lower() if toLower else roman
+
+
+##
+#  Safe I/O Wrappers
+##
+
+def safeIterDir(path: Path, *, alert: bool = False) -> Generator[Path, None, None]:
+    """Call Path.iterdir() with exception handling."""
+    try:
+        yield from path.iterdir()
+    except Exception as exc:
+        logException()
+        if alert:
+            from novelwriter import SHARED
+            SHARED.newStatusMessage(exc, "warning")
+
+def safeExists(path: Path, *, alert: bool = False) -> bool:
+    """Call Path.exists() with exception handling."""
+    try:
+        return path.exists()
+    except Exception as exc:
+        logException()
+        if alert:
+            from novelwriter import SHARED
+            SHARED.newStatusMessage(exc, "warning")
+        return False
+
+def safeIsFile(path: Path, *, alert: bool = False) -> bool:
+    """Call Path.is_file() with exception handling."""
+    try:
+        return path.is_file()
+    except Exception as exc:
+        logException()
+        if alert:
+            from novelwriter import SHARED
+            SHARED.newStatusMessage(exc, "warning")
+        return False
+
+
+def safeIsDir(path: Path, *, alert: bool = False) -> bool:
+    """Call Path.is_dir() with exception handling."""
+    try:
+        return path.is_dir()
+    except Exception as exc:
+        logException()
+        if alert:
+            from novelwriter import SHARED
+            SHARED.newStatusMessage(exc, "warning")
+        return False
 
 
 ##

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -565,11 +565,10 @@ class Config:
 
         # If the config and data folders don't exist, create them
         # This assumes that the os config and data folders exist
-        self._confPath.mkdir(exist_ok=True)
-        self._dataPath.mkdir(exist_ok=True)
-
         # Also create the themes and icons folders if possible
         try:
+            self._confPath.mkdir(exist_ok=True)
+            self._dataPath.mkdir(exist_ok=True)
             if self._dataPath.is_dir():
                 (self._dataPath / "cache").mkdir(exist_ok=True)
                 (self._dataPath / "icons").mkdir(exist_ok=True)

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -43,7 +43,8 @@ from PyQt6.QtWidgets import QApplication
 
 from novelwriter.common import (
     NWConfigParser, checkInt, checkPath, describeFont, fontMatcher,
-    formatTimeStamp, joinLines, languageName, processDialogSymbols, simplified
+    formatTimeStamp, joinLines, languageName, processDialogSymbols, safeExists,
+    safeIsDir, simplified
 )
 from novelwriter.constants import nwFiles, nwQuotes, nwUnicode
 from novelwriter.enum import nwTheme
@@ -139,7 +140,7 @@ class Config:
         self._nwLangPath = self._appPath / "assets" / "i18n"
         self._qtLangPath = QLibraryInfo.path(QLibraryInfo.LibraryPath.TranslationsPath)
 
-        hasLocale = (self._nwLangPath / f"nw_{QLocale.system().name()}.qm").exists()
+        hasLocale = safeExists(self._nwLangPath / f"nw_{QLocale.system().name()}.qm")
         self._qLocale = QLocale.system() if hasLocale else QLocale("en_GB")
         self._dLocale = QLocale.system()
         self._dShortDate = self._dLocale.dateFormat(QLocale.FormatType.ShortFormat)
@@ -148,10 +149,13 @@ class Config:
 
         # PDF Manual
         self._manuals: dict[str, Path] = {}
-        if (assets := self._appPath / "assets").is_dir():
-            for item in assets.iterdir():
-                if item.is_file() and item.stem.startswith("manual") and item.suffix == ".pdf":
-                    self._manuals[item.stem] = item
+        try:
+            if (assets := self._appPath / "assets").is_dir():
+                for item in assets.iterdir():
+                    if item.is_file() and item.stem.startswith("manual") and item.suffix == ".pdf":
+                        self._manuals[item.stem] = item
+        except Exception:
+            logException()
 
         # User Settings
         # =============
@@ -391,9 +395,9 @@ class Config:
         """
         if isinstance(path, str | Path):
             path = checkPath(path, self._homePath)
-            if not path.is_dir():
+            if not safeIsDir(path):
                 path = path.parent
-            if path.is_dir():
+            if safeIsDir(path):
                 self._recentPaths.setPath(key, path)
 
     def setBackupPath(self, path: Path | str) -> None:
@@ -468,14 +472,13 @@ class Config:
     def lastPath(self, key: str) -> Path:
         """Return the last path used by the user, if it exists."""
         if path := self._recentPaths.getPath(key):
-            asPath = Path(path)
-            if asPath.is_dir():
+            if safeIsDir(asPath := Path(path)):
                 return asPath
         return self._homePath
 
     def backupPath(self) -> Path:
         """Return the backup path."""
-        if isinstance(self._backupPath, Path) and self._backupPath.is_dir():
+        if isinstance(self._backupPath, Path) and safeIsDir(self._backupPath):
             return self._backupPath
         return self._backPath
 
@@ -516,15 +519,18 @@ class Config:
         else:
             return []
 
-        for qmFile in self._nwLangPath.iterdir():
-            qmName = qmFile.name
-            if not (qmFile.is_file() and qmName.startswith(fPre) and qmName.endswith(fExt)):
-                continue
+        try:
+            for qmFile in self._nwLangPath.iterdir():
+                qmName = qmFile.name
+                if not (qmFile.is_file() and qmName.startswith(fPre) and qmName.endswith(fExt)):
+                    continue
 
-            qmLang = qmName[len(fPre):-len(fExt)]
-            qmName = languageName(qmLang)
-            if qmLang and qmName and qmLang != "en_GB":
-                langList[qmLang] = qmName
+                qmLang = qmName[len(fPre):-len(fExt)]
+                qmName = languageName(qmLang)
+                if qmLang and qmName and qmLang != "en_GB":
+                    langList[qmLang] = qmName
+        except Exception as exc:
+            logger.error("Failed to load additional language files", exc_info=exc)
 
         return sorted(langList.items(), key=lambda x: x[0])
 
@@ -563,10 +569,13 @@ class Config:
         self._dataPath.mkdir(exist_ok=True)
 
         # Also create the themes and icons folders if possible
-        if self._dataPath.is_dir():
-            (self._dataPath / "cache").mkdir(exist_ok=True)
-            (self._dataPath / "icons").mkdir(exist_ok=True)
-            (self._dataPath / "themes").mkdir(exist_ok=True)
+        try:
+            if self._dataPath.is_dir():
+                (self._dataPath / "cache").mkdir(exist_ok=True)
+                (self._dataPath / "icons").mkdir(exist_ok=True)
+                (self._dataPath / "themes").mkdir(exist_ok=True)
+        except Exception:
+            logException()
 
         self._recentPaths.loadCache()
         self._recentProjects.loadCache()
@@ -582,7 +591,7 @@ class Config:
         QLocale.setDefault(self._qLocale)
         self._qtTrans = {}
 
-        hasLocale = (self._nwLangPath / f"nw_{self._qLocale.name()}.qm").exists()
+        hasLocale = safeExists(self._nwLangPath / f"nw_{self._qLocale.name()}.qm")
         self._dLocale = self._qLocale if hasLocale else QLocale.system()
         self._dShortDate = self._dLocale.dateFormat(QLocale.FormatType.ShortFormat)
         self._dShortDateTime = self._dLocale.dateTimeFormat(QLocale.FormatType.ShortFormat)
@@ -611,7 +620,7 @@ class Config:
         conf = NWConfigParser()
         cnfPath = self._confPath / nwFiles.CONF_FILE
 
-        if not cnfPath.exists():
+        if not safeExists(cnfPath):
             # Initial file, so we just create one from defaults
             self.setGuiFont(None)
             self.setTextFont(None)
@@ -927,9 +936,9 @@ class RecentProjects:
         """Load the cache file for recent projects."""
         self._data = {}
         self._map = {}
-        cacheFile = self._conf.dataPath(nwFiles.RECENT_FILE)
-        if cacheFile.is_file():
-            try:
+        try:
+            cacheFile = self._conf.dataPath(nwFiles.RECENT_FILE)
+            if cacheFile.is_file():
                 with open(cacheFile, mode="r", encoding="utf-8") as inFile:
                     data = json.load(inFile)
                 for path, entry in data.items():
@@ -940,10 +949,10 @@ class RecentProjects:
                     saved = checkInt(entry.get("time", 0), 0)
                     if path and title:
                         self._setEntry(puuid, path, title, words, chars, saved)
-            except Exception:
-                logger.error("Could not load recent project cache")
-                logException()
-                return False
+        except Exception:
+            logger.error("Could not load recent project cache")
+            logException()
+            return False
         return True
 
     def saveCache(self) -> bool:
@@ -1027,19 +1036,19 @@ class RecentPaths:
     def loadCache(self) -> bool:
         """Load the cache file for recent paths."""
         self._data = {}
-        cacheFile = self._conf.dataPath(nwFiles.RECENT_PATH)
-        if cacheFile.is_file():
-            try:
+        try:
+            cacheFile = self._conf.dataPath(nwFiles.RECENT_PATH)
+            if cacheFile.is_file():
                 with open(cacheFile, mode="r", encoding="utf-8") as inFile:
                     data = json.load(inFile)
                 if isinstance(data, dict):
                     for key, path in data.items():
                         if key in self.KEYS and isinstance(path, str):
                             self._data[key] = path
-            except Exception:
-                logger.error("Could not load recent paths cache")
-                logException()
-                return False
+        except Exception:
+            logger.error("Could not load recent paths cache")
+            logException()
+            return False
         return True
 
     def saveCache(self) -> bool:

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING
 from PyQt6.QtCore import QT_TRANSLATE_NOOP, QCoreApplication
 
 from novelwriter import CONFIG
-from novelwriter.common import checkUuid, isHandle, jsonEncode
+from novelwriter.common import checkUuid, isHandle, jsonEncode, safeExists, safeIsDir
 from novelwriter.constants import nwFiles, nwHeadFmt, nwStyles
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwBuildFmt
@@ -272,7 +272,7 @@ class BuildSettings:
     @property
     def lastBuildPath(self) -> Path:
         """The last used build path."""
-        if self._path.is_dir():
+        if safeIsDir(self._path):
             return self._path
         return CONFIG.homePath()
 
@@ -345,7 +345,7 @@ class BuildSettings:
         """Set the last used build path."""
         if isinstance(path, str):
             path = Path(path)
-        if isinstance(path, Path) and path.is_dir():
+        if isinstance(path, Path) and safeIsDir(path):
             self._path = path
         else:
             self._path = CONFIG.homePath()
@@ -617,7 +617,7 @@ class BuildCollection:
             return False
 
         data = {}
-        if buildsFile.exists():
+        if safeExists(buildsFile):
             logger.debug("Loading builds file")
             try:
                 with open(buildsFile, mode="r", encoding="utf-8") as inFile:

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -38,7 +38,7 @@ from zipfile import ZipFile, is_zipfile
 from PyQt6.QtCore import QCoreApplication
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import isHandle, minmax, simplified
+from novelwriter.common import isHandle, minmax, safeExists, safeIsFile, simplified
 from novelwriter.constants import nwConst, nwFiles, nwItemClass, nwStats
 from novelwriter.core.project import NWProject
 from novelwriter.core.storage import NWStorageCreate
@@ -520,13 +520,15 @@ class ProjectBuilder:
         update new settings.
         """
         source = data.get("template")
-        if not (isinstance(source, Path) and source.is_file()
-                and (source.name == nwFiles.PROJ_FILE or is_zipfile(source))):
+        if not (
+            isinstance(source, Path) and safeIsFile(source)
+            and (source.name == nwFiles.PROJ_FILE or is_zipfile(source))
+        ):
             logger.error("Could not access source project: %s", source)
             return False
 
         logger.info("Copying project: %s", source)
-        if path.exists():
+        if safeExists(path):
             SHARED.error(self.tr(
                 "The target folder already exists. "
                 "Please choose another folder."
@@ -566,14 +568,14 @@ class ProjectBuilder:
         """Make a copy of the sample project by extracting the
         sample.zip file to the new path.
         """
-        if path.exists():
+        if safeExists(path):
             SHARED.error(self.tr(
                 "The target folder already exists. "
                 "Please choose another folder."
             ))
             return False
 
-        if (sample := CONFIG.assetPath("sample.zip")).is_file():
+        if safeIsFile(sample := CONFIG.assetPath("sample.zip")):
             try:
                 shutil.unpack_archive(sample, path)
                 self._resetProject(path, data)

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING
 
-from novelwriter.common import formatTimeStamp, isHandle
+from novelwriter.common import formatTimeStamp, isHandle, safeExists, safeIsFile
 from novelwriter.enum import nwItemClass, nwItemLayout
 from novelwriter.error import formatException, logException
 
@@ -110,18 +110,17 @@ class NWDocument:
     @staticmethod
     def quickReadText(content: Path, tHandle: str) -> str:
         """Return the text of a document in a fast and efficient way."""
-        if (path := content / f"{tHandle}.nwd").is_file():
-            try:
+        try:
+            if (path := content / f"{tHandle}.nwd").is_file():
                 with open(path, mode="r", encoding="utf-8") as inFile:
                     line = ""
                     for _ in range(10):
                         if not (line := inFile.readline()).startswith(r"%%~"):
                             break
                     return line + inFile.read()
-            except Exception:
-                logger.error("Cannot read document with handle '%s'", tHandle)
-                logException()
-                return ""
+        except Exception:
+            logger.error("Cannot read document with handle '%s'", tHandle)
+            logException()
         return ""
 
     ##
@@ -138,7 +137,7 @@ class NWDocument:
             logger.error("No content path set")
             return False
 
-        return (contentPath / f"{self._handle}.nwd").is_file()
+        return safeIsFile(contentPath / f"{self._handle}.nwd")
 
     def readDocument(self, isOrphan: bool = False) -> str | None:
         """Read the document specified by the handle set in the
@@ -170,7 +169,7 @@ class NWDocument:
         self._docMeta = {}
         self._lastHash = ""
 
-        if docPath.exists():
+        if safeExists(docPath):
             try:
                 with open(docPath, mode="r", encoding="utf-8") as inFile:
                     # Check the first <= 10 lines for metadata
@@ -236,7 +235,7 @@ class NWDocument:
         updatedDate = self._docMeta.get("updated", "Unknown")
         if writeHash != self._lastHash:
             updatedDate = currTime
-        if not docPath.is_file():
+        if not safeIsFile(docPath):
             createdDate = currTime
             updatedDate = currTime
 

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -35,7 +35,8 @@ from typing import TYPE_CHECKING
 
 from novelwriter import SHARED, __hexversion__
 from novelwriter.common import (
-    formatTimeStamp, isHandle, isItemClass, isTitleTag, jsonCombine, jsonEncode
+    formatTimeStamp, isHandle, isItemClass, isTitleTag, jsonCombine,
+    jsonEncode, safeExists
 )
 from novelwriter.constants import nwFiles, nwKeyWords, nwStyles
 from novelwriter.core.indexdata import NOTE_TYPES, TT_NONE, IndexHeading, IndexNode, T_NoteTypes
@@ -241,7 +242,7 @@ class Index:
 
         tStart = time()
         self._indexBroken = False
-        if indexFile.exists():
+        if safeExists(indexFile):
             logger.debug("Loading index file")
             try:
                 with open(indexFile, mode="r", encoding="utf-8") as inFile:

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -31,7 +31,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from novelwriter.common import checkBool, checkFloat, checkInt, checkString, jsonEncode
+from novelwriter.common import checkBool, checkFloat, checkInt, checkString, jsonEncode, safeExists
 from novelwriter.constants import nwFiles
 from novelwriter.error import logException
 
@@ -102,7 +102,7 @@ class OptionState:
             return False
 
         data = {}
-        if stateFile.exists():
+        if safeExists(stateFile):
             logger.debug("Loading GUI options file")
             try:
                 with open(stateFile, mode="r", encoding="utf-8") as inFile:

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -37,7 +37,7 @@ from PyQt6.QtCore import QCoreApplication
 from novelwriter import CONFIG, SHARED, __hexversion__, __version__
 from novelwriter.common import (
     checkStringNone, formatInt, formatTimeStamp, getFileSize, hexToInt,
-    makeFileNameSafe, minmax
+    makeFileNameSafe, minmax, safeIsFile
 )
 from novelwriter.constants import nwLabels, trConst
 from novelwriter.core.index import Index
@@ -575,7 +575,7 @@ class NWProject:
             return False
 
         langFile = Path(CONFIG.nwLangPath) / f"project_{self._data.language}.json"
-        if not langFile.is_file():
+        if not safeIsFile(langFile):
             langFile = Path(CONFIG.nwLangPath) / "project_en_GB.json"
 
         try:

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -119,15 +119,14 @@ class NWSessionLog:
     def iterRecords(self) -> Iterable[dict]:
         """Iterate through all records in the log."""
         sessFile = self._project.storage.getMetaFile(nwFiles.SESS_FILE)
-        if isinstance(sessFile, Path) and sessFile.is_file():
-            try:
+        try:
+            if isinstance(sessFile, Path) and sessFile.is_file():
                 with open(sessFile, mode="r", encoding="utf-8") as fObj:
                     for line in fObj:
                         yield json.loads(line)
-            except Exception:
-                logger.error("Failed to process session stats file")
-                logException()
-        return
+        except Exception:
+            logger.error("Failed to process session stats file")
+            logException()
 
     def createInitial(self, total: int) -> str:
         """Low level function to create the initial log file record."""

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -218,15 +218,15 @@ class UserDictionary:
         """Load the user's dictionary."""
         self._words = set()
         wordList = self._project.storage.getMetaFile(nwFiles.DICT_FILE)
-        if isinstance(wordList, Path) and wordList.is_file():
-            try:
+        try:
+            if isinstance(wordList, Path) and wordList.is_file():
                 with open(wordList, mode="r", encoding="utf-8") as fObj:
                     data = json.load(fObj)
                 self._words = set(data.get("novelWriter.userDict", []))
                 logger.info("Loaded: %s", nwFiles.DICT_FILE)
-            except Exception:
-                logger.error("Failed to load user dictionary")
-                logException()
+        except Exception:
+            logger.error("Failed to load user dictionary")
+            logException()
 
     def save(self) -> None:
         """Save the user's dictionary."""

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -235,7 +235,7 @@ class NWStorage:
                 if child.is_dir() and child.name.startswith("data_"):
                     legacy.legacyDataFolder(basePath, child)
         except Exception as exc:
-            logger.error("Failed to create project folders", exc_info=exc)
+            logger.error("Failed to scan project folder content", exc_info=exc)
             self.clear()
             return NWStorageOpen.FAILED
 

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 
 from novelwriter import CONFIG
-from novelwriter.common import isHandle, minmax
+from novelwriter.common import isHandle, minmax, safeExists, safeIsDir, safeIsFile, safeIterDir
 from novelwriter.constants import nwFiles
 from novelwriter.core.document import NWDocument
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter
@@ -112,8 +112,7 @@ class NWStorage:
         already exist, otherwise this property is None.
         """
         if isinstance(self._runtimePath, Path):
-            contentPath = self._runtimePath / "content"
-            if contentPath.is_dir():
+            if safeIsDir(contentPath := self._runtimePath / "content", alert=True):
                 return contentPath
         logger.error("Content path cannot be resolved")
         return None
@@ -141,7 +140,7 @@ class NWStorage:
     def createNewProject(self, path: str | Path) -> NWStorageCreate:
         """Create a new project at the given location."""
         inPath = Path(path).resolve()
-        if inPath.is_dir() and len(list(inPath.iterdir())) > 0:
+        if safeIsDir(inPath) and len(list(safeIterDir(inPath))) > 0:
             logger.error("Folder is not empty: %s", inPath)
             return NWStorageCreate.NOT_EMPTY
 
@@ -177,9 +176,9 @@ class NWStorage:
         # Check what we're opening. Only two options are allowed:
         # 1. A folder with an nwProject.nwx file in it (not home)
         # 2. A full path to an nwProject.nwx file
-        if inPath.is_dir() and inPath != Path.home().resolve():
+        if safeIsDir(inPath, alert=True) and inPath != Path.home().resolve():
             nwxFile = inPath / nwFiles.PROJ_FILE
-        elif inPath.is_file():
+        elif safeIsFile(inPath, alert=True):
             if inPath.name == nwFiles.PROJ_FILE:
                 nwxFile = inPath
             else:
@@ -189,7 +188,7 @@ class NWStorage:
             logger.error("Not found: %s", inPath)
             return NWStorageOpen.NOT_FOUND
 
-        if not nwxFile.exists():
+        if not safeExists(nwxFile, alert=True):
             # The .nwx file must exist to continue
             logger.error("Not found: %s", nwxFile)
             return NWStorageOpen.NOT_FOUND
@@ -229,11 +228,16 @@ class NWStorage:
             return NWStorageOpen.FAILED
 
         # Check for legacy data folders
-        legacy = _LegacyStorage(self._project)
-        legacy.deprecatedFiles(basePath)
-        for child in basePath.iterdir():
-            if child.is_dir() and child.name.startswith("data_"):
-                legacy.legacyDataFolder(basePath, child)
+        try:
+            legacy = _LegacyStorage(self._project)
+            legacy.deprecatedFiles(basePath)
+            for child in basePath.iterdir():
+                if child.is_dir() and child.name.startswith("data_"):
+                    legacy.legacyDataFolder(basePath, child)
+        except Exception as exc:
+            logger.error("Failed to create project folders", exc_info=exc)
+            self.clear()
+            return NWStorageOpen.FAILED
 
         self._ready = True
 
@@ -298,7 +302,7 @@ class NWStorage:
         """
         contentPath = self.contentPath
         return [
-            item.stem for item in contentPath.iterdir()
+            item.stem for item in safeIterDir(contentPath)
             if item.suffix == ".nwd" and isHandle(item.stem)
         ] if contentPath else []
 
@@ -312,24 +316,24 @@ class NWStorage:
             logger.error("No path set")
             return False
 
-        baseMeta = basePath / "meta"
-        baseCont = basePath / "content"
-        files = [
-            (basePath / nwFiles.PROJ_FILE,   nwFiles.PROJ_FILE),
-            (baseMeta / nwFiles.BUILDS_FILE, f"meta/{nwFiles.BUILDS_FILE}"),
-            (baseMeta / nwFiles.INDEX_FILE,  f"meta/{nwFiles.INDEX_FILE}"),
-            (baseMeta / nwFiles.OPTS_FILE,   f"meta/{nwFiles.OPTS_FILE}"),
-            (baseMeta / nwFiles.DICT_FILE,   f"meta/{nwFiles.DICT_FILE}"),
-            (baseMeta / nwFiles.SESS_FILE,   f"meta/{nwFiles.SESS_FILE}"),
-        ]
-        for contItem in baseCont.iterdir():
-            name = contItem.name
-            if contItem.is_file() and len(name) == 17 and name.endswith(".nwd"):
-                files.append((contItem, f"content/{name}"))
-
-        comp = ZIP_STORED if compression is None else ZIP_DEFLATED
-        level = minmax(compression, 0, 9) if isinstance(compression, int) else None
         try:
+            baseMeta = basePath / "meta"
+            baseCont = basePath / "content"
+            files = [
+                (basePath / nwFiles.PROJ_FILE,   nwFiles.PROJ_FILE),
+                (baseMeta / nwFiles.BUILDS_FILE, f"meta/{nwFiles.BUILDS_FILE}"),
+                (baseMeta / nwFiles.INDEX_FILE,  f"meta/{nwFiles.INDEX_FILE}"),
+                (baseMeta / nwFiles.OPTS_FILE,   f"meta/{nwFiles.OPTS_FILE}"),
+                (baseMeta / nwFiles.DICT_FILE,   f"meta/{nwFiles.DICT_FILE}"),
+                (baseMeta / nwFiles.SESS_FILE,   f"meta/{nwFiles.SESS_FILE}"),
+            ]
+            for contItem in baseCont.iterdir():
+                name = contItem.name
+                if contItem.is_file() and len(name) == 17 and name.endswith(".nwd"):
+                    files.append((contItem, f"content/{name}"))
+
+            comp = ZIP_STORED if compression is None else ZIP_DEFLATED
+            level = minmax(compression, 0, 9) if isinstance(compression, int) else None
             with ZipFile(target, mode="w", compression=comp, compresslevel=level) as zipObj:
                 logger.info("Creating archive: %s", target)
                 for srcPath, zipPath in files:
@@ -351,7 +355,7 @@ class NWStorage:
         """Read the project lock file."""
         self._lockedBy = None
         path = self._lockFilePath
-        if isinstance(path, Path) and path.exists():
+        if isinstance(path, Path) and safeExists(path):
             try:
                 self._lockedBy = path.read_text(encoding="utf-8").strip().split(";")
             except Exception:
@@ -380,7 +384,7 @@ class NWStorage:
         """Remove the lock file, if it exists."""
         if self._lockFilePath is None:
             return False
-        if self._lockFilePath.exists():
+        if safeExists(self._lockFilePath):
             try:
                 self._lockFilePath.unlink()
             except Exception:

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Literal, overload
 from PyQt6.QtCore import QModelIndex
 
 from novelwriter import SHARED
+from novelwriter.common import safeIsFile
 from novelwriter.constants import nwFiles, nwLabels, nwStyles, trConst
 from novelwriter.core.item import NWItem
 from novelwriter.core.itemmodel import ProjectModel, ProjectNode
@@ -372,7 +373,7 @@ class NWTree:
         for node in self._model.root.allChildren():
             item = node.item
             file = f"{item.itemHandle}.nwd"
-            if (contentPath / file).is_file():
+            if safeIsFile(contentPath / file):
                 tocLine = "{0:<25s}  {1:<9s}  {2:<8s}  {3:s}".format(
                     f"content/{file}",
                     item.itemClass.name,

--- a/novelwriter/extensions/versioninfo.py
+++ b/novelwriter/extensions/versioninfo.py
@@ -130,7 +130,8 @@ class VersionInfoWidget(QWidget):
                 f"{version} \u2013 {self._trDownload.format(download)}"
             ))
         else:
-            self._lblRelease.setText(self._trLatest.format(reason or self.tr("Failed")))
+            self._lblRelease.setText(self._trLatest.format(self.tr("Failed")))
+            logger.error("Could not retrieve version info: %s", reason)
 
 
 class _Retriever(QRunnable):

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-
 class GuiMainStatus(QStatusBar):
     """GUI: Main Window Status Bar."""
 

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -27,9 +27,10 @@ import logging
 
 from datetime import datetime
 from time import time
+from typing import TYPE_CHECKING
 
-from PyQt6.QtCore import pyqtSlot
-from PyQt6.QtWidgets import QApplication, QLabel, QStatusBar, QWidget
+from PyQt6.QtCore import QTimer, pyqtSlot
+from PyQt6.QtWidgets import QApplication, QHBoxLayout, QLabel, QStatusBar, QWidget
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatTime, languageName
@@ -37,7 +38,11 @@ from novelwriter.constants import nwConst, nwLabels, nwStats, trStats
 from novelwriter.extensions.modified import NClickableLabel
 from novelwriter.extensions.statusled import StatusLED
 
+if TYPE_CHECKING:
+    from novelwriter.types import T_MsgSeverity
+
 logger = logging.getLogger(__name__)
+
 
 
 class GuiMainStatus(QStatusBar):
@@ -53,6 +58,9 @@ class GuiMainStatus(QStatusBar):
         self._debugInfo = False
 
         iPx = SHARED.theme.baseIconHeight
+
+        self.messageBox = _MessageWidget(self)
+        self.insertWidget(0, self.messageBox)
 
         # Permanent Widgets
         # =================
@@ -195,10 +203,10 @@ class GuiMainStatus(QStatusBar):
     #  Public Slots
     ##
 
-    @pyqtSlot(str)
-    def setStatusMessage(self, message: str) -> None:
+    @pyqtSlot(str, str)
+    def setStatusMessage(self, message: str, severity: T_MsgSeverity = "info") -> None:
         """Set the status bar message to display."""
-        self.showMessage(message, nwConst.STATUS_MSG_TIMEOUT)
+        self.messageBox.setMessage(message, severity, nwConst.STATUS_MSG_TIMEOUT)
         QApplication.processEvents()
 
     @pyqtSlot(str, str)
@@ -265,3 +273,32 @@ class GuiMainStatus(QStatusBar):
         )
         self.showMessage(f"Debug [{stamp}] {message}", 6000)
         logger.debug("[MEMINFO] %s", message)
+
+
+class _MessageWidget(QWidget):
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self._icon = QLabel(self)
+        self._text = QLabel(self)
+
+        self._layout = QHBoxLayout()
+        self._layout.addWidget(self._icon)
+        self._layout.addWidget(self._text)
+        self._layout.setSpacing(4)
+        self._layout.setContentsMargins(4, 0, 0, 0)
+        self.setLayout(self._layout)
+
+    def setMessage(self, message: str, severity: str, timeout: int) -> None:
+        """Set a status bar message with a timeout."""
+        iSz = SHARED.theme.baseIconHeight
+        icon = severity.replace("warning", "warn")
+        self._icon.setPixmap(SHARED.theme.getPixmap(f"alert_{icon}", (iSz, iSz), severity))
+        self._text.setText(message)
+        QTimer.singleShot(timeout, self.clearMessage)
+
+    @pyqtSlot()
+    def clearMessage(self) -> None:
+        """Clear the current status bar message and icon."""
+        self._icon.clear()
+        self._text.clear()

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -39,7 +39,7 @@ from PyQt6.QtGui import (
 from PyQt6.QtWidgets import QApplication, QWidget
 
 from novelwriter import CONFIG
-from novelwriter.common import checkInt, minmax
+from novelwriter.common import checkInt, minmax, safeIsFile
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS, DEF_TREECOL
 from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwStandardButton, nwTheme
@@ -914,7 +914,7 @@ class GuiIcons:
             logger.error("Decoration with name '%s' does not exist", name)
             return QPixmap()
 
-        if not imgPath.is_file():
+        if not safeIsFile(imgPath):
             logger.error("Asset not found: %s", imgPath)
             return QPixmap()
 
@@ -1031,5 +1031,8 @@ class GuiIcons:
 
 def _listContent(data: list[Path], path: Path, extension: str) -> None:
     """List files of a specific type and extend the list."""
-    if path.is_dir():
-        data.extend(n for n in path.iterdir() if n.is_file() and n.suffix == extension)
+    try:
+        if path.is_dir():
+            data.extend(n for n in path.iterdir() if n.is_file() and n.suffix == extension)
+    except Exception:
+        logException()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -38,7 +38,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED, __hexversion__, __version__
-from novelwriter.common import formatFileFilter, formatVersion, hexToInt, minmax
+from novelwriter.common import formatFileFilter, formatVersion, hexToInt, minmax, safeIsFile
 from novelwriter.constants import nwConst
 from novelwriter.dialogs.about import GuiAbout
 from novelwriter.dialogs.preferences import GuiPreferences
@@ -106,7 +106,7 @@ class GuiMain(QMainWindow):
         self._updateWindowTitle()
 
         nwIcon = CONFIG.assetPath("icons") / "novelwriter.svg"
-        self.nwIcon = QIcon(str(nwIcon)) if nwIcon.is_file() else QIcon()
+        self.nwIcon = QIcon(str(nwIcon)) if safeIsFile(nwIcon) else QIcon()
         self.setWindowIcon(self.nwIcon)
         QApplication.setWindowIcon(self.nwIcon)
 

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from novelwriter.core.status import T_StatusKind
     from novelwriter.gui.theme import GuiTheme
     from novelwriter.guimain import GuiMain
+    from novelwriter.types import T_MsgSeverity
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ class SharedData(QObject):
     novelStructureChanged = pyqtSignal(str)
     projectItemChanged = pyqtSignal(str, Enum)
     projectStatusChanged = pyqtSignal(bool)
-    projectStatusMessage = pyqtSignal(str)
+    projectStatusMessage = pyqtSignal(str, str)
     rootFolderChanged = pyqtSignal(str, Enum)
     spellLanguageChanged = pyqtSignal(str, str)
     statusLabelsChanged = pyqtSignal(str)
@@ -291,9 +292,9 @@ class SharedData(QObject):
         if gui := self._gui:
             QTimer.singleShot(int(delay*1000), gui.mainProgress.reset)
 
-    def newStatusMessage(self, message: str) -> None:
+    def newStatusMessage(self, message: str | Exception, severity: T_MsgSeverity = "info") -> None:
         """Request a new status message."""
-        self.projectStatusMessage.emit(message)
+        self.projectStatusMessage.emit(str(message), severity)
 
     def setGlobalProjectState(self, state: bool) -> None:
         """Change the global project status."""

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -40,7 +40,7 @@ from novelwriter.common import (
     formatFileFilter, formatInt, getFileSize, joinLines, openExternalPath
 )
 from novelwriter.enum import nwStandardButton
-from novelwriter.error import formatException
+from novelwriter.error import formatException, logException
 from novelwriter.extensions.modified import NIconToolButton, NNonBlockingDialog
 from novelwriter.types import QtHexArgb, QtMoveEnd, QtRoleDestruct
 
@@ -152,16 +152,21 @@ class GuiDictionaries(NNonBlockingDialog):
             logger.error("Could not get enchant path")
             return False
 
-        if path.is_dir():
-            self.inPath.setText(str(path))
-            hunspell = path / "hunspell"
-            if hunspell.is_dir():
-                self._currDicts = set(
-                    i.stem for i in hunspell.iterdir() if i.is_file() and i.suffix == ".aff"
-                )
-            self._appendLog(self.tr(
-                "Additional dictionaries found: {0}"
-            ).format(len(self._currDicts)))
+        try:
+            if path.is_dir():
+                self.inPath.setText(str(path))
+                hunspell = path / "hunspell"
+                if hunspell.is_dir():
+                    self._currDicts = set(
+                        i.stem for i in hunspell.iterdir() if i.is_file() and i.suffix == ".aff"
+                    )
+                self._appendLog(self.tr(
+                    "Additional dictionaries found: {0}"
+                ).format(len(self._currDicts)))
+        except Exception as exc:
+            SHARED.newStatusMessage(exc, "error")
+            logger.error("Failed to load additional dictionaries")
+            logException()
 
         QApplication.processEvents()
         self.adjustSize()
@@ -200,18 +205,18 @@ class GuiDictionaries(NNonBlockingDialog):
         procErr = self.tr("Could not process dictionary file")
         if self._installPath:
             temp = self.huInput.text()
-            if temp and (path := Path(temp)).is_file():
-                try:
+            try:
+                if temp and (path := Path(temp)).is_file():
                     hunspell = self._installPath / "hunspell"
                     hunspell.mkdir(exist_ok=True)
                     nAff, nDic = self._extractDicts(path, hunspell)
                     if nAff == 0 or nDic == 0:
                         self._appendLog(procErr, err=True)
-                except Exception as exc:
+                else:
                     self._appendLog(procErr, err=True)
-                    self._appendLog(formatException(exc), err=True)
-            else:
+            except Exception as exc:
                 self._appendLog(procErr, err=True)
+                self._appendLog(formatException(exc), err=True)
 
     @pyqtSlot()
     def _doOpenInstallLocation(self) -> None:

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -37,7 +37,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import SHARED
-from novelwriter.common import makeFileNameSafe, openExternalPath
+from novelwriter.common import makeFileNameSafe, openExternalPath, safeExists, safeIsDir
 from novelwriter.constants import nwLabels
 from novelwriter.core.docbuild import NWBuildDocument
 from novelwriter.core.item import NWItem
@@ -272,7 +272,7 @@ class GuiManuscriptBuild(NDialog):
     def _doSelectPath(self) -> None:
         """Select a folder for output."""
         bPath = Path(self.buildPath.text())
-        bPath = bPath if bPath.is_dir() else self._build.lastBuildPath
+        bPath = bPath if safeIsDir(bPath) else self._build.lastBuildPath
         savePath = QFileDialog.getExistingDirectory(
             self, self.tr("Select Folder"), str(bPath)
         )
@@ -308,14 +308,14 @@ class GuiManuscriptBuild(NDialog):
 
         self.buildProgress.setValue(0)
         bPath = Path(self.buildPath.text())
-        if not bPath.is_dir():
+        if not safeIsDir(bPath):
             SHARED.error(self.tr("Output folder does not exist."))
             return False
 
         bExt = nwLabels.BUILD_EXT[bFormat]
         buildPath = (bPath / makeFileNameSafe(bName)).with_suffix(bExt)
 
-        if buildPath.exists():
+        if safeExists(buildPath):
             if not SHARED.question(
                 self.tr("The file already exists. Do you want to overwrite it?")
             ):

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -43,7 +43,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import formatInt, makeFileNameSafe, qtAddAction
+from novelwriter.common import formatInt, makeFileNameSafe, qtAddAction, safeIsFile
 from novelwriter.constants import nwFiles
 from novelwriter.core.coretools import ProjectBuilder
 from novelwriter.enum import nwItemClass, nwStandardButton
@@ -341,7 +341,7 @@ class _OpenProjectPage(QWidget):
         self.selectedPath.setText(text)
         self.selectedPath.setToolTip(text)
         self.selectedPath.setCursorPosition(0)
-        self.aMissing.setVisible(value != "" and not (Path(value) / nwFiles.PROJ_FILE).is_file())
+        self.aMissing.setVisible(value != "" and not safeIsFile(Path(value) / nwFiles.PROJ_FILE))
 
     @pyqtSlot(QModelIndex)
     def _projectDoubleClicked(self, index: QModelIndex) -> None:

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -23,12 +23,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """  # noqa
 from __future__ import annotations
 
+from typing import Literal
+
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import (
     QColor, QFont, QPainter, QPalette, QTextCharFormat, QTextCursor,
     QTextFormat
 )
 from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QHeaderView, QSizePolicy, QStyle
+
+# Custom Types
+
+T_MsgSeverity = Literal["info", "warning", "error"]
 
 # Alignment Flags
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ forced_separate = ["tests.*"]
 line-length = 99
 
 [tool.ruff.lint]
-preview = false
+preview = true
 
 # Rules: https://docs.astral.sh/ruff/rules
 select = [
@@ -122,8 +122,9 @@ ignore = [
     "PLW2901", # redefined-loop-name
     "RET505",  # superfluous-else-return
     "RUF001",  # ambiguous-unicode-character-string
-    "RUF002",  # ambiguous-unicode-character-docstring
     "RUF015",  # unnecessary-iterable-allocation-for-first-element
+    "RUF067",  # non-empty-init-module
+    "RUF069",  # float-equality-comparison
     "UP015",   # redundant-open-modes
     "UP030",   # format-literals
 ]
@@ -149,7 +150,7 @@ quote-style = "double"
 
 [tool.pyright]
 include = ["novelwriter"]
-exclude = ["**/__pycache__"]
+exclude = ["**/__pycache__", "**/.*"]
 
 reportIncompatibleMethodOverride = false
 pythonVersion = "3.11"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def functionFixture(qtbot):
         shutil.rmtree(_TMP_CONF)
     _TMP_CONF.mkdir()
 
-    CONFIG.__init__()
+    CONFIG.__init__()  # noqa: PLC2801
     CONFIG.initConfig(confPath=_TMP_CONF, dataPath=_TMP_CONF)
     resetConfigVars()
     logging.getLogger("novelwriter").setLevel(logging.INFO)

--- a/tests/test_base/test_base_common.py
+++ b/tests/test_base/test_base_common.py
@@ -39,8 +39,9 @@ from novelwriter.common import (
     isItemClass, isItemLayout, isItemType, isListInstance, isTitleTag,
     joinLines, jsonCombine, jsonEncode, languageName, makeFileNameSafe, minmax,
     numberToRoman, openExternalPath, processDialogSymbols, processLangCode,
-    readTextFile, simplified, transferCase, uniqueCompact, utf16CharMap,
-    xmlElement, xmlIndent, xmlSubElem, yesNo
+    readTextFile, safeExists, safeIsDir, safeIsFile, safeIterDir, simplified,
+    transferCase, uniqueCompact, utf16CharMap, xmlElement, xmlIndent,
+    xmlSubElem, yesNo
 )
 from novelwriter.enum import nwItemClass
 
@@ -572,6 +573,51 @@ def testBaseCommon_numberToRoman():
     assert numberToRoman(999, False) == "CMXCIX"
     assert numberToRoman(2010, False) == "MMX"
     assert numberToRoman(999, True) == "cmxcix"
+
+
+@pytest.mark.base
+def testBaseCommon_safeIterDir(fncPath: Path):
+    """Test the safeIterDir function."""
+    files = [
+        fncPath / "file1.txt",
+        fncPath / "file2.txt",
+        fncPath / "file3.txt",
+    ]
+    for file in files:
+        file.touch()
+
+    assert sorted(safeIterDir(fncPath, alert=True)) == files
+    assert list(safeIterDir(None, alert=True)) == []  # type: ignore
+
+
+@pytest.mark.base
+def testBaseCommon_safeExists(fncPath: Path):
+    """Test the safeExists function."""
+    file = fncPath / "file1.txt"
+    file.touch()
+
+    assert safeExists(file, alert=True) is True
+    assert safeExists(None, alert=True) is False  # type: ignore
+
+
+@pytest.mark.base
+def testBaseCommon_safeIsFile(fncPath: Path):
+    """Test the safeIsFile function."""
+    file = fncPath / "file1.txt"
+    file.touch()
+
+    assert safeIsFile(file, alert=True) is True
+    assert safeIsFile(None, alert=True) is False  # type: ignore
+
+
+@pytest.mark.base
+def testBaseCommon_safeIsDir(fncPath: Path):
+    """Test the safeIsDir function."""
+    folder = fncPath / "folder1"
+    folder.mkdir()
+
+    assert safeIsDir(folder, alert=True) is True
+    assert safeIsDir(None, alert=True) is False  # type: ignore
 
 
 @pytest.mark.base

--- a/tests/test_base/test_base_config.py
+++ b/tests/test_base/test_base_config.py
@@ -446,3 +446,17 @@ def testBaseConfig_RecentPaths(monkeypatch, tstPaths):
         mp.setattr("builtins.open", causeOSError)
         assert recent.saveCache() is False
         assert recent.loadCache() is False
+
+
+@pytest.mark.base
+def testBaseConfig_IOError(monkeypatch):
+    """Test handling of I/O errors when using pathlib."""
+    with monkeypatch.context() as mp:
+        mp.setattr(Path, "iterdir", causeOSError)
+        config = Config()  # Loading manuals will fail if not handled
+        assert config.listLanguages(config.LANG_NW) == [("en_GB", "British English")]
+
+    with monkeypatch.context() as mp:
+        config = Config()
+        mp.setattr(Path, "is_dir", causeOSError)
+        config.initConfig()

--- a/tests/test_core/test_core_storage.py
+++ b/tests/test_core/test_core_storage.py
@@ -167,7 +167,7 @@ def testCoreStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
 
 
 @pytest.mark.core
-def testCoreStorage_InitProjectStorage_Invalid(mockGUI, fncPath):
+def testCoreStorage_InitProjectStorage_Invalid(monkeypatch, mockGUI, fncPath):
     """Test initialising a project in an invalid folder."""
     project = NWProject()
 
@@ -199,6 +199,13 @@ def testCoreStorage_InitProjectStorage_Invalid(mockGUI, fncPath):
     # Add the project file, and we should now fail on the folders
     (fncPath / nwFiles.PROJ_FILE).touch()
     assert storage.initProjectStorage(fncPath) == NWStorageOpen.FAILED
+
+    # Remove the files blocking the folders, but make the legacy storage scan fail
+    (fncPath / "meta").unlink()
+    (fncPath / "content").unlink()
+    with monkeypatch.context() as mp:
+        mp.setattr(_LegacyStorage, "deprecatedFiles", causeOSError)
+        assert storage.initProjectStorage(fncPath) == NWStorageOpen.FAILED
 
     project.closeProject()
 

--- a/tests/test_ext/test_ext_versioninfo.py
+++ b/tests/test_ext/test_ext_versioninfo.py
@@ -109,9 +109,6 @@ def testExtVersionInfo_Main(qtbot, monkeypatch):
         "Latest Version: 2.0 – Download from <a href='#website'>novelwriter.io</a>"
     )
 
-    version._updateReleaseInfo("", "Error")
-    assert version._lblRelease.text() == "Latest Version: Error"
-
     version._updateReleaseInfo("", "")
     assert version._lblRelease.text() == "Latest Version: Failed"
 

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -1393,7 +1393,6 @@ def testFmtToken_LineForMargin(mockGUI):
     ]
 
 
-
 @pytest.mark.core
 def testFmtToken_ShortcodeValue(mockGUI):
     """Test processing of shortcodes with values."""
@@ -1418,6 +1417,7 @@ def testFmtToken_ShortcodeValue(mockGUI):
             (13, TextFmt.FIELD, f"{TMH}:abcd"),
         ], BlockFmt.NONE
     )]
+
 
 @pytest.mark.core
 def testFmtToken_Dialogue(mockGUI):

--- a/tests/test_gui/test_gui_statusbar.py
+++ b/tests/test_gui/test_gui_statusbar.py
@@ -123,4 +123,10 @@ def testGuiStatusBar_Main(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
         nwGUI._timeTick()
         assert status.statsText.text() == "Characters: 40 (+40)"
 
+    # Set message
+    status.messageBox.setMessage("Hi!", "info", 10000)
+    assert status.messageBox._text.text() == "Hi!"
+    status.messageBox.clearMessage()
+    assert status.messageBox._text.text() == ""
+
     # qtbot.stop()

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -92,9 +92,13 @@ def testGuiTheme_ParseColor():
 def testGuiTheme_ScanThemes(monkeypatch):
     """Test the themes scanning."""
     theme = GuiTheme()
+    files = []
+
+    # Invalid path should be handled silently
+    _listContent(files, None, ".conf")  # type: ignore
+    assert len(files) == 0
 
     # Load built-in themes
-    files = []
     _listContent(files, CONFIG.assetPath("themes"), ".conf")
     assert len(files) > 0
 

--- a/tests/test_tools/test_tools_dictionaries.py
+++ b/tests/test_tools/test_tools_dictionaries.py
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """  # noqa
 from __future__ import annotations
 
+from pathlib import Path
 from zipfile import ZipFile
 
 import enchant
@@ -31,7 +32,7 @@ from PyQt6.QtWidgets import QFileDialog
 from novelwriter import SHARED
 from novelwriter.tools.dictionaries import GuiDictionaries
 
-from tests.mocked import causeException
+from tests.mocked import causeException, causeOSError
 
 
 @pytest.mark.gui
@@ -144,6 +145,11 @@ def testToolDictionaries_Main(qtbot, monkeypatch, nwGUI, fncPath):
         assert nwDicts.infoBox.toPlainText().splitlines()[-1] == (
             "Could not process dictionary file"
         )
+
+    # Re-init and fail to scan for dictionaries
+    with monkeypatch.context() as mp:
+        mp.setattr(Path, "iterdir", causeOSError)
+        nwDicts.initDialog()
 
     # Re-init
     nwDicts.initDialog()


### PR DESCRIPTION
**Summary:**

This PR adds exception handling to `Path.iterdir()`, `Path.exists()`, `Path.is_file()` and `Path.is_dir()` where they weren't already wrapped in exception handlers. It turns out that these can all raise PermissionError.

This was discovered on later MacOS where novelWriter by default runs under some restrictions. These errors should not crash the app.

The following changes are also included:
* Added a custom status message widget to the statusbar that also includes an icon.
* The pathlib safe helper functions can optional emit a warning to the status bar.
* The version info widget no longer prints the HTTP error if it fails and instead just prints "Failed".
* Ruff preview rules are enabled again since most pycodestyle rules are under this flag.

**Related Issue(s):**

Closes #2671

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
