### PR TITLE
Improve single quote dialogue regex

### DIFF
--- a/novelwriter/text/patterns.py
+++ b/novelwriter/text/patterns.py
@@ -98,8 +98,10 @@ class RegExPatterns:
             if CONFIG.dialogStyle in (1, 3):
                 qO = CONFIG.fmtSQuoteOpen.strip()[:1]
                 qC = CONFIG.fmtSQuoteClose.strip()[:1]
-                if qO == qC or qC in self.AMBIGUOUS:
+                if qO == qC:
                     rx.append(f"(?:\\B{qO}.+?{qC}\\B)")
+                elif qC in self.AMBIGUOUS:
+                    rx.append(f"(?:\\B{qO}[^{qO}]+{qC}\\B(?={qO}|\\s*))")
                 else:
                     rx.append(f"(?:{qO}[^{qO}]+{qC})")
                 if CONFIG.allowOpenDial:
@@ -107,8 +109,10 @@ class RegExPatterns:
             if CONFIG.dialogStyle in (2, 3):
                 qO = CONFIG.fmtDQuoteOpen.strip()[:1]
                 qC = CONFIG.fmtDQuoteClose.strip()[:1]
-                if qO == qC or qC in self.AMBIGUOUS:
+                if qO == qC:
                     rx.append(f"(?:\\B{qO}.+?{qC}\\B)")
+                elif qC in self.AMBIGUOUS:
+                    rx.append(f"(?:\\B{qO}[^{qO}]+{qC}\\B(?={qO}|\\s*))")
                 else:
                     rx.append(f"(?:{qO}[^{qO}]+{qC})")
                 if CONFIG.allowOpenDial:

--- a/tests/text/test_patterns.py
+++ b/tests/text/test_patterns.py
@@ -402,6 +402,50 @@ def testTextPatterns_DialogueStyle():
     # Single quotes are recognised, double quotes are not
     assert allMatches(regEx, "one \u2018two\u2019 three \u201cfour\u201d five") == [[("\u2018two\u2019", 4, 9)]]
 
+    # Check detecting closing single quote, see #2633
+    assert allMatches(regEx, "\u2018An evening at the book club,\u2019 she said.") == [
+        [("\u2018An evening at the book club,\u2019", 0, 30)]
+    ]
+
+    assert allMatches(regEx, "\u2018There's an evening at the book club,\u2019 she said.") == [
+        [("\u2018There's an evening at the book club,\u2019", 0, 38)]
+    ]
+
+    assert allMatches(regEx, "\u2018There\u2019s an author\u2019s evening at the book club,\u2019 she said.") == [
+        [("\u2018There\u2019s an author\u2019s evening at the book club,\u2019", 0, 47)]
+    ]
+
+    assert allMatches(
+        regEx,
+        "\u2018There\u2019s an author\u2019s evening at the book club,\u2019 "
+        "she said, \u2018I\u2019m going there tomorrow.\u2019",
+    ) == [
+        [("\u2018There\u2019s an author\u2019s evening at the book club,\u2019", 0, 47)],
+        [("\u2018I\u2019m going there tomorrow.\u2019", 58, 85)],
+    ]
+
+    assert allMatches(regEx, "\u2018There\u2019s an authors\u2019 evening at the book club,\u2019 she said.") == [
+        [("\u2018There\u2019s an authors\u2019 evening at the book club,\u2019", 0, 47)]
+    ]
+
+    assert allMatches(
+        regEx,
+        "\u2018There\u2019s an authors\u2019 evening at the book club,\u2019 "
+        "she said, \u2018I\u2019m going there tomorrow.\u2019",
+    ) == [
+        [("\u2018There\u2019s an authors\u2019 evening at the book club,\u2019", 0, 47)],
+        [("\u2018I\u2019m going there tomorrow.\u2019", 58, 85)],
+    ]
+
+    assert allMatches(
+        regEx,
+        "\u2018There\u2019s an \u201980s authors\u2019 evening at the book club,\u2019 "
+        "she said, \u2018I\u2019m going there tomorrow.\u2019",
+    ) == [
+        [("\u2018There\u2019s an \u201980s authors\u2019 evening at the book club,\u2019", 0, 52)],
+        [("\u2018I\u2019m going there tomorrow.\u2019", 63, 90)],
+    ]
+
 
 @pytest.mark.core
 def testTextPatterns_DialoguePlain():

--- a/tests/text/test_patterns.py
+++ b/tests/text/test_patterns.py
@@ -403,18 +403,6 @@ def testTextPatterns_DialogueStyle():
     assert allMatches(regEx, "one \u2018two\u2019 three \u201cfour\u201d five") == [[("\u2018two\u2019", 4, 9)]]
 
     # Check detecting closing single quote, see #2633
-    assert allMatches(regEx, "\u2018An evening at the book club,\u2019 she said.") == [
-        [("\u2018An evening at the book club,\u2019", 0, 30)]
-    ]
-
-    assert allMatches(regEx, "\u2018There's an evening at the book club,\u2019 she said.") == [
-        [("\u2018There's an evening at the book club,\u2019", 0, 38)]
-    ]
-
-    assert allMatches(regEx, "\u2018There\u2019s an author\u2019s evening at the book club,\u2019 she said.") == [
-        [("\u2018There\u2019s an author\u2019s evening at the book club,\u2019", 0, 47)]
-    ]
-
     assert allMatches(
         regEx,
         "\u2018There\u2019s an author\u2019s evening at the book club,\u2019 "
@@ -424,8 +412,39 @@ def testTextPatterns_DialogueStyle():
         [("\u2018I\u2019m going there tomorrow.\u2019", 58, 85)],
     ]
 
-    assert allMatches(regEx, "\u2018There\u2019s an authors\u2019 evening at the book club,\u2019 she said.") == [
-        [("\u2018There\u2019s an authors\u2019 evening at the book club,\u2019", 0, 47)]
+    assert allMatches(
+        regEx,
+        "\u2018There\u2019s an authors\u2019 evening at the book club,\u2019 "
+        "she said, \u2018I\u2019m going there tomorrow.\u2019",
+    ) == [
+        [("\u2018There\u2019s an authors\u2019 evening at the book club,\u2019", 0, 47)],
+        [("\u2018I\u2019m going there tomorrow.\u2019", 58, 85)],
+    ]
+
+    assert allMatches(
+        regEx,
+        "\u2018There\u2019s an \u201980s authors\u2019 evening at the book club,\u2019 "
+        "she said, \u2018I\u2019m going there tomorrow.\u2019",
+    ) == [
+        [("\u2018There\u2019s an \u201980s authors\u2019 evening at the book club,\u2019", 0, 52)],
+        [("\u2018I\u2019m going there tomorrow.\u2019", 63, 90)],
+    ]
+
+    # Using single quotes for double should yield the same result
+    CONFIG.fmtDQuoteOpen = nwUnicode.U_LSQUO
+    CONFIG.fmtDQuoteClose = nwUnicode.U_RSQUO
+
+    CONFIG.dialogStyle = 2
+    regEx = REGEX_PATTERNS.dialogStyle
+    assert regEx is not None
+
+    assert allMatches(
+        regEx,
+        "\u2018There\u2019s an author\u2019s evening at the book club,\u2019 "
+        "she said, \u2018I\u2019m going there tomorrow.\u2019",
+    ) == [
+        [("\u2018There\u2019s an author\u2019s evening at the book club,\u2019", 0, 47)],
+        [("\u2018I\u2019m going there tomorrow.\u2019", 58, 85)],
     ]
 
     assert allMatches(


### PR DESCRIPTION
**Summary:**

Improve the single quote dialogue parser and extend the special case where the closing quote is indistinguishable from an apostrophe.

**Related Issue(s):**

Part of #2633

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
