### PR TITLE
Add shortcuts to move between paragraphs

### DIFF
--- a/docs/source/features/shortcuts.rst
+++ b/docs/source/features/shortcuts.rst
@@ -129,6 +129,10 @@ Other Editor Shortcuts
    ":kbd:`Ctrl+F7`",        "Toggle spell checking"
    ":kbd:`Ctrl+Return`",    "Open the tag or reference under the cursor in the viewer"
    ":kbd:`Ctrl+Shift+A`",   "Select all text in the current paragraph"
+   ":kbd:`Ctrl+Left`",      "Move to previous word."
+   ":kbd:`Ctrl+Right`",     "Move to next word."
+   ":kbd:`Ctrl+Up`",        "Move to previous paragraph."
+   ":kbd:`Ctrl+Down`",      "Move to next paragraph."
 
 
 .. _docs_features_shortcuts_insert:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -202,12 +202,22 @@ class GuiDocEditor(QPlainTextEdit):
         self._followTag1 = QShortcut(self)
         self._followTag1.setKey("Ctrl+Return")
         self._followTag1.setContext(Qt.ShortcutContext.WidgetShortcut)
-        self._followTag1.activated.connect(self._processTag)
+        self._followTag1.activated.connect(qtLambda(self._processTag))
 
         self._followTag2 = QShortcut(self)
         self._followTag2.setKey("Ctrl+Enter")
         self._followTag2.setContext(Qt.ShortcutContext.WidgetShortcut)
-        self._followTag2.activated.connect(self._processTag)
+        self._followTag2.activated.connect(qtLambda(self._processTag))
+
+        self._prevLine = QShortcut(self)
+        self._prevLine.setKey("Ctrl+Up")
+        self._prevLine.setContext(Qt.ShortcutContext.WidgetShortcut)
+        self._prevLine.activated.connect(qtLambda(self._skipToParagraph, -1))
+
+        self._nextLine = QShortcut(self)
+        self._nextLine.setKey("Ctrl+Down")
+        self._nextLine.setContext(Qt.ShortcutContext.WidgetShortcut)
+        self._nextLine.activated.connect(qtLambda(self._skipToParagraph, 1))
 
         # Set Up Document Word Counter
         self._timerDoc = QTimer(self)
@@ -655,8 +665,7 @@ class GuiDocEditor(QPlainTextEdit):
     def setCursorLine(self, line: int | None) -> None:
         """Move the cursor to a given line in the document."""
         if isinstance(line, int) and line > 0:
-            block = self._qDocument.findBlockByNumber(line - 1)
-            if block:
+            if block := self._qDocument.findBlockByNumber(line - 1):
                 self.setCursorPosition(block.position())
                 logger.debug("Cursor moved to line %d", line)
 
@@ -2440,6 +2449,17 @@ class GuiDocEditor(QPlainTextEdit):
             self._doReplace = CONFIG.doReplace
         else:
             self._doReplace = False
+
+    def _skipToParagraph(self, step: int) -> None:
+        """Move cursor to next paragraph by step."""
+        cursor = self.textCursor()
+        limit = -1 if step < 0 else self._qDocument.blockCount()
+        for i in range(cursor.blockNumber() + step, limit, step):
+            block = self._qDocument.findBlockByNumber(i)
+            if block.isValid() and block.text().strip():
+                cursor.setPosition(block.position())
+                self.setTextCursor(cursor)
+                break
 
 
 class CommandCompleter(QMenu):

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -2452,14 +2452,15 @@ class GuiDocEditor(QPlainTextEdit):
 
     def _skipToParagraph(self, step: int) -> None:
         """Move cursor to next paragraph by step."""
-        cursor = self.textCursor()
-        limit = -1 if step < 0 else self._qDocument.blockCount()
-        for i in range(cursor.blockNumber() + step, limit, step):
-            block = self._qDocument.findBlockByNumber(i)
-            if block.isValid() and block.text().strip():
-                cursor.setPosition(block.position())
-                self.setTextCursor(cursor)
-                break
+        if step != 0:
+            cursor = self.textCursor()
+            limit = -1 if step < 0 else self._qDocument.blockCount()
+            for i in range(cursor.blockNumber() + step, limit, step):
+                block = self._qDocument.findBlockByNumber(i)
+                if block.isValid() and block.text().strip():
+                    cursor.setPosition(block.position())
+                    self.setTextCursor(cursor)
+                    break
 
 
 class CommandCompleter(QMenu):

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -941,6 +941,34 @@ def testGuiEditor_Actions(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
 
 @pytest.mark.gui
+def testGuiEditor_Navigation(qtbot, nwGUI, projPath, ipsumText, mockRnd):
+    """Test editor navigation."""
+    buildTestProject(nwGUI, projPath)
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    docEditor: GuiDocEditor = nwGUI.docEditor
+
+    text = "### A Scene\n\n{0}".format("\n\n".join(ipsumText[:3]))
+    docEditor.replaceText(text)
+    assert docEditor.textCursor().blockNumber() == 0
+
+    steps = [
+        (0, 0),  # No change
+        (1, 2),  # First paragraph
+        (1, 4),  # Second paragraph
+        (1, 6),  # Third paragraph
+        (1, 6),  # Third paragraph, end of document
+        (-1, 4),  # Second paragraph
+        (-1, 2),  # First paragraph
+        (-1, 0),  # Title
+        (-1, 0),  # First paragraph, start of document
+    ]
+
+    for step, pos in steps:
+        docEditor._skipToParagraph(step)
+        assert docEditor.textCursor().blockNumber() == pos
+
+
+@pytest.mark.gui
 def testGuiEditor_ToolBar(qtbot, nwGUI, projPath, mockRnd):
     """Test the document actions. This is not an extensive test of the
     action features, just that the actions are actually called. The


### PR DESCRIPTION
**Summary:**

This PR adds `Ctrl+Up` and `Ctrl+Down` as keyboard shortcuts to move between paragraphs in the editor.

**Related Issue(s):**

Closes #2635

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
