### PR TITLE
Add split document by cursor feature

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -43,8 +43,8 @@ from novelwriter.core.indexdata import NOTE_TYPES, TT_NONE, IndexHeading, IndexN
 from novelwriter.core.novelmodel import NovelModel
 from novelwriter.enum import nwComment, nwItemClass, nwItemLayout, nwItemType, nwNovelExtra
 from novelwriter.error import logException
-from novelwriter.text.comments import processComment
 from novelwriter.text.counting import standardCounter
+from novelwriter.text.formats import processComment, processHeading
 
 if TYPE_CHECKING:
     from collections.abc import ItemsView, Iterable
@@ -383,7 +383,7 @@ class Index:
                 continue
 
             if line.startswith("#"):
-                hDepth, hText = self._splitHeading(line)
+                hDepth, hText = processHeading(line)
                 if hDepth == "H0":
                     continue
 
@@ -438,28 +438,10 @@ class Index:
         """Scan an inactive document for meta data."""
         for line in text.splitlines():
             if line.startswith("#"):
-                hDepth, _ = self._splitHeading(line)
+                hDepth, _ = processHeading(line)
                 if hDepth != "H0":
                     nwItem.setMainHeading(hDepth)
                     break
-
-    def _splitHeading(self, line: str) -> tuple[str, str]:
-        """Split a heading into its heading level and text value."""
-        if line.startswith("# "):
-            return "H1", line[2:].strip()
-        elif line.startswith("## "):
-            return "H2", line[3:].strip()
-        elif line.startswith("### "):
-            return "H3", line[4:].strip()
-        elif line.startswith("#### "):
-            return "H4", line[5:].strip()
-        elif line.startswith("#! "):
-            return "H1", line[3:].strip()
-        elif line.startswith("##! "):
-            return "H2", line[4:].strip()
-        elif line.startswith("###! "):
-            return "H3", line[5:].strip()
-        return "H0", ""
 
     def _indexWordCounts(self, tHandle: str, text: str, sTitle: str) -> None:
         """Count text stats and save the counts to the index."""

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -203,7 +203,10 @@ class NWProject:
         self._tree.remove(tHandle)
         return True
 
-    def writeNewFile(self, tHandle: str, hLevel: int, isDocument: bool, text: str = "") -> bool:
+    def writeNewFile(
+        self, tHandle: str, hLevel: int, isDocument: bool,
+        text: str = "", *, addHeading: bool = True,
+    ) -> bool:
         """Write content to a new document after it is created. This
         will not run if the file exists and is not empty.
         """
@@ -213,8 +216,9 @@ class NWProject:
         if self._storage.getDocumentText(tHandle).strip():
             return False
 
-        indent = "#"*minmax(hLevel, 1, 4)
-        text = f"{indent} {tItem.itemName}\n\n{text}"
+        if addHeading:
+            indent = "#"*minmax(hLevel, 1, 4)
+            text = f"{indent} {tItem.itemName}\n\n{text}"
 
         if tItem.isNovelLike() and isDocument:
             tItem.setLayout(nwItemLayout.DOCUMENT)

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -258,6 +258,10 @@ class NWTree:
         self._model.endInsertRows()
         self._model.layoutChanged.emit()
 
+    def subTreePos(self, tHandle: str) -> int:
+        """Return the position of an item under its parent."""
+        return node.row() if (node := self._nodes.get(tHandle)) else -1
+
     def pickParent(self, sNode: ProjectNode, hLevel: int, isNote: bool) -> tuple[str | None, int]:
         """Pick an appropriate parent handle for adding a new item."""
         if sNode.item.isFolderType() or sNode.item.isRootType():

--- a/novelwriter/dialogs/editlabel.py
+++ b/novelwriter/dialogs/editlabel.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 class GuiEditLabel(NDialog):
     """GUI: Edit Item Label Dialog."""
 
-    def __init__(self, parent: QWidget, text: str = "") -> None:
+    def __init__(self, parent: QWidget, text: str = "", info: str = "") -> None:
         super().__init__(parent=parent)
 
         logger.debug("Create: GuiEditLabel")
@@ -74,6 +74,8 @@ class GuiEditLabel(NDialog):
 
         self.outerBox = QVBoxLayout()
         self.outerBox.setSpacing(12)
+        if info:
+            self.outerBox.addWidget(QLabel(info), 0)
         self.outerBox.addLayout(self.innerBox, 1)
         self.outerBox.addWidget(self.btnBox, 0)
 
@@ -89,9 +91,9 @@ class GuiEditLabel(NDialog):
         return self.edtValue.text()
 
     @classmethod
-    def getLabel(cls, parent: QWidget, text: str) -> tuple[str, bool]:
+    def getLabel(cls, parent: QWidget, text: str, info: str = "") -> tuple[str, bool]:
         """Pop the dialog and return the result."""
-        dialog = cls(parent, text=text)
+        dialog = cls(parent, text=text, info=info)
         dialog.exec()
         label = dialog.itemLabel
         accepted = dialog.result() == QtAccepted

--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -129,6 +129,7 @@ class nwDocAction(Enum):
     SC_MARK   = 36
     SC_SUP    = 37
     SC_SUB    = 38
+    MOVE_TEXT = 39
 
 
 class nwDocInsert(Enum):

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -43,7 +43,7 @@ from novelwriter.enum import nwComment, nwItemLayout
 from novelwriter.formats.shared import (
     BlockFmt, BlockTyp, T_Block, T_Formats, T_Note, TextDocumentTheme, TextFmt
 )
-from novelwriter.text.comments import processComment
+from novelwriter.text.formats import processComment
 from novelwriter.text.patterns import REGEX_PATTERNS, DialogParser
 
 if TYPE_CHECKING:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -57,12 +57,15 @@ from PyQt6.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import (
-    decodeMimeHandles, fontMatcher, minmax, qtAddAction, qtLambda, transferCase
+    decodeMimeHandles, fontMatcher, minmax, qtAddAction, qtAddMenu, qtLambda,
+    transferCase
 )
 from novelwriter.constants import (
-    nwConst, nwKeyWords, nwLabels, nwShortcode, nwStats, nwUnicode, trStats
+    nwConst, nwKeyWords, nwLabels, nwShortcode, nwStats, nwStyles, nwUnicode,
+    trStats
 )
 from novelwriter.core.document import NWDocument
+from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import (
     nwChange, nwComment, nwDocAction, nwDocInsert, nwDocMode, nwItemClass,
     nwItemType, nwState, nwVimMode
@@ -1206,6 +1209,7 @@ class GuiDocEditor(QPlainTextEdit):
         uCursor = self.textCursor()
         pCursor = self.cursorForPosition(pos)
         pBlock = pCursor.block()
+        hasSelection = uCursor.hasSelection()
 
         ctxMenu = QMenu(self)
         ctxMenu.setObjectName("ContextMenu")
@@ -1232,7 +1236,7 @@ class GuiDocEditor(QPlainTextEdit):
             ctxMenu.addSeparator()
 
         # Cut, Copy and Paste
-        if uCursor.hasSelection():
+        if hasSelection:
             action = qtAddAction(ctxMenu, self.tr("Cut"))
             action.triggered.connect(qtLambda(self.docAction, nwDocAction.CUT))
             action = qtAddAction(ctxMenu, self.tr("Copy"))
@@ -1249,6 +1253,15 @@ class GuiDocEditor(QPlainTextEdit):
         action.triggered.connect(qtLambda(self._makePosSelection, QtSelectWord, pos))
         action = qtAddAction(ctxMenu, self.tr("Select Paragraph"))
         action.triggered.connect(qtLambda(self._makePosSelection, QtSelectBlock, pos))
+
+        # Tools
+        mTools = qtAddMenu(ctxMenu, self.tr("Tools"))
+        if hasSelection:
+            action = qtAddAction(mTools, self.tr("Move to New Document"))
+            action.triggered.connect(self._moveTextToNewDocument)
+        else:
+            action = qtAddAction(mTools, self.tr("Split Document at Cursor"))
+            action.triggered.connect(self._moveTextToNewDocument)
 
         # Spell Checking
         if SHARED.project.data.spellCheck:
@@ -1301,6 +1314,32 @@ class GuiDocEditor(QPlainTextEdit):
                 self.docTextChanged.emit(self._docHandle, self._lastEdit)
 
         return
+
+    @pyqtSlot()
+    def _moveTextToNewDocument(self) -> None:
+        """Process request to move text to new document."""
+        cursor = self.textCursor()
+        if not cursor.hasSelection():
+            cursor.movePosition(QtMoveEnd, QtKeepAnchor)
+            self.setTextCursor(cursor)
+            QApplication.processEvents()
+
+        if (
+            cursor.hasSelection()
+            and (text := cursor.selectedText().strip())
+            and (item := self._nwItem)
+            and (parent := item.itemParent)
+        ):
+            label, dlgOk = GuiEditLabel.getLabel(
+                self, text=f"{item.itemName} (1)",
+                info=self.tr("Create a new document from selected text?")
+            )
+            if dlgOk and (tHandle := SHARED.project.newFile(
+                label, parent, SHARED.project.tree.subTreePos(item.itemHandle) + 1
+            )):
+                hLevel = nwStyles.H_LEVEL.get(item.mainHeading, 3)
+                if SHARED.project.writeNewFile(tHandle, hLevel, item.isDocumentLayout(), text):
+                    cursor.removeSelectedText()
 
     @pyqtSlot(int, int, int)
     def _updateDocCounts(self, cCount: int, wCount: int, pCount: int) -> None:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1344,6 +1344,8 @@ class GuiDocEditor(QPlainTextEdit):
                 if SHARED.project.writeNewFile(
                     tHandle, hLevel, item.isDocumentLayout(), text, addHeading=not hasHeading
                 ):
+                    SHARED.project.index.reIndexHandle(tHandle)
+                    SHARED.project.tree.refreshItems([tHandle])
                     cursor.removeSelectedText()
 
     @pyqtSlot(int, int, int)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -828,6 +828,8 @@ class GuiDocEditor(QPlainTextEdit):
             self._wrapSelection(nwShortcode.SUP_O, nwShortcode.SUP_C)
         elif action == nwDocAction.SC_SUB and not noFormat:
             self._wrapSelection(nwShortcode.SUB_O, nwShortcode.SUB_C)
+        elif action == nwDocAction.MOVE_TEXT:
+            self._moveTextToNewDocument()
         else:
             if noFormat:
                 logger.warning("Action '%s' not alowed on current block", action)
@@ -1255,10 +1257,10 @@ class GuiDocEditor(QPlainTextEdit):
         action = qtAddAction(ctxMenu, self.tr("Select Paragraph"))
         action.triggered.connect(qtLambda(self._makePosSelection, QtSelectBlock, pos))
 
-        # Tools
-        mTools = qtAddMenu(ctxMenu, self.tr("Tools"))
+        # Actions
+        mTools = qtAddMenu(ctxMenu, self.tr("Actions"))
         if hasSelection:
-            action = qtAddAction(mTools, self.tr("Move to New Document"))
+            action = qtAddAction(mTools, self.tr("Move Text to New Document"))
             action.triggered.connect(self._moveTextToNewDocument)
         else:
             action = qtAddAction(mTools, self.tr("Split Document at Cursor"))

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -114,8 +114,10 @@ class GuiDocEditor(QPlainTextEdit):
     __slots__ = (
         "_autoReplace", "_completer", "_doReplace", "_docChanged", "_docHandle", "_followTag1",
         "_followTag2", "_keyContext", "_lastActive", "_lastEdit", "_lastFind", "_nwDocument",
-        "_nwItem", "_qDocument", "_timerDoc", "_timerSel", "_vim", "_vpMargin", "_wCounterDoc",
-        "_wCounterSel",
+        "_nwItem", "_qDocument", "_timerDoc", "_timerSel", "_trActions", "_trAddWord", "_trCopy",
+        "_trCreateNote", "_trCut", "_trFollowTag", "_trIgnoreWord", "_trMoveText", "_trNoSuggest",
+        "_trOpenURL", "_trPaste", "_trSelectAll", "_trSelectPara", "_trSelectWord", "_trSetName",
+        "_trSpellSuggest", "_trSplitDoc", "_vim", "_vpMargin", "_wCounterDoc", "_wCounterSel",
     )
 
     MOVE_KEYS = (
@@ -158,6 +160,25 @@ class GuiDocEditor(QPlainTextEdit):
         self._doReplace  = False  # Switch to temporarily disable auto-replace
         self._lineColor  = QtTransparent
         self._selection  = QTextEdit.ExtraSelection()
+
+        # Context Menu Translation
+        self._trSetName = self.tr("Set as Document Name")
+        self._trOpenURL = self.tr("Open URL")
+        self._trFollowTag = self.tr("Follow Tag")
+        self._trCreateNote = self.tr("Create Note for Tag")
+        self._trCut = self.tr("Cut")
+        self._trCopy = self.tr("Copy")
+        self._trPaste = self.tr("Paste")
+        self._trSelectAll = self.tr("Select All")
+        self._trSelectWord = self.tr("Select Word")
+        self._trSelectPara = self.tr("Select Paragraph")
+        self._trMoveText = self.tr("Move Text to New Document")
+        self._trSplitDoc = self.tr("Split Document at Cursor")
+        self._trActions = self.tr("More Actions")
+        self._trSpellSuggest = self.tr("Spelling Suggestion(s)")
+        self._trNoSuggest = self.tr("No Suggestions")
+        self._trIgnoreWord = self.tr("Ignore Word")
+        self._trAddWord = self.tr("Add Word to Dictionary")
 
         # Auto-Replace
         self._autoReplace = TextAutoReplace()
@@ -1217,54 +1238,50 @@ class GuiDocEditor(QPlainTextEdit):
         ctxMenu = QMenu(self)
         ctxMenu.setObjectName("ContextMenu")
         if pBlock.userState() == BLOCK_TITLE:
-            action = qtAddAction(ctxMenu, self.tr("Set as Document Name"))
+            action = qtAddAction(ctxMenu, self._trSetName)
             action.triggered.connect(qtLambda(self._emitRenameItem, pBlock))
 
         # URL
         (mData, mType) = self._qDocument.metaDataAtPos(pCursor.position())
         if mData and mType == "url":
-            action = qtAddAction(ctxMenu, self.tr("Open URL"))
+            action = qtAddAction(ctxMenu, self._trOpenURL)
             action.triggered.connect(qtLambda(SHARED.openWebsite, mData))
             ctxMenu.addSeparator()
 
         # Follow
         status = self._processTag(cursor=pCursor, follow=False)
         if status & _TagAction.FOLLOW:
-            action = qtAddAction(ctxMenu, self.tr("Follow Tag"))
+            action = qtAddAction(ctxMenu, self._trFollowTag)
             action.triggered.connect(qtLambda(self._processTag, cursor=pCursor, follow=True))
             ctxMenu.addSeparator()
         elif status & _TagAction.CREATE:
-            action = qtAddAction(ctxMenu, self.tr("Create Note for Tag"))
+            action = qtAddAction(ctxMenu, self._trCreateNote)
             action.triggered.connect(qtLambda(self._processTag, cursor=pCursor, create=True))
             ctxMenu.addSeparator()
 
         # Cut, Copy and Paste
         if hasSelection:
-            action = qtAddAction(ctxMenu, self.tr("Cut"))
+            action = qtAddAction(ctxMenu, self._trCut)
             action.triggered.connect(qtLambda(self.docAction, nwDocAction.CUT))
-            action = qtAddAction(ctxMenu, self.tr("Copy"))
+            action = qtAddAction(ctxMenu, self._trCopy)
             action.triggered.connect(qtLambda(self.docAction, nwDocAction.COPY))
 
-        action = qtAddAction(ctxMenu, self.tr("Paste"))
+        action = qtAddAction(ctxMenu, self._trPaste)
         action.triggered.connect(qtLambda(self.docAction, nwDocAction.PASTE))
         ctxMenu.addSeparator()
 
         # Selections
-        action = qtAddAction(ctxMenu, self.tr("Select All"))
+        action = qtAddAction(ctxMenu, self._trSelectAll)
         action.triggered.connect(qtLambda(self.docAction, nwDocAction.SEL_ALL))
-        action = qtAddAction(ctxMenu, self.tr("Select Word"))
+        action = qtAddAction(ctxMenu, self._trSelectWord)
         action.triggered.connect(qtLambda(self._makePosSelection, QtSelectWord, pos))
-        action = qtAddAction(ctxMenu, self.tr("Select Paragraph"))
+        action = qtAddAction(ctxMenu, self._trSelectPara)
         action.triggered.connect(qtLambda(self._makePosSelection, QtSelectBlock, pos))
 
         # Actions
-        mTools = qtAddMenu(ctxMenu, self.tr("Actions"))
-        if hasSelection:
-            action = qtAddAction(mTools, self.tr("Move Text to New Document"))
-            action.triggered.connect(self._moveTextToNewDocument)
-        else:
-            action = qtAddAction(mTools, self.tr("Split Document at Cursor"))
-            action.triggered.connect(self._moveTextToNewDocument)
+        mTools = qtAddMenu(ctxMenu, self._trActions)
+        action = qtAddAction(mTools, self._trMoveText if hasSelection else self._trSplitDoc)
+        action.triggered.connect(self._moveTextToNewDocument)
 
         # Spell Checking
         if SHARED.project.data.spellCheck:
@@ -1277,18 +1294,17 @@ class GuiDocEditor(QPlainTextEdit):
                 sCursor.movePosition(QtMoveRight, QtKeepAnchor, len(word))
                 if suggest:
                     ctxMenu.addSeparator()
-                    qtAddAction(ctxMenu, self.tr("Spelling Suggestion(s)"))
+                    qtAddAction(ctxMenu, self._trSpellSuggest)
                     for option in suggest[:15]:
                         action = qtAddAction(ctxMenu, f"{nwUnicode.U_ENDASH} {option}")
                         action.triggered.connect(qtLambda(self._correctWord, sCursor, option))
                 else:
-                    trNone = self.tr("No Suggestions")
-                    qtAddAction(ctxMenu, f"{nwUnicode.U_ENDASH} {trNone}")
+                    qtAddAction(ctxMenu, f"{nwUnicode.U_ENDASH} {self._trNoSuggest}")
 
                 ctxMenu.addSeparator()
-                action = qtAddAction(ctxMenu, self.tr("Ignore Word"))
+                action = qtAddAction(ctxMenu, self._trIgnoreWord)
                 action.triggered.connect(qtLambda(self._addWord, word, block, False))
-                action = qtAddAction(ctxMenu, self.tr("Add Word to Dictionary"))
+                action = qtAddAction(ctxMenu, self._trAddWord)
                 action.triggered.connect(qtLambda(self._addWord, word, block, True))
 
         # Execute the context menu

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -77,6 +77,7 @@ from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE
 from novelwriter.gui.editordocument import GuiTextDocument
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.text.counting import standardCounter
+from novelwriter.text.formats import processHeading
 from novelwriter.tools.lipsum import GuiLipsum
 from novelwriter.types import (
     QtAlignCenterTop, QtAlignJustify, QtAlignLeft, QtAlignLeftTop,
@@ -1326,19 +1327,23 @@ class GuiDocEditor(QPlainTextEdit):
 
         if (
             cursor.hasSelection()
-            and (text := cursor.selectedText().strip())
+            and (text := self.getSelectedText().strip())  # This handles proper line breaks
             and (item := self._nwItem)
             and (parent := item.itemParent)
         ):
+            heading, title = processHeading(text.partition("\n")[0])
             label, dlgOk = GuiEditLabel.getLabel(
-                self, text=f"{item.itemName} (1)",
+                self, text=title or f"{item.itemName} (1)",
                 info=self.tr("Create a new document from selected text?")
             )
             if dlgOk and (tHandle := SHARED.project.newFile(
                 label, parent, SHARED.project.tree.subTreePos(item.itemHandle) + 1
             )):
-                hLevel = nwStyles.H_LEVEL.get(item.mainHeading, 3)
-                if SHARED.project.writeNewFile(tHandle, hLevel, item.isDocumentLayout(), text):
+                hasHeading = heading != "H0"
+                hLevel = nwStyles.H_LEVEL.get(heading if hasHeading else item.mainHeading, 3)
+                if SHARED.project.writeNewFile(
+                    tHandle, hLevel, item.isDocumentLayout(), text, addHeading=not hasHeading
+                ):
                     cursor.removeSelectedText()
 
     @pyqtSlot(int, int, int)

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -39,7 +39,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import checkInt, utf16CharMap
 from novelwriter.constants import nwStyles, nwUnicode
 from novelwriter.enum import nwComment
-from novelwriter.text.comments import processComment
+from novelwriter.text.formats import processComment
 from novelwriter.text.patterns import REGEX_PATTERNS, DialogParser
 from novelwriter.types import QtTextUserProperty
 

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -240,6 +240,12 @@ class GuiMainMenu(QMenuBar):
         self.aImportFile = qtAddAction(self.docuMenu, self.tr("Import Text from File"))
         self.aImportFile.triggered.connect(qtLambda(self.mainGui.importDocument))
 
+        # Document > Move Text
+        self.aMoveText = qtAddAction(self.docuMenu, self.tr("Move Text to New Document"))
+        self.aMoveText.triggered.connect(
+            lambda: self.requestDocAction.emit(nwDocAction.MOVE_TEXT)
+        )
+
     def _buildEditMenu(self) -> None:
         """Assemble the Edit menu."""
         # Edit

--- a/novelwriter/text/formats.py
+++ b/novelwriter/text/formats.py
@@ -68,3 +68,22 @@ def processComment(text: str) -> tuple[nwComment, str, str, int, int]:
         return MODIFIERS[clean], key, content.lstrip(), dot, col
 
     return nwComment.PLAIN, "", check, 0, 0
+
+
+def processHeading(line: str) -> tuple[str, str]:
+    """Split a heading into its heading level and text value."""
+    if line.startswith("# "):
+        return "H1", line[2:].strip()
+    elif line.startswith("## "):
+        return "H2", line[3:].strip()
+    elif line.startswith("### "):
+        return "H3", line[4:].strip()
+    elif line.startswith("#### "):
+        return "H4", line[5:].strip()
+    elif line.startswith("#! "):
+        return "H1", line[3:].strip()
+    elif line.startswith("##! "):
+        return "H2", line[4:].strip()
+    elif line.startswith("###! "):
+        return "H3", line[5:].strip()
+    return "H0", ""

--- a/tests/test_dialogs/test_dlg_dialogs.py
+++ b/tests/test_dialogs/test_dlg_dialogs.py
@@ -71,12 +71,12 @@ def testDlgOther_EditLabel(qtbot, monkeypatch):
 
     with monkeypatch.context() as mp:
         mp.setattr(GuiEditLabel, "result", lambda *a: QtAccepted)
-        newLabel, dlgOk = GuiEditLabel.getLabel(None, text="Hello World")  # type: ignore
+        newLabel, dlgOk = GuiEditLabel.getLabel(None, text="Stuff")  # type: ignore
         assert dlgOk is True
-        assert newLabel == "Hello World"
+        assert newLabel == "Stuff"
 
     with monkeypatch.context() as mp:
         mp.setattr(GuiEditLabel, "result", lambda *a: QtRejected)
-        newLabel, dlgOk = GuiEditLabel.getLabel(None, text="Hello World")  # type: ignore
+        newLabel, dlgOk = GuiEditLabel.getLabel(None, text="Stuff", info="Hi")  # type: ignore
         assert dlgOk is False
-        assert newLabel == "Hello World"
+        assert newLabel == "Stuff"

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -35,6 +35,7 @@ from PyQt6.QtWidgets import QApplication, QMenu, QPlainTextEdit
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import decodeMimeHandles
 from novelwriter.constants import nwKeyWords, nwUnicode
+from novelwriter.core.item import NWItem
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwDocAction, nwDocInsert, nwItemClass, nwItemLayout, nwState
 from novelwriter.gui.doceditor import GuiDocEditor, TextAutoReplace, _TagAction
@@ -365,7 +366,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Set as Document Name", "Paste",
-        "Select All", "Select Word", "Select Paragraph"
+        "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     with monkeypatch.context() as mp:
         mp.setattr(GuiEditLabel, "getLabel", lambda a, text: (text, True))
@@ -381,7 +382,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Open URL", "Paste",
-        "Select All", "Select Word", "Select Paragraph"
+        "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     ctxMenu.setObjectName("")
     ctxMenu.deleteLater()
@@ -392,7 +393,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Create Note for Tag", "Paste",
-        "Select All", "Select Word", "Select Paragraph"
+        "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     ctxMenu.actions()[0].trigger()
     janeItem = SHARED.project.tree["0000000000010"]
@@ -407,7 +408,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Follow Tag", "Paste",
-        "Select All", "Select Word", "Select Paragraph"
+        "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     ctxMenu.actions()[0].trigger()
     assert nwGUI.docViewer.docHandle == "0000000000010"
@@ -419,7 +420,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph"
+        "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     ctxMenu.actions()[3].trigger()
     assert docEditor.textCursor().selectedText() == "text"
@@ -431,7 +432,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph"
+        "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     ctxMenu.actions()[4].trigger()
     assert docEditor.textCursor().selectedText() == "Some text ..."
@@ -443,7 +444,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph"
+        "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     ctxMenu.actions()[2].trigger()
     assert docEditor.textCursor().selectedText() == docEditor.document().toRawText()
@@ -459,7 +460,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert docEditor.textCursor().selectedText() == "text"
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Cut", "Copy", "Paste", "Select All", "Select Word", "Select Paragraph"
+        "Cut", "Copy", "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
     ]
     clipboard.clear()
     ctxMenu.actions()[1].trigger()
@@ -537,13 +538,14 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     # With Suggestion
     with monkeypatch.context() as mp:
         mp.setattr(SHARED.spelling, "suggestWords", lambda *a: [LORAX])
+        suggestion = f"{nwUnicode.U_ENDASH} {LORAX}"
 
         ctxMenu = getMenuForPos(docEditor, 16)
         assert ctxMenu is not None
-        actions = [x.text() for x in ctxMenu.actions() if x.text()]
+        actions = [x.text() for x in ctxMenu.actions()]
         assert "Spelling Suggestion(s)" in actions
-        assert f"{nwUnicode.U_ENDASH} {LORAX}" in actions
-        ctxMenu.actions()[7].trigger()
+        assert suggestion in actions
+        ctxMenu.actions()[actions.index(suggestion)].trigger()
         QApplication.processEvents()
         assert docEditor.getText() == text.replace("Lorem", LORAX, 1)
         ctxMenu.setObjectName("")
@@ -558,7 +560,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
 
         ctxMenu = getMenuForPos(docEditor, 16)
         assert ctxMenu is not None
-        actions = [x.text() for x in ctxMenu.actions() if x.text()]
+        actions = [x.text() for x in ctxMenu.actions()]
         assert f"{nwUnicode.U_ENDASH} No Suggestions" in actions
         assert docEditor.getText() == text.replace("Lorem", LORAX, 1)
         ctxMenu.setObjectName("")
@@ -570,14 +572,14 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
 
         ctxMenu = getMenuForPos(docEditor, 16)
         assert ctxMenu is not None
-        actions = [x.text() for x in ctxMenu.actions() if x.text()]
+        actions = [x.text() for x in ctxMenu.actions()]
         assert "Ignore Word" in actions
         assert "Add Word to Dictionary" in actions
 
         assert LORAX not in SHARED.spelling._userDict
-        ctxMenu.actions()[7].trigger()  # Ignore
+        ctxMenu.actions()[actions.index("Ignore Word")].trigger()
         assert LORAX not in SHARED.spelling._userDict
-        ctxMenu.actions()[8].trigger()  # Add
+        ctxMenu.actions()[actions.index("Add Word to Dictionary")].trigger()
         assert LORAX in SHARED.spelling._userDict
         ctxMenu.setObjectName("")
         ctxMenu.deleteLater()
@@ -1862,6 +1864,53 @@ def testGuiEditor_Tags(qtbot, nwGUI, projPath, ipsumText, mockRnd):
 
     docEditor.setCursorPosition(47)
     assert docEditor._processTag() == _TagAction.NONE
+
+    # qtbot.stop()
+
+
+@pytest.mark.gui
+def testGuiEditor_MoveTextToNewDocument(qtbot, monkeypatch, nwGUI, projPath, ipsumText, mockRnd):
+    """Test the moving text to new document feature."""
+    monkeypatch.setattr(GuiEditLabel, "getLabel", lambda *a, text, info: (text, True))
+
+    buildTestProject(nwGUI, projPath)
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    docEditor: GuiDocEditor = nwGUI.docEditor
+
+    text = "### A Scene\n\n{0}".format("\n\n".join(ipsumText))
+    docEditor.replaceText(text)
+
+    # Move from cursor
+    nHandle = "0000000000010"
+    docEditor.setCursorLine(6)
+    docEditor._moveTextToNewDocument()
+    item = SHARED.project.tree[nHandle]
+    assert isinstance(item, NWItem)
+    assert item.itemName == "New Scene (1)"
+    assert nwGUI.openDocument(nHandle) is True
+    assert docEditor.getText() == "### New Scene (1)\n\n{0}\n".format("\n\n".join(ipsumText[2:]))
+
+    # New from selection, with existing header
+    nHandle = "0000000000011"
+    docEditor.setCursorLine(5)
+    sPos = docEditor.getCursorPosition()
+    docEditor.insertText("### Another Scene\n\n")
+
+    # Select new title plus next paragraph
+    docEditor.setCursorLine(8)
+    ePos = docEditor.getCursorPosition()
+    cursor = docEditor.textCursor()
+    cursor.setPosition(sPos)
+    cursor.movePosition(QtMoveRight, QtKeepAnchor, ePos - sPos)
+    docEditor.setTextCursor(cursor)
+
+    # Move to new document
+    docEditor._moveTextToNewDocument()
+    item = SHARED.project.tree[nHandle]
+    assert isinstance(item, NWItem)
+    assert item.itemName == "Another Scene"
+    assert nwGUI.openDocument(nHandle) is True
+    assert docEditor.getText() == f"### Another Scene\n\n{ipsumText[3]}\n"
 
     # qtbot.stop()
 

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -366,7 +366,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Set as Document Name", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     with monkeypatch.context() as mp:
         mp.setattr(GuiEditLabel, "getLabel", lambda a, text: (text, True))
@@ -382,7 +382,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Open URL", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     ctxMenu.setObjectName("")
     ctxMenu.deleteLater()
@@ -393,7 +393,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Create Note for Tag", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     ctxMenu.actions()[0].trigger()
     janeItem = SHARED.project.tree["0000000000010"]
@@ -408,7 +408,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Follow Tag", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     ctxMenu.actions()[0].trigger()
     assert nwGUI.docViewer.docHandle == "0000000000010"
@@ -420,7 +420,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Paste", "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     ctxMenu.actions()[3].trigger()
     assert docEditor.textCursor().selectedText() == "text"
@@ -432,7 +432,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Paste", "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     ctxMenu.actions()[4].trigger()
     assert docEditor.textCursor().selectedText() == "Some text ..."
@@ -444,7 +444,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Paste", "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     ctxMenu.actions()[2].trigger()
     assert docEditor.textCursor().selectedText() == docEditor.document().toRawText()
@@ -460,7 +460,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert docEditor.textCursor().selectedText() == "text"
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Cut", "Copy", "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
+        "Cut", "Copy", "Paste", "Select All", "Select Word", "Select Paragraph", "More Actions",
     ]
     clipboard.clear()
     ctxMenu.actions()[1].trigger()

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -366,7 +366,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Set as Document Name", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     with monkeypatch.context() as mp:
         mp.setattr(GuiEditLabel, "getLabel", lambda a, text: (text, True))
@@ -382,7 +382,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Open URL", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     ctxMenu.setObjectName("")
     ctxMenu.deleteLater()
@@ -393,7 +393,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Create Note for Tag", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     ctxMenu.actions()[0].trigger()
     janeItem = SHARED.project.tree["0000000000010"]
@@ -408,7 +408,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
         "Follow Tag", "Paste",
-        "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     ctxMenu.actions()[0].trigger()
     assert nwGUI.docViewer.docHandle == "0000000000010"
@@ -420,7 +420,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     ctxMenu.actions()[3].trigger()
     assert docEditor.textCursor().selectedText() == "text"
@@ -432,7 +432,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     ctxMenu.actions()[4].trigger()
     assert docEditor.textCursor().selectedText() == "Some text ..."
@@ -444,7 +444,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert ctxMenu is not None
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     ctxMenu.actions()[2].trigger()
     assert docEditor.textCursor().selectedText() == docEditor.document().toRawText()
@@ -460,7 +460,7 @@ def testGuiEditor_ContextMenu(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     assert docEditor.textCursor().selectedText() == "text"
     actions = [x.text() for x in ctxMenu.actions() if x.text()]
     assert actions == [
-        "Cut", "Copy", "Paste", "Select All", "Select Word", "Select Paragraph", "Tools",
+        "Cut", "Copy", "Paste", "Select All", "Select Word", "Select Paragraph", "Actions",
     ]
     clipboard.clear()
     ctxMenu.actions()[1].trigger()
@@ -1883,7 +1883,7 @@ def testGuiEditor_MoveTextToNewDocument(qtbot, monkeypatch, nwGUI, projPath, ips
     # Move from cursor
     nHandle = "0000000000010"
     docEditor.setCursorLine(6)
-    docEditor._moveTextToNewDocument()
+    docEditor.docAction(nwDocAction.MOVE_TEXT)
     item = SHARED.project.tree[nHandle]
     assert isinstance(item, NWItem)
     assert item.itemName == "New Scene (1)"
@@ -1905,7 +1905,7 @@ def testGuiEditor_MoveTextToNewDocument(qtbot, monkeypatch, nwGUI, projPath, ips
     docEditor.setTextCursor(cursor)
 
     # Move to new document
-    docEditor._moveTextToNewDocument()
+    docEditor.docAction(nwDocAction.MOVE_TEXT)
     item = SHARED.project.tree[nHandle]
     assert isinstance(item, NWItem)
     assert item.itemName == "Another Scene"

--- a/tests/test_text/test_text_formats.py
+++ b/tests/test_text/test_text_formats.py
@@ -23,11 +23,11 @@ from __future__ import annotations
 import pytest
 
 from novelwriter.enum import nwComment
-from novelwriter.text.comments import _checkModKey, processComment
+from novelwriter.text.formats import _checkModKey, processComment, processHeading
 
 
 @pytest.mark.core
-def testTextComments_checkModKey():
+def testTextFormats_checkModKey():
     """Test the _checkModKey function."""
     # Check Requirements
 
@@ -59,7 +59,7 @@ def testTextComments_checkModKey():
 
 
 @pytest.mark.core
-def testTextComments_processComment():
+def testTextFormats_processComment():
     """Test the comment processing function."""
     # Plain
     assert processComment("%Hi") == (nwComment.PLAIN, "", "Hi", 0, 0)
@@ -108,3 +108,23 @@ def testTextComments_processComment():
     assert processComment("% note.term : Hi") == (nwComment.NOTE, "term", "Hi", 7, 13)
     assert processComment("% note. term : Hi") == (nwComment.PLAIN, "", "note. term : Hi", 0, 0)
     assert processComment("% note . term : Hi") == (nwComment.PLAIN, "", "note . term : Hi", 0, 0)
+
+
+@pytest.mark.core
+def testTextFormats_processHeading():
+    """Test the heading processing function."""
+    # Correct titles
+    assert processHeading("# Title") == ("H1", "Title")
+    assert processHeading("#! Title") == ("H1", "Title")
+    assert processHeading("## Title") == ("H2", "Title")
+    assert processHeading("##! Title") == ("H2", "Title")
+    assert processHeading("### Title") == ("H3", "Title")
+    assert processHeading("###! Title") == ("H3", "Title")
+    assert processHeading("#### Title") == ("H4", "Title")
+
+    # Stripped text
+    assert processHeading("# \tTitle\t  ") == ("H1", "Title")
+
+    # Incorrect titles
+    assert processHeading("##### Title") == ("H0", "")
+    assert processHeading("#Title") == ("H0", "")


### PR DESCRIPTION
**Summary:**

This PR adds the following:
* With the cursor place somewhere in the document, one can right click and move the remaining text in the document to a new document.
* With a selection made, one can do the same.
* The new document will take the title of the selected text if the selection (or cursor position) starts with a heading. Otherwise a heading is generated from the current document's heading and main heading level.

**Related Issue(s):**

Closes #1486
Closes #2571

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
