### PR TITLE
Remove broken link in dictionary docs

### DIFF
--- a/docs/source/more/dictionaries.rst
+++ b/docs/source/more/dictionaries.rst
@@ -5,7 +5,6 @@ Spell Check Dictionaries
 ************************
 
 .. _Enchant: https://rrthomas.github.io/enchant/
-.. _Free Desktop: https://cgit.freedesktop.org/libreoffice/dictionaries/tree/
 
 Spell checking is provided by the Enchant_ library. Depending on your operating system, it may or
 may not load all installed spell check dictionaries automatically.
@@ -25,14 +24,18 @@ Windows
 For Windows, English is included with the installation. For other languages you have to download
 and add dictionaries yourself.
 
-**Install Tool**
+
+Install Tool
+------------
 
 A small tool to assist with this can be found under **Tools > Add Dictionaries**. It will import
 spell checking dictionaries from Free Office or Libre Office extensions. The dictionaries are then
 installed in the install location for the Enchant library and should thus work for any application
 that uses Enchant for spell checking.
 
-**Manual Install**
+
+Manual Install
+--------------
 
 If you prefer to do this manually or want to use a different source than the ones mentioned above,
 You need to get compatible dictionary files for your language. You need two files ending with
@@ -42,14 +45,3 @@ You need to get compatible dictionary files for your language. You need two file
 
 This assumes your user profile is stored at ``C:\Users\<USER>``. The last one or two folders may
 not exist, so you may need to create them.
-
-You can find the various dictionaries on the `Free Desktop`_ website.
-
-.. note::
-
-   The Free Desktop link points to a repository, and what may look like file links inside the
-   dictionary folder are actually links to web pages. If you right-click and download those, you
-   get HTML files, not dictionaries!
-
-   In order to download the actual dictionary files, right-click the "plain" label at the end of
-   each line and download that.


### PR DESCRIPTION
**Summary:**

Remove a broken link and its related text box from the docs.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
