### PR TITLE
Improve screen reader support

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -46,7 +46,7 @@ from novelwriter.common import (
     formatTimeStamp, joinLines, languageName, processDialogSymbols, safeExists,
     safeIsDir, simplified
 )
-from novelwriter.constants import nwFiles, nwQuotes, nwUnicode
+from novelwriter.constants import nwFiles, nwQuotes, nwUnicode, trStats
 from novelwriter.enum import nwTheme
 from novelwriter.error import formatException, logException
 
@@ -79,23 +79,24 @@ class Config:
         "_manuals", "_nwLangPath", "_qLocale", "_qtLangPath", "_qtTrans", "_recentPaths",
         "_recentProjects", "_splash", "allowOpenDial", "altDialogClose", "altDialogOpen",
         "appHandle", "appName", "askBeforeBackup", "askBeforeExit", "autoSaveDoc", "autoSaveProj",
-        "autoScroll", "autoScrollPos", "autoSelect", "backupOnClose", "cursorWidth", "darkTheme",
-        "dialogLine", "dialogStyle", "doJustify", "doReplace", "doReplaceDQuote", "doReplaceDash",
-        "doReplaceDots", "doReplaceSQuote", "dottedModCodes", "emphLabels", "fmtApostrophe",
-        "fmtDQuoteClose", "fmtDQuoteOpen", "fmtPadAfter", "fmtPadBefore", "fmtPadThin",
-        "fmtSQuoteClose", "fmtSQuoteOpen", "focusWidth", "fontWinSize", "guiFont", "guiLocale",
-        "hasEnchant", "hideFocusFooter", "hideHScroll", "hideVScroll", "highlightEmph", "hostName",
-        "iconColDocs", "iconColTree", "iconTheme", "incNotesWCount", "isDebug", "kernelVer",
-        "lastNotes", "lightTheme", "lineHighlight", "mainPanePos", "mainWinSize", "memInfo",
-        "moveMainWin", "narratorBreak", "narratorDialog", "nativeFont", "osDarwin", "osLinux",
-        "osType", "osUnknown", "osWindows", "outlinePanePos", "prefsWinSize", "scaleHeadings",
-        "scrollPastEnd", "searchCase", "searchLoop", "searchMatchCap", "searchNextFile",
-        "searchProjCase", "searchProjRegEx", "searchProjWord", "searchRegEx", "searchWord",
-        "showEditToolBar", "showFullPath", "showLineEndings", "showMultiSpaces", "showSessionTime",
-        "showTabsNSpaces", "showViewerPanel", "spellLanguage", "stopWhenIdle", "tabWidth",
-        "textFont", "textMargin", "textWidth", "themeMode", "useCharCount", "userIdleTime",
-        "verPyQtString", "verPyQtValue", "verPyString", "verQtString", "verQtValue",
-        "viewComments", "viewNotes", "viewPanePos", "viewSynopsis", "vimMode", "welcomeWinSize"
+        "autoScroll", "autoScrollPos", "autoSelect", "backupOnClose", "countUnit", "cursorWidth",
+        "darkTheme", "dialogLine", "dialogStyle", "doJustify", "doReplace", "doReplaceDQuote",
+        "doReplaceDash", "doReplaceDots", "doReplaceSQuote", "dottedModCodes", "emphLabels",
+        "fmtApostrophe", "fmtDQuoteClose", "fmtDQuoteOpen", "fmtPadAfter", "fmtPadBefore",
+        "fmtPadThin", "fmtSQuoteClose", "fmtSQuoteOpen", "focusWidth", "fontWinSize", "guiFont",
+        "guiLocale", "hasEnchant", "hideFocusFooter", "hideHScroll", "hideVScroll",
+        "highlightEmph", "hostName", "iconColDocs", "iconColTree", "iconTheme", "incNotesWCount",
+        "isDebug", "kernelVer", "lastNotes", "lightTheme", "lineHighlight", "mainPanePos",
+        "mainWinSize", "memInfo", "moveMainWin", "narratorBreak", "narratorDialog", "nativeFont",
+        "osDarwin", "osLinux", "osType", "osUnknown", "osWindows", "outlinePanePos",
+        "prefsWinSize", "scaleHeadings", "scrollPastEnd", "searchCase", "searchLoop",
+        "searchMatchCap", "searchNextFile", "searchProjCase", "searchProjRegEx", "searchProjWord",
+        "searchRegEx", "searchWord", "showEditToolBar", "showFullPath", "showLineEndings",
+        "showMultiSpaces", "showSessionTime", "showTabsNSpaces", "showViewerPanel",
+        "spellLanguage", "stopWhenIdle", "tabWidth", "textFont", "textMargin", "textWidth",
+        "themeMode", "useCharCount", "userIdleTime", "verPyQtString", "verPyQtValue",
+        "verPyString", "verQtString", "verQtValue", "viewComments", "viewNotes", "viewPanePos",
+        "viewSynopsis", "vimMode", "welcomeWinSize",
     )
 
     LANG_NW   = 1
@@ -176,6 +177,7 @@ class Config:
         self.nativeFont   = True           # Use native font dialog
         self.useCharCount = False          # Use character count as primary count
         self.vimMode      = False          # Enable Vim mode
+        self.countUnit    = "words"        # Primary count unit
 
         # Icons
         self.iconTheme   = DEF_ICONS    # Icons theme
@@ -450,6 +452,11 @@ class Config:
             self.textFont = fontMatcher(font)
             logger.debug("Text font set to: %s", describeFont(self.textFont))
 
+    def setPrimaryCount(self, useCharCount: bool) -> None:
+        """Set the primary count unit. This also updates the unit label."""
+        self.useCharCount = useCharCount
+        self.countUnit = trStats("Characters" if useCharCount else "Words").lower()
+
     ##
     #  Methods
     ##
@@ -609,6 +616,9 @@ class Config:
                         logger.debug("Loaded: %s.qm", lngFile)
                         nwApp.installTranslator(qTrans)
                         self._qtTrans[lngFile] = qTrans
+
+        # Refresh translated values
+        self.setPrimaryCount(self.useCharCount)
 
     def loadConfig(self, splash: NSplashScreen | None = None) -> bool:
         """Load preferences from file and replace default settings."""

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -176,8 +176,8 @@ class Config:
         self.lastNotes    = "0x0"          # The latest release notes that have been shown
         self.nativeFont   = True           # Use native font dialog
         self.useCharCount = False          # Use character count as primary count
-        self.vimMode      = False          # Enable Vim mode
         self.countUnit    = "words"        # Primary count unit
+        self.vimMode      = False          # Enable Vim mode
 
         # Icons
         self.iconTheme   = DEF_ICONS    # Icons theme

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 from PyQt6.QtCore import QAbstractItemModel, QMimeData, QModelIndex, Qt
 from PyQt6.QtGui import QFont, QIcon
 
+from novelwriter import CONFIG
 from novelwriter.common import decodeMimeHandles, encodeMimeHandles, minmax
 from novelwriter.constants import nwConst
 from novelwriter.core.item import NWItem
@@ -51,6 +52,8 @@ C_LABEL_FONT    = 0x0000 | Qt.ItemDataRole.FontRole
 C_COUNT_TEXT    = 0x0100 | Qt.ItemDataRole.DisplayRole
 C_COUNT_ICON    = 0x0100 | Qt.ItemDataRole.DecorationRole
 C_COUNT_ALIGN   = 0x0100 | Qt.ItemDataRole.TextAlignmentRole
+C_COUNT_TIP     = 0x0100 | Qt.ItemDataRole.ToolTipRole
+C_COUNT_ACCESS  = 0x0100 | Qt.ItemDataRole.AccessibleTextRole
 C_ACTIVE_ICON   = 0x0200 | Qt.ItemDataRole.DecorationRole
 C_ACTIVE_TIP    = 0x0200 | Qt.ItemDataRole.ToolTipRole
 C_ACTIVE_ACCESS = 0x0200 | Qt.ItemDataRole.AccessibleTextRole
@@ -164,7 +167,11 @@ class ProjectNode:
     def updateCount(self, propagate: bool = True) -> None:
         """Update counts, and propagate upwards in the tree."""
         self._count = self._item.mainCount + sum(c._count for c in self._children)  # noqa: SLF001
-        self._cache[C_COUNT_TEXT] = f"{self._count:n}"
+        text = f"{self._count:n}"
+        info = f"{text} {CONFIG.countUnit}"
+        self._cache[C_COUNT_TEXT] = text
+        self._cache[C_COUNT_TIP] = info
+        self._cache[C_COUNT_ACCESS] = info
         if propagate and (parent := self._parent):
             parent.updateCount()
 

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt
 from PyQt6.QtGui import QIcon, QPixmap
 
-from novelwriter import SHARED
+from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwKeyWords, nwLabels, nwStyles, trConst
 from novelwriter.enum import nwNovelExtra
 from novelwriter.types import QtAlignRight
@@ -201,11 +201,16 @@ class NovelModel(QAbstractTableModel):
     def _generateEntry(self, handle: str, key: str, head: IndexHeading) -> dict[int, T_NodeData]:
         """Generate a cache entry."""
         iLevel = nwStyles.H_LEVEL.get(head.level, 0)
+        countValue = f"{head.mainCount:n}"
+        countInfo = f"{countValue} {CONFIG.countUnit}"
+
         data = {}
         data[C_FACTOR*0 | R_TIP] = head.title
         data[C_FACTOR*0 | R_TEXT] = head.title
         data[C_FACTOR*0 | R_ICON] = SHARED.theme.getHeaderDecoration(iLevel)
-        data[C_FACTOR*1 | R_TEXT] = f"{head.mainCount:n}"
+        data[C_FACTOR*1 | R_TEXT] = countValue
+        data[C_FACTOR*1 | R_TIP] = countInfo
+        data[C_FACTOR*1 | R_ACCESS] = countInfo
         data[C_FACTOR*1 | R_ALIGN] = QtAlignRight
         if self._columns == 3:
             data[C_FACTOR*2 | R_ICON] = self._more

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -1058,8 +1058,8 @@ class GuiPreferences(NDialog):
         CONFIG.hideVScroll  = self.hideVScroll.isChecked()
         CONFIG.hideHScroll  = self.hideHScroll.isChecked()
         CONFIG.nativeFont   = self.nativeFont.isChecked()
-        CONFIG.useCharCount = useCharCount
         CONFIG.setGuiFont(self._guiFont)
+        CONFIG.setPrimaryCount(useCharCount)
 
         # Document Style
         CONFIG.showFullPath   = self.showFullPath.isChecked()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -212,6 +212,7 @@ class GuiPreferences(NDialog):
         self.guiFont.setText(describeFont(self._guiFont))
         self.guiFont.setCursorPosition(0)
         self.guiFontButton = NIconToolButton(self, iSz, "font", "tool")
+        self.guiFontButton.setToolTip(self.tr("Select Font"))
         self.guiFontButton.clicked.connect(self._selectGuiFont)
         self.mainForm.addRow(
             self.tr("Application font"), self.guiFont,
@@ -266,6 +267,7 @@ class GuiPreferences(NDialog):
         self.textFont.setText(describeFont(CONFIG.textFont))
         self.textFont.setCursorPosition(0)
         self.textFontButton = NIconToolButton(self, iSz, "font", "tool")
+        self.textFontButton.setToolTip(self.tr("Select Font"))
         self.textFontButton.clicked.connect(self._selectTextFont)
         self.mainForm.addRow(
             self.tr("Document font"), self.textFont,
@@ -683,6 +685,7 @@ class GuiPreferences(NDialog):
         self.dialogLine.setText(" ".join(CONFIG.dialogLine))
 
         self.dialogLineButton = NIconToolButton(self, iSz, "add", "add")
+        self.dialogLineButton.setToolTip(self.tr("Select Symbol"))
         self.dialogLineButton.setMenu(self.mnLineSymbols)
 
         self.mainForm.addRow(
@@ -833,6 +836,7 @@ class GuiPreferences(NDialog):
         self.fmtSQuoteOpen.setAlignment(QtAlignCenter)
         self.fmtSQuoteOpen.setText(CONFIG.fmtSQuoteOpen)
         self.btnSQuoteOpen = NIconToolButton(self, iSz, "quote", "tool")
+        self.btnSQuoteOpen.setToolTip(self.tr("Select Symbol"))
         self.btnSQuoteOpen.clicked.connect(self._changeSingleQuoteOpen)
         self.mainForm.addRow(
             self.tr("Single quote open style"), self.fmtSQuoteOpen,
@@ -847,6 +851,7 @@ class GuiPreferences(NDialog):
         self.fmtSQuoteClose.setAlignment(QtAlignCenter)
         self.fmtSQuoteClose.setText(CONFIG.fmtSQuoteClose)
         self.btnSQuoteClose = NIconToolButton(self, iSz, "quote", "tool")
+        self.btnSQuoteClose.setToolTip(self.tr("Select Symbol"))
         self.btnSQuoteClose.clicked.connect(self._changeSingleQuoteClose)
         self.mainForm.addRow(
             self.tr("Single quote close style"), self.fmtSQuoteClose,
@@ -862,6 +867,7 @@ class GuiPreferences(NDialog):
         self.fmtDQuoteOpen.setAlignment(QtAlignCenter)
         self.fmtDQuoteOpen.setText(CONFIG.fmtDQuoteOpen)
         self.btnDQuoteOpen = NIconToolButton(self, iSz, "quote", "tool")
+        self.btnDQuoteOpen.setToolTip(self.tr("Select Symbol"))
         self.btnDQuoteOpen.clicked.connect(self._changeDoubleQuoteOpen)
         self.mainForm.addRow(
             self.tr("Double quote open style"), self.fmtDQuoteOpen,
@@ -876,6 +882,7 @@ class GuiPreferences(NDialog):
         self.fmtDQuoteClose.setAlignment(QtAlignCenter)
         self.fmtDQuoteClose.setText(CONFIG.fmtDQuoteClose)
         self.btnDQuoteClose = NIconToolButton(self, iSz, "quote", "tool")
+        self.btnDQuoteClose.setToolTip(self.tr("Select Symbol"))
         self.btnDQuoteClose.clicked.connect(self._changeDoubleQuoteClose)
         self.mainForm.addRow(
             self.tr("Double quote close style"), self.fmtDQuoteClose,

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -41,7 +41,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatFileFilter, qtAddAction, qtLambda, simplified
 from novelwriter.constants import nwLabels, trConst
 from novelwriter.core.status import CUSTOM_COL, NWStatus, StatusEntry
-from novelwriter.enum import nwStandardButton, nwStatusShape
+from novelwriter.enum import nwStandardButton, nwStatusShape, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel, NFixedPage, NScrollableForm
 from novelwriter.extensions.modified import NComboBox, NDialog, NIconToolButton
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
@@ -356,28 +356,22 @@ class _StatusPage(NFixedPage):
             self._addItem(key, StatusEntry.duplicate(entry))
 
         # List Controls
-        self.addButton = NIconToolButton(self, iSz, "add", "add")
-        self.addButton.setToolTip(self.tr("Add Label"))
+        self.addButton = SHARED.theme.getToolButton(nwToolButton.ADD, self)
         self.addButton.clicked.connect(self._onItemCreate)
 
-        self.delButton = NIconToolButton(self, iSz, "remove", "remove")
-        self.delButton.setToolTip(self.tr("Delete Label"))
+        self.delButton = SHARED.theme.getToolButton(nwToolButton.REMOVE, self)
         self.delButton.clicked.connect(self._onItemDelete)
 
-        self.upButton = NIconToolButton(self, iSz, "chevron_up", "action")
-        self.upButton.setToolTip(self.tr("Move Up"))
+        self.upButton = SHARED.theme.getToolButton(nwToolButton.MOVE_UP, self)
         self.upButton.clicked.connect(qtLambda(self._moveItem, -1))
 
-        self.downButton = NIconToolButton(self, iSz, "chevron_down", "action")
-        self.downButton.setToolTip(self.tr("Move Down"))
+        self.downButton = SHARED.theme.getToolButton(nwToolButton.MOVE_DOWN, self)
         self.downButton.clicked.connect(qtLambda(self._moveItem, 1))
 
-        self.importButton = NIconToolButton(self, iSz, "import", "apply")
-        self.importButton.setToolTip(self.tr("Import Labels"))
+        self.importButton = SHARED.theme.getToolButton(nwToolButton.IMPORT, self)
         self.importButton.clicked.connect(self._importLabels)
 
-        self.exportButton = NIconToolButton(self, iSz, "export", "action")
-        self.exportButton.setToolTip(self.tr("Export Labels"))
+        self.exportButton = SHARED.theme.getToolButton(nwToolButton.EXPORT, self)
         self.exportButton.clicked.connect(self._exportLabels)
 
         # Edit Form
@@ -702,7 +696,6 @@ class _ReplacePage(NFixedPage):
 
         self._changed = False
 
-        iSz = SHARED.theme.baseIconSize
         wCol0 = SHARED.project.options.getInt("GuiProjectSettings", "replaceColW", 130)
 
         # Title
@@ -729,10 +722,10 @@ class _ReplacePage(NFixedPage):
         self.listBox.setSortingEnabled(True)
 
         # List Controls
-        self.addButton = NIconToolButton(self, iSz, "add", "add")
+        self.addButton = SHARED.theme.getToolButton(nwToolButton.ADD, self)
         self.addButton.clicked.connect(self._onEntryCreated)
 
-        self.delButton = NIconToolButton(self, iSz, "remove", "remove")
+        self.delButton = SHARED.theme.getToolButton(nwToolButton.REMOVE, self)
         self.delButton.clicked.connect(self._onEntryDeleted)
 
         # Edit Form

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -250,7 +250,7 @@ class _SettingsPage(NScrollableForm):
         self.projAuthor.setMinimumWidth(200)
         self.projAuthor.setText(data.author)
         self.addRow(
-            self.tr("Author(s)"), self.projAuthor,
+            self.tr("Author"), self.projAuthor,
             self.tr("Only used when building the manuscript."),
             stretch=(3, 2)
         )

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -37,9 +37,9 @@ from PyQt6.QtWidgets import (
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatFileFilter
 from novelwriter.core.spellcheck import UserDictionary
-from novelwriter.enum import nwStandardButton
+from novelwriter.enum import nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel
-from novelwriter.extensions.modified import NDialog, NIconToolButton
+from novelwriter.extensions.modified import NDialog
 from novelwriter.types import QtRoleAccept, QtRoleDestruct
 
 if TYPE_CHECKING:
@@ -60,8 +60,6 @@ class GuiWordList(NDialog):
         self.setObjectName("GuiWordList")
         self.setWindowTitle(self.tr("Project Word List"))
 
-        iSz = SHARED.theme.baseIconSize
-
         self.setMinimumWidth(250)
         self.setMinimumHeight(250)
         self.resize(
@@ -75,11 +73,11 @@ class GuiWordList(NDialog):
             scale=NColorLabel.HEADER_SCALE
         )
 
-        self.importButton = NIconToolButton(self, iSz, "import", "apply")
+        self.importButton = SHARED.theme.getToolButton(nwToolButton.IMPORT, self)
         self.importButton.setToolTip(self.tr("Import words from text file"))
         self.importButton.clicked.connect(self._importWords)
 
-        self.exportButton = NIconToolButton(self, iSz, "export", "action")
+        self.exportButton = SHARED.theme.getToolButton(nwToolButton.EXPORT, self)
         self.exportButton.setToolTip(self.tr("Export words to text file"))
         self.exportButton.clicked.connect(self._exportWords)
 
@@ -97,12 +95,10 @@ class GuiWordList(NDialog):
         # Add/Remove Form
         self.newEntry = QLineEdit(self)
 
-        self.addButton = NIconToolButton(self, iSz, "add", "add")
-        self.addButton.setToolTip(self.tr("Add Word"))
+        self.addButton = SHARED.theme.getToolButton(nwToolButton.ADD, self)
         self.addButton.clicked.connect(self._doAdd)
 
-        self.delButton = NIconToolButton(self, iSz, "remove", "remove")
-        self.delButton.setToolTip(self.tr("Remove Word"))
+        self.delButton = SHARED.theme.getToolButton(nwToolButton.REMOVE, self)
         self.delButton.clicked.connect(self._doDelete)
 
         self.editBox = QHBoxLayout()

--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -281,6 +281,20 @@ class nwStandardButton(Enum):
     PREVIEW = 16
 
 
+class nwToolButton(Enum):
+    """Enum: Standard Tool Buttons."""
+
+    ADD       = 0
+    REMOVE    = 1
+    MOVE_UP   = 2
+    MOVE_DOWN = 3
+    IMPORT    = 4
+    EXPORT    = 5
+    BROWSE    = 6
+    EDIT      = 7
+    REVERT    = 8
+
+
 class nwState(Enum):
     """Enum: Object state values."""
 

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -197,16 +197,18 @@ class NScrollableForm(QScrollArea):
         else:
             qWidget = widget
 
-        text = label or ""
-        qLabel = QLabel(text, self)
+        qLabel = QLabel(label or "", self)
         qLabel.setIndent(self._indent)
         qLabel.setBuddy(qWidget)
+        qWidget.setAccessibleName(label)
 
         if helpText:
             qHelp = NColorLabel(
                 str(helpText), self, color=self._helpCol,
                 scale=self._fontScale, wrap=True, indent=self._indent
             )
+            qHelp.setBuddy(qWidget)
+            qWidget.setAccessibleDescription(helpText)
             labelBox = QVBoxLayout()
             labelBox.addWidget(qLabel, 0)
             labelBox.addWidget(qHelp, 1)
@@ -214,16 +216,17 @@ class NScrollableForm(QScrollArea):
             row.addLayout(labelBox, stretch[0])
             if editable:
                 self._editable[editable] = qHelp
-            text = f"{text}: {helpText}"
         else:
             row.addWidget(qLabel, stretch[0])
 
         if isinstance(unit, str):
+            qUnit = QLabel(unit, self)
+            qUnit.setBuddy(qWidget)
+            qWidget.setAccessibleDescription(f"{unit}. {qWidget.accessibleDescription()}")
             box = QHBoxLayout()
             box.addWidget(qWidget, 1)
-            box.addWidget(QLabel(unit, self), 0)
+            box.addWidget(qUnit, 0)
             row.addLayout(box, stretch[1])
-            text = f"{text} Unit: {unit}"
         elif isinstance(button, QAbstractButton):
             box = QHBoxLayout()
             box.addWidget(qWidget, 1)
@@ -236,7 +239,6 @@ class NScrollableForm(QScrollArea):
         self._layout.addLayout(row)
         if label:
             self._index[label.strip()] = qWidget
-        qLabel.setAccessibleName(text)
 
     def finalise(self) -> None:
         """Finalise the layout when the form is built."""
@@ -268,7 +270,6 @@ class NColorLabel(QLabel):
         self._color = color or default
         self._faded = faded or default
         self._error = error or default
-        self._crumbs = ""
 
         font = self.font()
         font.setPointSizeF(scale*font.pointSizeF())

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -293,6 +293,8 @@ class NIconToolButton(QToolButton):
     A quicker way to create a tool button using the app theme.
     """
 
+    __slots__ = ("_color", "_icon")
+
     def __init__(
         self, parent: QWidget, iconSize: QSize,
         icon: str | None = None, color: str | None = None
@@ -306,7 +308,13 @@ class NIconToolButton(QToolButton):
 
     def setThemeIcon(self, icon: str, color: str) -> None:
         """Set an icon from the current theme."""
+        self._icon = icon
+        self._color = color
         self.setIcon(SHARED.theme.getIcon(icon, color))
+
+    def refreshIcon(self) -> None:
+        """Refresh the icon for theme updates."""
+        self.setIcon(SHARED.theme.getIcon(self._icon, self._color))
 
 
 class NIconToggleButton(QToolButton):

--- a/novelwriter/extensions/pagedsidebar.py
+++ b/novelwriter/extensions/pagedsidebar.py
@@ -86,6 +86,7 @@ class NPagedSideBar(QToolBar):
         """Add a new button to the toolbar."""
         button = _PagedToolButton(self)
         button.setText(text)
+        button.setAccessibleIdentifier(text)
         self.insertWidget(self._stretchAction, button)
         self._group.addButton(button, id=buttonId)
         self._buttons[buttonId] = button

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -840,38 +840,38 @@ class GuiDocViewFooter(QWidget):
 
         # Show/Hide Details
         self.showHide = NIconToolButton(self, iSz)
-        self.showHide.clicked.connect(lambda: self.docViewer.togglePanelVisibility.emit())
         self.showHide.setToolTip(self.tr("Show/Hide Viewer Panel"))
+        self.showHide.clicked.connect(lambda: self.docViewer.togglePanelVisibility.emit())
 
         # Show Comments
         self.showComments = QToolButton(self)
         self.showComments.setText(self.tr("Comments"))
+        self.showComments.setToolTip(self.tr("Show Comments"))
         self.showComments.setCheckable(True)
         self.showComments.setChecked(CONFIG.viewComments)
         self.showComments.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.showComments.setIconSize(iSz)
         self.showComments.toggled.connect(self._doToggleComments)
-        self.showComments.setToolTip(self.tr("Show Comments"))
 
         # Show Synopsis
         self.showSynopsis = QToolButton(self)
         self.showSynopsis.setText(self.tr("Synopsis"))
+        self.showSynopsis.setToolTip(self.tr("Show Synopsis Comments"))
         self.showSynopsis.setCheckable(True)
         self.showSynopsis.setChecked(CONFIG.viewSynopsis)
         self.showSynopsis.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.showSynopsis.setIconSize(iSz)
         self.showSynopsis.toggled.connect(self._doToggleSynopsis)
-        self.showSynopsis.setToolTip(self.tr("Show Synopsis Comments"))
 
         # Show Notes
         self.showNotes = QToolButton(self)
         self.showNotes.setText(self.tr("Notes"))
+        self.showNotes.setToolTip(self.tr("Show Notes"))
         self.showNotes.setCheckable(True)
         self.showNotes.setChecked(CONFIG.viewNotes)
         self.showNotes.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.showNotes.setIconSize(iSz)
         self.showNotes.toggled.connect(self._doToggleNotes)
-        self.showNotes.setToolTip(self.tr("Show Notes"))
 
         # Assemble Layout
         self.outerBox = QHBoxLayout()

--- a/novelwriter/gui/docviewerpanel.py
+++ b/novelwriter/gui/docviewerpanel.py
@@ -75,6 +75,7 @@ class GuiDocViewerPanel(QWidget):
         self.aInactive.toggled.connect(self._toggleHideInactive)
 
         self.optsButton = NIconToolButton(self, iSz)
+        self.optsButton.setToolTip(self.tr("Options"))
         self.optsButton.setMenu(self.optsMenu)
         self.optsButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -42,9 +42,12 @@ from novelwriter import CONFIG
 from novelwriter.common import checkInt, minmax, safeIsFile
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS, DEF_TREECOL
 from novelwriter.constants import nwLabels
-from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwStandardButton, nwTheme
+from novelwriter.enum import (
+    nwItemClass, nwItemLayout, nwItemType, nwStandardButton, nwTheme,
+    nwToolButton
+)
 from novelwriter.error import logException
-from novelwriter.extensions.modified import NPushButton
+from novelwriter.extensions.modified import NIconToolButton, NPushButton
 from novelwriter.types import (
     QtBlack, QtColActive, QtColDisabled, QtColInactive, QtHexArgb,
     QtPaintAntiAlias, QtTransparent
@@ -77,6 +80,18 @@ STANDARD_BUTTONS = {
     nwStandardButton.BUILD:   (QT_TRANSLATE_NOOP("Button", "Build"), "btn_build", "action"),
     nwStandardButton.PRINT:   (QT_TRANSLATE_NOOP("Button", "Print"), "btn_print", "action"),
     nwStandardButton.PREVIEW: (QT_TRANSLATE_NOOP("Button", "Preview"), "btn_preview", "action"),
+}
+
+TOOL_BUTTONS = {
+    nwToolButton.ADD:       (QT_TRANSLATE_NOOP("Button", "Add"), "add", "add"),
+    nwToolButton.REMOVE:    (QT_TRANSLATE_NOOP("Button", "Remove"), "remove", "remove"),
+    nwToolButton.MOVE_UP:   (QT_TRANSLATE_NOOP("Button", "Move Up"), "chevron_up", "action"),
+    nwToolButton.MOVE_DOWN: (QT_TRANSLATE_NOOP("Button", "Move Down"), "chevron_down", "action"),
+    nwToolButton.IMPORT:    (QT_TRANSLATE_NOOP("Button", "Import"), "import", "apply"),
+    nwToolButton.EXPORT:    (QT_TRANSLATE_NOOP("Button", "Export"), "export", "action"),
+    nwToolButton.BROWSE:    (QT_TRANSLATE_NOOP("Button", "Browse"), "browse", "systemio"),
+    nwToolButton.EDIT:      (QT_TRANSLATE_NOOP("Button", "Edit"), "edit", "change"),
+    nwToolButton.REVERT:    (QT_TRANSLATE_NOOP("Button", "Revert"), "revert", "reset"),
 }
 
 
@@ -145,10 +160,10 @@ class GuiTheme:
         "_qColors", "_styleSheets", "_svgColors", "_syntaxList", "accentCol", "baseButtonHeight",
         "baseIconHeight", "baseIconSize", "errorText", "fadedText", "fontPixelSize",
         "fontPointSize", "getDecoration", "getHeaderDecoration", "getHeaderDecorationNarrow",
-        "getIcon", "getItemIcon", "getPixmap", "getStandardButton", "getToggleIcon", "guiFont",
-        "guiFontB", "guiFontBU", "guiFontFixed", "guiFontSmall", "helpText", "iconCache",
-        "isDarkTheme", "pushButtonIconSize", "sidebarIconSize", "syntaxTheme", "textNHeight",
-        "textNWidth", "toolButtonIconSize",
+        "getIcon", "getItemIcon", "getPixmap", "getStandardButton", "getToggleIcon",
+        "getToolButton", "guiFont", "guiFontB", "guiFontBU", "guiFontFixed", "guiFontSmall",
+        "helpText", "iconCache", "isDarkTheme", "pushButtonIconSize", "sidebarIconSize",
+        "syntaxTheme", "textNHeight", "textNWidth", "toolButtonIconSize",
     )
 
     def __init__(self) -> None:
@@ -179,6 +194,7 @@ class GuiTheme:
         self.getItemIcon = self.iconCache.getItemIcon
         self.getToggleIcon = self.iconCache.getToggleIcon
         self.getDecoration = self.iconCache.getDecoration
+        self.getToolButton = self.iconCache.getToolButton
         self.getStandardButton = self.iconCache.getStandardButton
         self.getHeaderDecoration = self.iconCache.getHeaderDecoration
         self.getHeaderDecorationNarrow = self.iconCache.getHeaderDecorationNarrow
@@ -902,6 +918,15 @@ class GuiIcons:
             parent, QCoreApplication.translate("Button", text),
             self._theme.pushButtonIconSize, icon, color
         )
+
+    def getToolButton(self, button: nwToolButton, parent: QWidget) -> NIconToolButton:
+        """Return a tool button with icon."""
+        toolTip, icon, color = TOOL_BUTTONS.get(button, ("", "", ""))
+        toolButton = NIconToolButton(
+            parent, self._theme.baseIconSize, icon, color
+        )
+        toolButton.setToolTip(QCoreApplication.translate("Button", toolTip))
+        return toolButton
 
     def getDecoration(self, name: str, w: int | None = None, h: int | None = None) -> QPixmap:
         """Load graphical decoration element based on the decoration

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -39,9 +39,9 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import (
     formatFileFilter, formatInt, getFileSize, joinLines, openExternalPath
 )
-from novelwriter.enum import nwStandardButton
+from novelwriter.enum import nwStandardButton, nwToolButton
 from novelwriter.error import formatException, logException
-from novelwriter.extensions.modified import NIconToolButton, NNonBlockingDialog
+from novelwriter.extensions.modified import NNonBlockingDialog
 from novelwriter.types import QtHexArgb, QtMoveEnd, QtRoleDestruct
 
 if TYPE_CHECKING:
@@ -68,8 +68,6 @@ class GuiDictionaries(NNonBlockingDialog):
         self._installPath = None
         self._currDicts = set()
 
-        iSz = SHARED.theme.baseIconSize
-
         self.setMinimumWidth(500)
         self.setMinimumHeight(300)
 
@@ -84,7 +82,7 @@ class GuiDictionaries(NNonBlockingDialog):
         self.huInfo.setOpenExternalLinks(True)
         self.huInfo.setWordWrap(True)
         self.huInput = QLineEdit(self)
-        self.huBrowse = NIconToolButton(self, iSz, "browse", "systemio")
+        self.huBrowse = SHARED.theme.getToolButton(nwToolButton.BROWSE, self)
         self.huBrowse.clicked.connect(self._doBrowseHunspell)
         self.huImport = QPushButton(self.tr("Add Dictionary"), self)
         self.huImport.setIcon(SHARED.theme.getIcon("add", "add"))
@@ -102,7 +100,7 @@ class GuiDictionaries(NNonBlockingDialog):
         self.inInfo = QLabel(self.tr("Dictionary install location"), self)
         self.inPath = QLineEdit(self)
         self.inPath.setReadOnly(True)
-        self.inBrowse = NIconToolButton(self, iSz, "browse", "systemio")
+        self.inBrowse = SHARED.theme.getToolButton(nwToolButton.BROWSE, self)
         self.inBrowse.clicked.connect(self._doOpenInstallLocation)
 
         self.inBox = QHBoxLayout()

--- a/novelwriter/tools/manusbuild.py
+++ b/novelwriter/tools/manusbuild.py
@@ -41,7 +41,7 @@ from novelwriter.common import makeFileNameSafe, openExternalPath, safeExists, s
 from novelwriter.constants import nwLabels
 from novelwriter.core.docbuild import NWBuildDocument
 from novelwriter.core.item import NWItem
-from novelwriter.enum import nwBuildFmt, nwStandardButton
+from novelwriter.enum import nwBuildFmt, nwStandardButton, nwToolButton
 from novelwriter.extensions.modified import NDialog, NIconToolButton, NPushButton
 from novelwriter.extensions.progressbars import NProgressSimple
 from novelwriter.types import QtAlignCenter, QtRoleAction, QtRoleDestruct, QtUserRole
@@ -144,7 +144,7 @@ class GuiManuscriptBuild(NDialog):
         # Build Path
         self.lblPath = QLabel(self.tr("Path"), self)
         self.buildPath = QLineEdit(self)
-        self.btnBrowse = NIconToolButton(self, iSz, "browse", "systemio")
+        self.btnBrowse = SHARED.theme.getToolButton(nwToolButton.BROWSE, self)
 
         self.pathBox = QHBoxLayout()
         self.pathBox.addWidget(self.buildPath)

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -43,7 +43,7 @@ from novelwriter.common import (
 )
 from novelwriter.constants import nwHeadFmt, nwKeyWords, nwLabels, nwStyles, nwUnicode, trConst
 from novelwriter.core.buildsettings import BuildSettings, FilterMode
-from novelwriter.enum import nwStandardButton
+from novelwriter.enum import nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import (
     NColorLabel, NFixedPage, NScrollableForm, NScrollablePage
 )
@@ -591,7 +591,6 @@ class _HeadingsTab(NScrollablePage):
         self._editing = 0
 
         iPx = SHARED.theme.baseIconHeight
-        iSz = SHARED.theme.baseIconSize
         trHide = self.tr("Hide")
 
         # Format Boxes
@@ -603,7 +602,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblPart = QLabel(self._build.getLabel("headings.fmtPart"), self)
         self.fmtPart = QLineEdit("", self)
         self.fmtPart.setReadOnly(True)
-        self.btnPart = NIconToolButton(self, iSz)
+        self.btnPart = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
         self.btnPart.clicked.connect(qtLambda(self._editHeading, self.EDIT_TITLE))
         self.swtPart = NSwitch(self, height=iPx)
         self.hdePart = QLabel(trHide, self)
@@ -620,7 +619,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblChapter = QLabel(self._build.getLabel("headings.fmtChapter"), self)
         self.fmtChapter = QLineEdit("", self)
         self.fmtChapter.setReadOnly(True)
-        self.btnChapter = NIconToolButton(self, iSz)
+        self.btnChapter = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
         self.btnChapter.clicked.connect(qtLambda(self._editHeading, self.EDIT_CHAPTER))
         self.swtChapter = NSwitch(self, height=iPx)
         self.hdeChapter = QLabel(trHide, self)
@@ -637,7 +636,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblUnnumbered = QLabel(self._build.getLabel("headings.fmtUnnumbered"), self)
         self.fmtUnnumbered = QLineEdit("", self)
         self.fmtUnnumbered.setReadOnly(True)
-        self.btnUnnumbered = NIconToolButton(self, iSz)
+        self.btnUnnumbered = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
         self.btnUnnumbered.clicked.connect(qtLambda(self._editHeading, self.EDIT_UNNUM))
         self.swtUnnumbered = NSwitch(self, height=iPx)
         self.hdeUnnumbered = QLabel(trHide, self)
@@ -654,7 +653,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblScene = QLabel(self._build.getLabel("headings.fmtScene"), self)
         self.fmtScene = QLineEdit("", self)
         self.fmtScene.setReadOnly(True)
-        self.btnScene = NIconToolButton(self, iSz)
+        self.btnScene = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
         self.btnScene.clicked.connect(qtLambda(self._editHeading, self.EDIT_SCENE))
         self.swtScene = NSwitch(self, height=iPx)
         self.hdeScene = QLabel(trHide, self)
@@ -671,7 +670,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblAScene = QLabel(self._build.getLabel("headings.fmtAltScene"), self)
         self.fmtAScene = QLineEdit("", self)
         self.fmtAScene.setReadOnly(True)
-        self.btnAScene = NIconToolButton(self, iSz)
+        self.btnAScene = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
         self.btnAScene.clicked.connect(qtLambda(self._editHeading, self.EDIT_HSCENE))
         self.swtAScene = NSwitch(self, height=iPx)
         self.hdeAScene = QLabel(trHide, self)
@@ -688,7 +687,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblSection = QLabel(self._build.getLabel("headings.fmtSection"), self)
         self.fmtSection = QLineEdit("", self)
         self.fmtSection.setReadOnly(True)
-        self.btnSection = NIconToolButton(self, iSz)
+        self.btnSection = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
         self.btnSection.clicked.connect(qtLambda(self._editHeading, self.EDIT_SECTION))
         self.swtSection = NSwitch(self, height=iPx)
         self.hdeSection = QLabel(trHide, self)
@@ -822,19 +821,20 @@ class _HeadingsTab(NScrollablePage):
         self.outerBox.addLayout(self.layoutMatrix)
         self.outerBox.addStretch(1)
 
-        self.updateTheme()
+        self.updateTheme(onInit=True)
         self.setCentralLayout(self.outerBox)
 
-    def updateTheme(self) -> None:
+    def updateTheme(self, onInit: bool = False) -> None:
         """Update theme elements."""
         logger.debug("Theme Update: _HeadingsTab")
 
-        self.btnPart.setThemeIcon("edit", "change")
-        self.btnChapter.setThemeIcon("edit", "change")
-        self.btnUnnumbered.setThemeIcon("edit", "change")
-        self.btnScene.setThemeIcon("edit", "change")
-        self.btnAScene.setThemeIcon("edit", "change")
-        self.btnSection.setThemeIcon("edit", "change")
+        if not onInit:
+            self.btnPart.refreshIcon()
+            self.btnChapter.refreshIcon()
+            self.btnUnnumbered.refreshIcon()
+            self.btnScene.refreshIcon()
+            self.btnAScene.refreshIcon()
+            self.btnSection.refreshIcon()
 
         self.formSyntax.initHighlighter()
         self.formSyntax.rehighlight()
@@ -1003,7 +1003,7 @@ class _FormattingTab(NScrollableForm):
 
         self.setHelpTextStyle(SHARED.theme.helpText)
         self.buildForm()
-        self.updateTheme()
+        self.updateTheme(onInit=True)
 
     def buildForm(self) -> None:
         """Build the formatting form."""
@@ -1048,7 +1048,8 @@ class _FormattingTab(NScrollableForm):
                 lambda keyword=keyword: self._updateIgnoredKeywords(keyword)
             )
 
-        self.ignoredKeywordsButton = NIconToolButton(self, iSz)
+        self.ignoredKeywordsButton = NIconToolButton(self, iSz, "add", "add")
+        self.ignoredKeywordsButton.setToolTip(self.tr("Select Keyword"))
         self.ignoredKeywordsButton.setMenu(self.mnKeywords)
         self.addRow(
             self._build.getLabel("text.ignoredKeywords"), self.ignoredKeywords,
@@ -1070,7 +1071,8 @@ class _FormattingTab(NScrollableForm):
         # Text Font
         self.textFont = QLineEdit(self)
         self.textFont.setReadOnly(True)
-        self.btnTextFont = NIconToolButton(self, iSz)
+        self.btnTextFont = NIconToolButton(self, iSz, "font", "tool")
+        self.btnTextFont.setToolTip(self.tr("Select Font"))
         self.btnTextFont.clicked.connect(self._selectFont)
         self.addRow(
             self._build.getLabel("format.textFont"), self.textFont,
@@ -1152,7 +1154,7 @@ class _FormattingTab(NScrollableForm):
         self.titleMarginT.setFixedWidth(dbW)
         self.titleMarginB = NDoubleSpinBox(self)
         self.titleMarginB.setFixedWidth(dbW)
-        self.btnTitleProps = NIconToolButton(self, iSz)
+        self.btnTitleProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnTitleProps.clicked.connect(self._resetTitleProps)
 
         self.pixH0S = QLabel(self)
@@ -1176,7 +1178,7 @@ class _FormattingTab(NScrollableForm):
         self.h1MarginT.setFixedWidth(dbW)
         self.h1MarginB = NDoubleSpinBox(self)
         self.h1MarginB.setFixedWidth(dbW)
-        self.btnH1Props = NIconToolButton(self, iSz)
+        self.btnH1Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH1Props.clicked.connect(self._resetH1Props)
 
         self.pixH1S = QLabel(self)
@@ -1200,7 +1202,7 @@ class _FormattingTab(NScrollableForm):
         self.h2MarginT.setFixedWidth(dbW)
         self.h2MarginB = NDoubleSpinBox(self)
         self.h2MarginB.setFixedWidth(dbW)
-        self.btnH2Props = NIconToolButton(self, iSz)
+        self.btnH2Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH2Props.clicked.connect(self._resetH2Props)
 
         self.pixH2S = QLabel(self)
@@ -1224,7 +1226,7 @@ class _FormattingTab(NScrollableForm):
         self.h3MarginT.setFixedWidth(dbW)
         self.h3MarginB = NDoubleSpinBox(self)
         self.h3MarginB.setFixedWidth(dbW)
-        self.btnH3Props = NIconToolButton(self, iSz)
+        self.btnH3Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH3Props.clicked.connect(self._resetH3Props)
 
         self.pixH3S = QLabel(self)
@@ -1248,7 +1250,7 @@ class _FormattingTab(NScrollableForm):
         self.h4MarginT.setFixedWidth(dbW)
         self.h4MarginB = NDoubleSpinBox(self)
         self.h4MarginB.setFixedWidth(dbW)
-        self.btnH4Props = NIconToolButton(self, iSz)
+        self.btnH4Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH4Props.clicked.connect(self._resetH4Props)
 
         self.pixH4S = QLabel(self)
@@ -1270,7 +1272,7 @@ class _FormattingTab(NScrollableForm):
         self.textMarginT.setFixedWidth(dbW)
         self.textMarginB = NDoubleSpinBox(self)
         self.textMarginB.setFixedWidth(dbW)
-        self.btnTextProps = NIconToolButton(self, iSz)
+        self.btnTextProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnTextProps.clicked.connect(self._resetTextProps)
 
         self.pixTTT = QLabel(self)
@@ -1287,7 +1289,7 @@ class _FormattingTab(NScrollableForm):
         self.sepMarginT.setFixedWidth(dbW)
         self.sepMarginB = NDoubleSpinBox(self)
         self.sepMarginB.setFixedWidth(dbW)
-        self.btnSepProps = NIconToolButton(self, iSz)
+        self.btnSepProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnSepProps.clicked.connect(self._resetSepProps)
 
         self.pixSPT = QLabel(self)
@@ -1379,7 +1381,7 @@ class _FormattingTab(NScrollableForm):
         # Header
         self.pageHeader = QLineEdit(self)
         self.pageHeader.setMinimumWidth(200)
-        self.btnPageHeader = NIconToolButton(self, iSz)
+        self.btnPageHeader = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnPageHeader.clicked.connect(self._resetPageHeader)
         self.addRow(
             self._build.getLabel("doc.pageHeader"), self.pageHeader,
@@ -1424,20 +1426,21 @@ class _FormattingTab(NScrollableForm):
         # Finalise
         self.finalise()
 
-    def updateTheme(self) -> None:
+    def updateTheme(self, onInit: bool = False) -> None:
         """Update theme elements."""
         logger.debug("Theme Update: _FormattingTab")
 
-        self.ignoredKeywordsButton.setThemeIcon("add", "add")
-        self.btnTextFont.setThemeIcon("font", "tool")
-        self.btnPageHeader.setThemeIcon("revert", "reset")
-        self.btnTitleProps.setThemeIcon("revert", "reset")
-        self.btnH1Props.setThemeIcon("revert", "reset")
-        self.btnH2Props.setThemeIcon("revert", "reset")
-        self.btnH3Props.setThemeIcon("revert", "reset")
-        self.btnH4Props.setThemeIcon("revert", "reset")
-        self.btnTextProps.setThemeIcon("revert", "reset")
-        self.btnSepProps.setThemeIcon("revert", "reset")
+        if not onInit:
+            self.ignoredKeywordsButton.refreshIcon()
+            self.btnTextFont.refreshIcon()
+            self.btnPageHeader.refreshIcon()
+            self.btnTitleProps.refreshIcon()
+            self.btnH1Props.refreshIcon()
+            self.btnH2Props.refreshIcon()
+            self.btnH3Props.refreshIcon()
+            self.btnH4Props.refreshIcon()
+            self.btnTextProps.refreshIcon()
+            self.btnSepProps.refreshIcon()
 
         iPx = SHARED.theme.baseIconHeight
 

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -576,28 +576,39 @@ class _NewProjectForm(QWidget):
         self.projName.setPlaceholderText(self.tr("Required"))
         self.projName.textChanged.connect(self._updateProjPath)
 
-        # Author(s)
+        self.projNameLabel = QLabel(self.tr("Project Name"), self)
+        self.projNameLabel.setBuddy(self.projName)
+
+        # Author
         self.projAuthor = QLineEdit(self)
         self.projAuthor.setMaxLength(200)
         self.projAuthor.setPlaceholderText(self.tr("Optional"))
         self.projAuthor.setText(CONFIG.lastAuthor)
+
+        self.projAuthorLabel = QLabel(self.tr("Author"), self)
+        self.projAuthorLabel.setBuddy(self.projAuthor)
 
         # Project Path
         self.projPath = QLineEdit(self)
         self.projPath.setReadOnly(True)
 
         self.browsePath = NIconToolButton(self, iSz, "browse", "systemio")
+        self.browsePath.setToolTip(self.tr("Browse for new project path"))
         self.browsePath.clicked.connect(self._doBrowse)
 
         self.pathBox = QHBoxLayout()
         self.pathBox.addWidget(self.projPath)
         self.pathBox.addWidget(self.browsePath)
 
+        self.projPathLabel = QLabel(self.tr("Project Path"), self)
+        self.projPathLabel.setBuddy(self.projPath)
+
         # Fill Project
         self.projFill = QLineEdit(self)
         self.projFill.setReadOnly(True)
 
         self.browseFill = NIconToolButton(self, iSz, "document_add", "add")
+        self.browseFill.setToolTip(self.tr("Fill new project"))
 
         self.fillMenu = QMenu(self.browseFill)
 
@@ -619,13 +630,16 @@ class _NewProjectForm(QWidget):
         self.fillBox.addWidget(self.projFill)
         self.fillBox.addWidget(self.browseFill)
 
+        self.projFillLabel = QLabel(self.tr("Prefill Project"), self)
+        self.projFillLabel.setBuddy(self.projFill)
+
         # Project Form
         self.projectForm = QFormLayout()
         self.projectForm.setAlignment(QtAlignLeft)
-        self.projectForm.addRow(self.tr("Project Name"), self.projName)
-        self.projectForm.addRow(self.tr("Author"), self.projAuthor)
-        self.projectForm.addRow(self.tr("Project Path"), self.pathBox)
-        self.projectForm.addRow(self.tr("Prefill Project"), self.fillBox)
+        self.projectForm.addRow(self.projNameLabel, self.projName)
+        self.projectForm.addRow(self.projAuthorLabel, self.projAuthor)
+        self.projectForm.addRow(self.projPathLabel, self.pathBox)
+        self.projectForm.addRow(self.projFillLabel, self.fillBox)
 
         # Chapters and Scenes
         # ===================


### PR DESCRIPTION
**Summary:**

This PR adds tooltips and to all tool buttons and improves screen reader support on settings pages and various other places. It also adds the words or characters unit to the tooltip and accessibility description in the project tree and novel view.

With the previous update of all GUI push buttons, this should complete the button tooltips.

**Related Issue(s):**

Closes #2338

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
