### PR TITLE
Update document headers

### DIFF
--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -436,9 +436,9 @@ class NWTree:
 
     def itemPath(self, tHandle: str, withName: bool = False) -> list:
         """Iterate upwards in the tree until we find the item with
-        parent None, the root item, and return the list of handles, or
-        alternatively item names. We do this with a for loop with a
-        maximum depth to make infinite loops impossible.
+        parent None, the root item, and return the list of handles,
+        alternatively including item names. We do this with a for loop
+        with a maximum depth to make infinite loops impossible.
         """
         path = []
         if node := self._nodes.get(tHandle):

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -428,7 +428,13 @@ class NWTree:
             return tItem.itemType == itemType
         return False
 
-    def itemPath(self, tHandle: str, asName: bool = False) -> list[str]:
+    @overload
+    def itemPath(self, tHandle: str, withName: Literal[True]) -> list[tuple[str, str]]: ...
+
+    @overload
+    def itemPath(self, tHandle: str, withName: Literal[False]) -> list[str]: ...
+
+    def itemPath(self, tHandle: str, withName: bool = False) -> list:
         """Iterate upwards in the tree until we find the item with
         parent None, the root item, and return the list of handles, or
         alternatively item names. We do this with a for loop with a
@@ -437,8 +443,8 @@ class NWTree:
         path = []
         if node := self._nodes.get(tHandle):
             for _ in range(MAX_DEPTH):
-                if parent := node.parent():
-                    path.append(node.item.itemName if asName else tHandle)
+                if (parent := node.parent()) and (item := node.item):
+                    path.append((item.itemHandle, item.itemName) if withName else tHandle)
                     node = parent
                 else:
                     return path

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -36,7 +36,7 @@ from PyQt6.QtWidgets import (
 
 from novelwriter.constants import nwUnicode
 from novelwriter.enum import nwState
-from novelwriter.types import QtBlack, QtHexArgb, QtScrollAsNeeded
+from novelwriter.types import QtHexArgb, QtScrollAsNeeded
 
 DEFAULT_SCALE = 0.9
 
@@ -280,21 +280,6 @@ class NColorLabel(QLabel):
         self.setWordWrap(wrap)
         self.setColorState(nwState.NORMAL)
 
-    def clear(self) -> None:
-        """Overload clear to also clear path text."""
-        self._crumbs = ""
-        super().clear()
-
-    def setPathText(self, crumbs: list[tuple[str, str]]) -> None:
-        """Set a clickable crumb-trail of links."""
-        self._crumbs = ("<font style='color: #000000'>{inner}</font>".format(
-            inner=f"  {nwUnicode.U_RSAQUO}  ".join(reversed([
-                f"<a href='#{h}' style='color: #000000; text-decoration: none'>{n}</a>"
-                for h, n in crumbs
-            ]))
-        ))
-        self._refeshTextColor()
-
     def setTextColors(
         self, *, color: QColor | None = None,
         faded: QColor | None = None, error: QColor | None = None,
@@ -313,20 +298,41 @@ class NColorLabel(QLabel):
 
     def _refeshTextColor(self) -> None:
         """Refresh the colour of the text on the label."""
-        color = QtBlack
+        palette = self.palette()
         match self._state:
             case nwState.NORMAL:
-                color = self._color
+                palette.setColor(QPalette.ColorRole.Text, self._color)
             case nwState.INACTIVE:
-                color = self._faded
+                palette.setColor(QPalette.ColorRole.Text, self._faded)
             case nwState.ERROR:
-                color = self._error
-
-        palette = self.palette()
-        palette.setColor(QPalette.ColorRole.Text, color)
+                palette.setColor(QPalette.ColorRole.Text, self._error)
         self.setPalette(palette)
-        if self._crumbs:
-            self.setText(self._crumbs.replace("#000000", color.name(QtHexArgb)))
+
+
+class NPathColorLabel(NColorLabel):
+    """Extension: A Coloured Label for Paths."""
+
+    _text = ""
+
+    def setText(self, value: str | list[tuple[str, str]]) -> None:
+        """Set the text or a clickable crumb-trail of links."""
+        if isinstance(value, str):
+            self._text = ""
+            super().setText(value)
+        else:
+            self._text = ("<font style='color: #000000'>{inner}</font>".format(
+                inner=f"  {nwUnicode.U_RSAQUO}  ".join(reversed([
+                    f"<a href='#{h}' style='color: #000000; text-decoration: none'>{n}</a>"
+                    for h, n in value
+                ]))
+            ))
+            self._refeshTextColor()
+
+    def _refeshTextColor(self) -> None:
+        """Refresh the colour of the text on the label."""
+        super()._refeshTextColor()
+        color = self.palette().text().color().name(QtHexArgb)
+        super().setText(self._text.replace("#000000", color))
 
 
 class NWrappedWidgetBox(QHBoxLayout):

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -27,14 +27,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """  # noqa
 from __future__ import annotations
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor, QFont, QPalette
 from PyQt6.QtWidgets import (
     QAbstractButton, QFrame, QHBoxLayout, QLabel, QLayout, QScrollArea,
     QVBoxLayout, QWidget
 )
 
+from novelwriter.constants import nwUnicode
 from novelwriter.enum import nwState
-from novelwriter.types import QtScrollAsNeeded
+from novelwriter.types import QtBlack, QtHexArgb, QtScrollAsNeeded
 
 DEFAULT_SCALE = 0.9
 
@@ -266,23 +268,31 @@ class NColorLabel(QLabel):
         self._color = color or default
         self._faded = faded or default
         self._error = error or default
+        self._crumbs = ""
 
         font = self.font()
         font.setPointSizeF(scale*font.pointSizeF())
         font.setWeight(QFont.Weight.Bold if bold else QFont.Weight.Normal)
-        if color:
-            colour = self.palette()
-            colour.setColor(QPalette.ColorRole.WindowText, color)
-            self.setPalette(colour)
 
+        self.setTextFormat(Qt.TextFormat.RichText)
         self.setFont(font)
         self.setIndent(indent)
         self.setWordWrap(wrap)
         self.setColorState(nwState.NORMAL)
 
+    def setPathText(self, crumbs: list[tuple[str, str]]) -> None:
+        """Set a clickable crumb-trail of links."""
+        self._crumbs = ("<font style='color: #000000'>{inner}</font>".format(
+            inner=f"  {nwUnicode.U_RSAQUO}  ".join(reversed([
+                f"<a href='#{h}' style='color: #000000; text-decoration: none'>{n}</a>"
+                for h, n in crumbs
+            ]))
+        ))
+        self._refeshTextColor()
+
     def setTextColors(
         self, *, color: QColor | None = None,
-        faded: QColor | None = None, error: QColor | None = None
+        faded: QColor | None = None, error: QColor | None = None,
     ) -> None:
         """Set or update the text colours."""
         self._color = color or self._color
@@ -298,15 +308,20 @@ class NColorLabel(QLabel):
 
     def _refeshTextColor(self) -> None:
         """Refresh the colour of the text on the label."""
-        palette = self.palette()
+        color = QtBlack
         match self._state:
             case nwState.NORMAL:
-                palette.setColor(QPalette.ColorRole.WindowText, self._color)
+                color = self._color
             case nwState.INACTIVE:
-                palette.setColor(QPalette.ColorRole.WindowText, self._faded)
+                color = self._faded
             case nwState.ERROR:
-                palette.setColor(QPalette.ColorRole.WindowText, self._error)
+                color = self._error
+
+        palette = self.palette()
+        palette.setColor(QPalette.ColorRole.Text, color)
         self.setPalette(palette)
+        if self._crumbs:
+            self.setText(self._crumbs.replace("#000000", color.name(QtHexArgb)))
 
 
 class NWrappedWidgetBox(QHBoxLayout):

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -280,6 +280,11 @@ class NColorLabel(QLabel):
         self.setWordWrap(wrap)
         self.setColorState(nwState.NORMAL)
 
+    def clear(self) -> None:
+        """Overload clear to also clear path text."""
+        self._crumbs = ""
+        super().clear()
+
     def setPathText(self, crumbs: list[tuple[str, str]]) -> None:
         """Set a clickable crumb-trail of links."""
         self._crumbs = ("<font style='color: #000000'>{inner}</font>".format(

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -301,11 +301,11 @@ class NColorLabel(QLabel):
         palette = self.palette()
         match self._state:
             case nwState.NORMAL:
-                palette.setColor(QPalette.ColorRole.Text, self._color)
+                palette.setColor(QPalette.ColorRole.WindowText, self._color)
             case nwState.INACTIVE:
-                palette.setColor(QPalette.ColorRole.Text, self._faded)
+                palette.setColor(QPalette.ColorRole.WindowText, self._faded)
             case nwState.ERROR:
-                palette.setColor(QPalette.ColorRole.Text, self._error)
+                palette.setColor(QPalette.ColorRole.WindowText, self._error)
         self.setPalette(palette)
 
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -3250,7 +3250,7 @@ class GuiDocEditHeader(QWidget):
         self.itemTitle.setContentsMargins(0, 0, 0, 0)
         self.itemTitle.setAutoFillBackground(True)
         self.itemTitle.setAlignment(QtAlignCenterTop)
-        self.itemTitle.setFixedHeight(iPx)
+        self.itemTitle.setFixedHeight(SHARED.theme.fontPixelSize)
 
         # Other Widgets
         self.outlineMenu = QMenu(self)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -77,12 +77,13 @@ from novelwriter.text.counting import standardCounter
 from novelwriter.tools.lipsum import GuiLipsum
 from novelwriter.types import (
     QtAlignCenterTop, QtAlignJustify, QtAlignLeft, QtAlignLeftTop,
-    QtAlignRight, QtBlack, QtImCurrentSelection, QtImCursorRectangle,
-    QtKeepAnchor, QtModCtrl, QtModNone, QtModShift, QtMoveAnchor, QtMoveDown,
-    QtMoveEnd, QtMoveEndOfLine, QtMoveEndOfWord, QtMoveLeft, QtMoveNextChar,
-    QtMoveNextWord, QtMovePreviousWord, QtMoveRight, QtMoveStart,
-    QtMoveStartOfLine, QtMoveUp, QtScrollAlwaysOff, QtScrollAsNeeded,
-    QtSelectBlock, QtSelectDocument, QtSelectLine, QtSelectWord, QtTransparent
+    QtAlignMiddle, QtAlignRight, QtBlack, QtImCurrentSelection,
+    QtImCursorRectangle, QtKeepAnchor, QtModCtrl, QtModNone, QtModShift,
+    QtMoveAnchor, QtMoveDown, QtMoveEnd, QtMoveEndOfLine, QtMoveEndOfWord,
+    QtMoveLeft, QtMoveNextChar, QtMoveNextWord, QtMovePreviousWord,
+    QtMoveRight, QtMoveStart, QtMoveStartOfLine, QtMoveUp, QtScrollAlwaysOff,
+    QtScrollAsNeeded, QtSelectBlock, QtSelectDocument, QtSelectLine,
+    QtSelectWord, QtTransparent
 )
 
 logger = logging.getLogger(__name__)
@@ -3239,6 +3240,7 @@ class GuiDocEditHeader(QWidget):
 
         iPx = SHARED.theme.baseIconHeight
         iSz = SHARED.theme.baseIconSize
+        fPx = SHARED.theme.fontPixelSize
 
         # Main Widget Settings
         self.setAutoFillBackground(True)
@@ -3249,7 +3251,7 @@ class GuiDocEditHeader(QWidget):
         self.itemTitle.setContentsMargins(0, 0, 0, 0)
         self.itemTitle.setAutoFillBackground(True)
         self.itemTitle.setAlignment(QtAlignCenterTop)
-        self.itemTitle.setFixedHeight(SHARED.theme.fontPixelSize)
+        self.itemTitle.setFixedHeight(fPx)
         self.itemTitle.linkActivated.connect(self._processLabelLink)
 
         # Other Widgets
@@ -3283,15 +3285,15 @@ class GuiDocEditHeader(QWidget):
 
         # Assemble Layout
         self.outerBox = QHBoxLayout()
-        self.outerBox.addWidget(self.tbButton, 0)
-        self.outerBox.addWidget(self.outlineButton, 0)
-        self.outerBox.addWidget(self.searchButton, 0)
+        self.outerBox.addWidget(self.tbButton, 0, QtAlignMiddle)
+        self.outerBox.addWidget(self.outlineButton, 0, QtAlignMiddle)
+        self.outerBox.addWidget(self.searchButton, 0, QtAlignMiddle)
         self.outerBox.addSpacing(4)
-        self.outerBox.addWidget(self.itemTitle, 1)
+        self.outerBox.addWidget(self.itemTitle, 1, QtAlignMiddle)
         self.outerBox.addSpacing(4)
         self.outerBox.addSpacing(iPx)
-        self.outerBox.addWidget(self.minmaxButton, 0)
-        self.outerBox.addWidget(self.closeButton, 0)
+        self.outerBox.addWidget(self.minmaxButton, 0, QtAlignMiddle)
+        self.outerBox.addWidget(self.closeButton, 0, QtAlignMiddle)
         self.outerBox.setContentsMargins(4, 4, 4, 4)
         self.outerBox.setSpacing(0)
 
@@ -3303,7 +3305,7 @@ class GuiDocEditHeader(QWidget):
         # Fix Margins and Size
         # This is needed for high DPI systems. See issue #499.
         self.setContentsMargins(0, 0, 0, 0)
-        self.setMinimumHeight(iPx + 8)
+        self.setMinimumHeight(fPx + 4)
 
         self.updateFont()
         self.updateTheme()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -3321,7 +3321,7 @@ class GuiDocEditHeader(QWidget):
         self._docHandle = None
         self._docOutline = {}
 
-        self.itemTitle.setText("")
+        self.itemTitle.clear()
         self.outlineMenu.clear()
         self.tbButton.setVisible(False)
         self.outlineButton.setVisible(False)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -67,7 +67,7 @@ from novelwriter.enum import (
     nwChange, nwComment, nwDocAction, nwDocInsert, nwDocMode, nwItemClass,
     nwItemType, nwState, nwVimMode
 )
-from novelwriter.extensions.configlayout import NColorLabel
+from novelwriter.extensions.configlayout import NPathColorLabel
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton
 from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE
@@ -3246,7 +3246,7 @@ class GuiDocEditHeader(QWidget):
         self.setAutoFillBackground(True)
 
         # Title Label
-        self.itemTitle = NColorLabel("", self)
+        self.itemTitle = NPathColorLabel("", self)
         self.itemTitle.setMargin(0)
         self.itemTitle.setContentsMargins(0, 0, 0, 0)
         self.itemTitle.setAutoFillBackground(True)
@@ -3321,7 +3321,7 @@ class GuiDocEditHeader(QWidget):
         self._docHandle = None
         self._docOutline = {}
 
-        self.itemTitle.clear()
+        self.itemTitle.setText("")
         self.outlineMenu.clear()
         self.tbButton.setVisible(False)
         self.outlineButton.setVisible(False)
@@ -3396,9 +3396,9 @@ class GuiDocEditHeader(QWidget):
         """
         self._docHandle = tHandle
         if CONFIG.showFullPath:
-            self.itemTitle.setPathText(SHARED.project.tree.itemPath(tHandle, withName=True))
+            self.itemTitle.setText(SHARED.project.tree.itemPath(tHandle, withName=True))
         elif item := SHARED.project.tree[tHandle]:
-            self.itemTitle.setPathText([(item.itemHandle, item.itemName)])
+            self.itemTitle.setText([(item.itemHandle, item.itemName)])
 
         self.tbButton.setVisible(True)
         self.searchButton.setVisible(True)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -78,12 +78,11 @@ from novelwriter.tools.lipsum import GuiLipsum
 from novelwriter.types import (
     QtAlignCenterTop, QtAlignJustify, QtAlignLeft, QtAlignLeftTop,
     QtAlignRight, QtBlack, QtImCurrentSelection, QtImCursorRectangle,
-    QtKeepAnchor, QtModCtrl, QtModNone, QtModShift, QtMouseLeft, QtMoveAnchor,
-    QtMoveDown, QtMoveEnd, QtMoveEndOfLine, QtMoveEndOfWord, QtMoveLeft,
-    QtMoveNextChar, QtMoveNextWord, QtMovePreviousWord, QtMoveRight,
-    QtMoveStart, QtMoveStartOfLine, QtMoveUp, QtScrollAlwaysOff,
-    QtScrollAsNeeded, QtSelectBlock, QtSelectDocument, QtSelectLine,
-    QtSelectWord, QtTransparent
+    QtKeepAnchor, QtModCtrl, QtModNone, QtModShift, QtMoveAnchor, QtMoveDown,
+    QtMoveEnd, QtMoveEndOfLine, QtMoveEndOfWord, QtMoveLeft, QtMoveNextChar,
+    QtMoveNextWord, QtMovePreviousWord, QtMoveRight, QtMoveStart,
+    QtMoveStartOfLine, QtMoveUp, QtScrollAlwaysOff, QtScrollAsNeeded,
+    QtSelectBlock, QtSelectDocument, QtSelectLine, QtSelectWord, QtTransparent
 )
 
 logger = logging.getLogger(__name__)
@@ -3251,6 +3250,7 @@ class GuiDocEditHeader(QWidget):
         self.itemTitle.setAutoFillBackground(True)
         self.itemTitle.setAlignment(QtAlignCenterTop)
         self.itemTitle.setFixedHeight(SHARED.theme.fontPixelSize)
+        self.itemTitle.linkActivated.connect(self._processLabelLink)
 
         # Other Widgets
         self.outlineMenu = QMenu(self)
@@ -3393,13 +3393,10 @@ class GuiDocEditHeader(QWidget):
         the whole document path within the project.
         """
         self._docHandle = tHandle
-
         if CONFIG.showFullPath:
-            self.itemTitle.setText(f"  {nwUnicode.U_RSAQUO}  ".join(reversed(
-                [name for name in SHARED.project.tree.itemPath(tHandle, asName=True)]
-            )))
-        else:
-            self.itemTitle.setText(i.itemName if (i := SHARED.project.tree[tHandle]) else "")
+            self.itemTitle.setPathText(SHARED.project.tree.itemPath(tHandle, withName=True))
+        elif item := SHARED.project.tree[tHandle]:
+            self.itemTitle.setPathText([(item.itemHandle, item.itemName)])
 
         self.tbButton.setVisible(True)
         self.searchButton.setVisible(True)
@@ -3432,16 +3429,11 @@ class GuiDocEditHeader(QWidget):
         """Reset the colour state of the header title."""
         self.itemTitle.setColorState(self._state)
 
-    ##
-    #  Events
-    ##
-
-    def mousePressEvent(self, event: QMouseEvent) -> None:
-        """Capture a click on the title and ensure that the item is
-        selected in the project tree.
-        """
-        if event.button() == QtMouseLeft:
-            self.docEditor.requestProjectItemSelected.emit(self._docHandle or "", True)
+    @pyqtSlot(str)
+    def _processLabelLink(self, link: str) -> None:
+        """Process an activated link in the label."""
+        if link.startswith("#"):
+            self.docEditor.requestProjectItemSelected.emit(link.lstrip("#"), True)
 
 
 class GuiDocEditFooter(QWidget):

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -45,7 +45,7 @@ from novelwriter.common import decodeMimeHandles, qtAddAction, qtLambda
 from novelwriter.constants import nwConst, nwStyles, nwUnicode
 from novelwriter.enum import nwChange, nwComment, nwDocAction, nwDocMode, nwItemType, nwState
 from novelwriter.error import logException
-from novelwriter.extensions.configlayout import NColorLabel
+from novelwriter.extensions.configlayout import NPathColorLabel
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.formats.shared import TextDocumentTheme
@@ -614,7 +614,7 @@ class GuiDocViewHeader(QWidget):
         self.setAutoFillBackground(True)
 
         # Title Label
-        self.itemTitle = NColorLabel("", self, faded=SHARED.theme.fadedText)
+        self.itemTitle = NPathColorLabel("", self, faded=SHARED.theme.fadedText)
         self.itemTitle.setMargin(0)
         self.itemTitle.setContentsMargins(0, 0, 0, 0)
         self.itemTitle.setAutoFillBackground(True)
@@ -691,7 +691,7 @@ class GuiDocViewHeader(QWidget):
         self._docHandle = None
         self._docOutline = {}
 
-        self.itemTitle.clear()
+        self.itemTitle.setText("")
         self.outlineMenu.clear()
         self.outlineButton.setVisible(False)
         self.backButton.setVisible(False)
@@ -770,9 +770,9 @@ class GuiDocViewHeader(QWidget):
         """
         self._docHandle = tHandle
         if CONFIG.showFullPath:
-            self.itemTitle.setPathText(SHARED.project.tree.itemPath(tHandle, withName=True))
+            self.itemTitle.setText(SHARED.project.tree.itemPath(tHandle, withName=True))
         elif item := SHARED.project.tree[tHandle]:
-            self.itemTitle.setPathText([(item.itemHandle, item.itemName)])
+            self.itemTitle.setText([(item.itemHandle, item.itemName)])
 
         self.backButton.setVisible(True)
         self.forwardButton.setVisible(True)

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -691,7 +691,7 @@ class GuiDocViewHeader(QWidget):
         self._docHandle = None
         self._docOutline = {}
 
-        self.itemTitle.setText("")
+        self.itemTitle.clear()
         self.outlineMenu.clear()
         self.outlineButton.setVisible(False)
         self.backButton.setVisible(False)

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -52,8 +52,9 @@ from novelwriter.formats.shared import TextDocumentTheme
 from novelwriter.formats.toqdoc import ToQTextDocument
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import (
-    QtAlignCenterTop, QtKeepAnchor, QtMoveAnchor, QtScrollAlwaysOff,
-    QtScrollAsNeeded, QtSelectBlock, QtSelectDocument, QtSelectWord
+    QtAlignCenterTop, QtAlignMiddle, QtKeepAnchor, QtMoveAnchor,
+    QtScrollAlwaysOff, QtScrollAsNeeded, QtSelectBlock, QtSelectDocument,
+    QtSelectWord
 )
 
 logger = logging.getLogger(__name__)
@@ -606,8 +607,8 @@ class GuiDocViewHeader(QWidget):
         self._docHandle = None
         self._docOutline: dict[str, tuple[str, int]] = {}
 
-        iPx = SHARED.theme.baseIconHeight
         iSz = SHARED.theme.baseIconSize
+        fPx = SHARED.theme.fontPixelSize
 
         # Main Widget Settings
         self.setAutoFillBackground(True)
@@ -618,7 +619,7 @@ class GuiDocViewHeader(QWidget):
         self.itemTitle.setContentsMargins(0, 0, 0, 0)
         self.itemTitle.setAutoFillBackground(True)
         self.itemTitle.setAlignment(QtAlignCenterTop)
-        self.itemTitle.setFixedHeight(SHARED.theme.fontPixelSize)
+        self.itemTitle.setFixedHeight(fPx)
         self.itemTitle.linkActivated.connect(self._processLabelLink)
 
         # Other Widgets
@@ -657,15 +658,15 @@ class GuiDocViewHeader(QWidget):
 
         # Assemble Layout
         self.outerBox = QHBoxLayout()
-        self.outerBox.addWidget(self.outlineButton, 0)
-        self.outerBox.addWidget(self.backButton, 0)
-        self.outerBox.addWidget(self.forwardButton, 0)
+        self.outerBox.addWidget(self.outlineButton, 0, QtAlignMiddle)
+        self.outerBox.addWidget(self.backButton, 0, QtAlignMiddle)
+        self.outerBox.addWidget(self.forwardButton, 0, QtAlignMiddle)
         self.outerBox.addSpacing(4)
-        self.outerBox.addWidget(self.itemTitle, 1)
+        self.outerBox.addWidget(self.itemTitle, 1, QtAlignMiddle)
         self.outerBox.addSpacing(4)
-        self.outerBox.addWidget(self.editButton, 0)
-        self.outerBox.addWidget(self.refreshButton, 0)
-        self.outerBox.addWidget(self.closeButton, 0)
+        self.outerBox.addWidget(self.editButton, 0, QtAlignMiddle)
+        self.outerBox.addWidget(self.refreshButton, 0, QtAlignMiddle)
+        self.outerBox.addWidget(self.closeButton, 0, QtAlignMiddle)
         self.outerBox.setSpacing(0)
 
         self.setLayout(self.outerBox)
@@ -674,7 +675,7 @@ class GuiDocViewHeader(QWidget):
         # This is needed for high DPI systems. See issue #499.
         self.setContentsMargins(0, 0, 0, 0)
         self.outerBox.setContentsMargins(4, 4, 4, 4)
-        self.setMinimumHeight(iPx + 8)
+        self.setMinimumHeight(fPx + 4)
 
         self.updateFont()
         self.updateTheme()

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -52,9 +52,8 @@ from novelwriter.formats.shared import TextDocumentTheme
 from novelwriter.formats.toqdoc import ToQTextDocument
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import (
-    QtAlignCenterTop, QtKeepAnchor, QtMouseLeft, QtMoveAnchor,
-    QtScrollAlwaysOff, QtScrollAsNeeded, QtSelectBlock, QtSelectDocument,
-    QtSelectWord
+    QtAlignCenterTop, QtKeepAnchor, QtMoveAnchor, QtScrollAlwaysOff,
+    QtScrollAsNeeded, QtSelectBlock, QtSelectDocument, QtSelectWord
 )
 
 logger = logging.getLogger(__name__)
@@ -620,6 +619,7 @@ class GuiDocViewHeader(QWidget):
         self.itemTitle.setAutoFillBackground(True)
         self.itemTitle.setAlignment(QtAlignCenterTop)
         self.itemTitle.setFixedHeight(SHARED.theme.fontPixelSize)
+        self.itemTitle.linkActivated.connect(self._processLabelLink)
 
         # Other Widgets
         self.outlineMenu = QMenu(self)
@@ -755,7 +755,8 @@ class GuiDocViewHeader(QWidget):
         palette.setColor(QPalette.ColorRole.Text, syntax.text)
         self.setPalette(palette)
         self.itemTitle.setTextColors(
-            color=palette.windowText().color(), faded=SHARED.theme.fadedText
+            color=palette.windowText().color(),
+            faded=SHARED.theme.fadedText,
         )
 
     def changeFocusState(self, state: bool) -> None:
@@ -763,17 +764,14 @@ class GuiDocViewHeader(QWidget):
         self.itemTitle.setColorState(nwState.NORMAL if state else nwState.INACTIVE)
 
     def setHandle(self, tHandle: str) -> None:
-        """Set the document title from the handle, or alternatively,
-        set the whole document path.
+        """Set the document title from the handle, or alternatively, set
+        the whole document path within the project.
         """
         self._docHandle = tHandle
-
         if CONFIG.showFullPath:
-            self.itemTitle.setText(f"  {nwUnicode.U_RSAQUO}  ".join(reversed(
-                [name for name in SHARED.project.tree.itemPath(tHandle, asName=True)]
-            )))
-        else:
-            self.itemTitle.setText(i.itemName if (i := SHARED.project.tree[tHandle]) else "")
+            self.itemTitle.setPathText(SHARED.project.tree.itemPath(tHandle, withName=True))
+        elif item := SHARED.project.tree[tHandle]:
+            self.itemTitle.setPathText([(item.itemHandle, item.itemName)])
 
         self.backButton.setVisible(True)
         self.forwardButton.setVisible(True)
@@ -808,16 +806,11 @@ class GuiDocViewHeader(QWidget):
         if tHandle := self._docHandle:
             self.docViewer.openDocumentRequest.emit(tHandle, nwDocMode.EDIT, "", True)
 
-    ##
-    #  Events
-    ##
-
-    def mousePressEvent(self, event: QMouseEvent) -> None:
-        """Capture a click on the title and ensure that the item is
-        selected in the project tree.
-        """
-        if event.button() == QtMouseLeft:
-            self.docViewer.requestProjectItemSelected.emit(self._docHandle, True)
+    @pyqtSlot(str)
+    def _processLabelLink(self, link: str) -> None:
+        """Process an activated link in the label."""
+        if link.startswith("#"):
+            self.docViewer.requestProjectItemSelected.emit(link.lstrip("#"), True)
 
 
 class GuiDocViewFooter(QWidget):

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -619,7 +619,7 @@ class GuiDocViewHeader(QWidget):
         self.itemTitle.setContentsMargins(0, 0, 0, 0)
         self.itemTitle.setAutoFillBackground(True)
         self.itemTitle.setAlignment(QtAlignCenterTop)
-        self.itemTitle.setFixedHeight(iPx)
+        self.itemTitle.setFixedHeight(SHARED.theme.fontPixelSize)
 
         # Other Widgets
         self.outlineMenu = QMenu(self)

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -380,10 +380,16 @@ def testCoreTree_ItemMethods(monkeypatch, mockGUI, mockItems):
     assert tree.checkType(C.hInvalid, nwItemType.FILE) is False
 
     # Item Path
-    assert tree.itemPath(C.hSceneDoc, asName=True) == ["New Scene", "New Folder", "Novel"]
+    assert tree.itemPath(C.hSceneDoc, withName=True) == [
+        ("000000000000f", "New Scene"),
+        ("000000000000d", "New Folder"),
+        ("0000000000008", "Novel"),
+    ]
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.tree.MAX_DEPTH", 1)
-        assert tree.itemPath(C.hSceneDoc, asName=True) == ["New Scene"]
+        assert tree.itemPath(C.hSceneDoc, withName=True) == [
+            ("000000000000f", "New Scene"),
+        ]
 
     # Sub Tree
     assert tree.subTree(C.hInvalid) == []

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -86,7 +86,13 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert docEditor.horizontalScrollBarPolicy() == QtScrollAsNeeded
     assert docEditor._autoReplace._padChar == nwUnicode.U_NBSP
     assert docEditor.docHeader.itemTitle.text() == (
-        "Novel  \u203a  New Folder  \u203a  New Scene"
+        "<font style='color: #ff303030'>"
+        "<a href='#ff3030300000008' style='color: #ff303030; text-decoration: none'>Novel</a>"
+        "  \u203a  "
+        "<a href='#ff303030000000d' style='color: #ff303030; text-decoration: none'>New Folder</a>"
+        "  \u203a  "
+        "<a href='#ff303030000000f' style='color: #ff303030; text-decoration: none'>New Scene</a>"
+        "</font>"
     )
     assert docEditor.docHeader._docOutline == {0: "### New Scene"}
 
@@ -110,7 +116,11 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert docEditor.verticalScrollBarPolicy() == QtScrollAlwaysOff
     assert docEditor.horizontalScrollBarPolicy() == QtScrollAlwaysOff
     assert docEditor._autoReplace._padChar == nwUnicode.U_THNBSP
-    assert docEditor.docHeader.itemTitle.text() == "New Scene"
+    assert docEditor.docHeader.itemTitle.text() == (
+        "<font style='color: #ff303030'>"
+        "<a href='#ff303030000000f' style='color: #ff303030; text-decoration: none'>New Scene</a>"
+        "</font>"
+    )
 
     # Header
     # ======
@@ -122,7 +132,7 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     # Select item from header
     with qtbot.waitSignal(docEditor.requestProjectItemSelected, timeout=1000) as signal:
-        qtbot.mouseClick(docEditor.docHeader, QtMouseLeft)
+        docEditor.docHeader._processLabelLink(f"#{docEditor.docHeader._docHandle}")
         assert signal.args == [docEditor.docHeader._docHandle, True]
 
     # Close from header
@@ -133,11 +143,7 @@ def testGuiEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     assert docEditor.docHeader.searchButton.isVisible() is False
     assert docEditor.docHeader.closeButton.isVisible() is False
     assert docEditor.docHeader.minmaxButton.isVisible() is False
-
-    # Select item from header
-    with qtbot.waitSignal(docEditor.requestProjectItemSelected, timeout=1000) as signal:
-        qtbot.mouseClick(docEditor.docHeader, QtMouseLeft)
-        assert signal.args == ["", True]
+    assert docEditor.docHeader.itemTitle.text() == ""
 
     # qtbot.stop()
 

--- a/tests/test_gui/test_gui_docviewer.py
+++ b/tests/test_gui/test_gui_docviewer.py
@@ -24,11 +24,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from PyQt6.QtCore import QEvent, QMimeData, QPointF, Qt, QUrl
-from PyQt6.QtGui import (
-    QAction, QDesktopServices, QDragEnterEvent, QDragMoveEvent, QDropEvent,
-    QMouseEvent
-)
+from PyQt6.QtCore import QMimeData, QPointF, Qt, QUrl
+from PyQt6.QtGui import QAction, QDesktopServices, QDragEnterEvent, QDragMoveEvent, QDropEvent
 from PyQt6.QtWidgets import QApplication, QMenu, QTextBrowser
 
 from novelwriter import CONFIG, SHARED
@@ -66,11 +63,8 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwGUI.projView.projTree.clearSelection()
     assert nwGUI.projView.projTree.getSelectedHandle() is None
 
-    # Re-select via header click
-    button = QtMouseLeft
-    modifier = QtModNone
-    event = QMouseEvent(QEvent.Type.MouseButtonPress, QPointF(), button, button, modifier)
-    docViewer.docHeader.mousePressEvent(event)
+    # Re-select via header link
+    docViewer.docHeader._processLabelLink("#88243afbe5ed8")
     assert nwGUI.projView.projTree.getSelectedHandle() == "88243afbe5ed8"
 
     # Reload the text
@@ -212,12 +206,22 @@ def testGuiViewer_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwItem.setName("Test Title")  # type: ignore
     assert nwItem.itemName == "Test Title"  # type: ignore
     docViewer.onProjectItemChanged("4c4f28287af27", nwChange.UPDATE)
-    assert docViewer.docHeader.itemTitle.text() == "Characters  \u203a  Test Title"
+    assert docViewer.docHeader.itemTitle.text() == (
+        "<font style='color: #ff303030'>"
+        "<a href='#67a8707f2f249' style='color: #ff303030; text-decoration: none'>Characters</a>"
+        "  \u203a  "
+        "<a href='#4c4f28287af27' style='color: #ff303030; text-decoration: none'>Test Title</a>"
+        "</font>"
+    )
 
     # Title without full path
     CONFIG.showFullPath = False
     docViewer.onProjectItemChanged("4c4f28287af27", nwChange.UPDATE)
-    assert docViewer.docHeader.itemTitle.text() == "Test Title"
+    assert docViewer.docHeader.itemTitle.text() == (
+        "<font style='color: #ff303030'>"
+        "<a href='#4c4f28287af27' style='color: #ff303030; text-decoration: none'>Test Title</a>"
+        "</font>"
+    )
     CONFIG.showFullPath = True
 
     # Document footer show/hide synopsis


### PR DESCRIPTION
**Summary:**

This PR:
* Sets the correct text height for the label size in the editor/viewer header. It was set to the text ascent, which clips the bottom of descending characters.
* Makes each part of the document header path clickable, which selects it in the project tree.
* Removes the clickable bar in favour of clickable text.

**Related Issue(s):**

Closes #2674
Closes #2664

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
