### PR TITLE
Improve error handling and reporting

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -298,7 +298,8 @@ class Index:
                     "novelWriter.tagsIndex": jsonEncode(self._tagsIndex.packData(), n=1, nmax=2),
                     "novelWriter.itemIndex": jsonEncode(self._itemIndex.packData(), n=1, nmax=4),
                 }))
-        except Exception:
+        except Exception as exc:
+            SHARED.appendErrorMessage(exc)
             logger.error("Failed to save index file")
             logException()
             return False

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -31,6 +31,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from novelwriter import SHARED
 from novelwriter.common import checkBool, checkFloat, checkInt, checkString, jsonEncode, safeExists
 from novelwriter.constants import nwFiles
 from novelwriter.error import logException
@@ -134,7 +135,8 @@ class OptionState:
             with open(stateFile, mode="w+", encoding="utf-8") as fObj:
                 data = {"novelWriter.guiOptions": self._state}
                 fObj.write(jsonEncode(data, nmax=4))
-        except Exception:
+        except Exception as exc:
+            SHARED.appendErrorMessage(exc)
             logger.error("Failed to save GUI options file")
             logException()
             return False

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -414,10 +414,11 @@ class NWProject:
             return False
 
         saveTime = time()
+        SHARED.clearErrorCache()
         editTime = self._data.editTime + max(round(saveTime - self._session.start), 0)
         content = self._tree.pack()
         if not xmlWriter.write(self._data, content, saveTime, editTime):
-            SHARED.error(self.tr("Failed to save project."), exc=xmlWriter.error)
+            self._reportErrors(self.tr("Issues encountered when saving project:"))
             return False
 
         # Save other project data
@@ -429,6 +430,8 @@ class NWProject:
         if storagePath := self._storage.storagePath:
             CONFIG.recentProjects.update(storagePath, self._data, saveTime)
 
+        self._reportErrors(self.tr("Issues encountered when saving project:"))
+
         SHARED.newStatusMessage(self.tr("Saved Project: {0}").format(self._data.name))
         self.setProjectChanged(False)
 
@@ -437,11 +440,14 @@ class NWProject:
     def closeProject(self, idleTime: float = 0.0) -> None:
         """Close the project."""
         logger.info("Closing project")
+
+        SHARED.clearErrorCache()
         self._index.clear()  # Triggers clear signal, see #1718
         self._options.saveSettings()
         self._tree.writeToCFile()
         self._session.appendSession(idleTime)
         self._storage.closeSession()
+        self._reportErrors(self.tr("Issues encountered when closing project:"))
 
     def backupProject(self, doNotify: bool) -> bool:
         """Create a zip file of the entire project."""
@@ -567,6 +573,10 @@ class NWProject:
     ##
     #  Internal Functions
     ##
+    def _reportErrors(self, title: str) -> None:
+        """Report any errors from the error cache."""
+        if errors := SHARED.errorCache():
+            SHARED.error(title, "<br><br>".join(errors))
 
     def _loadProjectLocalisation(self) -> bool:
         """Load the language data for the current project language."""

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING
 
-from novelwriter import __hexversion__, __version__
+from novelwriter import SHARED, __hexversion__, __version__
 from novelwriter.common import (
     checkBool, checkInt, checkString, checkStringNone, formatTimeStamp,
     hexToInt, simplified, xmlIndent, yesNo
@@ -468,16 +468,6 @@ class ProjectXMLWriter:
 
     def __init__(self, path: str | Path) -> None:
         self._path = Path(path)
-        self._error = None
-
-    ##
-    #  Properties
-    ##
-
-    @property
-    def error(self) -> Exception | None:
-        """Return the error status."""
-        return self._error
 
     ##
     #  Methods
@@ -552,7 +542,7 @@ class ProjectXMLWriter:
             xml.write(tmp, encoding="utf-8", xml_declaration=True)
             tmp.replace(self._path)
         except Exception as exc:
-            self._error = exc
+            SHARED.appendErrorMessage(exc)
             return False
 
         logger.debug("Project XML saved in %.3f ms", (time() - tStart)*1000)

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING
 
+from novelwriter import SHARED
 from novelwriter.common import formatTimeStamp
 from novelwriter.constants import nwFiles
 from novelwriter.error import logException
@@ -109,7 +110,8 @@ class NWSessionLog:
                     cnotes=cCNotes,
                 ))
 
-        except Exception:
+        except Exception as exc:
+            SHARED.appendErrorMessage(exc)
             logger.error("Failed to write to session stats file")
             logException()
             return False

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -396,7 +396,8 @@ class NWTree:
                 toc.write("\n".join(entries))
                 toc.write("\n")
 
-        except Exception:
+        except Exception as exc:
+            SHARED.appendErrorMessage(exc)
             logger.error("Could not write ToC file")
             logException()
             return False

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -34,12 +34,15 @@ from typing import TYPE_CHECKING, TypeVar
 
 from PyQt6.QtCore import QObject, QRunnable, QThreadPool, QTimer, QUrl, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QDesktopServices, QFont, QScreen
-from PyQt6.QtWidgets import QApplication, QFileDialog, QMessageBox, QWidget
+from PyQt6.QtWidgets import (
+    QApplication, QFileDialog, QGridLayout, QMessageBox, QSpacerItem, QWidget
+)
 
 from novelwriter.common import appendIfSet, formatFileFilter, joinLines
 from novelwriter.constants import nwFiles
 from novelwriter.core.spellcheck import NWSpellEnchant
 from novelwriter.enum import nwChange, nwItemClass, nwStandardButton
+from novelwriter.types import QtSizeExpanding, QtSizeMinimum
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -405,7 +408,7 @@ class SharedData(QObject):
         self._lastAlert = alert.logMessage
         if log:
             self._logMessage(self._lastAlert, logger.info)
-        alert.exec()
+        alert.pop()
 
     def warn(self, text: T_Msg, info: str = "", details: str = "", log: bool = True) -> None:
         """Open a warning alert box."""
@@ -415,7 +418,7 @@ class SharedData(QObject):
         self._lastAlert = alert.logMessage
         if log:
             self._logMessage(self._lastAlert, logger.warning)
-        alert.exec()
+        alert.pop()
 
     def error(self, text: T_Msg, info: str = "", details: str = "", log: bool = True,
               exc: Exception | None = None) -> None:
@@ -428,7 +431,7 @@ class SharedData(QObject):
         self._lastAlert = alert.logMessage
         if log:
             self._logMessage(self._lastAlert, logger.error)
-        alert.exec()
+        alert.pop()
 
     def question(self, text: T_Msg, info: str = "", details: str = "", warn: bool = False) -> bool:
         """Open a question box."""
@@ -436,7 +439,7 @@ class SharedData(QObject):
         alert.setMessage(text, info, details)
         alert.setAlertType(_GuiAlert.WARN if warn else _GuiAlert.ASK, True)
         self._lastAlert = alert.logMessage
-        alert.exec()
+        alert.pop()
         return alert.finalState
 
     ##
@@ -497,6 +500,14 @@ class _GuiAlert(QMessageBox):
     @property
     def finalState(self) -> bool:
         return self._state
+
+    def pop(self) -> int:
+        """Make sure the message box isn't too small."""
+        # See https://stackoverflow.com/a/50549396
+        self._spacer = QSpacerItem(20*self._theme.fontPixelSize, 0, QtSizeMinimum, QtSizeExpanding)
+        if isinstance(layout := self.layout(), QGridLayout):
+            layout.addItem(self._spacer, layout.rowCount(), 0, 1, layout.columnCount())
+        return self.exec()
 
     def setMessage(self, text: T_Msg, info: str, details: str) -> None:
         """Set the alert box message."""

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -102,6 +102,7 @@ class SharedData(QObject):
         self._idleTime = 0.0
         self._idleRefTime = time()
         self._focusMode = False
+        self._cachedErrors = []
 
         self._clock = QTimer(self)
         self._clock.setInterval(1000)
@@ -395,6 +396,26 @@ class SharedData(QObject):
         """Emit the rootFolderChanged signal."""
         if self._project and self._project.data.uuid == project.data.uuid:
             self.rootFolderChanged.emit(handle, change)
+
+    ##
+    #  Error Cache
+    ##
+
+    def clearErrorCache(self) -> None:
+        """Clear all cached errors."""
+        self._cachedErrors = []
+
+    def appendErrorMessage(self, message: str | Exception) -> None:
+        """Append an error message to the error cache."""
+        if isinstance(message, Exception):
+            message = f"{type(message).__name__}: {message!s}"
+        self._cachedErrors.append(message)
+
+    def errorCache(self) -> list[str]:
+        """Return all cached errors and clear cache."""
+        errors = self._cachedErrors
+        self._cachedErrors = []
+        return errors
 
     ##
     #  Alert Boxes

--- a/tests/test_core/test_core_project.py
+++ b/tests/test_core/test_core_project.py
@@ -411,6 +411,12 @@ def testCoreProject_Methods(monkeypatch, mockGUI, fncPath, mockRnd):
     assert project.data.autoReplace == {"A": "B", "C": "D"}
     assert project.projChanged
 
+    # Error Report
+    SHARED.appendErrorMessage("Error 1")
+    SHARED.appendErrorMessage("Error 2")
+    project._reportErrors("Opps!")
+    assert SHARED.lastAlert == ["Opps!", "Error 1<br><br>Error 2"]
+
 
 @pytest.mark.core
 def testCoreProject_Backup(monkeypatch, mockGUI, fncPath, tstPaths):

--- a/tests/test_core/test_core_projectxml.py
+++ b/tests/test_core/test_core_projectxml.py
@@ -27,6 +27,7 @@ from shutil import copyfile
 
 import pytest
 
+from novelwriter import SHARED
 from novelwriter.constants import nwFiles
 from novelwriter.core.item import NWItem
 from novelwriter.core.projectdata import NWProjectData
@@ -245,17 +246,19 @@ def testCoreProjectXML_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
     xmlWriter = ProjectXMLWriter(fncPath / nwFiles.PROJ_FILE)
 
     # Fail saving
+    SHARED.clearErrorCache()
     with monkeypatch.context() as mp:
         mp.setattr("xml.etree.ElementTree.ElementTree.write", causeOSError)
         assert xmlWriter.write(data, packedContent, timeStamp, 1000) is False
-        assert str(xmlWriter.error) == "Mock OSError"
+        assert SHARED.errorCache() == ["OSError: Mock OSError"]
 
+    SHARED.clearErrorCache()
     with monkeypatch.context() as mp:
         mp.setattr("pathlib.Path.replace", causeOSError)
         assert xmlWriter.write(data, packedContent, timeStamp, 1000) is False
-        assert str(xmlWriter.error) == "Mock OSError"
+        assert SHARED.errorCache() == ["OSError: Mock OSError"]
 
-    # Successful save (should be twice)
+    # Successful save (should be run twice)
     assert xmlWriter.write(data, packedContent, timeStamp, 1000) is True
     assert xmlWriter.write(data, packedContent, timeStamp, 1000) is True
     copyfile(outFile, tstFile)


### PR DESCRIPTION
**Summary:**

This PR:
* Capture errors in the various project objects on save and cache them to the SharedData instance. These errors are the reported at the end of a project save or close.
* Sets a minimum size for popup boxes so that they aren't so narrow if they show little text but a lot of additional info.

**Related Issue(s):**

Closes #2529

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
