### PR TITLE
Fix Qt 6.9 dependency issue

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   buildI18n:
+    name: Build i18n
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lock_threads.yml
+++ b/.github/workflows/lock_threads.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   action:
+    name: Lock Old Issues & PRs
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v6

--- a/.github/workflows/part_appimage.yml
+++ b/.github/workflows/part_appimage.yml
@@ -6,6 +6,7 @@ jobs:
   buildLinux-AppImage:
     # Needs to stay on 22.04 as long as we're using manylinux_2_28
     # as libxcb-cursor0 in 22.04 supports glibc >= 2.17
+    name: Build AppImage
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/part_assets.yml
+++ b/.github/workflows/part_assets.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   buildAssets:
+    name: Build Assets
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/part_macos_amd64.yml
+++ b/.github/workflows/part_macos_amd64.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   buildMac-AMD64:
+    name: Build on MACOS AMD64
     runs-on: macos-latest
     permissions:
       contents: read

--- a/.github/workflows/part_macos_m1.yml
+++ b/.github/workflows/part_macos_m1.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   buildMac-M1:
+    name: Build on MacOS AARCH64
     runs-on: macos-latest
     permissions:
       contents: read

--- a/.github/workflows/part_win_x64.yml
+++ b/.github/workflows/part_win_x64.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   buildWin-X64:
+    name: Build on Windows
     runs-on: windows-2022
     permissions:
       contents: read

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: Syntax
 
 on:
   push:
@@ -12,6 +12,7 @@ on:
 
 jobs:
   checkSyntax:
+    name: Linting and Type Checking
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   testLinux:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
@@ -20,7 +21,7 @@ jobs:
           - "3.13"
           - "3.14"
       fail-fast: false
-    runs-on: ubuntu-latest
+    name: Test Python ${{ matrix.python-version }}
     permissions:
       contents: read
     steps:
@@ -57,3 +58,33 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+  testUbuntu24:
+    name: Test Ubuntu 24.04 & Sys Packages
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v6
+
+      - name: Install System Packages
+        run: |
+          sudo apt update
+          sudo apt install \
+            python3-pyqt6 \
+            python3-pyqt6.qtsvg \
+            python3-pytest \
+            python3-pytestqt \
+            python3-enchant \
+            python3-pytest-timeout \
+            qt6-image-formats-plugins
+
+      - name: Build Assets
+        run: |
+          python3 pkgutils.py sample
+
+      - name: Run Tests
+        run: |
+          export QT_QPA_PLATFORM=offscreen
+          python3 -m pytest -v --timeout=60

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   testMac:
     runs-on: macos-latest
+    name: Test Python 3.13
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   testWin:
     runs-on: windows-latest
+    name: Test Python 3.13
     permissions:
       contents: read
     steps:

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -499,6 +499,10 @@ class Config:
         self._errData = []
         return message
 
+    def checkMinQtVersion(self, version: int) -> bool:
+        """Check if a minimum Qt version is satisfied."""
+        return self.verPyQtValue >= version and self.verQtValue >= version
+
     def localDate(self, value: datetime) -> str:
         """Return a localised date format."""
         # Explicitly convert the date first, see bug #2325

--- a/novelwriter/extensions/pagedsidebar.py
+++ b/novelwriter/extensions/pagedsidebar.py
@@ -86,7 +86,7 @@ class NPagedSideBar(QToolBar):
         """Add a new button to the toolbar."""
         button = _PagedToolButton(self)
         button.setText(text)
-        button.setAccessibleIdentifier(text)
+        button.setAccessibleName(text)
         self.insertWidget(self._stretchAction, button)
         self._group.addButton(button, id=buttonId)
         self._buttons[buttonId] = button

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -300,7 +300,7 @@ class GuiTheme:
 
     def isDesktopDarkMode(self) -> bool:
         """Check if the desktop is in dark mode."""
-        if CONFIG.verQtValue >= 0x060500 and (hint := QGuiApplication.styleHints()):
+        if CONFIG.checkMinQtVersion(0x060500) and (hint := QGuiApplication.styleHints()):
             return hint.colorScheme() == Qt.ColorScheme.Dark
 
         palette = QPalette()
@@ -513,7 +513,7 @@ class GuiTheme:
         self._guiPalette.setBrush(QtColInactive, QPalette.ColorRole.Highlight, highlight)
         self._guiPalette.setBrush(QtColDisabled, QPalette.ColorRole.Highlight, grey)
 
-        if CONFIG.verQtValue >= 0x060600:
+        if CONFIG.checkMinQtVersion(0x060600):
             self._guiPalette.setBrush(QtColActive, QPalette.ColorRole.Accent, self.accentCol)
             self._guiPalette.setBrush(QtColInactive, QPalette.ColorRole.Accent, self.accentCol)
             self._guiPalette.setBrush(QtColDisabled, QPalette.ColorRole.Accent, grey)

--- a/tests/test_gui/test_gui_theme.py
+++ b/tests/test_gui/test_gui_theme.py
@@ -148,19 +148,20 @@ def testGuiTheme_LoadThemes(monkeypatch):
     assert theme._currentTheme == DEF_GUI_DARK
 
     # Let auto switch back to light, then dark
-    with monkeypatch.context() as mp:
-        mp.setattr(CONFIG, "verQtValue", 0x060500)
-        mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Light)
-        CONFIG.themeMode = nwTheme.AUTO
-        theme.loadTheme()
-        assert theme._currentTheme == DEF_GUI_LIGHT
+    if CONFIG.checkMinQtVersion(0x060500):  # Don't run for old Qt
+        with monkeypatch.context() as mp:
+            mp.setattr(CONFIG, "verQtValue", 0x060500)
+            mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Light)
+            CONFIG.themeMode = nwTheme.AUTO
+            theme.loadTheme()
+            assert theme._currentTheme == DEF_GUI_LIGHT
 
-    with monkeypatch.context() as mp:
-        mp.setattr(CONFIG, "verQtValue", 0x060500)
-        mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Dark)
-        CONFIG.themeMode = nwTheme.AUTO
-        theme.loadTheme()
-        assert theme._currentTheme == DEF_GUI_DARK
+        with monkeypatch.context() as mp:
+            mp.setattr(CONFIG, "verQtValue", 0x060500)
+            mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Dark)
+            CONFIG.themeMode = nwTheme.AUTO
+            theme.loadTheme()
+            assert theme._currentTheme == DEF_GUI_DARK
 
     # Error Cases
     # ===========
@@ -321,14 +322,15 @@ def testGuiTheme_Methods(monkeypatch):
     assert theme.getTextWidth("MMMMM", font) < theme.getTextWidth("MMMMM")
 
     # Detect desktop mode Qt 6.5+
-    with monkeypatch.context() as mp:
-        mp.setattr(CONFIG, "verQtValue", 0x060500)
+    if CONFIG.checkMinQtVersion(0x060500):  # Don't run for old Qt
+        with monkeypatch.context() as mp:
+            mp.setattr(CONFIG, "verQtValue", 0x060500)
 
-        mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Light)
-        assert theme.isDesktopDarkMode() is False
+            mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Light)
+            assert theme.isDesktopDarkMode() is False
 
-        mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Dark)
-        assert theme.isDesktopDarkMode() is True
+            mp.setattr(QStyleHints, "colorScheme", lambda *a: Qt.ColorScheme.Dark)
+            assert theme.isDesktopDarkMode() is True
 
     # Detect desktop mode Qt 6.4
     mockWhite = Mock()


### PR DESCRIPTION
**Summary:**

The 26.1 Beta 1 release only works for Qt 6.9 and larger. This PR fixes that, and adds explicit tests for minimal Qt version.

**Related Issue(s):**

Closes #2706

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
