### PR TITLE
Add spin box fixed size settings

### DIFF
--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -336,10 +336,8 @@ class GuiPreferences(NDialog):
         self.mainForm.addGroupLabel(title, section)
 
         # Document Save Timer
-        self.autoSaveDoc = NSpinBox(self)
-        self.autoSaveDoc.setMinimum(5)
-        self.autoSaveDoc.setMaximum(600)
-        self.autoSaveDoc.setSingleStep(1)
+        self.autoSaveDoc = NSpinBox(self, minVal=5, maxVal=600)
+        self.autoSaveDoc.setFixedNumbersWidth(3)
         self.autoSaveDoc.setValue(CONFIG.autoSaveDoc)
         self.mainForm.addRow(
             self.tr("Save document interval"), self.autoSaveDoc,
@@ -347,10 +345,8 @@ class GuiPreferences(NDialog):
         )
 
         # Project Save Timer
-        self.autoSaveProj = NSpinBox(self)
-        self.autoSaveProj.setMinimum(5)
-        self.autoSaveProj.setMaximum(600)
-        self.autoSaveProj.setSingleStep(1)
+        self.autoSaveProj = NSpinBox(self, minVal=5, maxVal=600)
+        self.autoSaveProj.setFixedNumbersWidth(3)
         self.autoSaveProj.setValue(CONFIG.autoSaveProj)
         self.mainForm.addRow(
             self.tr("Save project interval"), self.autoSaveProj,
@@ -429,11 +425,8 @@ class GuiPreferences(NDialog):
         )
 
         # Inactive Time for Idle
-        self.userIdleTime = NDoubleSpinBox(self)
-        self.userIdleTime.setMinimum(0.5)
-        self.userIdleTime.setMaximum(600.0)
-        self.userIdleTime.setSingleStep(0.5)
-        self.userIdleTime.setDecimals(1)
+        self.userIdleTime = NDoubleSpinBox(self, minVal=0.5, maxVal=600.0, step=0.5, prec=1)
+        self.userIdleTime.setFixedNumbersWidth(5)
         self.userIdleTime.setValue(CONFIG.userIdleTime/60.0)
         self.mainForm.addRow(
             self.tr("Editor inactive time before pausing timer"), self.userIdleTime,
@@ -453,10 +446,8 @@ class GuiPreferences(NDialog):
         self.mainForm.addGroupLabel(title, section)
 
         # Max Text Width in Normal Mode
-        self.textWidth = NSpinBox(self)
-        self.textWidth.setMinimum(0)
-        self.textWidth.setMaximum(10000)
-        self.textWidth.setSingleStep(10)
+        self.textWidth = NSpinBox(self, minVal=0, maxVal=10000, step=10)
+        self.textWidth.setFixedNumbersWidth(5)
         self.textWidth.setValue(CONFIG.textWidth)
         self.mainForm.addRow(
             self.tr('Maximum text width in "Normal Mode"'), self.textWidth,
@@ -464,10 +455,8 @@ class GuiPreferences(NDialog):
         )
 
         # Max Text Width in Focus Mode
-        self.focusWidth = NSpinBox(self)
-        self.focusWidth.setMinimum(200)
-        self.focusWidth.setMaximum(10000)
-        self.focusWidth.setSingleStep(10)
+        self.focusWidth = NSpinBox(self, minVal=200, maxVal=10000, step=10)
+        self.focusWidth.setFixedNumbersWidth(5)
         self.focusWidth.setValue(CONFIG.focusWidth)
         self.mainForm.addRow(
             self.tr('Maximum text width in "Focus Mode"'), self.focusWidth,
@@ -491,10 +480,8 @@ class GuiPreferences(NDialog):
         )
 
         # Document Margins
-        self.textMargin = NSpinBox(self)
-        self.textMargin.setMinimum(0)
-        self.textMargin.setMaximum(900)
-        self.textMargin.setSingleStep(1)
+        self.textMargin = NSpinBox(self, minVal=0, maxVal=900)
+        self.textMargin.setFixedNumbersWidth(3)
         self.textMargin.setValue(CONFIG.textMargin)
         self.mainForm.addRow(
             self.tr("Minimum text margin"), self.textMargin,
@@ -503,10 +490,8 @@ class GuiPreferences(NDialog):
         )
 
         # Tab Width
-        self.tabWidth = NSpinBox(self)
-        self.tabWidth.setMinimum(0)
-        self.tabWidth.setMaximum(200)
-        self.tabWidth.setSingleStep(1)
+        self.tabWidth = NSpinBox(self, minVal=0, maxVal=200)
+        self.tabWidth.setFixedNumbersWidth(3)
         self.tabWidth.setValue(CONFIG.tabWidth)
         self.mainForm.addRow(
             self.tr("Tab width"), self.tabWidth,
@@ -550,10 +535,8 @@ class GuiPreferences(NDialog):
         )
 
         # Cursor Width
-        self.cursorWidth = NSpinBox(self)
-        self.cursorWidth.setMinimum(1)
-        self.cursorWidth.setMaximum(20)
-        self.cursorWidth.setSingleStep(1)
+        self.cursorWidth = NSpinBox(self, minVal=1, maxVal=20)
+        self.cursorWidth.setFixedNumbersWidth(2)
         self.cursorWidth.setValue(CONFIG.cursorWidth)
         self.mainForm.addRow(
             self.tr("Cursor width"), self.cursorWidth,
@@ -614,10 +597,8 @@ class GuiPreferences(NDialog):
         )
 
         # Typewriter Position
-        self.autoScrollPos = NSpinBox(self)
-        self.autoScrollPos.setMinimum(10)
-        self.autoScrollPos.setMaximum(90)
-        self.autoScrollPos.setSingleStep(1)
+        self.autoScrollPos = NSpinBox(self, minVal=10, maxVal=90)
+        self.autoScrollPos.setFixedNumbersWidth(2)
         self.autoScrollPos.setValue(int(CONFIG.autoScrollPos))
         self.mainForm.addRow(
             self.tr("Minimum position for Typewriter scrolling"), self.autoScrollPos,

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -216,9 +216,19 @@ class NSpinBox(QSpinBox):
     window of many widgets.
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        minVal: int = 0,
+        maxVal: int = 15,
+        step: int = 1,
+    ) -> None:
         super().__init__(parent=parent)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self.setMinimum(minVal)
+        self.setMaximum(maxVal)
+        self.setSingleStep(step)
 
     def wheelEvent(self, event: QWheelEvent) -> None:
         """Only capture the mouse wheel if the widget has focus."""
@@ -226,6 +236,10 @@ class NSpinBox(QSpinBox):
             super().wheelEvent(event)
         else:
             event.ignore()
+
+    def setFixedNumbersWidth(self, count: int) -> None:
+        """Set a fixed with for a certain amount of numbers."""
+        self.setFixedWidth(count*SHARED.theme.textNWidth + 24)
 
 
 class NDoubleSpinBox(QDoubleSpinBox):
@@ -258,6 +272,10 @@ class NDoubleSpinBox(QDoubleSpinBox):
             super().wheelEvent(event)
         else:
             event.ignore()
+
+    def setFixedNumbersWidth(self, count: int) -> None:
+        """Set a fixed with for a certain amount of numbers."""
+        self.setFixedWidth(count*SHARED.theme.textNWidth + 24)
 
 
 class NPushButton(QPushButton):

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -1012,8 +1012,6 @@ class _FormattingTab(NScrollableForm):
         iSp = 6
         iPx = SHARED.theme.baseIconHeight
         iSz = SHARED.theme.baseIconSize
-        spW = 6*SHARED.theme.textNWidth
-        dbW = 7*SHARED.theme.textNWidth
 
         # Text Content
         # ============
@@ -1080,12 +1078,8 @@ class _FormattingTab(NScrollableForm):
         )
 
         # Line Height
-        self.lineHeight = NDoubleSpinBox(self)
-        self.lineHeight.setFixedWidth(spW)
-        self.lineHeight.setMinimum(0.75)
-        self.lineHeight.setMaximum(3.0)
-        self.lineHeight.setSingleStep(0.05)
-        self.lineHeight.setDecimals(2)
+        self.lineHeight = NDoubleSpinBox(self, minVal=0.75, maxVal=3.0, step=0.05, prec=2)
+        self.lineHeight.setFixedNumbersWidth(4)
         self.addRow(self._build.getLabel("format.lineHeight"), self.lineHeight, unit="em")
 
         # Text Options
@@ -1128,12 +1122,8 @@ class _FormattingTab(NScrollableForm):
         self.firstIndent = NSwitch(self, height=iPx)
         self.indentFirstPar = NSwitch(self, height=iPx)
 
-        self.indentWidth = NDoubleSpinBox(self)
-        self.indentWidth.setFixedWidth(spW)
-        self.indentWidth.setMinimum(0.1)
-        self.indentWidth.setMaximum(9.9)
-        self.indentWidth.setSingleStep(0.1)
-        self.indentWidth.setDecimals(1)
+        self.indentWidth = NDoubleSpinBox(self, minVal=0.1, maxVal=9.9, step=0.1, prec=1)
+        self.indentWidth.setFixedNumbersWidth(4)
 
         self.addRow(self._build.getLabel("format.firstLineIndent"), self.firstIndent)
         self.addRow(self._build.getLabel("format.firstIndentWidth"), self.indentWidth, unit="em")
@@ -1149,11 +1139,11 @@ class _FormattingTab(NScrollableForm):
 
         # Title
         self.titleSize = NDoubleSpinBox(self, minVal=0.8, maxVal=10.0, step=0.05)
-        self.titleSize.setFixedWidth(dbW)
-        self.titleMarginT = NDoubleSpinBox(self)
-        self.titleMarginT.setFixedWidth(dbW)
-        self.titleMarginB = NDoubleSpinBox(self)
-        self.titleMarginB.setFixedWidth(dbW)
+        self.titleSize.setFixedNumbersWidth(4)
+        self.titleMarginT = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.titleMarginT.setFixedNumbersWidth(4)
+        self.titleMarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.titleMarginB.setFixedNumbersWidth(4)
         self.btnTitleProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnTitleProps.clicked.connect(self._resetTitleProps)
 
@@ -1173,11 +1163,11 @@ class _FormattingTab(NScrollableForm):
 
         # Heading 1
         self.h1Size = NDoubleSpinBox(self, minVal=0.8, maxVal=10.0, step=0.05)
-        self.h1Size.setFixedWidth(dbW)
-        self.h1MarginT = NDoubleSpinBox(self)
-        self.h1MarginT.setFixedWidth(dbW)
-        self.h1MarginB = NDoubleSpinBox(self)
-        self.h1MarginB.setFixedWidth(dbW)
+        self.h1Size.setFixedNumbersWidth(4)
+        self.h1MarginT = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h1MarginT.setFixedNumbersWidth(4)
+        self.h1MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h1MarginB.setFixedNumbersWidth(4)
         self.btnH1Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH1Props.clicked.connect(self._resetH1Props)
 
@@ -1197,11 +1187,11 @@ class _FormattingTab(NScrollableForm):
 
         # Heading 2
         self.h2Size = NDoubleSpinBox(self, minVal=0.8, maxVal=10.0, step=0.05)
-        self.h2Size.setFixedWidth(dbW)
-        self.h2MarginT = NDoubleSpinBox(self)
-        self.h2MarginT.setFixedWidth(dbW)
-        self.h2MarginB = NDoubleSpinBox(self)
-        self.h2MarginB.setFixedWidth(dbW)
+        self.h2Size.setFixedNumbersWidth(4)
+        self.h2MarginT = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h2MarginT.setFixedNumbersWidth(4)
+        self.h2MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h2MarginB.setFixedNumbersWidth(4)
         self.btnH2Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH2Props.clicked.connect(self._resetH2Props)
 
@@ -1221,11 +1211,11 @@ class _FormattingTab(NScrollableForm):
 
         # Heading 3
         self.h3Size = NDoubleSpinBox(self, minVal=0.8, maxVal=10.0, step=0.05)
-        self.h3Size.setFixedWidth(dbW)
-        self.h3MarginT = NDoubleSpinBox(self)
-        self.h3MarginT.setFixedWidth(dbW)
-        self.h3MarginB = NDoubleSpinBox(self)
-        self.h3MarginB.setFixedWidth(dbW)
+        self.h3Size.setFixedNumbersWidth(4)
+        self.h3MarginT = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h3MarginT.setFixedNumbersWidth(4)
+        self.h3MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h3MarginB.setFixedNumbersWidth(4)
         self.btnH3Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH3Props.clicked.connect(self._resetH3Props)
 
@@ -1245,11 +1235,11 @@ class _FormattingTab(NScrollableForm):
 
         # Heading 4
         self.h4Size = NDoubleSpinBox(self, minVal=0.8, maxVal=10.0, step=0.05)
-        self.h4Size.setFixedWidth(dbW)
-        self.h4MarginT = NDoubleSpinBox(self)
-        self.h4MarginT.setFixedWidth(dbW)
-        self.h4MarginB = NDoubleSpinBox(self)
-        self.h4MarginB.setFixedWidth(dbW)
+        self.h4Size.setFixedNumbersWidth(4)
+        self.h4MarginT = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h4MarginT.setFixedNumbersWidth(4)
+        self.h4MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.h4MarginB.setFixedNumbersWidth(4)
         self.btnH4Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnH4Props.clicked.connect(self._resetH4Props)
 
@@ -1268,10 +1258,10 @@ class _FormattingTab(NScrollableForm):
         )
 
         # Text
-        self.textMarginT = NDoubleSpinBox(self)
-        self.textMarginT.setFixedWidth(dbW)
-        self.textMarginB = NDoubleSpinBox(self)
-        self.textMarginB.setFixedWidth(dbW)
+        self.textMarginT = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.textMarginT.setFixedNumbersWidth(4)
+        self.textMarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.textMarginB.setFixedNumbersWidth(4)
         self.btnTextProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnTextProps.clicked.connect(self._resetTextProps)
 
@@ -1285,10 +1275,10 @@ class _FormattingTab(NScrollableForm):
         )
 
         # Separator
-        self.sepMarginT = NDoubleSpinBox(self)
-        self.sepMarginT.setFixedWidth(dbW)
-        self.sepMarginB = NDoubleSpinBox(self)
-        self.sepMarginB.setFixedWidth(dbW)
+        self.sepMarginT = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.sepMarginT.setFixedNumbersWidth(4)
+        self.sepMarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
+        self.sepMarginB.setFixedNumbersWidth(4)
         self.btnSepProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
         self.btnSepProps.clicked.connect(self._resetSepProps)
 
@@ -1327,12 +1317,12 @@ class _FormattingTab(NScrollableForm):
         for key, name in nwLabels.PAPER_NAME.items():
             self.pageSize.addItem(trConst(name), key)
 
-        self.pageWidth = NDoubleSpinBox(self, maxVal=500.0)
-        self.pageWidth.setFixedWidth(dbW)
+        self.pageWidth = NDoubleSpinBox(self, minVal=1.0, maxVal=500.0)
+        self.pageWidth.setFixedNumbersWidth(5)
         self.pageWidth.valueChanged.connect(self._pageSizeValueChanged)
 
-        self.pageHeight = NDoubleSpinBox(self, maxVal=500.0)
-        self.pageHeight.setFixedWidth(dbW)
+        self.pageHeight = NDoubleSpinBox(self, minVal=1.0, maxVal=500.0)
+        self.pageHeight.setFixedNumbersWidth(5)
         self.pageHeight.valueChanged.connect(self._pageSizeValueChanged)
 
         self.pixPSH = QLabel(self)
@@ -1345,16 +1335,16 @@ class _FormattingTab(NScrollableForm):
 
         # Page Margins
         self.topMargin = NDoubleSpinBox(self)
-        self.topMargin.setFixedWidth(dbW)
+        self.topMargin.setFixedNumbersWidth(5)
 
         self.bottomMargin = NDoubleSpinBox(self)
-        self.bottomMargin.setFixedWidth(dbW)
+        self.bottomMargin.setFixedNumbersWidth(5)
 
         self.leftMargin = NDoubleSpinBox(self)
-        self.leftMargin.setFixedWidth(dbW)
+        self.leftMargin.setFixedNumbersWidth(5)
 
         self.rightMargin = NDoubleSpinBox(self)
-        self.rightMargin.setFixedWidth(dbW)
+        self.rightMargin.setFixedNumbersWidth(5)
 
         self.pixPMT = QLabel(self)
         self.pixPMB = QLabel(self)
@@ -1388,11 +1378,8 @@ class _FormattingTab(NScrollableForm):
             button=self.btnPageHeader, stretch=(1, 1)
         )
 
-        self.pageCountOffset = NSpinBox(self)
-        self.pageCountOffset.setMinimum(0)
-        self.pageCountOffset.setMaximum(999)
-        self.pageCountOffset.setSingleStep(1)
-        self.pageCountOffset.setMinimumWidth(spW)
+        self.pageCountOffset = NSpinBox(self, minVal=0, maxVal=999)
+        self.pageCountOffset.setFixedNumbersWidth(4)
         self.addRow(self._build.getLabel("doc.pageCountOffset"), self.pageCountOffset)
 
         # Meta Language
@@ -1701,12 +1688,14 @@ class _FormattingTab(NScrollableForm):
         nDec = 1 if isMM else 2
         nStep = 1.0 if isMM else 0.1
         pMax = 500.0 if isMM else 50.0
+        pMin = 10.0 if isMM else 1.0
         mMax = 150.0 if isMM else 15.0
 
         self.pageWidth.blockSignals(True)
         self.pageWidth.setDecimals(nDec)
         self.pageWidth.setSingleStep(nStep)
         self.pageWidth.setMaximum(pMax)
+        self.pageWidth.setMinimum(pMin)
         self.pageWidth.setValue(pageWidth)
         self.pageWidth.blockSignals(False)
 
@@ -1714,6 +1703,7 @@ class _FormattingTab(NScrollableForm):
         self.pageHeight.setDecimals(nDec)
         self.pageHeight.setSingleStep(nStep)
         self.pageHeight.setMaximum(pMax)
+        self.pageHeight.setMinimum(pMin)
         self.pageHeight.setValue(pageHeight)
         self.pageHeight.blockSignals(False)
 

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -636,8 +636,8 @@ class _NewProjectForm(QWidget):
         # Chapters and Scenes
         # ===================
 
-        self.numChapters = NSpinBox(self)
-        self.numChapters.setRange(0, 200)
+        self.numChapters = NSpinBox(self, minVal=0, maxVal=200)
+        self.numChapters.setFixedNumbersWidth(3)
         self.numChapters.setValue(0)
         self.numChapters.setToolTip(self.tr("Set to 0 to only add scenes"))
 
@@ -646,8 +646,8 @@ class _NewProjectForm(QWidget):
         )
         self.chapterBox.addStretch(1)
 
-        self.numScenes = NSpinBox(self)
-        self.numScenes.setRange(0, 200)
+        self.numScenes = NSpinBox(self, minVal=0, maxVal=200)
+        self.numScenes.setFixedNumbersWidth(3)
         self.numScenes.setValue(0)
 
         self.sceneBox = NWrappedWidgetBox(


### PR DESCRIPTION
**Summary:**

This PR adds a setting to spin boxes, both for integers and floats, that will calculate a fixed width based on the current fornt and the number og visible digits requested. This takes into account the size needed for the spin buttons and default margins, so should work also for narrow fonts.

**Related Issue(s):**

Closes #2703

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
