### PR TITLE
Add option for dotted underline for formatting tags and modifiers

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -81,10 +81,10 @@ class Config:
         "appHandle", "appName", "askBeforeBackup", "askBeforeExit", "autoSaveDoc", "autoSaveProj",
         "autoScroll", "autoScrollPos", "autoSelect", "backupOnClose", "cursorWidth", "darkTheme",
         "dialogLine", "dialogStyle", "doJustify", "doReplace", "doReplaceDQuote", "doReplaceDash",
-        "doReplaceDots", "doReplaceSQuote", "emphLabels", "fmtApostrophe", "fmtDQuoteClose",
-        "fmtDQuoteOpen", "fmtPadAfter", "fmtPadBefore", "fmtPadThin", "fmtSQuoteClose",
-        "fmtSQuoteOpen", "focusWidth", "fontWinSize", "guiFont", "guiLocale", "hasEnchant",
-        "hideFocusFooter", "hideHScroll", "hideVScroll", "highlightEmph", "hostName",
+        "doReplaceDots", "doReplaceSQuote", "dottedModCodes", "emphLabels", "fmtApostrophe",
+        "fmtDQuoteClose", "fmtDQuoteOpen", "fmtPadAfter", "fmtPadBefore", "fmtPadThin",
+        "fmtSQuoteClose", "fmtSQuoteOpen", "focusWidth", "fontWinSize", "guiFont", "guiLocale",
+        "hasEnchant", "hideFocusFooter", "hideHScroll", "hideVScroll", "highlightEmph", "hostName",
         "iconColDocs", "iconColTree", "iconTheme", "incNotesWCount", "isDebug", "kernelVer",
         "lastNotes", "lightTheme", "lineHighlight", "mainPanePos", "mainWinSize", "memInfo",
         "moveMainWin", "narratorBreak", "narratorDialog", "nativeFont", "osDarwin", "osLinux",
@@ -237,6 +237,7 @@ class Config:
         self.altDialogOpen   = ""       # Alternative dialog symbol, open
         self.altDialogClose  = ""       # Alternative dialog symbol, close
         self.highlightEmph   = True     # Add colour to text emphasis
+        self.dottedModCodes  = False    # Add dotted lines under codes and modifiers
 
         self.stopWhenIdle    = True     # Stop the status bar clock when the user is idle
         self.userIdleTime    = 300      # Time of inactivity to consider user idle
@@ -718,6 +719,7 @@ class Config:
         self.altDialogOpen   = conf.rdStr(sec, "altdialogopen", self.altDialogOpen)
         self.altDialogClose  = conf.rdStr(sec, "altdialogclose", self.altDialogClose)
         self.highlightEmph   = conf.rdBool(sec, "highlightemph", self.highlightEmph)
+        self.dottedModCodes  = conf.rdBool(sec, "dottedmodcodes", self.dottedModCodes)
         self.stopWhenIdle    = conf.rdBool(sec, "stopwhenidle", self.stopWhenIdle)
         self.userIdleTime    = conf.rdInt(sec, "useridletime", self.userIdleTime)
 
@@ -850,6 +852,7 @@ class Config:
             "altdialogopen":   str(self.altDialogOpen),
             "altdialogclose":  str(self.altDialogClose),
             "highlightemph":   str(self.highlightEmph),
+            "dottedmodcodes":  str(self.dottedModCodes),
             "stopwhenidle":    str(self.stopWhenIdle),
             "useridletime":    str(self.userIdleTime),
         }

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -719,6 +719,14 @@ class GuiPreferences(NDialog):
             self.tr("Applies to the document editor only.")
         )
 
+        # Dotted Codes and Modifiers
+        self.dottedModCodes = NSwitch(self)
+        self.dottedModCodes.setChecked(CONFIG.dottedModCodes)
+        self.mainForm.addRow(
+            self.tr("Add dotted lines under codes and modifiers"), self.dottedModCodes,
+            self.tr("Applies to the document editor only.")
+        )
+
         # Additional Spaces
         self.showMultiSpaces = NSwitch(self)
         self.showMultiSpaces.setChecked(CONFIG.showMultiSpaces)
@@ -1116,6 +1124,7 @@ class GuiPreferences(NDialog):
         altDialogOpen   = compact(self.altDialogOpen.text())
         altDialogClose  = compact(self.altDialogClose.text())
         highlightEmph   = self.highlightEmph.isChecked()
+        dottedModCodes  = self.dottedModCodes.isChecked()
         showMultiSpaces = self.showMultiSpaces.isChecked()
 
         updateSyntax |= CONFIG.dialogStyle != dialogueStyle
@@ -1126,6 +1135,7 @@ class GuiPreferences(NDialog):
         updateSyntax |= CONFIG.altDialogOpen != altDialogOpen
         updateSyntax |= CONFIG.altDialogClose != altDialogClose
         updateSyntax |= CONFIG.highlightEmph != highlightEmph
+        updateSyntax |= CONFIG.dottedModCodes != dottedModCodes
         updateSyntax |= CONFIG.showMultiSpaces != showMultiSpaces
 
         CONFIG.dialogStyle     = dialogueStyle
@@ -1136,6 +1146,7 @@ class GuiPreferences(NDialog):
         CONFIG.altDialogOpen   = altDialogOpen
         CONFIG.altDialogClose  = altDialogClose
         CONFIG.highlightEmph   = highlightEmph
+        CONFIG.dottedModCodes  = dottedModCodes
         CONFIG.showMultiSpaces = showMultiSpaces
 
         # Text Automation

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -94,6 +94,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         syntax = SHARED.theme.syntaxTheme
 
         colEmph = syntax.emph if CONFIG.highlightEmph else None
+        dotCodes = "dot" if CONFIG.dottedModCodes else ""
 
         h1Size = nwStyles.H_SIZES[1] if CONFIG.scaleHeadings else None
         h2Size = nwStyles.H_SIZES[2] if CONFIG.scaleHeadings else None
@@ -118,16 +119,16 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._addCharFormat("nobreak",   syntax.space, "bg")
         self._addCharFormat("altdialog", syntax.dialA)
         self._addCharFormat("dialog",    syntax.dialN)
-        self._addCharFormat("replace",   syntax.repTag)
+        self._addCharFormat("replace",   syntax.repTag, dotCodes)
         self._addCharFormat("hidden",    syntax.hidden)
         self._addCharFormat("markup",    syntax.hidden)
         self._addCharFormat("link",      syntax.link, "u")
         self._addCharFormat("note",      syntax.note)
-        self._addCharFormat("code",      syntax.code)
+        self._addCharFormat("code",      syntax.code, dotCodes)
         self._addCharFormat("keyword",   syntax.key)
         self._addCharFormat("tag",       syntax.tag, "u")
-        self._addCharFormat("modifier",  syntax.mod)
-        self._addCharFormat("value",     syntax.val)
+        self._addCharFormat("modifier",  syntax.mod, dotCodes)
+        self._addCharFormat("value",     syntax.val, dotCodes)
         self._addCharFormat("optional",  syntax.opt)
         self._addCharFormat("invalid",   None, "err")
 
@@ -488,6 +489,8 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 charFormat.setFontUnderline(True)
             if "s" in styles:
                 charFormat.setFontStrikeOut(True)
+            if "dot" in styles:
+                charFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.DotLine)
             if "err" in styles:
                 charFormat.setUnderlineColor(SHARED.theme.syntaxTheme.error)
                 charFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -94,7 +94,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         syntax = SHARED.theme.syntaxTheme
 
         colEmph = syntax.emph if CONFIG.highlightEmph else None
-        dotCodes = "dot" if CONFIG.dottedModCodes else ""
+        fmtCodes = "dot" if CONFIG.dottedModCodes else ""
 
         h1Size = nwStyles.H_SIZES[1] if CONFIG.scaleHeadings else None
         h2Size = nwStyles.H_SIZES[2] if CONFIG.scaleHeadings else None
@@ -119,16 +119,16 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._addCharFormat("nobreak",   syntax.space, "bg")
         self._addCharFormat("altdialog", syntax.dialA)
         self._addCharFormat("dialog",    syntax.dialN)
-        self._addCharFormat("replace",   syntax.repTag, dotCodes)
+        self._addCharFormat("replace",   syntax.repTag, fmtCodes)
         self._addCharFormat("hidden",    syntax.hidden)
         self._addCharFormat("markup",    syntax.hidden)
         self._addCharFormat("link",      syntax.link, "u")
         self._addCharFormat("note",      syntax.note)
-        self._addCharFormat("code",      syntax.code, dotCodes)
+        self._addCharFormat("code",      syntax.code, fmtCodes)
         self._addCharFormat("keyword",   syntax.key)
         self._addCharFormat("tag",       syntax.tag, "u")
-        self._addCharFormat("modifier",  syntax.mod, dotCodes)
-        self._addCharFormat("value",     syntax.val, dotCodes)
+        self._addCharFormat("modifier",  syntax.mod, fmtCodes)
+        self._addCharFormat("value",     syntax.val, fmtCodes)
         self._addCharFormat("optional",  syntax.opt)
         self._addCharFormat("invalid",   None, "err")
 

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2026-02-18 09:57:24
+timestamp = 2026-03-28 17:05:05
 
 [Main]
 font = 
@@ -78,6 +78,7 @@ narratordialog =
 altdialogopen = 
 altdialogclose = 
 highlightemph = True
+dottedmodcodes = False
 stopwhenidle = True
 useridletime = 300
 

--- a/tests/test_dialogs/test_dlg_preferences.py
+++ b/tests/test_dialogs/test_dlg_preferences.py
@@ -280,6 +280,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     prefs.altDialogOpen.setText("%")  # Symbol also tests for #2455
     prefs.altDialogClose.setText("%")  # Symbol also tests for #2455
     prefs.highlightEmph.setChecked(False)
+    prefs.dottedModCodes.setChecked(True)
     prefs.showMultiSpaces.setChecked(True)
 
     prefs._insertDialogLineSymbol(nwUnicode.U_ENDASH)
@@ -293,6 +294,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.altDialogOpen == ""
     assert CONFIG.altDialogClose == ""
     assert CONFIG.highlightEmph is True
+    assert CONFIG.dottedModCodes is False
     assert CONFIG.showMultiSpaces is False
 
     # Text Automation
@@ -419,6 +421,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.altDialogOpen == "%"
     assert CONFIG.altDialogClose == "%"
     assert CONFIG.highlightEmph is False
+    assert CONFIG.dottedModCodes is True
     assert CONFIG.showMultiSpaces is True
 
     # Text Automation


### PR DESCRIPTION
**Summary:**

This PR adds a new setting to Preferences that adds dotted lines under all non-text modifiers, shortcodes and replacement tags used in context with text. This makes them easier to spot when the colouring is harder to see. This is an accessibility feature.

**Related Issue(s):**

Closes #2691

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
