### PR TITLE
Allow backwards search also to loop through documents

### DIFF
--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -62,13 +62,14 @@ class NWTree:
     also used for file names.
     """
 
-    __slots__ = ("_items", "_model", "_nodes", "_project", "_ready", "_trash")
+    __slots__ = ("_docs", "_items", "_model", "_nodes", "_project", "_ready", "_trash")
 
     def __init__(self, project: NWProject) -> None:
         self._project = project
         self._model = ProjectModel(self)
         self._items: dict[str, NWItem] = {}
         self._nodes: dict[str, ProjectNode] = {}
+        self._docs: list[str] = []
         self._trash = None
         self._ready = False
         logger.debug("Ready: NWTree")
@@ -262,6 +263,15 @@ class NWTree:
         """Return the position of an item under its parent."""
         return node.row() if (node := self._nodes.get(tHandle)) else -1
 
+    def allDocs(self) -> list[str]:
+        """Return a list of all document handles."""
+        if not self._docs:
+            self._docs = [
+                node.item.itemHandle for node in self._model.root.allChildren()
+                if node.item.isFileType()
+            ]
+        return self._docs
+
     def pickParent(self, sNode: ProjectNode, hLevel: int, isNote: bool) -> tuple[str | None, int]:
         """Pick an appropriate parent handle for adding a new item."""
         if sNode.item.isFolderType() or sNode.item.isRootType():
@@ -312,6 +322,7 @@ class NWTree:
     def novelStructureChanged(self, tHandle: str) -> None:
         """Emit a novel structure change signal."""
         if self._ready:
+            self._docs = []
             SHARED.novelStructureChanged.emit(tHandle)
 
     def checkConsistency(self, prefix: str) -> tuple[int, int]:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -134,7 +134,7 @@ class GuiDocEditor(QPlainTextEdit):
     loadDocumentTagRequest = pyqtSignal(str, Enum)
     openDocumentRequest = pyqtSignal(str, Enum, str, bool)
     requestNewNoteCreation = pyqtSignal(str, nwItemClass)
-    requestNextDocument = pyqtSignal(str, bool)
+    requestNextDocument = pyqtSignal(str, bool, bool)
     requestProjectItemRenamed = pyqtSignal(str, str)
     requestProjectItemSelected = pyqtSignal(str, bool)
     spellCheckStateChanged = pyqtSignal(bool)
@@ -689,10 +689,11 @@ class GuiDocEditor(QPlainTextEdit):
 
     def setCursorLine(self, line: int | None) -> None:
         """Move the cursor to a given line in the document."""
-        if isinstance(line, int) and line > 0:
-            if block := self._qDocument.findBlockByNumber(line - 1):
+        if isinstance(line, int) and line != 0:
+            line = self._qDocument.blockCount() + line if line < 0 else line - 1
+            if block := self._qDocument.findBlockByNumber(line):
                 self.setCursorPosition(block.position())
-                logger.debug("Cursor moved to line %d", line)
+                logger.debug("Cursor moved to line %d", line + 1)
 
     def setCursorSelection(self, start: int, length: int) -> None:
         """Make a text selection."""
@@ -1458,8 +1459,8 @@ class GuiDocEditor(QPlainTextEdit):
         if len(resS) == 0 and self._docHandle:
             self.docSearch.setResultCount(0, 0)
             self._lastFind = None
-            if CONFIG.searchNextFile and not goBack:
-                self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop)
+            if CONFIG.searchNextFile:
+                self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop, goBack)
                 QApplication.processEvents()
                 self.beginSearch()
                 prevFocus.setFocus()
@@ -1474,16 +1475,15 @@ class GuiDocEditor(QPlainTextEdit):
         if goBack:
             resIdx -= 2
 
-        if resIdx < 0:
-            resIdx = maxIdx if doLoop else 0
-
-        if resIdx > maxIdx and self._docHandle:
-            if CONFIG.searchNextFile and not goBack:
-                self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop)
+        if ((resIdx < 0 and goBack) or (resIdx > maxIdx and not goBack)) and self._docHandle:
+            if CONFIG.searchNextFile:
+                self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop, goBack)
                 QApplication.processEvents()
                 self.beginSearch()
                 prevFocus.setFocus()
                 return
+            elif goBack:
+                resIdx = maxIdx if doLoop else 0
             else:
                 resIdx = 0 if doLoop else maxIdx
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -559,8 +559,9 @@ class GuiMain(QMainWindow):
 
     @pyqtSlot(str, bool, bool)
     def openNextDocument(self, tHandle: str, wrapAround: bool, goBack: bool) -> None:
-        """Open the next document in the project tree, following the
-        document with the given handle. Stop when reaching the end.
+        """Open the next (or previous) document in the project tree,
+        next to the document with the given handle. Stop when reaching
+        the edge unless the wrapAround flag is set.
         """
         if SHARED.hasProject and (allDocs := SHARED.project.tree.allDocs()):
             try:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -557,29 +557,25 @@ class GuiMain(QMainWindow):
 
         return True
 
-    @pyqtSlot(str, bool)
-    def openNextDocument(self, tHandle: str, wrapAround: bool) -> None:
+    @pyqtSlot(str, bool, bool)
+    def openNextDocument(self, tHandle: str, wrapAround: bool, goBack: bool) -> None:
         """Open the next document in the project tree, following the
         document with the given handle. Stop when reaching the end.
         """
-        if SHARED.hasProject:
-            nHandle = None   # The next handle after tHandle
-            fHandle = None   # The first file handle we encounter
-            foundIt = False  # We've found tHandle, pick the next we see
-            for tItem in SHARED.project.tree:
-                if not tItem.isFileType():
-                    continue
-                if fHandle is None:
-                    fHandle = tItem.itemHandle
-                if tItem.itemHandle == tHandle:
-                    foundIt = True
-                elif foundIt:
-                    nHandle = tItem.itemHandle
-                    break
-            if nHandle is not None:
-                self.openDocument(nHandle, tLine=1, doScroll=True)
-            elif wrapAround:
-                self.openDocument(fHandle, tLine=1, doScroll=True)
+        if SHARED.hasProject and (allDocs := SHARED.project.tree.allDocs()):
+            try:
+                currIdx = allDocs.index(tHandle)
+                nHandle = (
+                    (allDocs[-1] if wrapAround else None)
+                    if currIdx == 0 else allDocs[currIdx - 1]
+                ) if goBack else (
+                    (allDocs[0] if wrapAround else None)
+                    if currIdx == len(allDocs) - 1 else allDocs[currIdx + 1]
+                )
+                if nHandle is not None:
+                    self.openDocument(nHandle, tLine=(-1 if goBack else 1), doScroll=True)
+            except Exception:
+                logger.error("Could not find next document for '%s'", tHandle)
 
     def saveDocument(self, force: bool = False) -> None:
         """Save the current documents."""

--- a/tests/test_core/test_core_tree.py
+++ b/tests/test_core/test_core_tree.py
@@ -71,6 +71,7 @@ def testCoreTree_Populate(monkeypatch, mockGUI, mockItems):
         "Novel", "Title Page", "New Folder", "New Chapter", "New Scene",
         "Plot", "Characters", "Locations", "Trash",
     ]
+    assert tree.allDocs() == [C.hTitlePage, C.hChapterDoc, C.hSceneDoc]
 
     # Pack the data again
     assert [n["name"] for n in tree.pack()] == [

--- a/tests/test_gui/test_gui_dochighlighter.py
+++ b/tests/test_gui/test_gui_dochighlighter.py
@@ -46,6 +46,7 @@ def syntax(nwGUI):
     CONFIG.altDialogOpen = "::"
     CONFIG.altDialogClose = "::"
     CONFIG.showMultiSpaces = True
+    CONFIG.dottedModCodes = True
 
     theme = SHARED.theme
     theme.loadTheme(force=True)
@@ -328,9 +329,12 @@ def testGuiDocHighlighter_Comments(syntax):
     assert formats[1].foreground().color().getRgb() == colHidden
     assert formats[1].fontStrikeOut() is True
     assert formats[2].foreground().color().getRgb() == colMod
+    assert formats[2].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[3].foreground().color().getRgb() == colNote
     assert formats[4].foreground().color().getRgb() == colMod
+    assert formats[4].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[5].foreground().color().getRgb() == colValue
+    assert formats[5].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[6].foreground().color().getRgb() == colNote
 
     # Unicode <= 0xFFFF
@@ -354,9 +358,12 @@ def testGuiDocHighlighter_Comments(syntax):
     assert formats[1].foreground().color().getRgb() == colHidden
     assert formats[1].fontStrikeOut() is True
     assert formats[2].foreground().color().getRgb() == colMod
+    assert formats[2].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[3].foreground().color().getRgb() == colNote
     assert formats[4].foreground().color().getRgb() == colMod
+    assert formats[4].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[5].foreground().color().getRgb() == colValue
+    assert formats[5].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[6].foreground().color().getRgb() == colNote
 
     # Unicode > 0xFFFF
@@ -380,9 +387,12 @@ def testGuiDocHighlighter_Comments(syntax):
     assert formats[1].foreground().color().getRgb() == colHidden
     assert formats[1].fontStrikeOut() is True
     assert formats[2].foreground().color().getRgb() == colMod
+    assert formats[2].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[3].foreground().color().getRgb() == colNote
     assert formats[4].foreground().color().getRgb() == colMod
+    assert formats[4].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[5].foreground().color().getRgb() == colValue
+    assert formats[5].underlineStyle() == QTextCharFormat.UnderlineStyle.DotLine
     assert formats[6].foreground().color().getRgb() == colNote
 
 

--- a/tests/test_gui/test_gui_guimain.py
+++ b/tests/test_gui/test_gui_guimain.py
@@ -42,6 +42,7 @@ from novelwriter.gui.doceditor import GuiDocEditor
 from novelwriter.gui.noveltree import GuiNovelView
 from novelwriter.gui.outline import GuiOutlineView
 from novelwriter.gui.projtree import GuiProjectTree
+from novelwriter.guimain import GuiMain
 from novelwriter.shared import _GuiAlert
 from novelwriter.tools.welcome import GuiWelcome
 from novelwriter.types import QtModCtrl, QtModShift
@@ -831,9 +832,29 @@ def testGuiMain_Features(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
 
 @pytest.mark.gui
-def testGuiMain_OpenClose(qtbot, monkeypatch, nwGUI, projPath, fncPath, mockRnd):
+def testGuiMain_OpenClose(qtbot, monkeypatch, nwGUI: GuiMain, projPath, fncPath, mockRnd):
     """Test various features of the main window."""
     buildTestProject(nwGUI, projPath)
+
+    # Check open document and prev/next with no wraparound
+    nwGUI.openNextDocument(C.hSceneDoc, False, True)  # Backwards
+    assert nwGUI.docEditor._docHandle == C.hChapterDoc
+    nwGUI.openNextDocument(C.hChapterDoc, False, False)  # Forwards
+    assert nwGUI.docEditor._docHandle == C.hSceneDoc
+
+    # Check open document and prev/next with wraparound
+    nwGUI.openNextDocument(C.hSceneDoc, True, False)  # Forwards
+    assert nwGUI.docEditor._docHandle == C.hTitlePage
+    nwGUI.openNextDocument(C.hTitlePage, True, True)  # Backwards
+    assert nwGUI.docEditor._docHandle == C.hSceneDoc
+
+    # Check with handle that is not a document, should do nothing
+    nwGUI.openDocument(C.hSceneDoc)
+    assert nwGUI.docEditor._docHandle == C.hSceneDoc
+    nwGUI.openNextDocument(C.hNovelRoot, True, True)
+    assert nwGUI.docEditor._docHandle == C.hSceneDoc
+
+    # Open some test documents
     nwGUI.openDocument(C.hSceneDoc)
     nwGUI.viewDocument(C.hTitlePage)
 


### PR DESCRIPTION
**Summary:**

This PR rewrites the lookup code that handles finding the next document during looped editor searches. It can no also look up documents in reversed order.

**Related Issue(s):**

Closes #1451

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
